### PR TITLE
bugfix(specialpower): Charge uninitialized special powers on new buildings

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1652,6 +1652,27 @@ void Player::onStructureConstructionComplete( Object *builder, Object *structure
 	if( m_ai )
 		m_ai->onStructureProduced( builder, structure );
 
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix bobtista 10/06/2026 Buildings constructed under OBJECT_STATUS_UNDER_CONSTRUCTION
+	// skip the SpecialPowerModule recharge and, without a SpecialPowerCreate module, never leave the
+	// uninitialized 0xFFFFFFFF ready frame (e.g. Strategy Center battle plans, Detention Camp CIA Intelligence).
+	// Make any such special power ready now on completion to match retail availability.
+	for( BehaviorModule** module = structure->getBehaviorModules(); *module; ++module )
+	{
+		SpecialPowerModuleInterface* specialPower = (*module)->getSpecialPower();
+		if( specialPower == nullptr )
+		{
+			continue;
+		}
+		if( specialPower->getReadyFrame() == 0xFFFFFFFF )
+		{
+			specialPower->setReadyFrame( TheGameLogic->getFrame() );
+			DEBUG_LOG(( "onStructureConstructionComplete: charged uninitialized special power '%s' on '%s' to ready.",
+				specialPower->getPowerName().str(), structure->getTemplate()->getName().str() ));
+		}
+	}
+#endif
+
 	// the GUI needs to re-evaluate the information being displayed to the user now
 	if( TheControlBar )
 		TheControlBar->markUIDirty();


### PR DESCRIPTION
With RETAIL_COMPATIBLE_CRC=0, special-power buttons on freshly built buildings that lack a SpecialPowerCreate module (Strategy Center battle plans, Intelligence) are permanently disabled. Addresses #2780 

Cause

PR #1218 initialized SpecialPowerModule::m_availableOnFrame to 0xFFFFFFFF under !RETAIL_COMPATIBLE_CRC. The constructor only calls startPowerRecharge() when the object is not UNDER_CONSTRUCTION; for built structures the recharge is otherwise driven by SpecialPowerCreate::onBuildComplete(). Buildings without that module never leave the sentinel value, so isReady() never returns true.

Fix

In Player::onStructureConstructionComplete(), after a structure finishes building, charge any special-power module still at the 0xFFFFFFFF sentinel to ready-now (setReadyFrame(TheGameLogic->getFrame())). This restores retail's immediate availability for these powers. Guarded with #if !RETAIL_COMPATIBLE_CRC, so retail CRC/replay compatibility is unchanged.

Testing

- [x]Fresh game: build a Strategy Center → battle-plan buttons are enabled and clickable; build a Detention Camp → CIA Intelligence is usable. DebugLogFile.txt logs the charged power.

Todo

[] Replicate to Generals