### PR TITLE
bugfix(texture): Prevent compressed texture reduction below 4x4 limit and fix binarytstream texture rendering

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -1457,7 +1457,6 @@ bool TextureLoadTaskClass::Begin_Compressed_Load()
 	Width		= width;
 	Height	= height;
 	Format	= Get_Valid_Texture_Format(orig_format, Texture->Is_Compression_Allowed());
-	Reduction = reduction;
 
 
 	if (!Texture->Is_Reducible() || Texture->MipLevelCount == MIP_LEVELS_1)
@@ -1479,9 +1478,13 @@ bool TextureLoadTaskClass::Begin_Compressed_Load()
 	// Otherwise take as many mip levels as the texture wants, not to exceed the count in file...
 	if (!mip_level_count)
 	{
-		reducedWidth >>= Reduction;
-		reducedHeight >>= Reduction;
-		mip_level_count = orig_mip_count-Reduction;//dds_file.Get_Mip_Level_Count();
+		if(reducedWidth !=4 && reducedHeight !=4)
+		{
+			reducedWidth >>= Reduction;
+			reducedHeight >>= Reduction;
+			mip_level_count = orig_mip_count-Reduction;//dds_file.Get_Mip_Level_Count();
+		}
+
 		if (mip_level_count < 1)
 			mip_level_count = 1;	//sanity check to make sure something gets loaded.
 	}
@@ -1835,6 +1838,7 @@ bool TextureLoadTaskClass::Load_Compressed_Mipmap()
 
 	if (Reduction)
 	{	for (unsigned int level = 0; level < Reduction; ++level) {
+			if (height == 4 || width == 4) break;
 			width		>>= 1;
 			height		>>= 1;
 		}


### PR DESCRIPTION
* Closes #1990 


In ```Begin_Compressed_Load```, the hardware aspect-ratio validation loop calculates ```Reduction``` to find a hardware-compliant mip level for a non-compliant texture (or thin textures like binary stream). However, the value was immediately overwritten following the loop. 
This causes ```Load_Compressed_Mipmap``` to open the DDS file at reduction=0 (full 16×256) while trying to copy into a 4×32 surface which caused a silent dimension mismatch where ```DDSFileClass::Copy_Level_To_Surface``` hits its unimplemented scaling branch and copies nothing, leaving the texture blank.

The binary stream texture ```EXBinaryStream.tga``` is of dimensions ```16×256``` which is a thin texture (aspect ratio exceeding 1:8) and became invisible in Generals while still appearing correctly in Zero Hour because it replaced by ```EXBinaryStream32.tga``` (```32×256```), which has a compliant 1:8 aspect ratio and never triggers the buggy code path.

This fix removes the line that overwrites the aspect-ratio reduction and performs minimum dimension clamping (4px) to prevent over-shifting in ```Begin_Compressed_Load``` and ```Load_Compressed_Mipmap```

## Note on original Generals behavior
The original pre-PR Generals loader also had a bug in its reduction loop: it passed the wrong variables to ```Validate_Texture_Size```, causing the loop to always break at i=1, producing ```8×128``` instead of the more consistent ```4×32```. This fix produces ```4×32```, which differs slightly from original Generals retail behavior. If exact retail compatibility is required, a precompiler flag approach might be considered.

## Testing
Verified that Lotus' and patriot's binary stream renders  in Generals and ZH.
Played multiple skirmishes in generals and ZH and no apparent unwanted changes were noticed.