### PR TITLE
bugfix(milesaudiomanager): Prevent dangling pointer to AudioEventRTS in PlayingAudio when handing it over to a new AudioRequest after a call to MilesAudioManager::startNextLoop()

### DIFF
--- a/Core/GameEngine/Include/Common/AudioEventRTS.h
+++ b/Core/GameEngine/Include/Common/AudioEventRTS.h
@@ -199,14 +199,27 @@ protected:
 	PortionToPlay m_portionToPlayNext;	///< Which portion (attack, sound, decay) should be played next?
 };
 
-class DynamicAudioEventRTS : public MemoryPoolObject
+class DynamicAudioEventRTS : public MemoryPoolObject, public RefCountClass, public AudioEventRTS
 {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(DynamicAudioEventRTS, "DynamicAudioEventRTS" )
 public:
 
-	DynamicAudioEventRTS() { }
-	DynamicAudioEventRTS(const AudioEventRTS& a) : m_event(a) { }
+	DynamicAudioEventRTS() {}
+	DynamicAudioEventRTS( const AsciiString& eventName ) : AudioEventRTS(eventName) {}
+	DynamicAudioEventRTS( const AsciiString& eventName, ObjectID ownerID ) : AudioEventRTS(eventName, ownerID) {}
+	DynamicAudioEventRTS( const AsciiString& eventName, DrawableID drawableID ) : AudioEventRTS(eventName, drawableID) {}
+	DynamicAudioEventRTS( const AsciiString& eventName, const Coord3D *positionOfAudio ) : AudioEventRTS(eventName, positionOfAudio) {}
 
-	AudioEventRTS	m_event;
+	DynamicAudioEventRTS(const AudioEventRTS& a) : AudioEventRTS(a) {}
+	DynamicAudioEventRTS& operator=( const AudioEventRTS& right )
+	{
+		*static_cast<AudioEventRTS*>(this) = right;
+		return *this;
+	}
+
+	void Delete_This() override
+	{
+		deleteInstance(this);
+	}
 };
 EMPTY_DTOR(DynamicAudioEventRTS)

--- a/Core/GameEngine/Include/Common/AudioRequest.h
+++ b/Core/GameEngine/Include/Common/AudioRequest.h
@@ -30,8 +30,9 @@
 
 #include "Common/GameAudio.h"
 #include "Common/GameMemory.h"
+#include "Common/AudioHandleSpecialValues.h"
 
-class AudioEventRTS;
+class DynamicAudioEventRTS;
 
 enum RequestType CPP_11(: Int)
 {
@@ -45,14 +46,16 @@ struct AudioRequest : public MemoryPoolObject
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( AudioRequest, "AudioRequest" )
 
 public:
-	AudioEventRTS* releasePendingEvent();
+
+	AudioRequest()
+		: m_request(AR_Play)
+		, m_pendingEvent(nullptr)
+		, m_handleToInteractOn(AHSV_Error)
+		, m_requiresCheckForSample(false)
+	{}
 
 	RequestType m_request;
-	union
-	{
-		AudioEventRTS *m_pendingEvent;
-		AudioHandle m_handleToInteractOn;
-	};
-	Bool m_usePendingEvent;
+	RefCountPtr<DynamicAudioEventRTS> m_pendingEvent;
+	AudioHandle m_handleToInteractOn;
 	Bool m_requiresCheckForSample;
 };

--- a/Core/GameEngine/Include/Common/GameAudio.h
+++ b/Core/GameEngine/Include/Common/GameAudio.h
@@ -257,9 +257,9 @@ class AudioManager : public SubsystemInterface
 		virtual void setListenerPosition( const Coord3D *newListenerPos, const Coord3D *newListenerOrientation );
 		virtual const Coord3D *getListenerPosition() const;
 
-		virtual AudioRequest *allocateAudioRequest( Bool useAudioEvent );
+		virtual AudioRequest *allocateAudioRequest();
 		virtual void releaseAudioRequest( AudioRequest *requestToRelease );
-		virtual void appendAudioRequest( AudioRequest *m_request );
+		virtual void appendAudioRequest( AudioRequest *request );
 		virtual void processRequestList();
 
 		virtual AudioEventInfo *newAudioEventInfo( AsciiString newEventName );
@@ -268,9 +268,6 @@ class AudioManager : public SubsystemInterface
 
 		const AudioSettings *getAudioSettings() const;
 		const MiscAudio *getMiscAudio() const;
-
-		// This function should only be called by AudioManager, MusicManager and SoundManager
-		virtual void releaseAudioEventRTS( AudioEventRTS *&eventToRelease );
 
 		// For INI
 		AudioSettings *friend_getAudioSettings();

--- a/Core/GameEngine/Include/Common/GameMusic.h
+++ b/Core/GameEngine/Include/Common/GameMusic.h
@@ -102,10 +102,10 @@ class MusicManager
 		MusicManager();
 		virtual ~MusicManager();
 
-		void playTrack( AudioEventRTS *eventToUse );
+		void playTrack( DynamicAudioEventRTS *eventToUse );
 		void stopTrack( AudioHandle eventToRemove );
 
-		virtual void addAudioEvent(AudioEventRTS *eventToAdd);	// pre-copied
+		virtual void addAudioEvent( DynamicAudioEventRTS *eventToAdd );	// pre-copied
 		virtual void removeAudioEvent( AudioHandle eventToRemove );
 
 		void setVolume( Real m_volume );

--- a/Core/GameEngine/Include/Common/GameSounds.h
+++ b/Core/GameEngine/Include/Common/GameSounds.h
@@ -45,8 +45,8 @@
 #include "Common/GameAudio.h"
 #include "Common/GameType.h"
 
-// Forward declarations
 class AudioEventRTS;
+class DynamicAudioEventRTS;
 
 class SoundManager : public SubsystemInterface
 {
@@ -67,7 +67,7 @@ class SoundManager : public SubsystemInterface
 		virtual void setCameraAudibleDistance( Real audibleDistance );
 		virtual Real getCameraAudibleDistance();
 
-		virtual void addAudioEvent(AudioEventRTS *&eventToAdd);	// pre-copied
+		virtual Bool addAudioEvent(DynamicAudioEventRTS *eventToAdd);	// pre-copied
 
 		// empty string means that this sound wasn't found or some error occurred. CHECK FOR EMPTY STRING.
 		virtual AsciiString getFilenameForPlayFromAudioEvent( const AudioEventRTS *eventToGetFrom );

--- a/Core/GameEngine/Source/Common/Audio/AudioRequest.cpp
+++ b/Core/GameEngine/Source/Common/Audio/AudioRequest.cpp
@@ -30,20 +30,4 @@
 
 AudioRequest::~AudioRequest()
 {
-	if (m_usePendingEvent)
-	{
-		delete m_pendingEvent;
-	}
-}
-
-AudioEventRTS* AudioRequest::releasePendingEvent()
-{
-	if (m_usePendingEvent)
-	{
-		m_usePendingEvent = false;
-		AudioEventRTS* event = m_pendingEvent;
-		m_pendingEvent = nullptr;
-		return event;
-	}
-	return nullptr;
 }

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -437,7 +437,8 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 		return AHSV_NotForLocal;
 	}
 
-	AudioEventRTS *audioEvent = MSGNEW("AudioEventRTS") AudioEventRTS(*eventToAdd);		// poolify
+	RefCountPtr<DynamicAudioEventRTS> audioEvent;
+	audioEvent.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS)(*eventToAdd));
 	audioEvent->setPlayingHandle( allocateNewHandle() );
 	audioEvent->generateFilename();	// which file are we actually going to play?
 	eventToAdd->setPlayingAudioIndex( audioEvent->getPlayingAudioIndex() );
@@ -454,7 +455,6 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 #if RETAIL_COMPATIBLE_CRC
 	if (notForLocal)
 	{
-		releaseAudioEventRTS(audioEvent);
 		return AHSV_NotForLocal;
 	}
 #endif
@@ -464,21 +464,22 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 #ifdef INTENSIVE_AUDIO_DEBUG
 		DEBUG_LOG((" - culled due to muting (%d).", audioEvent->getVolume()));
 #endif
-		releaseAudioEventRTS(audioEvent);
 		return AHSV_Muted;
 	}
 
 	if (soundType == AT_Music)
 	{
-		m_music->addAudioEvent(audioEvent);
+		m_music->addAudioEvent(audioEvent.Peek());
 	}
 	else
 	{
-		//Possible to nuke audioEvent inside.
-		m_sound->addAudioEvent(audioEvent);
+		if (!m_sound->addAudioEvent(audioEvent.Peek()))
+		{
+			audioEvent.Clear();
+		}
 	}
 
-	if( audioEvent )
+	if( audioEvent != nullptr )
 	{
 		return audioEvent->getPlayingHandle();
 	}
@@ -576,7 +577,7 @@ void AudioManager::removeAudioEvent(AudioHandle audioEvent)
 		return;
 	}
 
-	AudioRequest *req = allocateAudioRequest( false );
+	AudioRequest *req = allocateAudioRequest();
 	req->m_handleToInteractOn = audioEvent;
 	req->m_request = AR_Stop;
 	appendAudioRequest( req );
@@ -786,10 +787,9 @@ const Coord3D *AudioManager::getListenerPosition() const
 }
 
 //-------------------------------------------------------------------------------------------------
-AudioRequest *AudioManager::allocateAudioRequest( Bool useAudioEvent )
+AudioRequest *AudioManager::allocateAudioRequest()
 {
 	AudioRequest *audioReq = newInstance(AudioRequest);
-	audioReq->m_usePendingEvent = useAudioEvent;
 	audioReq->m_requiresCheckForSample = false;
 	return audioReq;
 }
@@ -801,21 +801,20 @@ void AudioManager::releaseAudioRequest( AudioRequest *requestToRelease )
 }
 
 //-------------------------------------------------------------------------------------------------
-void AudioManager::appendAudioRequest( AudioRequest *m_request )
+void AudioManager::appendAudioRequest( AudioRequest *request )
 {
-	m_audioRequests.push_back(m_request);
+	m_audioRequests.push_back(request);
 }
 
 //-------------------------------------------------------------------------------------------------
 // Remove all pending audio requests
 void AudioManager::removeAllAudioRequests()
 {
-  std::list<AudioRequest*>::iterator it;
-  for ( it = m_audioRequests.begin(); it != m_audioRequests.end(); it++ ) {
-    releaseAudioRequest( *it );
-  }
-
-  m_audioRequests.clear();
+	std::list<AudioRequest*>::iterator it;
+	for ( it = m_audioRequests.begin(); it != m_audioRequests.end(); ++it ) {
+		releaseAudioRequest( *it );
+	}
+	m_audioRequests.clear();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1043,15 +1042,8 @@ Bool AudioManager::shouldPlayLocally(const AudioEventRTS *audioEvent)
 //-------------------------------------------------------------------------------------------------
 AudioHandle AudioManager::allocateNewHandle()
 {
-	// note, intenionally a post increment rather than a pre increment.
+	// note, intentionally a post increment rather than a pre increment.
 	return theAudioHandlePool++;
-}
-
-//-------------------------------------------------------------------------------------------------
-void AudioManager::releaseAudioEventRTS( AudioEventRTS *&eventToRelease )
-{
-	delete eventToRelease;
-	eventToRelease = nullptr;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Source/Common/Audio/GameMusic.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameMusic.cpp
@@ -95,10 +95,10 @@ MusicManager::~MusicManager()
 }
 
 //-------------------------------------------------------------------------------------------------
-void MusicManager::playTrack( AudioEventRTS *eventToUse )
+void MusicManager::playTrack( DynamicAudioEventRTS *eventToUse )
 {
-	AudioRequest *audioRequest = TheAudio->allocateAudioRequest( true );
-	audioRequest->m_pendingEvent = eventToUse;
+	AudioRequest *audioRequest = TheAudio->allocateAudioRequest();
+	audioRequest->m_pendingEvent.Assign_Add_Ref(eventToUse);
 	audioRequest->m_request = AR_Play;
 	TheAudio->appendAudioRequest( audioRequest );
 }
@@ -106,14 +106,14 @@ void MusicManager::playTrack( AudioEventRTS *eventToUse )
 //-------------------------------------------------------------------------------------------------
 void MusicManager::stopTrack( AudioHandle eventToRemove )
 {
-	AudioRequest *audioRequest = TheAudio->allocateAudioRequest( false );
+	AudioRequest *audioRequest = TheAudio->allocateAudioRequest();
 	audioRequest->m_handleToInteractOn = eventToRemove;
 	audioRequest->m_request = AR_Stop;
 	TheAudio->appendAudioRequest( audioRequest );
 }
 
 //-------------------------------------------------------------------------------------------------
-void MusicManager::addAudioEvent( AudioEventRTS *eventToAdd )
+void MusicManager::addAudioEvent( DynamicAudioEventRTS *eventToAdd )
 {
 	playTrack( eventToAdd );
 }

--- a/Core/GameEngine/Source/Common/Audio/GameSounds.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameSounds.cpp
@@ -132,19 +132,20 @@ Real SoundManager::getCameraAudibleDistance()
 }
 
 //-------------------------------------------------------------------------------------------------
-void SoundManager::addAudioEvent(AudioEventRTS *&eventToAdd)
+Bool SoundManager::addAudioEvent(DynamicAudioEventRTS *eventToAdd)
 {
 	if (canPlayNow(eventToAdd)) {
 #ifdef INTENSIVE_AUDIO_DEBUG
 		DEBUG_LOG((" - appended to request list with handle '%d'.", (UnsignedInt) eventToAdd->getPlayingHandle()));
 #endif
-		AudioRequest *audioRequest = TheAudio->allocateAudioRequest( true );
-		audioRequest->m_pendingEvent = eventToAdd;
+		AudioRequest *audioRequest = TheAudio->allocateAudioRequest();
+		audioRequest->m_pendingEvent.Assign_Add_Ref(eventToAdd);
 		audioRequest->m_request = AR_Play;
 		TheAudio->appendAudioRequest(audioRequest);
-	} else {
-		TheAudio->releaseAudioEventRTS(eventToAdd);
+		return true;
 	}
+
+	return false;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -1167,23 +1167,22 @@ void INI::parseICoord2D( INI* ini, void * /*instance*/, void *store, const void*
 void INI::parseDynamicAudioEventRTS( INI *ini, void * /*instance*/, void *store, const void* userData )
 {
 	const char *token = ini->getNextToken();
-	DynamicAudioEventRTS** theSound = (DynamicAudioEventRTS**)store;
+	RefCountPtr<DynamicAudioEventRTS>* theSound = (RefCountPtr<DynamicAudioEventRTS>*)store;
 
 	// translate the string into a sound
 	if (stricmp(token, "NoSound") == 0)
 	{
-		deleteInstance(*theSound);
-		*theSound = nullptr;
+		theSound->Clear();
 	}
 	else
 	{
 		if (*theSound == nullptr)
-			*theSound = newInstance(DynamicAudioEventRTS);
-		(*theSound)->m_event.setEventName(AsciiString(token));
+			*theSound = Create_No_Add_Ref(newInstance(DynamicAudioEventRTS));
+		(*theSound)->setEventName(AsciiString(token));
 	}
 
 	if (*theSound)
-		TheAudio->getInfoForAudioEvent(&(*theSound)->m_event);
+		TheAudio->getInfoForAudioEvent(theSound->Peek());
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -26,6 +26,7 @@
 #include "WWLib/mutex.h"
 
 class AudioEventRTS;
+class DynamicAudioEventRTS;
 
 enum { MAXPROVIDERS = 64 };
 
@@ -61,13 +62,13 @@ struct PlayingAudio
 		HSTREAM m_stream;
 	};
 
-	AudioEventRTS *m_audioEventRTS;
+	RefCountPtr<DynamicAudioEventRTS> m_audioEventRTS;
 	void *m_file; // The file that was opened to play this
 	PlayingAudioType m_type;
 	volatile PlayingStatus m_status; // This member is adjusted by another running thread.
 	Short m_framesFaded;
 	Bool m_fade;
-	Bool m_cleanupAudioEventRTS;
+	volatile Bool m_rerequestOnNextUpdate;
 
 	PlayingAudio()
 		: m_sample(nullptr)
@@ -77,7 +78,7 @@ struct PlayingAudio
 		, m_status(PS_Playing)
 		, m_framesFaded(0)
 		, m_fade(false)
-		, m_cleanupAudioEventRTS(true)
+		, m_rerequestOnNextUpdate(false)
 	{}
 
 	static_assert(sizeof(m_status) == sizeof(long), "Must be size of long, because it is used with Interlocked functions");
@@ -175,7 +176,7 @@ class MilesAudioManager : public AudioManager
 		///< NOTE NOTE NOTE !!DO NOT USE THIS IN FOR GAMELOGIC PURPOSES!! NOTE NOTE NOTE
 		virtual Bool isCurrentlyPlaying( AudioHandle handle ) override;
 
-		virtual void notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt flags ) override;
+		virtual void notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt flags ) override; ///< Is called on MSS Timer thread
 		virtual PlayingAudio *findPlayingAudioFrom( UnsignedInt handle, UnsignedInt flags );
 
 		virtual UnsignedInt getProviderCount() const override;
@@ -265,6 +266,8 @@ class MilesAudioManager : public AudioManager
 		void releaseMilesHandles( PlayingAudio *release );
 		void releasePlayingAudio( PlayingAudio *release );
 		void stopPlayingAudio( PlayingAudio *release );
+		void rerequestPlayingAudio( PlayingAudio *playing );
+		void rerequestPlayingAudioWhenSignalled( PlayingAudio *playing );
 		void fadePlayingAudio( PlayingAudio *playing );
 
 		PlayingAudio *findActiveMusic( const AsciiString *trackName = nullptr );

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -236,18 +236,19 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		for (Int i = 1; i <= maxChannels && i <= channelCount; ++i) {
 			playing = playingArray[i];
 			if (!playing) {
-				dd->printf("%d: Silence\n", i);
+				dd->printf("%2d: Silence\n", i);
 				continue;
 			}
 
-			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
+			AudioEventRTS *event = playing->m_audioEventRTS.Peek();
+			filenameNoSlashes = event->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind('\\') + 1;
 
 			// Calculate Sample volume
 			volume = 100.0f;
-			volume *= getEffectiveVolume(playing->m_audioEventRTS);
+			volume *= getEffectiveVolume(event);
 
-			dd->printf("%2d: %-20s - (%s) Volume: %d (2D)\n", i, playing->m_audioEventRTS->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT(volume));
+			dd->printf("%2d: %-20s - (%s) Volume: %d (2D)\n", i, event->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT(volume));
 			playingArray[i] = nullptr;
 		}
 	}
@@ -259,18 +260,19 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 		{
 			playing = *it;
-			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
+			AudioEventRTS *event = playing->m_audioEventRTS.Peek();
+			filenameNoSlashes = event->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind( '\\' ) + 1;
 
 			// Calculate Sample volume
 			volume = 100.0f;
-			volume *= getEffectiveVolume( playing->m_audioEventRTS );
+			volume *= getEffectiveVolume( event );
 
-			fprintf( fp, "%2d: %-20s - (%s) Volume: %d (2D)\n", channel++, playing->m_audioEventRTS->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT( volume ) );
+			fprintf( fp, "%2d: %-20s - (%s) Volume: %d (2D)\n", channel++, event->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT( volume ) );
 		}
 		for( int i = channel; i <= channelCount; ++i )
 		{
-			fprintf( fp, "%d: Silence\n", i );
+			fprintf( fp, "%2d: Silence\n", i );
 		}
 	}
 
@@ -291,18 +293,19 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 			playing = playingArray[i];
 			if (!playing)
 			{
-				dd->printf("%d: Silence\n", i);
+				dd->printf("%2d: Silence\n", i);
 				continue;
 			}
 
-			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
+			AudioEventRTS *event = playing->m_audioEventRTS.Peek();
+			filenameNoSlashes = event->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind('\\') + 1;
 
 			// Calculate Sample volume
 			volume = 100.0f;
-			volume *= getEffectiveVolume(playing->m_audioEventRTS);
+			volume *= getEffectiveVolume(event);
 			Real dist = -1.0f;
-			const Coord3D *pos = playing->m_audioEventRTS->getPosition();
+			const Coord3D *pos = event->getPosition();
 			char distStr[32];
 			if( pos )
 			{
@@ -316,7 +319,7 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 				sprintf( distStr, "???" );
 			}
 			char str[32];
-			switch( playing->m_audioEventRTS->getOwnerType() )
+			switch( event->getOwnerType() )
 			{
 				case OT_Positional:
 					sprintf( str, "(3D)" );
@@ -334,7 +337,7 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 			}
 
 			dd->printf("%2d: %-20s - (%s) Volume: %d, Dist: %s, %s\n",
-				i, playing->m_audioEventRTS->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT(volume), distStr, str );
+				i, event->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT(volume), distStr, str );
 			playingArray[i] = nullptr;
 		}
 	}
@@ -346,13 +349,14 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 		{
 			playing = *it;
-			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
+			AudioEventRTS *event = playing->m_audioEventRTS.Peek();
+			filenameNoSlashes = event->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind('\\') + 1;
 
 			// Calculate Sample volume
 			volume = 100.0f;
-			volume *= getEffectiveVolume( playing->m_audioEventRTS );
-			fprintf( fp, "%2d: %-24s - (%s) Volume: %d \n", channel++, playing->m_audioEventRTS->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT( volume ) );
+			volume *= getEffectiveVolume( event );
+			fprintf( fp, "%2d: %-24s - (%s) Volume: %d \n", channel++, event->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT( volume ) );
 		}
 
 		for( int i = channel; i <= channelCount; ++i )
@@ -369,14 +373,15 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		channel = 1;
 		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 			playing = *it;
-			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
+			AudioEventRTS *event = playing->m_audioEventRTS.Peek();
+			filenameNoSlashes = event->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind('\\') + 1;
 
 			// Calculate Sample volume
 			volume = 100.0f;
-			volume *= getEffectiveVolume(playing->m_audioEventRTS);
+			volume *= getEffectiveVolume(event);
 
-			dd->printf("%2d: %-24s - (%s)  Volume: %d (Stream)\n", channel++, playing->m_audioEventRTS->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT(volume));
+			dd->printf("%2d: %-24s - (%s)  Volume: %d (Stream)\n", channel++, event->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT(volume));
 		}
 
 		for ( int i = channel; i <= channelCount; ++i) {
@@ -392,14 +397,15 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		for( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it )
 		{
 			playing = *it;
-			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
+			AudioEventRTS *event = playing->m_audioEventRTS.Peek();
+			filenameNoSlashes = event->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind('\\') + 1;
 
 			// Calculate Sample volume
 			volume = 100.0f;
-			volume *= getEffectiveVolume(playing->m_audioEventRTS);
+			volume *= getEffectiveVolume(event);
 
-			fprintf( fp, "%2d: %-24s - (%s)  Volume: %d (Stream)\n", channel++, playing->m_audioEventRTS->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT( volume ) );
+			fprintf( fp, "%2d: %-24s - (%s)  Volume: %d (Stream)\n", channel++, event->getEventName().str(), filenameNoSlashes.str(), REAL_TO_INT( volume ) );
 		}
 
 		for( int i = channel; i <= channelCount; ++i )
@@ -610,9 +616,9 @@ void MilesAudioManager::pauseAmbient( Bool shouldPause )
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::playAudioEvent( AudioRequest* req )
 {
-	DEBUG_ASSERTCRASH(req->m_usePendingEvent && req->m_pendingEvent, ("audio request was expected to contain a valid audio event"));
+	DEBUG_ASSERTCRASH(req->m_pendingEvent != nullptr, ("audio request was expected to contain a valid audio event"));
 
-	AudioEventRTS* event = req->m_pendingEvent;
+	AudioEventRTS* event = req->m_pendingEvent.Peek();
 
 #ifdef INTENSIVE_AUDIO_DEBUG
 	DEBUG_LOG(("MILES (%d) - Processing play request: %d (%s)", TheGameLogic->getFrame(), event->getPlayingHandle(), event->getEventName().str()));
@@ -665,7 +671,7 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 			}
 
 			// Put this on here, so that the audio event RTS will be cleaned up regardless.
-			audio->m_audioEventRTS = event = req->releasePendingEvent();
+			audio->m_audioEventRTS = req->m_pendingEvent;
 			audio->m_stream = stream;
 			audio->m_type = PAT_Stream;
 
@@ -732,7 +738,7 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 					sample3D = nullptr;
 				}
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = event = req->releasePendingEvent();
+				audio->m_audioEventRTS = req->m_pendingEvent;
 				audio->m_3DSample = sample3D;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_3DSample;
@@ -798,7 +804,7 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 				}
 
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = event = req->releasePendingEvent();
+				audio->m_audioEventRTS = req->m_pendingEvent;
 				audio->m_sample = sample;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_Sample;
@@ -899,7 +905,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 	for( ait = m_audioRequests.begin(); ait != m_audioRequests.end(); ait++ )
 	{
 		AudioRequest *req = (*ait);
-		if( req->m_usePendingEvent && req->m_pendingEvent->getPlayingHandle() == audioEvent )
+		if( req->m_pendingEvent && req->m_pendingEvent->getPlayingHandle() == audioEvent )
 		{
 			deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
@@ -943,9 +949,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 			return;
 		}
 	}
-
 }
-
 
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::pauseAudioEvent( AudioHandle handle )
@@ -1022,10 +1026,6 @@ void MilesAudioManager::releasePlayingAudio( PlayingAudio *release )
 		release->m_file = nullptr;
 	}
 
-	if (release->m_cleanupAudioEventRTS) {
-		releaseAudioEventRTS(release->m_audioEventRTS);
-	}
-
 	delete release;
 }
 
@@ -1040,6 +1040,24 @@ void MilesAudioManager::stopPlayingAudio( PlayingAudio *release )
 		return;
 	}
 	releaseMilesHandles(release);
+}
+
+//-------------------------------------------------------------------------------------------------
+void MilesAudioManager::rerequestPlayingAudio( PlayingAudio *playing )
+{
+	AudioRequest *req = allocateAudioRequest();
+	req->m_pendingEvent = playing->m_audioEventRTS;
+	req->m_requiresCheckForSample = true;
+	appendAudioRequest(req);
+}
+
+//-------------------------------------------------------------------------------------------------
+void MilesAudioManager::rerequestPlayingAudioWhenSignalled( PlayingAudio *playing )
+{
+	if (playing->m_rerequestOnNextUpdate) {
+		rerequestPlayingAudio(playing);
+		playing->m_rerequestOnNextUpdate = false;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1211,18 +1229,18 @@ void MilesAudioManager::adjustPlayingVolume( PlayingAudio *audio )
 	Real pan;
 	if (audio->m_type == PAT_Sample) {
 		AIL_sample_volume_pan(audio->m_sample, nullptr, &pan);
-		AIL_set_sample_volume_pan(audio->m_sample, getEffectiveVolume(audio->m_audioEventRTS), pan);
+		AIL_set_sample_volume_pan(audio->m_sample, getEffectiveVolume(audio->m_audioEventRTS.Peek()), pan);
 
 	} else if (audio->m_type == PAT_3DSample) {
-		AIL_set_3D_sample_volume(audio->m_3DSample, getEffectiveVolume(audio->m_audioEventRTS));
+		AIL_set_3D_sample_volume(audio->m_3DSample, getEffectiveVolume(audio->m_audioEventRTS.Peek()));
 
 	} else if (audio->m_type == PAT_Stream) {
 		AIL_stream_volume_pan(audio->m_stream, nullptr, &pan);
 		if (audio->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music ) {
-			AIL_set_stream_volume_pan(audio->m_stream, getEffectiveVolume(audio->m_audioEventRTS), pan);
+			AIL_set_stream_volume_pan(audio->m_stream, getEffectiveVolume(audio->m_audioEventRTS.Peek()), pan);
 
 		} else {
-			AIL_set_stream_volume_pan(audio->m_stream, getEffectiveVolume(audio->m_audioEventRTS), pan);
+			AIL_set_stream_volume_pan(audio->m_stream, getEffectiveVolume(audio->m_audioEventRTS.Peek()), pan);
 
 		}
 	}
@@ -1423,7 +1441,7 @@ Bool MilesAudioManager::isCurrentlyPlaying( AudioHandle handle )
 	AudioRequest *req = nullptr;
 	for (ait = m_audioRequests.begin(); ait != m_audioRequests.end(); ++ait) {
 		req = *ait;
-		if (req->m_usePendingEvent && req->m_pendingEvent->getPlayingHandle() == handle) {
+		if (req->m_pendingEvent && req->m_pendingEvent->getPlayingHandle() == handle) {
 			return true;
 		}
 	}
@@ -1463,7 +1481,7 @@ void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt
 	if (playing->m_audioEventRTS->getNextPlayPortion() != PP_Done) {
 		if (playing->m_type == PAT_Sample) {
 			closeFile(playing->m_file);	// close it so as not to leak it.
-			playing->m_file = playSample(playing->m_audioEventRTS, playing->m_sample);
+			playing->m_file = playSample(playing->m_audioEventRTS.Peek(), playing->m_sample);
 
 			// If we don't have a file now, then we should drop to the stopped status so that
 			// We correctly close this handle.
@@ -1472,7 +1490,7 @@ void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt
 			}
 		} else if (playing->m_type == PAT_3DSample) {
 			closeFile(playing->m_file);	// close it so as not to leak it.
-			playing->m_file = playSample3D(playing->m_audioEventRTS, playing->m_3DSample);
+			playing->m_file = playSample3D(playing->m_audioEventRTS.Peek(), playing->m_3DSample);
 
 			// If we don't have a file now, then we should drop to the stopped status so that
 			// We correctly close this handle.
@@ -1484,7 +1502,7 @@ void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt
 
 	if (playing->m_type == PAT_Stream) {
 		if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-			playStream(playing->m_audioEventRTS, playing->m_stream);
+			playStream(playing->m_audioEventRTS.Peek(), playing->m_stream);
 			return;
 		}
 	}
@@ -1792,13 +1810,10 @@ Bool MilesAudioManager::doesViolateLimit( AudioEventRTS *event ) const
 	std::list<AudioRequest*>::const_iterator arIt;
 	for (arIt = m_audioRequests.begin(); arIt != m_audioRequests.end(); ++arIt) {
 		AudioRequest *req = (*arIt);
-		if( req->m_usePendingEvent )
+		if( req->m_pendingEvent && req->m_pendingEvent->getEventName() == event->getEventName() )
 		{
-			if( req->m_pendingEvent->getEventName() == event->getEventName() )
-			{
-				totalRequestCount++;
-				totalCount++;
-			}
+			totalRequestCount++;
+			totalCount++;
 		}
 	}
 
@@ -1900,7 +1915,7 @@ AudioEventRTS* MilesAudioManager::findLowestPrioritySound( AudioEventRTS *event 
 		//3D
 		for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 		{
-			AudioEventRTS *itEvent = (*it)->m_audioEventRTS;
+			AudioEventRTS *itEvent = (*it)->m_audioEventRTS.Peek();
 			AudioPriority itPriority = itEvent->getAudioEventInfo()->m_priority;
 			if( itPriority < priority )
 			{
@@ -1921,7 +1936,7 @@ AudioEventRTS* MilesAudioManager::findLowestPrioritySound( AudioEventRTS *event 
 		//2D
 		for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 		{
-			AudioEventRTS *itEvent = (*it)->m_audioEventRTS;
+			AudioEventRTS *itEvent = (*it)->m_audioEventRTS.Peek();
 			AudioPriority itPriority = itEvent->getAudioEventInfo()->m_priority;
 			if( itPriority < priority )
 			{
@@ -1988,8 +2003,7 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 			for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 			{
 				PlayingAudio *playing = (*it);
-
-				if( playing->m_audioEventRTS && playing->m_audioEventRTS == lowestPriorityEvent )
+				if( playing->m_audioEventRTS.Peek() == lowestPriorityEvent )
 				{
 					//Release this 3D sound channel immediately because we are going to play another sound in it's place.
 					stopPlayingAudio(playing);
@@ -2002,8 +2016,7 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 			for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 			{
 				PlayingAudio *playing = (*it);
-
-				if( playing->m_audioEventRTS && playing->m_audioEventRTS == lowestPriorityEvent )
+				if( playing->m_audioEventRTS.Peek() == lowestPriorityEvent )
 				{
 					//Release this sound channel immediately because we are going to play another sound in it's place.
 					stopPlayingAudio(playing);
@@ -2025,30 +2038,36 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 	PlayingAudio *playing = nullptr;
 	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 		playing = *it;
-		if (playing->m_audioEventRTS->getEventName() == eventName) {
+		AudioEventRTS *itEvent = playing->m_audioEventRTS.Peek();
+
+		if (itEvent->getEventName() == eventName) {
 			DEBUG_ASSERTCRASH(playing->m_sample, ("Sample is not expected to be null"));
-			playing->m_audioEventRTS->setVolume(newVolume);
+			itEvent->setVolume(newVolume);
 			AIL_sample_volume_pan(playing->m_sample, nullptr, &pan);
-			AIL_set_sample_volume_pan(playing->m_sample, getEffectiveVolume(playing->m_audioEventRTS), pan);
+			AIL_set_sample_volume_pan(playing->m_sample, getEffectiveVolume(itEvent), pan);
 		}
 	}
 
 	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 		playing = *it;
-		if (playing->m_audioEventRTS->getEventName() == eventName) {
+		AudioEventRTS *itEvent = playing->m_audioEventRTS.Peek();
+
+		if (itEvent->getEventName() == eventName) {
 			DEBUG_ASSERTCRASH(playing->m_3DSample, ("3D Sample is not expected to be null"));
-			playing->m_audioEventRTS->setVolume(newVolume);
-			AIL_set_3D_sample_volume(playing->m_3DSample, getEffectiveVolume(playing->m_audioEventRTS));
+			itEvent->setVolume(newVolume);
+			AIL_set_3D_sample_volume(playing->m_3DSample, getEffectiveVolume(itEvent));
 		}
 	}
 
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 		playing = *it;
-		if (playing->m_audioEventRTS->getEventName() == eventName) {
+		AudioEventRTS *itEvent = playing->m_audioEventRTS.Peek();
+
+		if (itEvent->getEventName() == eventName) {
 			DEBUG_ASSERTCRASH(playing->m_stream, ("Stream is not expected to be null"));
-			playing->m_audioEventRTS->setVolume(newVolume);
+			itEvent->setVolume(newVolume);
 			AIL_stream_volume_pan(playing->m_stream, nullptr, &pan);
-			AIL_set_stream_volume_pan(playing->m_stream, getEffectiveVolume(playing->m_audioEventRTS), pan);
+			AIL_set_stream_volume_pan(playing->m_stream, getEffectiveVolume(itEvent), pan);
 		}
 	}
 }
@@ -2156,6 +2175,7 @@ void MilesAudioManager::processPlayingList()
 		playing = (*it);
 
 		if (playing->m_status == PS_Stopping) {
+			rerequestPlayingAudioWhenSignalled(playing);
 			stopPlayingAudio(playing);
 			continue;
 		}
@@ -2174,6 +2194,7 @@ void MilesAudioManager::processPlayingList()
 		playing = (*it);
 
 		if (playing->m_status == PS_Stopping) {
+			rerequestPlayingAudioWhenSignalled(playing);
 			stopPlayingAudio(playing);
 			continue;
 		}
@@ -2187,7 +2208,7 @@ void MilesAudioManager::processPlayingList()
 			adjustPlayingVolume(playing);
 		}
 
-		const Coord3D *pos = getCurrentPositionFromEvent(playing->m_audioEventRTS);
+		const Coord3D *pos = getCurrentPositionFromEvent(playing->m_audioEventRTS.Peek());
 		if (pos)
 		{
 			if( playing->m_audioEventRTS->isDead() )
@@ -2196,7 +2217,7 @@ void MilesAudioManager::processPlayingList()
 			}
 			else
 			{
-				Real volForConsideration = getEffectiveVolume(playing->m_audioEventRTS);
+				Real volForConsideration = getEffectiveVolume(playing->m_audioEventRTS.Peek());
 				volForConsideration /= (m_sound3DVolume > 0.0f ? m_soundVolume : 1.0f);
 				Bool playAnyways = BitIsSet( playing->m_audioEventRTS->getAudioEventInfo()->m_type, ST_GLOBAL)
 					|| playing->m_audioEventRTS->getAudioEventInfo()->m_priority == AP_CRITICAL;
@@ -2224,6 +2245,7 @@ void MilesAudioManager::processPlayingList()
 		playing = (*it);
 
 		if (playing->m_status == PS_Stopping) {
+			rerequestPlayingAudioWhenSignalled(playing);
 			stopPlayingAudio(playing);
 			continue;
 		}
@@ -2329,7 +2351,7 @@ void MilesAudioManager::processFadingList()
 		}
 
 		++playing->m_framesFaded;
-		Real volume = getEffectiveVolume(playing->m_audioEventRTS);
+		Real volume = getEffectiveVolume(playing->m_audioEventRTS.Peek());
 		volume *= (1.0f - 1.0f * playing->m_framesFaded / getAudioSettings()->m_fadeAudioFrames);
 
 		switch(playing->m_type)
@@ -2363,7 +2385,7 @@ void MilesAudioManager::processFadingList()
 //-------------------------------------------------------------------------------------------------
 Bool MilesAudioManager::shouldProcessRequestThisFrame( AudioRequest *req ) const
 {
-	if (!req->m_usePendingEvent) {
+	if (req->m_pendingEvent == nullptr) {
 		return true;
 	}
 
@@ -2377,7 +2399,7 @@ Bool MilesAudioManager::shouldProcessRequestThisFrame( AudioRequest *req ) const
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::adjustRequest( AudioRequest *req )
 {
-	if (!req->m_usePendingEvent) {
+	if (req->m_pendingEvent == nullptr) {
 		return;
 	}
 
@@ -2388,14 +2410,14 @@ void MilesAudioManager::adjustRequest( AudioRequest *req )
 //-------------------------------------------------------------------------------------------------
 Bool MilesAudioManager::checkForSample( AudioRequest *req )
 {
-	if (!req->m_usePendingEvent) {
+	if (req->m_pendingEvent == nullptr) {
 		return true;
 	}
 
   if ( req->m_pendingEvent->getAudioEventInfo() == nullptr )
   {
     // Fill in event info
-    getInfoForAudioEvent( req->m_pendingEvent );
+    getInfoForAudioEvent( req->m_pendingEvent.Peek() );
   }
 
 	if (req->m_pendingEvent->getAudioEventInfo()->m_type != AT_SoundEffect)
@@ -2403,7 +2425,7 @@ Bool MilesAudioManager::checkForSample( AudioRequest *req )
 		return true;
 	}
 
-	return m_sound->canPlayNow(req->m_pendingEvent);
+	return m_sound->canPlayNow(req->m_pendingEvent.Peek());
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -2612,22 +2634,15 @@ Bool MilesAudioManager::startNextLoop( PlayingAudio *looping )
 		looping->m_audioEventRTS->generateFilename();
 
 		if (looping->m_audioEventRTS->getDelay() > MSEC_PER_LOGICFRAME_REAL) {
-			// fake it out so that this sound appears done, but also so that it will not
-			// delete the sound on completion (which would suck)
-			looping->m_cleanupAudioEventRTS = false;
+			looping->m_rerequestOnNextUpdate = true;
 			InterlockedCompareExchange(reinterpret_cast<volatile long*>(&looping->m_status), PS_Stopping, PS_Playing);
-
-			AudioRequest *req = allocateAudioRequest(true);
-			req->m_pendingEvent = looping->m_audioEventRTS;
-			req->m_requiresCheckForSample = true;
-			appendAudioRequest(req);
 			return true;
 		}
 
 		if (looping->m_type == PAT_3DSample) {
-			looping->m_file = playSample3D(looping->m_audioEventRTS, looping->m_3DSample);
+			looping->m_file = playSample3D(looping->m_audioEventRTS.Peek(), looping->m_3DSample);
 		} else {
-			looping->m_file = playSample(looping->m_audioEventRTS, looping->m_sample);
+			looping->m_file = playSample(looping->m_audioEventRTS.Peek(), looping->m_sample);
 		}
 
 		return looping->m_file != nullptr;
@@ -2823,9 +2838,9 @@ void *MilesAudioManager::getHandleForBink()
 {
 	if (m_binkHandle == nullptr) {
 		PlayingAudio *aud = allocatePlayingAudio();
-		aud->m_audioEventRTS = NEW AudioEventRTS("BinkHandle");	// poolify
-		getInfoForAudioEvent(aud->m_audioEventRTS);
-		aud->m_sample = getAvailable2DSample(aud->m_audioEventRTS);
+		aud->m_audioEventRTS.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS)("BinkHandle"));
+		getInfoForAudioEvent(aud->m_audioEventRTS.Peek());
+		aud->m_sample = getAvailable2DSample(aud->m_audioEventRTS.Peek());
 		aud->m_type = PAT_Sample;
 
 		if (!aud->m_sample) {

--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -144,26 +144,18 @@ enum ThingTemplateAudioType CPP_11(: Int)
 class AudioArray
 {
 public:
-	DynamicAudioEventRTS* m_audio[TTAUDIO_COUNT];
+	RefCountPtr<DynamicAudioEventRTS> m_audio[TTAUDIO_COUNT];
 
-	AudioArray()
-	{
-		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
-			m_audio[i] = nullptr;
-	}
+	AudioArray() {}
 
-	~AudioArray()
-	{
-		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
-			deleteInstance(m_audio[i]);
-	}
+	~AudioArray() {}
 
 	AudioArray(const AudioArray& that)
 	{
 		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
 		{
 			if (that.m_audio[i])
-				m_audio[i] = newInstance(DynamicAudioEventRTS)(*that.m_audio[i]);
+				m_audio[i].Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS)(*that.m_audio[i]));
 			else
 				m_audio[i] = nullptr;
 		}
@@ -180,7 +172,7 @@ public:
 					if (m_audio[i])
 						*m_audio[i] = *that.m_audio[i];
 					else
-						m_audio[i] = newInstance(DynamicAudioEventRTS)(*that.m_audio[i]);
+						m_audio[i].Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS)(*that.m_audio[i]));
 				}
 				else
 				{
@@ -620,7 +612,7 @@ protected:
 	Real getBuildTime() const { return m_buildTime; }
 	const PerUnitSoundMap* getAllPerUnitSounds() const { return &m_perUnitSounds; }
 	void validateAudio();
-	const AudioEventRTS* getAudio(ThingTemplateAudioType t) const { return m_audioarray.m_audio[t] ? &m_audioarray.m_audio[t]->m_event : &s_audioEventNoSound; }
+	const AudioEventRTS* getAudio(ThingTemplateAudioType t) const { return m_audioarray.m_audio[t] ? m_audioarray.m_audio[t].Peek() : &s_audioEventNoSound; }
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	/** Table for parsing the object fields */

--- a/Generals/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Drawable.h
@@ -576,7 +576,7 @@ public:
   // Stuff for overriding ambient sound
   const AudioEventInfo * getBaseSoundAmbientInfo() const; //< Possible starting point if only some parameters are customized
   void enableAmbientSoundFromScript( Bool enable );
-  const AudioEventRTS * getAmbientSound() const { return m_ambientSound == nullptr ? nullptr : &m_ambientSound->m_event; }
+  const AudioEventRTS * getAmbientSound() const { return m_ambientSound == nullptr ? nullptr : m_ambientSound.Peek(); }
   void setCustomSoundAmbientOff(); //< Kill the ambient sound
   void setCustomSoundAmbientInfo( DynamicAudioEventInfo * customAmbientInfo ); //< Set ambient sound.
   void clearCustomSoundAmbient() { clearCustomSoundAmbient( true ); } //< Return to using defaults
@@ -696,7 +696,7 @@ private:
 
 	PhysicsXformInfo* m_physicsXform;
 
-	DynamicAudioEventRTS*	m_ambientSound;		///< sound module for ambient sound (lazily allocated)
+	RefCountPtr<DynamicAudioEventRTS> m_ambientSound;		///< sound module for ambient sound (lazily allocated)
 
 	Module** m_modules[NUM_DRAWABLE_MODULE_TYPES];
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
@@ -183,7 +183,7 @@ public:
 	void setExtraFriction(Real b) { m_extraFriction = b; }
 
 	void setBounceSound(const AudioEventRTS* bounceSound);
-	const AudioEventRTS* getBounceSound() { return m_bounceSound ? &m_bounceSound->m_event : TheAudio->getValidSilentAudioEvent(); }
+	const AudioEventRTS* getBounceSound() { return m_bounceSound ? m_bounceSound.Peek() : TheAudio->getValidSilentAudioEvent(); }
 
 	/**
 		Reset all values (vel, accel, etc) to starting values.
@@ -253,7 +253,7 @@ private:
 	Real												m_yawRate;								///< rate of rotation around up vector
 	Real												m_rollRate;								///< rate of rotation around forward vector
 	Real												m_pitchRate;							///< rate or rotation around side vector
-	DynamicAudioEventRTS*				m_bounceSound;						///< The sound for when this thing bounces, or nullptr
+	RefCountPtr<DynamicAudioEventRTS> m_bounceSound;			///< The sound for when this thing bounces, or nullptr
 	Coord3D											m_accel;									///< current acceleration
 	Coord3D											m_prevAccel;							///< last frame's acceleration
 	Coord3D											m_vel;										///< current velocity

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -545,8 +545,7 @@ Drawable::~Drawable()
 
 	stopAmbientSound();
 
-	deleteInstance(m_ambientSound);
-	m_ambientSound = nullptr;
+	m_ambientSound.Clear();
 
   clearCustomSoundAmbient( false );
 
@@ -1282,15 +1281,15 @@ void Drawable::updateDrawable()
   // End result: a hack of testing the looping bit and only restarting the sound if the looping
   // bit is on and the loop count is 0 (loop forever).
   if( m_ambientSound && m_ambientSoundEnabled && m_ambientSoundEnabledFromScript &&
-      !m_ambientSound->m_event.getEventName().isEmpty() && !m_ambientSound->m_event.isCurrentlyPlaying() )
+      !m_ambientSound->getEventName().isEmpty() && !m_ambientSound->isCurrentlyPlaying() )
   {
-    const AudioEventInfo * eventInfo = m_ambientSound->m_event.getAudioEventInfo();
+    const AudioEventInfo * eventInfo = m_ambientSound->getAudioEventInfo();
 
     if ( eventInfo == nullptr && TheAudio != nullptr )
     {
       // We'll need this in a second anyway so cache it
-      TheAudio->getInfoForAudioEvent( &m_ambientSound->m_event );
-      eventInfo = m_ambientSound->m_event.getAudioEventInfo();
+      TheAudio->getInfoForAudioEvent( m_ambientSound.Peek() );
+      eventInfo = m_ambientSound->getAudioEventInfo();
     }
 
     if ( eventInfo == nullptr || ( eventInfo->isPermanentSound() ) )
@@ -1309,7 +1308,7 @@ void Drawable::onLevelStart()
   // actually start the sound if the constructor is called during level load.
   if( m_ambientSoundEnabled && m_ambientSoundEnabledFromScript &&
       ( m_ambientSound == nullptr ||
-        ( !m_ambientSound->m_event.getEventName().isEmpty() && !m_ambientSound->m_event.isCurrentlyPlaying() ) ) )
+        ( !m_ambientSound->getEventName().isEmpty() && !m_ambientSound->isCurrentlyPlaying() ) ) )
   {
     // Unlike the check in the update() function, we want to do this for looping & one-shot sounds equally
     startAmbientSound();
@@ -4059,7 +4058,7 @@ void Drawable::setID( DrawableID id )
 	{
 		TheGameClient->addDrawableToLookupTable( this );
 		if (m_ambientSound)
-			m_ambientSound->m_event.setDrawableID(m_id);
+			m_ambientSound->setDrawableID(m_id);
 	}
 
 }
@@ -4367,7 +4366,7 @@ void Drawable::clearCustomSoundAmbient( bool restartSound )
   if ( m_ambientSound )
   {
     // Make sure sound doesn't keep a reference to the deleted pointer
-    m_ambientSound->m_event.setAudioEventInfo( nullptr );
+    m_ambientSound->setAudioEventInfo( nullptr );
   }
 
   // Stop using old info
@@ -4397,11 +4396,11 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
     if ( m_customSoundAmbientInfo != getNoSoundMarker() )
     {
       if (m_ambientSound == nullptr)
-        m_ambientSound = newInstance(DynamicAudioEventRTS);
+        m_ambientSound.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS));
 
       // Make sure m_event will accept the custom info
-      m_ambientSound->m_event.setEventName( m_customSoundAmbientInfo->m_audioName );
-      m_ambientSound->m_event.setAudioEventInfo( m_customSoundAmbientInfo );
+      m_ambientSound->setEventName( m_customSoundAmbientInfo->m_audioName );
+      m_ambientSound->setAudioEventInfo( m_customSoundAmbientInfo );
       trySound = TRUE;
     }
   }
@@ -4413,9 +4412,9 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 	  if( audio.getEventName().isNotEmpty() )
 	  {
 		  if (m_ambientSound == nullptr)
-			  m_ambientSound = newInstance(DynamicAudioEventRTS);
+			  m_ambientSound.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS));
 
-		  (m_ambientSound->m_event) = audio;
+		  *m_ambientSound = audio;
 		  trySound = TRUE;
 	  }
 	  else if( dt != BODY_PRISTINE && dt != BODY_RUBBLE )
@@ -4427,8 +4426,8 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 		  if( pristineAudio.getEventName().isNotEmpty() )
 		  {
 			  if (m_ambientSound == nullptr)
-				  m_ambientSound = newInstance(DynamicAudioEventRTS);
-			  (m_ambientSound->m_event) = pristineAudio;
+				  m_ambientSound.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS));
+			  *m_ambientSound = pristineAudio;
 			  trySound = TRUE;
 		  }
 	  }
@@ -4437,7 +4436,7 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 
 	if( trySound && m_ambientSound )
 	{
-		const AudioEventInfo *info = m_ambientSound->m_event.getAudioEventInfo();
+		const AudioEventInfo *info = m_ambientSound->getAudioEventInfo();
 		if( info )
 		{
       if ( !onlyIfPermanent || info->isPermanentSound() )
@@ -4445,9 +4444,9 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 			  if( BitIsSet( info->m_type, ST_GLOBAL) || info->m_priority == AP_CRITICAL )
 			  {
 				  //Play it anyways.
-				  m_ambientSound->m_event.setDrawableID(getID());
-				  m_ambientSound->m_event.setTimeOfDay(tod);
-				  m_ambientSound->m_event.setPlayingHandle(TheAudio->addAudioEvent( &m_ambientSound->m_event ));
+				  m_ambientSound->setDrawableID(getID());
+				  m_ambientSound->setTimeOfDay(tod);
+				  m_ambientSound->setPlayingHandle(TheAudio->addAudioEvent( m_ambientSound.Peek() ));
 			  }
 			  else
 			  {
@@ -4457,18 +4456,17 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 				  Real distSqr = vector.lengthSqr();
 				  if( distSqr < sqr( info->m_maxDistance ) )
 				  {
-					  m_ambientSound->m_event.setDrawableID(getID());
-					  m_ambientSound->m_event.setTimeOfDay(tod);
-					  m_ambientSound->m_event.setPlayingHandle(TheAudio->addAudioEvent( &m_ambientSound->m_event ));
+					  m_ambientSound->setDrawableID(getID());
+					  m_ambientSound->setTimeOfDay(tod);
+					  m_ambientSound->setPlayingHandle(TheAudio->addAudioEvent( m_ambientSound.Peek() ));
 				  }
 			  }
       }
 		}
 		else
 		{
-			DEBUG_CRASH( ("Ambient sound %s missing! Skipping...", m_ambientSound->m_event.getEventName().str() ) );
-			deleteInstance(m_ambientSound);
-			m_ambientSound = nullptr;
+			DEBUG_CRASH( ("Ambient sound %s missing! Skipping...", m_ambientSound->getEventName().str() ) );
+			m_ambientSound.Clear();
 		}
 	}
 }
@@ -4499,7 +4497,7 @@ void	Drawable::stopAmbientSound()
 {
 	if (m_ambientSound)
   {
-		TheAudio->removeAudioEvent(m_ambientSound->m_event.getPlayingHandle());
+		TheAudio->removeAudioEvent(m_ambientSound->getPlayingHandle());
   }
 }
 
@@ -4868,9 +4866,8 @@ void Drawable::xfer( Xfer *xfer )
 	//and restore it in loadPostProcess().
 	if( xfer->getXferMode() == XFER_LOAD && m_ambientSound )
 	{
-		TheAudio->killAudioEventImmediately( m_ambientSound->m_event.getPlayingHandle() );
-		deleteInstance(m_ambientSound);
-		m_ambientSound = nullptr;
+		TheAudio->killAudioEventImmediately( m_ambientSound->getPlayingHandle() );
+		m_ambientSound.Clear();
 	}
 
 	// drawable id

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -239,8 +239,6 @@ void PhysicsBehavior::onObjectCreated()
 //-------------------------------------------------------------------------------------------------
 PhysicsBehavior::~PhysicsBehavior()
 {
-	deleteInstance(m_bounceSound);
-	m_bounceSound = nullptr;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -517,14 +515,13 @@ void PhysicsBehavior::setBounceSound(const AudioEventRTS* bounceSound)
 	if (bounceSound)
 	{
 		if (m_bounceSound == nullptr)
-			m_bounceSound = newInstance(DynamicAudioEventRTS);
+			m_bounceSound.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS));
 
-		m_bounceSound->m_event = *bounceSound;
+		*m_bounceSound = *bounceSound;
 	}
 	else
 	{
-		deleteInstance(m_bounceSound);
-		m_bounceSound = nullptr;
+		m_bounceSound.Clear();
 	}
 }
 
@@ -990,7 +987,7 @@ void PhysicsBehavior::doBounceSound(const Coord3D& prevPos)
 	const Real NORMAL_MASS	= 50.0f;
 
 	// get the per-unit sound for the collision which was stuffed in on Object creation.
-	AudioEventRTS collisionSound = m_bounceSound->m_event;
+	AudioEventRTS collisionSound = *m_bounceSound.Peek();
 
 //Real vel = fabs(getVelocity()->z);
 // can't use velocity, because it's already been updated this frame, and will be zero... (srj)

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -140,26 +140,18 @@ enum ThingTemplateAudioType CPP_11(: Int)
 class AudioArray
 {
 public:
-	DynamicAudioEventRTS* m_audio[TTAUDIO_COUNT];
+	RefCountPtr<DynamicAudioEventRTS> m_audio[TTAUDIO_COUNT];
 
-	AudioArray()
-	{
-		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
-			m_audio[i] = nullptr;
-	}
+	AudioArray() {}
 
-	~AudioArray()
-	{
-		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
-			deleteInstance(m_audio[i]);
-	}
+	~AudioArray() {}
 
 	AudioArray(const AudioArray& that)
 	{
 		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
 		{
 			if (that.m_audio[i])
-				m_audio[i] = newInstance(DynamicAudioEventRTS)(*that.m_audio[i]);
+				m_audio[i].Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS)(*that.m_audio[i]));
 			else
 				m_audio[i] = nullptr;
 		}
@@ -176,7 +168,7 @@ public:
 					if (m_audio[i])
 						*m_audio[i] = *that.m_audio[i];
 					else
-						m_audio[i] = newInstance(DynamicAudioEventRTS)(*that.m_audio[i]);
+						m_audio[i].Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS)(*that.m_audio[i]));
 				}
 				else
 				{
@@ -633,7 +625,7 @@ protected:
 	Real getBuildTime() const { return m_buildTime; }
 	const PerUnitSoundMap* getAllPerUnitSounds() const { return &m_perUnitSounds; }
 	void validateAudio();
-	const AudioEventRTS* getAudio(ThingTemplateAudioType t) const { return m_audioarray.m_audio[t] ? &m_audioarray.m_audio[t]->m_event : &s_audioEventNoSound; }
+	const AudioEventRTS* getAudio(ThingTemplateAudioType t) const { return m_audioarray.m_audio[t] ? m_audioarray.m_audio[t].Peek() : &s_audioEventNoSound; }
   Bool hasAudio(ThingTemplateAudioType t) const { return m_audioarray.m_audio[t] != nullptr; }
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
@@ -576,7 +576,7 @@ public:
   // Stuff for overriding ambient sound
   const AudioEventInfo * getBaseSoundAmbientInfo() const; //< Possible starting point if only some parameters are customized
   void enableAmbientSoundFromScript( Bool enable );
-  const AudioEventRTS * getAmbientSound() const { return m_ambientSound == nullptr ? nullptr : &m_ambientSound->m_event; }
+  const AudioEventRTS * getAmbientSound() const { return m_ambientSound == nullptr ? nullptr : m_ambientSound.Peek(); }
   void setCustomSoundAmbientOff(); //< Kill the ambient sound
   void setCustomSoundAmbientInfo( DynamicAudioEventInfo * customAmbientInfo ); //< Set ambient sound.
   void clearCustomSoundAmbient() { clearCustomSoundAmbient( true ); } //< Return to using defaults
@@ -696,7 +696,7 @@ private:
 
 	PhysicsXformInfo* m_physicsXform;
 
-	DynamicAudioEventRTS*	m_ambientSound;		///< sound module for ambient sound (lazily allocated)
+	RefCountPtr<DynamicAudioEventRTS> m_ambientSound;		///< sound module for ambient sound (lazily allocated)
 
 	Module** m_modules[NUM_DRAWABLE_MODULE_TYPES];
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
@@ -191,7 +191,7 @@ public:
 	void setExtraFriction(Real b) { m_extraFriction = b; }
 
 	void setBounceSound(const AudioEventRTS* bounceSound);
-	const AudioEventRTS* getBounceSound() { return m_bounceSound ? &m_bounceSound->m_event : TheAudio->getValidSilentAudioEvent(); }
+	const AudioEventRTS* getBounceSound() { return m_bounceSound ? m_bounceSound.Peek() : TheAudio->getValidSilentAudioEvent(); }
 
 	/**
 		Reset all values (vel, accel, etc) to starting values.
@@ -263,7 +263,7 @@ private:
 	Real												m_yawRate;								///< rate of rotation around up vector
 	Real												m_rollRate;								///< rate of rotation around forward vector
 	Real												m_pitchRate;							///< rate or rotation around side vector
-	DynamicAudioEventRTS*				m_bounceSound;						///< The sound for when this thing bounces, or nullptr
+	RefCountPtr<DynamicAudioEventRTS> m_bounceSound;			///< The sound for when this thing bounces, or nullptr
 	Coord3D											m_accel;									///< current acceleration
 	Coord3D											m_prevAccel;							///< last frame's acceleration
 	Coord3D											m_vel;										///< current velocity

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -545,8 +545,7 @@ Drawable::~Drawable()
 
 	stopAmbientSound();
 
-	deleteInstance(m_ambientSound);
-	m_ambientSound = nullptr;
+	m_ambientSound.Clear();
 
   clearCustomSoundAmbient( false );
 
@@ -1284,15 +1283,15 @@ void Drawable::updateDrawable()
   // End result: a hack of testing the looping bit and only restarting the sound if the looping
   // bit is on and the loop count is 0 (loop forever).
   if( m_ambientSound && m_ambientSoundEnabled && m_ambientSoundEnabledFromScript &&
-      !m_ambientSound->m_event.getEventName().isEmpty() && !m_ambientSound->m_event.isCurrentlyPlaying() )
+      !m_ambientSound->getEventName().isEmpty() && !m_ambientSound->isCurrentlyPlaying() )
   {
-    const AudioEventInfo * eventInfo = m_ambientSound->m_event.getAudioEventInfo();
+    const AudioEventInfo * eventInfo = m_ambientSound->getAudioEventInfo();
 
     if ( eventInfo == nullptr && TheAudio != nullptr )
     {
       // We'll need this in a second anyway so cache it
-      TheAudio->getInfoForAudioEvent( &m_ambientSound->m_event );
-      eventInfo = m_ambientSound->m_event.getAudioEventInfo();
+      TheAudio->getInfoForAudioEvent( m_ambientSound.Peek() );
+      eventInfo = m_ambientSound->getAudioEventInfo();
     }
 
     if ( eventInfo == nullptr || ( eventInfo->isPermanentSound() ) )
@@ -1311,7 +1310,7 @@ void Drawable::onLevelStart()
   // actually start the sound if the constructor is called during level load.
   if( m_ambientSoundEnabled && m_ambientSoundEnabledFromScript &&
       ( m_ambientSound == nullptr ||
-        ( !m_ambientSound->m_event.getEventName().isEmpty() && !m_ambientSound->m_event.isCurrentlyPlaying() ) ) )
+        ( !m_ambientSound->getEventName().isEmpty() && !m_ambientSound->isCurrentlyPlaying() ) ) )
   {
     // Unlike the check in the update() function, we want to do this for looping & one-shot sounds equally
     startAmbientSound();
@@ -4064,7 +4063,7 @@ void Drawable::setID( DrawableID id )
 	{
 		TheGameClient->addDrawableToLookupTable( this );
 		if (m_ambientSound)
-			m_ambientSound->m_event.setDrawableID(m_id);
+			m_ambientSound->setDrawableID(m_id);
 	}
 
 }
@@ -4372,7 +4371,7 @@ void Drawable::clearCustomSoundAmbient( bool restartSound )
   if ( m_ambientSound )
   {
     // Make sure sound doesn't keep a reference to the deleted pointer
-    m_ambientSound->m_event.setAudioEventInfo( nullptr );
+    m_ambientSound->setAudioEventInfo( nullptr );
   }
 
   // Stop using old info
@@ -4402,11 +4401,11 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
     if ( m_customSoundAmbientInfo != getNoSoundMarker() )
     {
       if (m_ambientSound == nullptr)
-        m_ambientSound = newInstance(DynamicAudioEventRTS);
+        m_ambientSound.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS));
 
       // Make sure m_event will accept the custom info
-      m_ambientSound->m_event.setEventName( m_customSoundAmbientInfo->m_audioName );
-      m_ambientSound->m_event.setAudioEventInfo( m_customSoundAmbientInfo );
+      m_ambientSound->setEventName( m_customSoundAmbientInfo->m_audioName );
+      m_ambientSound->setAudioEventInfo( m_customSoundAmbientInfo );
       trySound = TRUE;
     }
   }
@@ -4418,9 +4417,9 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 	  if( audio.getEventName().isNotEmpty() )
 	  {
 		  if (m_ambientSound == nullptr)
-			  m_ambientSound = newInstance(DynamicAudioEventRTS);
+			  m_ambientSound.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS));
 
-		  (m_ambientSound->m_event) = audio;
+		  *m_ambientSound = audio;
 		  trySound = TRUE;
 	  }
 	  else if( dt != BODY_PRISTINE && dt != BODY_RUBBLE )
@@ -4432,8 +4431,8 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 		  if( pristineAudio.getEventName().isNotEmpty() )
 		  {
 			  if (m_ambientSound == nullptr)
-				  m_ambientSound = newInstance(DynamicAudioEventRTS);
-			  (m_ambientSound->m_event) = pristineAudio;
+				  m_ambientSound.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS));
+			  *m_ambientSound = pristineAudio;
 			  trySound = TRUE;
 		  }
 	  }
@@ -4442,7 +4441,7 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 
 	if( trySound && m_ambientSound )
 	{
-		const AudioEventInfo *info = m_ambientSound->m_event.getAudioEventInfo();
+		const AudioEventInfo *info = m_ambientSound->getAudioEventInfo();
 		if( info )
 		{
       if ( !onlyIfPermanent || info->isPermanentSound() )
@@ -4450,9 +4449,9 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 			  if( BitIsSet( info->m_type, ST_GLOBAL) || info->m_priority == AP_CRITICAL )
 			  {
 				  //Play it anyways.
-				  m_ambientSound->m_event.setDrawableID(getID());
-				  m_ambientSound->m_event.setTimeOfDay(tod);
-				  m_ambientSound->m_event.setPlayingHandle(TheAudio->addAudioEvent( &m_ambientSound->m_event ));
+				  m_ambientSound->setDrawableID(getID());
+				  m_ambientSound->setTimeOfDay(tod);
+				  m_ambientSound->setPlayingHandle(TheAudio->addAudioEvent( m_ambientSound.Peek() ));
 			  }
 			  else
 			  {
@@ -4462,18 +4461,17 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 				  Real distSqr = vector.lengthSqr();
 				  if( distSqr < sqr( info->m_maxDistance ) )
 				  {
-					  m_ambientSound->m_event.setDrawableID(getID());
-					  m_ambientSound->m_event.setTimeOfDay(tod);
-					  m_ambientSound->m_event.setPlayingHandle(TheAudio->addAudioEvent( &m_ambientSound->m_event ));
+					  m_ambientSound->setDrawableID(getID());
+					  m_ambientSound->setTimeOfDay(tod);
+					  m_ambientSound->setPlayingHandle(TheAudio->addAudioEvent( m_ambientSound.Peek() ));
 				  }
 			  }
       }
 		}
 		else
 		{
-			DEBUG_CRASH( ("Ambient sound %s missing! Skipping...", m_ambientSound->m_event.getEventName().str() ) );
-			deleteInstance(m_ambientSound);
-			m_ambientSound = nullptr;
+			DEBUG_CRASH( ("Ambient sound %s missing! Skipping...", m_ambientSound->getEventName().str() ) );
+			m_ambientSound.Clear();
 		}
 	}
 }
@@ -4504,7 +4502,7 @@ void	Drawable::stopAmbientSound()
 {
 	if (m_ambientSound)
   {
-		TheAudio->removeAudioEvent(m_ambientSound->m_event.getPlayingHandle());
+		TheAudio->removeAudioEvent(m_ambientSound->getPlayingHandle());
   }
 }
 
@@ -4873,9 +4871,8 @@ void Drawable::xfer( Xfer *xfer )
 	//and restore it in loadPostProcess().
 	if( xfer->getXferMode() == XFER_LOAD && m_ambientSound )
 	{
-		TheAudio->killAudioEventImmediately( m_ambientSound->m_event.getPlayingHandle() );
-		deleteInstance(m_ambientSound);
-		m_ambientSound = nullptr;
+		TheAudio->killAudioEventImmediately( m_ambientSound->getPlayingHandle() );
+		m_ambientSound.Clear();
 	}
 
 	// drawable id

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -257,8 +257,6 @@ void PhysicsBehavior::onObjectCreated()
 //-------------------------------------------------------------------------------------------------
 PhysicsBehavior::~PhysicsBehavior()
 {
-	deleteInstance(m_bounceSound);
-	m_bounceSound = nullptr;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -600,14 +598,13 @@ void PhysicsBehavior::setBounceSound(const AudioEventRTS* bounceSound)
 	if (bounceSound)
 	{
 		if (m_bounceSound == nullptr)
-			m_bounceSound = newInstance(DynamicAudioEventRTS);
+			m_bounceSound.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS));
 
-		m_bounceSound->m_event = *bounceSound;
+		*m_bounceSound = *bounceSound;
 	}
 	else
 	{
-		deleteInstance(m_bounceSound);
-		m_bounceSound = nullptr;
+		m_bounceSound.Clear();
 	}
 }
 
@@ -1115,7 +1112,7 @@ void PhysicsBehavior::doBounceSound(const Coord3D& prevPos)
 	const Real NORMAL_MASS	= 50.0f;
 
 	// get the per-unit sound for the collision which was stuffed in on Object creation.
-	AudioEventRTS collisionSound = m_bounceSound->m_event;
+	AudioEventRTS collisionSound = *m_bounceSound.Peek();
 
 //Real vel = fabs(getVelocity()->z);
 // can't use velocity, because it's already been updated this frame, and will be zero... (srj)


### PR DESCRIPTION
**Merge with Rebase**

* Fixes #2770
* Merge after #2784
* Merge after #3097

This change has 2 commits to work towards fixing race conditions in `MilesAudioManager` concerning a shared `AudioEventRTS` instance in classes `AudioRequest` and `PlayingAudio`.

~~The first commit implements a new `RefCountMTClass` which is fundamentally identical to `RefCountClass`, except it has a thread safe counter and all the debug functionality is omitted.~~

The first commit adds the ~~`RefCountMTClass`~~ `RefCountClass` to `DynamicAudioEventRTS` to allow for shared ownership. All existing users of `DynamicAudioEventRTS` accomodate it and will now use `RefCountPtr` for automatic reference counting.

The second commit replaces `AudioEventRTS*` with `RefCountPtr<DynamicAudioEventRTS>` in `AudioRequest` and `PlayingAudio` to allow sharing the audio event data between them. This is needed, because ownership will be shared in function `MilesAudioManager::startNextLoop` (or `MilesAudioManager::stopPlayingAudio`), where previously `AudioRequest` was given the sole authority to delete the `AudioEventRTS` while `PlayingAudio` still kept a pointer to it. Now both classes need to release their reference count before the audio event data is deleted.

This likely was also a problem in retail, because `AudioEventRTS` is heap allocated, not pool allocated.

## TODO

- [x] Add pull ids to commit titles
- [x] Rename the second commit in regards to RefCountMTClass
- [x] Rename the third commit because it is no longer accurate
- [x] Fix condition in killAudioEventImmediately after #2784 is merged
- [x] Replicate in Generals
- [x] Verify commits compile on their own