### PR TITLE
perf: Reduce cost of retrieving labels from Waypoint and PolygonTrigger by 90%

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
@@ -125,7 +125,7 @@ public:
 	Int getID() const {return m_triggerID;}
 	PolygonTrigger *getNext() {return m_nextPolygonTrigger;}
 	const PolygonTrigger *getNext() const {return m_nextPolygonTrigger;}
-	AsciiString getTriggerName()  const {return m_triggerName;} ///< Gets the trigger name.
+	const AsciiString& getTriggerName()  const {return m_triggerName;} ///< Gets the trigger name.
 	Bool pointInTrigger(ICoord3D &point) const;
 	Bool doExportWithScripts() const {return m_exportWithScripts;}
 	void setDoExportWithScripts(Bool val) {m_exportWithScripts = val;}

--- a/Generals/Code/GameEngine/Include/GameLogic/TerrainLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/TerrainLogic.h
@@ -112,11 +112,11 @@ public:
 	/// Get the waypoint's position
 	const Coord3D *getLocation() const { return &m_location;  }
 	/// Get the waypoint's first path label
-	AsciiString getPathLabel1() const { return m_pathLabel1;  }
+	const AsciiString& getPathLabel1() const { return m_pathLabel1;  }
 	/// Get the waypoint's second path label
-	AsciiString getPathLabel2() const { return m_pathLabel2;  }
+	const AsciiString& getPathLabel2() const { return m_pathLabel2;  }
 	/// Get the waypoint's third path label
-	AsciiString getPathLabel3() const { return m_pathLabel3;  }
+	const AsciiString& getPathLabel3() const { return m_pathLabel3;  }
 	/// Get bi-directionality.
 	Bool getBiDirectional() const { return m_biDirectional; }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1633,7 +1633,7 @@ Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, AsciiString label )
 PolygonTrigger *TerrainLogic::getTriggerAreaByName( AsciiString name )
 {
 	for (PolygonTrigger* pTrig = PolygonTrigger::getFirstPolygonTrigger(); pTrig; pTrig = pTrig->getNext()) {
-		AsciiString trigName = pTrig->getTriggerName();
+		const AsciiString& trigName = pTrig->getTriggerName();
 		if (name == trigName)
 			return pTrig;
 	}

--- a/Generals/Code/Tools/WorldBuilder/src/WaterOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WaterOptions.cpp
@@ -162,7 +162,7 @@ void WaterOptions::OnChangeWaterEdit()
 		PolygonTrigger *pTrig;
 		for (pTrig=PolygonTrigger::getFirstPolygonTrigger(); !didMatch && pTrig; pTrig = pTrig->getNext()) {
 			if (pTrig==theTrigger) continue; // don't check against yourself.
-			AsciiString trigName = pTrig->getTriggerName();
+			const AsciiString& trigName = pTrig->getTriggerName();
 			if (name == trigName) {
 				if (pTrig->isValid()) {
 					didMatch = true;

--- a/Generals/Code/Tools/WorldBuilder/src/WaypointOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WaypointOptions.cpp
@@ -486,7 +486,7 @@ void WaypointOptions::OnChangeWaypointnameEdit()
 		PolygonTrigger *pTrig;
 		for (pTrig=PolygonTrigger::getFirstPolygonTrigger(); !didMatch && pTrig; pTrig = pTrig->getNext()) {
 			if (pTrig==theTrigger) continue; // don't check against yourself.
-			AsciiString trigName = pTrig->getTriggerName();
+			const AsciiString& trigName = pTrig->getTriggerName();
 			if (name == trigName) {
 				if (pTrig->isValid()) {
 					didMatch = true;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
@@ -137,7 +137,7 @@ public:
 	Int getID() const {return m_triggerID;}
 	PolygonTrigger *getNext() {return m_nextPolygonTrigger;}
 	const PolygonTrigger *getNext() const {return m_nextPolygonTrigger;}
-	AsciiString getTriggerName()  const {return m_triggerName;} ///< Gets the trigger name.
+	const AsciiString& getTriggerName()  const {return m_triggerName;} ///< Gets the trigger name.
 	Bool pointInTrigger(ICoord3D &point) const;
 	Bool doExportWithScripts() const {return m_exportWithScripts;}
 	void setDoExportWithScripts(Bool val) {m_exportWithScripts = val;}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/TerrainLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/TerrainLogic.h
@@ -112,11 +112,11 @@ public:
 	/// Get the waypoint's position
 	const Coord3D *getLocation() const { return &m_location;  }
 	/// Get the waypoint's first path label
-	AsciiString getPathLabel1() const { return m_pathLabel1;  }
+	const AsciiString& getPathLabel1() const { return m_pathLabel1;  }
 	/// Get the waypoint's second path label
-	AsciiString getPathLabel2() const { return m_pathLabel2;  }
+	const AsciiString& getPathLabel2() const { return m_pathLabel2;  }
 	/// Get the waypoint's third path label
-	AsciiString getPathLabel3() const { return m_pathLabel3;  }
+	const AsciiString& getPathLabel3() const { return m_pathLabel3;  }
 	/// Get bi-directionality.
 	Bool getBiDirectional() const { return m_biDirectional; }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1633,7 +1633,7 @@ Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, AsciiString label )
 PolygonTrigger *TerrainLogic::getTriggerAreaByName( AsciiString name )
 {
 	for (PolygonTrigger* pTrig = PolygonTrigger::getFirstPolygonTrigger(); pTrig; pTrig = pTrig->getNext()) {
-		AsciiString trigName = pTrig->getTriggerName();
+		const AsciiString& trigName = pTrig->getTriggerName();
 		if (name == trigName)
 			return pTrig;
 	}

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/LayersList.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/LayersList.cpp
@@ -447,7 +447,7 @@ void LayersList::updateUIFromList()
 		}
 
 		for (ListPolygonTriggerPtrIt triggerIt = layersIt->polygonTriggersInLayer.begin(); triggerIt != layersIt->polygonTriggersInLayer.end(); ++triggerIt) {
-			AsciiString uniqueID = (*triggerIt)->getTriggerName();
+			const AsciiString& uniqueID = (*triggerIt)->getTriggerName();
 			pTree->InsertItem(uniqueID.str(), iconToShow, iconToShow, thisBranch);
 		}
 	}
@@ -609,7 +609,7 @@ void LayersList::addPolygonTriggerToLayer(IN PolygonTrigger *triggerToAdd, IN Li
 	// only update this object.
 	HTREEITEM hItem = findTreeLayerNamed(layerToAddTo->layerName);
 	if (hItem) {
-		AsciiString triggerName = triggerToAdd->getTriggerName();
+		const AsciiString& triggerName = triggerToAdd->getTriggerName();
 		int iconToShow = (layerToAddTo->show ? 0 : 1);
 		mTree->InsertItem(triggerName.str(), iconToShow, iconToShow, hItem);
 	}
@@ -691,7 +691,7 @@ void LayersList::removePolygonTriggerFromLayer(IN PolygonTrigger *triggerToRemov
 	// only remove this object
 	HTREEITEM layer = findTreeLayerNamed(layerToRemoveFrom->layerName);
 	if (layer) {
-		AsciiString triggerUID = (*triggerBeingRemove)->getTriggerName();
+		const AsciiString& triggerUID = (*triggerBeingRemove)->getTriggerName();
 		HTREEITEM itemToDelete = findTreeObjectNamed(triggerUID.str(), layer);
 		if (itemToDelete) {
 			mTree->DeleteItem(itemToDelete);
@@ -1227,7 +1227,7 @@ Bool LayersList::findAndSelectPolygonTrigger(AsciiString selectedItemAsciiString
 	PolygonTrigger *trigger = PolygonTrigger::getFirstPolygonTrigger();
 
 	while (trigger) {
-		AsciiString triggerName = trigger->getTriggerName();
+		const AsciiString& triggerName = trigger->getTriggerName();
 
 		if (triggerName.compareNoCase(selectedItemAsciiString) == 0) {
 			// Found it... select this object
@@ -1307,7 +1307,7 @@ PolygonTrigger* LayersList::findPolygonTriggerByUID(AsciiString triggerIDToFind)
 	PolygonTrigger *trigger = PolygonTrigger::getFirstPolygonTrigger();
 
 	while (trigger) {
-		AsciiString triggerName = trigger->getTriggerName();
+		const AsciiString& triggerName = trigger->getTriggerName();
 
 		if (triggerName.compareNoCase(triggerIDToFind) == 0) {
 			return (trigger);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WaterOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WaterOptions.cpp
@@ -162,7 +162,7 @@ void WaterOptions::OnChangeWaterEdit()
 		PolygonTrigger *pTrig;
 		for (pTrig=PolygonTrigger::getFirstPolygonTrigger(); !didMatch && pTrig; pTrig = pTrig->getNext()) {
 			if (pTrig==theTrigger) continue; // don't check against yourself.
-			AsciiString trigName = pTrig->getTriggerName();
+			const AsciiString& trigName = pTrig->getTriggerName();
 			if (name == trigName) {
 				if (pTrig->isValid()) {
 					didMatch = true;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WaypointOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WaypointOptions.cpp
@@ -486,7 +486,7 @@ void WaypointOptions::OnChangeWaypointnameEdit()
 		PolygonTrigger *pTrig;
 		for (pTrig=PolygonTrigger::getFirstPolygonTrigger(); !didMatch && pTrig; pTrig = pTrig->getNext()) {
 			if (pTrig==theTrigger) continue; // don't check against yourself.
-			AsciiString trigName = pTrig->getTriggerName();
+			const AsciiString& trigName = pTrig->getTriggerName();
 			if (name == trigName) {
 				if (pTrig->isValid()) {
 					didMatch = true;


### PR DESCRIPTION
This PR reduces the allocation overhead seen when waypoint path labels and polygontrigger names are retrieved.

In mod maps with a lot of path scripted ai, such as Cobal Rush, waypoint labels are retrieved and compared every frame.
This will occur for every AI unit that is pathing along the waypoint. Polygon triggers also have a similar issue where they can be repeatedly compared every frame per scripted unit.

The following shows the side effects of this change for waypoint path labels.

Before:
<img width="1321" height="324" alt="image" src="https://github.com/user-attachments/assets/a77df084-60f4-4bc5-8a04-7933a82d13e5" />


After:
<img width="1293" height="345" alt="image" src="https://github.com/user-attachments/assets/15c16ee9-4490-4f2e-abb6-4ad37ea4ecb9" />

In game the most significant observation was that the first wave in Cobalt Rush went from stuttering to smooth.
The average FPS also significantly increased when observing the first wave and the camera also stopped stuttering.

The above flame graphs were captured in a debug build, but the stuttering still occurs in a release build and is alleviated with the same fix.

