### PR TITLE
chore: Prevent conflict between clang-format and pre-C++11 nested template parsing

### DIFF
--- a/Core/GameEngine/Include/Common/FileSystem.h
+++ b/Core/GameEngine/Include/Common/FileSystem.h
@@ -63,7 +63,7 @@
 //           Type Defines
 //----------------------------------------------------------------------------
 
-typedef std::set<AsciiString, rts::less_than_nocase<AsciiString> > FilenameList;
+typedef std::set<AsciiString, rts::less_than_nocase<AsciiString>/**/> FilenameList;
 typedef FilenameList::iterator FilenameListIter;
 typedef UnsignedByte FileInstance;
 
@@ -174,7 +174,7 @@ protected:
 	typedef std::hash_map<
 		rts::string_key<AsciiString>, FileExistData,
 		rts::string_key_hash<AsciiString>,
-		rts::string_key_equal<AsciiString> > FileExistMap;
+		rts::string_key_equal<AsciiString>/**/> FileExistMap;
 
 	mutable FileExistMap m_fileExist;
 	mutable FastCriticalSectionClass m_fileExistMutex;

--- a/Core/GameEngine/Include/Common/GameAudio.h
+++ b/Core/GameEngine/Include/Common/GameAudio.h
@@ -66,7 +66,7 @@ struct AudioRequest;
 struct AudioSettings;
 struct MiscAudio;
 
-typedef std::hash_map<AsciiString, AudioEventInfo*, rts::hash<AsciiString>, rts::equal_to<AsciiString> > AudioEventInfoHash;
+typedef std::hash_map<AsciiString, AudioEventInfo*, rts::hash<AsciiString>, rts::equal_to<AsciiString>/**/> AudioEventInfoHash;
 typedef AudioEventInfoHash::iterator AudioEventInfoHashIt;
 typedef UnsignedInt AudioHandle;
 
@@ -338,7 +338,7 @@ class AudioManager : public SubsystemInterface
 
 		AudioEventInfoHash m_allAudioEventInfo;
 		AudioHandle theAudioHandlePool;
-		std::list<std::pair<AsciiString, Real> > m_adjustedVolumes;
+		std::list<std::pair<AsciiString, Real>/**/> m_adjustedVolumes;
 
 		Real m_musicVolume;
 		Real m_soundVolume;

--- a/Core/GameEngine/Include/Common/STLTypedefs.h
+++ b/Core/GameEngine/Include/Common/STLTypedefs.h
@@ -108,8 +108,8 @@ typedef std::vector<NamedRequest>::iterator								VecNamedRequestsIt;
 typedef std::vector<Bool>																	BoolVector;
 typedef std::vector<Bool>::iterator												BoolVectorIterator;
 
-typedef std::map< NameKeyType, Real, std::less<NameKeyType> > ProductionChangeMap;
-typedef std::map< NameKeyType, VeterancyLevel, std::less<NameKeyType> > ProductionVeterancyMap;
+typedef std::map< NameKeyType, Real, std::less<NameKeyType>/**/> ProductionChangeMap;
+typedef std::map< NameKeyType, VeterancyLevel, std::less<NameKeyType>/**/> ProductionVeterancyMap;
 
 // Some useful, common hash and equal_to functors for use with hash_map
 namespace rts

--- a/Core/GameEngine/Include/GameClient/FXList.h
+++ b/Core/GameEngine/Include/GameClient/FXList.h
@@ -209,7 +209,7 @@ public:
 private:
 
 	// use the hashing function for Ints.
-	typedef std::hash_map< NameKeyType, FXList, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > FXListMap;
+	typedef std::hash_map< NameKeyType, FXList, rts::hash<NameKeyType>, rts::equal_to<NameKeyType>/**/> FXListMap;
 
 	FXListMap m_fxmap;
 

--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -743,8 +743,8 @@ public:
 
 	typedef std::list<ParticleSystem*> ParticleSystemList;
 	typedef ParticleSystemList::iterator ParticleSystemListIt;
-	typedef std::hash_map<ParticleSystemID, ParticleSystem *, rts::hash<ParticleSystemID>, rts::equal_to<ParticleSystemID> > ParticleSystemIDMap;
-	typedef std::hash_map<AsciiString, ParticleSystemTemplate *, rts::hash<AsciiString>, rts::equal_to<AsciiString> > TemplateMap;
+	typedef std::hash_map<ParticleSystemID, ParticleSystem *, rts::hash<ParticleSystemID>, rts::equal_to<ParticleSystemID>/**/> ParticleSystemIDMap;
+	typedef std::hash_map<AsciiString, ParticleSystemTemplate *, rts::hash<AsciiString>, rts::equal_to<AsciiString>/**/> TemplateMap;
 
 	ParticleSystemManager();
 	virtual ~ParticleSystemManager() override;

--- a/Core/GameEngine/Include/GameClient/WindowVideoManager.h
+++ b/Core/GameEngine/Include/GameClient/WindowVideoManager.h
@@ -153,7 +153,7 @@ private:
 	}
 	};
 
-	typedef std::hash_map< ConstGameWindowPtr, WindowVideo *, hashConstGameWindowPtr, std::equal_to<ConstGameWindowPtr> > WindowVideoMap;
+	typedef std::hash_map< ConstGameWindowPtr, WindowVideo *, hashConstGameWindowPtr, std::equal_to<ConstGameWindowPtr>/**/> WindowVideoMap;
 
 	WindowVideoMap m_playingVideos;								///< List of currently playin Videos
 	//WindowVideoMap m_pausedVideos;									///< List of currently paused Videos

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -443,7 +443,7 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 	eventToAdd->setPlayingAudioIndex( audioEvent->getPlayingAudioIndex() );
 	audioEvent->generatePlayInfo();	// generate pitch shift and volume shift now as well
 
-	std::list<std::pair<AsciiString, Real> >::iterator it;
+	std::list<std::pair<AsciiString, Real>/**/>::iterator it;
 	for (it = m_adjustedVolumes.begin(); it != m_adjustedVolumes.end(); ++it) {
 		if (it->first == audioEvent->getEventName()) {
 			audioEvent->setVolume(it->second);
@@ -601,7 +601,7 @@ void AudioManager::setAudioEventVolumeOverride( AsciiString eventToAffect, Real 
 		adjustVolumeOfPlayingAudio(eventToAffect, newVolume);
 	}
 
-	std::list<std::pair<AsciiString, Real> >::iterator it;
+	std::list<std::pair<AsciiString, Real>/**/>::iterator it;
 	for (it = m_adjustedVolumes.begin(); it != m_adjustedVolumes.end(); ++it) {
 		if (it->first == eventToAffect) {
 			if (newVolume == -1.0f) {

--- a/Core/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemory.cpp
@@ -184,7 +184,7 @@ DECLARE_PERF_TIMER(MemoryPoolInitFilling)
 		Int used, peak, waste, peakwaste;
 		UsedNPeak() : used(0), peak(0), waste(0), peakwaste(0) { }
 	};
-	typedef std::map< const char*, UsedNPeak, std::less<const char*> > UsedNPeakMap;
+	typedef std::map< const char*, UsedNPeak, std::less<const char*>/**/> UsedNPeakMap;
 	static UsedNPeakMap TheUsedNPeakMap;
 	static Int doingIntenseDMA = 0;
 #endif

--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -722,7 +722,7 @@ Bool WouldMapTransfer( const AsciiString& mapName )
 }
 
 //-------------------------------------------------------------------------------------------------
-typedef std::set<UnicodeString, rts::less_than_nocase<UnicodeString> > MapNameList;
+typedef std::set<UnicodeString, rts::less_than_nocase<UnicodeString>/**/> MapNameList;
 typedef std::map<UnicodeString, AsciiString> MapDisplayToFileNameList;
 
 static void buildMapListForNumPlayers(MapNameList &outMapNames, MapDisplayToFileNameList &outFileNames, Int numPlayers)

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -98,7 +98,7 @@ struct OpenAudioFile
 	const AudioEventInfo *m_eventInfo;	// Not mutable, unlike the one on AudioEventRTS.
 };
 
-typedef std::hash_map< AsciiString, OpenAudioFile, rts::hash<AsciiString>, rts::equal_to<AsciiString> > OpenFilesHash;
+typedef std::hash_map< AsciiString, OpenAudioFile, rts::hash<AsciiString>, rts::equal_to<AsciiString>/**/> OpenFilesHash;
 typedef OpenFilesHash::iterator OpenFilesHashIt;
 
 class AudioFileCache

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
@@ -135,7 +135,7 @@ struct PristineBoneInfo
 	Int boneIndex;
 };
 //typedef std::hash_map< NameKeyType, PristineBoneInfo, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > PristineBoneInfoMap;
-typedef std::map< NameKeyType, PristineBoneInfo, std::less<NameKeyType> > PristineBoneInfoMap;
+typedef std::map< NameKeyType, PristineBoneInfo, std::less<NameKeyType>/**/> PristineBoneInfoMap;
 
 //-------------------------------------------------------------------------------------------------
 
@@ -268,7 +268,7 @@ typedef std::vector<ModelConditionInfo> ModelConditionVector;
 
 //-------------------------------------------------------------------------------------------------
 //typedef std::hash_map< TransitionSig, ModelConditionInfo, std::hash<TransitionSig>, std::equal_to<TransitionSig> > TransitionMap;
-typedef std::map< TransitionSig, ModelConditionInfo, std::less<TransitionSig> > TransitionMap;
+typedef std::map< TransitionSig, ModelConditionInfo, std::less<TransitionSig>/**/> TransitionMap;
 
 //-------------------------------------------------------------------------------------------------
 // this is more efficient and also helps solve a projectile-launch-offset problem for double-upgraded

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -3014,7 +3014,7 @@ void MilesAudioManager::friend_forcePlayAudioEventRTS(const AudioEventRTS* event
 	event.generateFilename();
 	event.generatePlayInfo();
 
-	std::list<std::pair<AsciiString, Real> >::iterator it;
+	std::list<std::pair<AsciiString, Real>/**/>::iterator it;
 	for (it = m_adjustedVolumes.begin(); it != m_adjustedVolumes.end(); ++it) {
 		if (it->first == event.getEventName()) {
 			event.setVolume(it->second);

--- a/Core/Libraries/Source/WWVegas/WWAudio/AudioEvents.h
+++ b/Core/Libraries/Source/WWVegas/WWAudio/AudioEvents.h
@@ -141,12 +141,12 @@ struct AUDIO_CALLBACK_STRUCT
 //	Protected structures
 /////////////////////////////////////////////////////////////////////////////////
 template <class T>
-class AudioCallbackListClass : public SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T> >
+class AudioCallbackListClass : public SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T>/**/>
 {
-	using SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T> >::Vector;
-	using SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T> >::ActiveCount;
-	using SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T> >::Delete;
-	using SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T> >::Add;
+	using SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T>/**/>::Vector;
+	using SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T>/**/>::ActiveCount;
+	using SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T>/**/>::Delete;
+	using SimpleDynVecClass< AUDIO_CALLBACK_STRUCT<T>/**/>::Add;
 
 public:
 

--- a/Core/Libraries/Source/WWVegas/WWLib/DbgHelpLoader.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/DbgHelpLoader.h
@@ -206,7 +206,7 @@ private:
 	MiniDumpWriteDump_t m_miniDumpWriteDump;
 #endif
 
-	typedef std::set<HANDLE, std::less<HANDLE>, stl::system_allocator<HANDLE> > Processes;
+	typedef std::set<HANDLE, std::less<HANDLE>, stl::system_allocator<HANDLE>/**/> Processes;
 
 	Processes m_initializedProcesses;
 	HMODULE m_dllModule;

--- a/Core/Libraries/Source/WWVegas/WWLib/STLUtils.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/STLUtils.h
@@ -124,21 +124,21 @@ Iter advance_in_range(Iter first, Iter last, ptrdiff_t n)
 }
 
 template <typename Key, typename Val>
-range<std::multimap<Key, Val> > get_range(std::multimap<Key, Val>& mm, const Key& key, ptrdiff_t n = 0)
+range<std::multimap<Key, Val>/**/> get_range(std::multimap<Key, Val>& mm, const Key& key, ptrdiff_t n = 0)
 {
 	typedef typename std::multimap<Key, Val>::iterator Iter;
 	const std::pair<Iter, Iter> pair = mm.equal_range(key);
 	const Iter it = advance_in_range(pair.first, pair.second, n);
-	return range<std::multimap<Key, Val> >(it, pair.second);
+	return range<std::multimap<Key, Val>/**/>(it, pair.second);
 }
 
 template <typename Key, typename Val>
-const_range<std::multimap<Key, Val> > get_range(const std::multimap<Key, Val>& mm, const Key& key, ptrdiff_t n = 0)
+const_range<std::multimap<Key, Val>/**/> get_range(const std::multimap<Key, Val>& mm, const Key& key, ptrdiff_t n = 0)
 {
 	typedef typename std::multimap<Key, Val>::const_iterator Iter;
 	const std::pair<Iter, Iter> pair = mm.equal_range(key);
 	const Iter it = advance_in_range(pair.first, pair.second, n);
-	return const_range<std::multimap<Key, Val> >(it, pair.second);
+	return const_range<std::multimap<Key, Val>/**/>(it, pair.second);
 }
 
 } // namespace stl

--- a/Core/Tools/matchbot/wlib/ustring.h
+++ b/Core/Tools/matchbot/wlib/ustring.h
@@ -32,7 +32,7 @@
 #define MAX_BYTES_PER_CHAR 1
 
 template <class charT>
-class UstringT : public basic_string<charT, string_char_traits<charT> >
+class UstringT : public basic_string<charT, string_char_traits<charT>/**/>
 {
  public:
 		explicit UstringT(int max_charlength) {
@@ -46,8 +46,8 @@ class UstringT : public basic_string<charT, string_char_traits<charT> >
 
       bool     operator==(const UstringT<charT> &other)
       {
-        const basic_string<charT, string_char_traits<charT> > *other_basic=&other;
-        const basic_string<charT, string_char_traits<charT> > *this_basic=this;
+        const basic_string<charT, string_char_traits<charT>/**/> *other_basic=&other;
+        const basic_string<charT, string_char_traits<charT>/**/> *this_basic=this;
         return((*other_basic)==(*this_basic));
       }
 

--- a/Generals/Code/GameEngine/Include/Common/DamageFX.h
+++ b/Generals/Code/GameEngine/Include/Common/DamageFX.h
@@ -156,7 +156,7 @@ public:
 
 private:
 
-	typedef std::hash_map< NameKeyType, DamageFX, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > DamageFXMap;
+	typedef std::hash_map< NameKeyType, DamageFX, rts::hash<NameKeyType>, rts::equal_to<NameKeyType>/**/> DamageFXMap;
 	DamageFXMap m_dfxmap;
 
 };

--- a/Generals/Code/GameEngine/Include/Common/ModuleFactory.h
+++ b/Generals/Code/GameEngine/Include/Common/ModuleFactory.h
@@ -113,7 +113,7 @@ protected:
 
 	static NameKeyType makeDecoratedNameKey(const AsciiString& name, ModuleType type);
 
-	typedef std::map< NameKeyType, ModuleTemplate, std::less<NameKeyType> > ModuleTemplateMap;
+	typedef std::map< NameKeyType, ModuleTemplate, std::less<NameKeyType>/**/> ModuleTemplateMap;
 	typedef std::vector<const ModuleData*> ModuleDataList;
 
 	ModuleTemplateMap			m_moduleTemplateMap;

--- a/Generals/Code/GameEngine/Include/Common/Player.h
+++ b/Generals/Code/GameEngine/Include/Common/Player.h
@@ -147,7 +147,7 @@ struct SpecialPowerReadyTimerType
 
 
 // ------------------------------------------------------------------------------------------------
-typedef std::hash_map< PlayerIndex, Relationship, std::hash<PlayerIndex>, std::equal_to<PlayerIndex> > PlayerRelationMapType;
+typedef std::hash_map< PlayerIndex, Relationship, std::hash<PlayerIndex>, std::equal_to<PlayerIndex>/**/> PlayerRelationMapType;
 class PlayerRelationMap : public MemoryPoolObject,
 													public Snapshot
 {

--- a/Generals/Code/GameEngine/Include/Common/Team.h
+++ b/Generals/Code/GameEngine/Include/Common/Team.h
@@ -42,7 +42,7 @@ typedef UnsignedInt TeamPrototypeID;
 #define TEAM_PROTOTYPE_ID_INVALID 0
 
 // ------------------------------------------------------------------------------------------------
-typedef std::hash_map< TeamID, Relationship, std::hash<TeamID>, std::equal_to<TeamID> > TeamRelationMapType;
+typedef std::hash_map< TeamID, Relationship, std::hash<TeamID>, std::equal_to<TeamID>/**/> TeamRelationMapType;
 class TeamRelationMap : public MemoryPoolObject,
 												public Snapshot
 {
@@ -733,7 +733,7 @@ protected:
 
 private:
 
-	typedef std::map< NameKeyType, TeamPrototype*, std::less<NameKeyType> > TeamPrototypeMap;
+	typedef std::map< NameKeyType, TeamPrototype*, std::less<NameKeyType>/**/> TeamPrototypeMap;
 
 	TeamPrototypeMap m_prototypes;
 	TeamPrototypeID m_uniqueTeamPrototypeID;		///< used to assign unique ids to each team prototype

--- a/Generals/Code/GameEngine/Include/Common/ThingFactory.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingFactory.h
@@ -44,7 +44,7 @@ class Object;
 class Drawable;
 class INI;
 
-typedef std::hash_map<AsciiString, ThingTemplate*, rts::hash<AsciiString>, rts::equal_to<AsciiString> > ThingTemplateHashMap;
+typedef std::hash_map<AsciiString, ThingTemplate*, rts::hash<AsciiString>, rts::equal_to<AsciiString>/**/> ThingTemplateHashMap;
 typedef ThingTemplateHashMap::iterator ThingTemplateHashMapIt;
 //-------------------------------------------------------------------------------------------------
 /** Implementation of the thing manager interface singleton */

--- a/Generals/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameClient.h
@@ -54,7 +54,7 @@ struct RayEffectData;
 
 /// Function pointers for use by GameClient callback functions.
 typedef void (*GameClientFuncPtr)( Drawable *draw, void *userData );
-typedef std::hash_map<DrawableID, Drawable *, rts::hash<DrawableID>, rts::equal_to<DrawableID> > DrawablePtrHash;
+typedef std::hash_map<DrawableID, Drawable *, rts::hash<DrawableID>, rts::equal_to<DrawableID>/**/> DrawablePtrHash;
 typedef DrawablePtrHash::iterator DrawablePtrHashIt;
 
 //-----------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Armor.h
@@ -121,7 +121,7 @@ public:
 
 private:
 
-	typedef std::hash_map< NameKeyType, ArmorTemplate, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > ArmorTemplateMap;
+	typedef std::hash_map< NameKeyType, ArmorTemplate, rts::hash<NameKeyType>, rts::equal_to<NameKeyType>/**/> ArmorTemplateMap;
 	ArmorTemplateMap m_armorTemplates;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -88,7 +88,7 @@ enum
 
 /// Function pointers for use by GameLogic callback functions.
 typedef void (*GameLogicFuncPtr)( Object *obj, void *userData );
-typedef std::hash_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID> > ObjectPtrHash;
+typedef std::hash_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID>/**/> ObjectPtrHash;
 typedef ObjectPtrHash::const_iterator ObjectPtrIter;
 
 typedef std::vector<Object*> ObjectPtrVector;
@@ -292,13 +292,13 @@ private:
 		overrides to thing template buildable status. doesn't really belong here,
 		but has to go somewhere. (srj)
 	*/
-	typedef std::hash_map< AsciiString, BuildableStatus, rts::hash<AsciiString>, rts::equal_to<AsciiString> > BuildableMap;
+	typedef std::hash_map< AsciiString, BuildableStatus, rts::hash<AsciiString>, rts::equal_to<AsciiString>/**/> BuildableMap;
 	BuildableMap m_thingTemplateBuildableOverrides;
 
 	/**
 		overrides to control bars. doesn't really belong here, but has to go somewhere. (srj)
 	*/
-	typedef std::hash_map< AsciiString, ConstCommandButtonPtr, rts::hash<AsciiString>, rts::equal_to<AsciiString> > ControlBarOverrideMap;
+	typedef std::hash_map< AsciiString, ConstCommandButtonPtr, rts::hash<AsciiString>, rts::equal_to<AsciiString>/**/> ControlBarOverrideMap;
 	ControlBarOverrideMap m_controlBarOverrides;
 
 	Real m_width, m_height;																	///< Dimensions of the world

--- a/Generals/Code/GameEngine/Include/GameLogic/Locomotor.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Locomotor.h
@@ -484,7 +484,7 @@ protected:
 
 private:
 
-	typedef std::map< NameKeyType, LocomotorTemplate*, std::less<NameKeyType> > LocomotorTemplateMap;
+	typedef std::map< NameKeyType, LocomotorTemplate*, std::less<NameKeyType>/**/> LocomotorTemplateMap;
 
 	LocomotorTemplateMap m_locomotorTemplates;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -184,7 +184,7 @@ enum MoodActionAdjustment CPP_11(: Int)
 
 //-------------------------------------------------------------------------------------------------
 typedef std::vector< const LocomotorTemplate* > LocomotorTemplateVector;
-typedef std::map< LocomotorSetType, LocomotorTemplateVector, std::less<LocomotorSetType> > LocomotorTemplateMap;
+typedef std::map< LocomotorSetType, LocomotorTemplateVector, std::less<LocomotorSetType>/**/> LocomotorTemplateMap;
 
 //-------------------------------------------------------------------------------------------------
 class AIUpdateModuleData : public UpdateModuleData

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -238,7 +238,7 @@ protected:
 	UnsignedInt					m_containListSize;							///< size of contained list
 private:
 
-	typedef std::map< ObjectID, ObjectEnterExitType, std::less<ObjectID> > ObjectEnterExitMap;
+	typedef std::map< ObjectID, ObjectEnterExitType, std::less<ObjectID>/**/> ObjectEnterExitMap;
 
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.

--- a/Generals/Code/GameEngine/Include/GameLogic/ObjectCreationList.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ObjectCreationList.h
@@ -205,7 +205,7 @@ public:
 
 private:
 
-	typedef std::map< NameKeyType, ObjectCreationList, std::less<NameKeyType> > ObjectCreationListMap;
+	typedef std::map< NameKeyType, ObjectCreationList, std::less<NameKeyType>/**/> ObjectCreationListMap;
 	ObjectCreationListMap m_ocls;
 
 	// note, this list doesn't own the nuggets; all nuggets are owned by the Store.

--- a/Generals/Code/GameEngine/Include/GameLogic/ScriptEngine.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ScriptEngine.h
@@ -99,7 +99,7 @@ typedef std::pair<AsciiString, UnsignedInt> PairAsciiStringUINT;
 typedef std::list<PairAsciiStringUINT> ListAsciiStringUINT;
 typedef ListAsciiStringUINT::iterator ListAsciiStringUINTIt;
 
-typedef std::map< const ThingTemplate *, Int, std::less<const ThingTemplate *> > AttackPriorityMap;
+typedef std::map< const ThingTemplate *, Int, std::less<const ThingTemplate *>/**/> AttackPriorityMap;
 typedef std::pair<AsciiString, ObjectID> AsciiStringObjectIDPair;
 typedef std::list<AsciiStringObjectIDPair> ListAsciiStringObjectID;
 typedef std::list<AsciiStringObjectIDPair>::iterator ListAsciiStringObjectIDIt;

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -864,7 +864,7 @@ private:
 	std::vector<WeaponTemplate*> m_weaponTemplateVector;
 
 	// TheSuperHackers @performance IamInnocent 01/01/2026 - Now additionally stores the same weapon templates in a hash map to optimize lookups by name key
-	typedef std::hash_map<NameKeyType, WeaponTemplate*, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > WeaponTemplateMap;
+	typedef std::hash_map<NameKeyType, WeaponTemplate*, rts::hash<NameKeyType>, rts::equal_to<NameKeyType>/**/> WeaponTemplateMap;
 	WeaponTemplateMap m_weaponTemplateHashMap;
 
 	std::list<WeaponDelayedDamageInfo> m_weaponDDI;

--- a/Generals/Code/GameEngine/Source/Common/PerfTimer.cpp
+++ b/Generals/Code/GameEngine/Source/Common/PerfTimer.cpp
@@ -209,7 +209,7 @@ void InitPrecisionTimer()
 /*static*/ Bool AutoPerfGatherIgnore::s_ignoring = false;
 
 //-------------------------------------------------------------------------------------------------
-typedef std::vector< std::pair< AsciiString, AsciiString > > StringPairVec;
+typedef std::vector< std::pair< AsciiString, AsciiString >/**/> StringPairVec;
 
 //-------------------------------------------------------------------------------------------------
 // PerfMetrics class. Basically, request a handle with your name and it will return. We use a vector

--- a/Generals/Code/Tools/WorldBuilder/include/GroveOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/GroveOptions.h
@@ -39,7 +39,7 @@ UnicodeString GetDisplayNameFromPair(const PairNameDisplayName *pNamePair);
 class GroveOptions : public COptionsPanel
 {
 	protected:
-		std::vector<std::pair<Int, Int> >	mVecGroup;
+		std::vector<std::pair<Int, Int>/**/>	mVecGroup;
 		VecPairNameDisplayName mVecDisplayNames;
 
 		Int	mNumTrees;

--- a/GeneralsMD/Code/GameEngine/Include/Common/DamageFX.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/DamageFX.h
@@ -156,7 +156,7 @@ public:
 
 private:
 
-	typedef std::hash_map< NameKeyType, DamageFX, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > DamageFXMap;
+	typedef std::hash_map< NameKeyType, DamageFX, rts::hash<NameKeyType>, rts::equal_to<NameKeyType>/**/> DamageFXMap;
 	DamageFXMap m_dfxmap;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/Common/ModuleFactory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ModuleFactory.h
@@ -113,7 +113,7 @@ protected:
 
 	static NameKeyType makeDecoratedNameKey(const AsciiString& name, ModuleType type);
 
-	typedef std::map< NameKeyType, ModuleTemplate, std::less<NameKeyType> > ModuleTemplateMap;
+	typedef std::map< NameKeyType, ModuleTemplate, std::less<NameKeyType>/**/> ModuleTemplateMap;
 	typedef std::vector<const ModuleData*> ModuleDataList;
 
 	ModuleTemplateMap			m_moduleTemplateMap;

--- a/GeneralsMD/Code/GameEngine/Include/Common/Player.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Player.h
@@ -148,7 +148,7 @@ struct SpecialPowerReadyTimerType
 
 
 // ------------------------------------------------------------------------------------------------
-typedef std::hash_map< PlayerIndex, Relationship, std::hash<PlayerIndex>, std::equal_to<PlayerIndex> > PlayerRelationMapType;
+typedef std::hash_map< PlayerIndex, Relationship, std::hash<PlayerIndex>, std::equal_to<PlayerIndex>/**/> PlayerRelationMapType;
 class PlayerRelationMap : public MemoryPoolObject,
 													public Snapshot
 {

--- a/GeneralsMD/Code/GameEngine/Include/Common/Team.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Team.h
@@ -42,7 +42,7 @@ typedef UnsignedInt TeamPrototypeID;
 #define TEAM_PROTOTYPE_ID_INVALID 0
 
 // ------------------------------------------------------------------------------------------------
-typedef std::hash_map< TeamID, Relationship, std::hash<TeamID>, std::equal_to<TeamID> > TeamRelationMapType;
+typedef std::hash_map< TeamID, Relationship, std::hash<TeamID>, std::equal_to<TeamID>/**/> TeamRelationMapType;
 class TeamRelationMap : public MemoryPoolObject,
 												public Snapshot
 {
@@ -733,7 +733,7 @@ protected:
 
 private:
 
-	typedef std::map< NameKeyType, TeamPrototype*, std::less<NameKeyType> > TeamPrototypeMap;
+	typedef std::map< NameKeyType, TeamPrototype*, std::less<NameKeyType>/**/> TeamPrototypeMap;
 
 	TeamPrototypeMap m_prototypes;
 	TeamPrototypeID m_uniqueTeamPrototypeID;		///< used to assign unique ids to each team prototype

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
@@ -44,7 +44,7 @@ class Object;
 class Drawable;
 class INI;
 
-typedef std::hash_map<AsciiString, ThingTemplate*, rts::hash<AsciiString>, rts::equal_to<AsciiString> > ThingTemplateHashMap;
+typedef std::hash_map<AsciiString, ThingTemplate*, rts::hash<AsciiString>, rts::equal_to<AsciiString>/**/> ThingTemplateHashMap;
 typedef ThingTemplateHashMap::iterator ThingTemplateHashMapIt;
 //-------------------------------------------------------------------------------------------------
 /** Implementation of the thing manager interface singleton */

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
@@ -121,7 +121,7 @@ public:
 
 private:
 
-	typedef std::hash_map< NameKeyType, ArmorTemplate, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > ArmorTemplateMap;
+	typedef std::hash_map< NameKeyType, ArmorTemplate, rts::hash<NameKeyType>, rts::equal_to<NameKeyType>/**/> ArmorTemplateMap;
 	ArmorTemplateMap m_armorTemplates;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -302,13 +302,13 @@ private:
 		overrides to thing template buildable status. doesn't really belong here,
 		but has to go somewhere. (srj)
 	*/
-	typedef std::hash_map< AsciiString, BuildableStatus, rts::hash<AsciiString>, rts::equal_to<AsciiString> > BuildableMap;
+	typedef std::hash_map< AsciiString, BuildableStatus, rts::hash<AsciiString>, rts::equal_to<AsciiString>/**/> BuildableMap;
 	BuildableMap m_thingTemplateBuildableOverrides;
 
 	/**
 		overrides to control bars. doesn't really belong here, but has to go somewhere. (srj)
 	*/
-	typedef std::hash_map< AsciiString, ConstCommandButtonPtr, rts::hash<AsciiString>, rts::equal_to<AsciiString> > ControlBarOverrideMap;
+	typedef std::hash_map< AsciiString, ConstCommandButtonPtr, rts::hash<AsciiString>, rts::equal_to<AsciiString>/**/> ControlBarOverrideMap;
 	ControlBarOverrideMap m_controlBarOverrides;
 
 	Real m_width, m_height;																	///< Dimensions of the world

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Locomotor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Locomotor.h
@@ -502,7 +502,7 @@ protected:
 
 private:
 
-	typedef std::map< NameKeyType, LocomotorTemplate*, std::less<NameKeyType> > LocomotorTemplateMap;
+	typedef std::map< NameKeyType, LocomotorTemplate*, std::less<NameKeyType>/**/> LocomotorTemplateMap;
 
 	LocomotorTemplateMap m_locomotorTemplates;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -185,7 +185,7 @@ enum MoodActionAdjustment CPP_11(: Int)
 
 //-------------------------------------------------------------------------------------------------
 typedef std::vector< const LocomotorTemplate* > LocomotorTemplateVector;
-typedef std::map< LocomotorSetType, LocomotorTemplateVector, std::less<LocomotorSetType> > LocomotorTemplateMap;
+typedef std::map< LocomotorSetType, LocomotorTemplateVector, std::less<LocomotorSetType>/**/> LocomotorTemplateMap;
 
 //-------------------------------------------------------------------------------------------------
 class AIUpdateModuleData : public UpdateModuleData

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -259,7 +259,7 @@ protected:
 	UnsignedInt					m_containListSize;							///< size of contained list
 private:
 
-	typedef std::map< ObjectID, ObjectEnterExitType, std::less<ObjectID> > ObjectEnterExitMap;
+	typedef std::map< ObjectID, ObjectEnterExitType, std::less<ObjectID>/**/> ObjectEnterExitMap;
 
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectCreationList.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectCreationList.h
@@ -205,7 +205,7 @@ public:
 
 private:
 
-	typedef std::map< NameKeyType, ObjectCreationList, std::less<NameKeyType> > ObjectCreationListMap;
+	typedef std::map< NameKeyType, ObjectCreationList, std::less<NameKeyType>/**/> ObjectCreationListMap;
 	ObjectCreationListMap m_ocls;
 
 	// note, this list doesn't own the nuggets; all nuggets are owned by the Store.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptEngine.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptEngine.h
@@ -99,7 +99,7 @@ typedef std::pair<AsciiString, UnsignedInt> PairAsciiStringUINT;
 typedef std::list<PairAsciiStringUINT> ListAsciiStringUINT;
 typedef ListAsciiStringUINT::iterator ListAsciiStringUINTIt;
 
-typedef std::map< const ThingTemplate *, Int, std::less<const ThingTemplate *> > AttackPriorityMap;
+typedef std::map< const ThingTemplate *, Int, std::less<const ThingTemplate *>/**/> AttackPriorityMap;
 typedef std::pair<AsciiString, ObjectID> AsciiStringObjectIDPair;
 typedef std::list<AsciiStringObjectIDPair> ListAsciiStringObjectID;
 typedef std::list<AsciiStringObjectIDPair>::iterator ListAsciiStringObjectIDIt;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -889,7 +889,7 @@ private:
 	std::vector<WeaponTemplate*> m_weaponTemplateVector;
 
 	// TheSuperHackers @performance IamInnocent 01/01/2026 - Now additionally stores the same weapon templates in a hash map to optimize lookups by name key
-	typedef std::hash_map<NameKeyType, WeaponTemplate*, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > WeaponTemplateMap;
+	typedef std::hash_map<NameKeyType, WeaponTemplate*, rts::hash<NameKeyType>, rts::equal_to<NameKeyType>/**/> WeaponTemplateMap;
 	WeaponTemplateMap m_weaponTemplateHashMap;
 
 	std::list<WeaponDelayedDamageInfo> m_weaponDDI;

--- a/GeneralsMD/Code/GameEngine/Source/Common/PerfTimer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/PerfTimer.cpp
@@ -209,7 +209,7 @@ void InitPrecisionTimer()
 /*static*/ Bool AutoPerfGatherIgnore::s_ignoring = false;
 
 //-------------------------------------------------------------------------------------------------
-typedef std::vector< std::pair< AsciiString, AsciiString > > StringPairVec;
+typedef std::vector< std::pair< AsciiString, AsciiString >/**/> StringPairVec;
 
 //-------------------------------------------------------------------------------------------------
 // PerfMetrics class. Basically, request a handle with your name and it will return. We use a vector

--- a/GeneralsMD/Code/Tools/GUIEdit/Include/HierarchyView.h
+++ b/GeneralsMD/Code/Tools/GUIEdit/Include/HierarchyView.h
@@ -149,7 +149,7 @@ protected:
  		}
  	};
 
- 	typedef std::hash_map< ConstGameWindowPtr, HTREEITEM, hashConstGameWindowPtr, std::equal_to<ConstGameWindowPtr> > TreeHash;
+ 	typedef std::hash_map< ConstGameWindowPtr, HTREEITEM, hashConstGameWindowPtr, std::equal_to<ConstGameWindowPtr>/**/> TreeHash;
 
  	TreeHash 		m_treeHash;	///< Speed up the search with a nice hash.
 #endif

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/GroveOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/GroveOptions.h
@@ -39,7 +39,7 @@ UnicodeString GetDisplayNameFromPair(const PairNameDisplayName *pNamePair);
 class GroveOptions : public COptionsPanel
 {
 	protected:
-		std::vector<std::pair<Int, Int> >	mVecGroup;
+		std::vector<std::pair<Int, Int>/**/>	mVecGroup;
 		VecPairNameDisplayName mVecDisplayNames;
 
 		Int	mNumTrees;


### PR DESCRIPTION
This PR resolves compilation errors in pre-C++11 compilers (such as VC6) caused by the `>>` token sequence in nested template declarations.

Instead of restructuring the code with `typedef`s, the issue is addressed by safely separating the consecutive closing angle brackets with an empty comment: `>/* */>`. This prevents the compiler from misinterpreting the sequence as a right-shift operator while preserving the original code structure and type definitions intact.

**Key Details:**

* **Scope:** A total of **68 instances** of nested templates (found by searching for `> >`) were updated using this pattern.
* **Edge Cases & Comments:** Nested templates located within code comments were intentionally left unchanged.

