### PR TITLE
fix(terrain): Cover the visible ground at high camera zoom

### DIFF
--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
@@ -119,7 +119,7 @@ public:
 	///allocate resources needed to render heightmap
 	virtual int initHeightData(Int width, Int height, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator, Bool updateExtraPassTiles=TRUE);
 	virtual Int freeMapResources();	///< free resources used to render heightmap
-	virtual void updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator);
+	virtual void updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator, const Vector2 *drawCenter = nullptr);
  	virtual void adjustTerrainLOD(Int adj);
 	virtual void doPartialUpdate(const IRegion2D &partialRange, WorldHeightMap *htMap, RefRenderObjListIterator *pLightsIterator) = 0;
 	virtual void staticLightingChanged();

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/FlatHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/FlatHeightMap.h
@@ -66,7 +66,7 @@ public:
 	///allocate resources needed to render heightmap
 	virtual int initHeightData(Int width, Int height, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator,Bool updateExtraPassTiles=TRUE) override;
 	virtual Int freeMapResources() override;	///< free resources used to render heightmap
-	virtual void updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator) override;
+	virtual void updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator, const Vector2 *drawCenter = nullptr) override;
  	virtual void adjustTerrainLOD(Int adj) override;
 	virtual void reset() override;
 	virtual void oversizeTerrain(Int tilesToOversize) override; ///< Oversize the visible terrain area.

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
@@ -56,8 +56,6 @@ class HeightMapRenderObjClass : public BaseHeightMapRenderObjClass
 
 public:
 
-	enum { CENTER_LIMIT = 2 }; ///< Maximum draw-origin drift, in terrain cells.
-
 	HeightMapRenderObjClass();
 	virtual ~HeightMapRenderObjClass() override;
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
@@ -56,6 +56,8 @@ class HeightMapRenderObjClass : public BaseHeightMapRenderObjClass
 
 public:
 
+	enum { CENTER_LIMIT = 2 }; ///< Maximum draw-origin drift, in terrain cells.
+
 	HeightMapRenderObjClass();
 	virtual ~HeightMapRenderObjClass() override;
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
@@ -73,7 +73,7 @@ public:
 	///allocate resources needed to render heightmap
 	virtual int initHeightData(Int width, Int height, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator, Bool updateExtraPassTiles=TRUE) override;
 	virtual Int freeMapResources() override;	///< free resources used to render heightmap
-	virtual void updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator) override;
+	virtual void updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator, const Vector2 *drawCenter = nullptr) override;
 
 	virtual void staticLightingChanged() override;
 	virtual	void adjustTerrainLOD(Int adj) override;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -326,7 +326,7 @@ private:
 	void pitchCameraOneFrame();							///< Do one frame of a pitch camera movement.
 	void getAxisAlignedViewRegion(Region3D &axisAlignedRegion);	///< Find 3D Region enclosing all possible drawables.
 	void calcDeltaScroll(Coord2D &screenDelta);
-	bool getDesiredTerrainDrawSize(ICoord2D &dimensions) const;
+	bool getDesiredTerrainDrawSize(ICoord2D &dimensions, Vector2 &drawCenter) const;
 	void updateTerrain();
 
 	// (gth) C&C3 animation controlled camera feature

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -2394,7 +2394,7 @@ rendered portion of the terrain.  Only a 96x96 section is rendered at any time,
 even though maps can be up to 1024x1024.  This function determines which subset
 is rendered. */
 //=============================================================================
-void BaseHeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator)
+void BaseHeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator, const Vector2 *drawCenter)
 {
 	if (m_map==nullptr) {
 		return;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
@@ -408,13 +408,13 @@ rendered portion of the terrain.  Only a 96x96 section is rendered at any time,
 even though maps can be up to 1024x1024.  This function determines which subset
 is rendered. */
 //=============================================================================
-void FlatHeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator)
+void FlatHeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator, const Vector2 *drawCenter)
 {
 #ifdef DO_UNIT_TIMINGS
 #pragma MESSAGE("*** WARNING *** DOING DO_UNIT_TIMINGS!!!!")
 	return;
 #endif
-	BaseHeightMapRenderObjClass::updateCenter(camera, cameraPivot, pLightsIterator);
+	BaseHeightMapRenderObjClass::updateCenter(camera, cameraPivot, pLightsIterator, drawCenter);
 	m_needFullUpdate = false;
 	Int i, j;
 	Int culled = 0;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1539,7 +1539,6 @@ void HeightMapRenderObjClass::staticLightingChanged()
 	BaseHeightMapRenderObjClass::staticLightingChanged();
 }
 
-#define CENTER_LIMIT 2
 #define BIG_JUMP 16
 #define WIDE_STEP 32
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1631,7 +1631,7 @@ heightmap.  As the view slides around, this determines what is the actually
 rendered portion of the terrain. Only a small section is rendered at any time.
 */
 //=============================================================================
-void HeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator)
+void HeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *cameraPivot, RefRenderObjListIterator *pLightsIterator, const Vector2 *drawCenter)
 {
 	if (m_map==nullptr) {
 		return;
@@ -1642,7 +1642,7 @@ void HeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *c
 	if (m_vertexBufferTiles ==nullptr)
 		return;		//did not initialize resources yet.
 
-	BaseHeightMapRenderObjClass::updateCenter(camera, cameraPivot, pLightsIterator);
+	BaseHeightMapRenderObjClass::updateCenter(camera, cameraPivot, pLightsIterator, drawCenter);
 
 	m_updating = true;
 
@@ -1658,11 +1658,17 @@ void HeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *c
 		return; // no need to center.
 	}
 
-	const Real cameraPitch = asin(fabs(camera->Get_Forward_Dir().Z));
 	Int newOrgX;
 	Int newOrgY;
 
-	if (cameraPitch > ViewDefaultLowPitchRadians)
+	if (drawCenter)
+	{
+		// TheSuperHackers @performance sailro 06/09/2026 Reuse the footprint used for sizing instead of
+		// scanning the heightmap again or applying the low-pitch center approximation.
+		newOrgX = WWMath::Round(drawCenter->X/MAP_XY_FACTOR) - m_x/2 + m_map->getBorderSizeInline();
+		newOrgY = WWMath::Round(drawCenter->Y/MAP_XY_FACTOR) - m_y/2 + m_map->getBorderSizeInline();
+	}
+	else if (asin(fabs(camera->Get_Forward_Dir().Z)) > ViewDefaultLowPitchRadians)
 	{
 		// TheSuperHackers @info This is the original code to determine the center position for the visible terrain area.
 		// It is relatively expensive and breaks when the frustum planes can no longer intersect with the terrain at low camera
@@ -1826,7 +1832,7 @@ void HeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *c
 			// It is much more efficient to update a couple of columns one frame, and then
 			// a couple of rows.  So if we aren't "jumping" to a new view, and have done X
 			// recently, return.
-			if (abs(deltaX) < BIG_JUMP && !m_doXNextTime) {
+			if (!drawCenter && abs(deltaX) < BIG_JUMP && !m_doXNextTime) {
 				m_updating = false;
 				m_doXNextTime = true;
 				return;	// Only do the y this frame.  Do x next frame.  jba.

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1539,6 +1539,7 @@ void HeightMapRenderObjClass::staticLightingChanged()
 	BaseHeightMapRenderObjClass::staticLightingChanged();
 }
 
+#define CENTER_LIMIT 2
 #define BIG_JUMP 16
 #define WIDE_STEP 32
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -3765,7 +3765,8 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions) const
 	// enough to span them. At normal zoom the footprint is smaller than the normal window, so this is a
 	// no-op and behavior is unchanged; the window only grows - bounded by the map extent - as the camera
 	// zooms out. The size is snapped to whole vertex-buffer tiles so the terrain reallocates only when a
-	// zoom threshold is crossed, and a single square size keeps it stable as the camera rotates.
+	// zoom threshold is crossed, and a single square size avoids swapping the draw dimensions as the
+	// camera rotates.
 	//
 	// This also applies to the scripted camera (for example the main menu shell map), whose view can reach
 	// past the regular draw window and would otherwise leave the ground uncovered.
@@ -3830,17 +3831,25 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions) const
 			}
 		}
 
-		// Use a single square size (the larger footprint dimension) so the window does not reallocate as the
-		// camera rotates, plus one tile block of margin to match the search padding updateCenter() applies.
+		// Use a single square size (the larger footprint dimension) so the window covers the footprint at
+		// any camera yaw without swapping its X and Y extents. Add a small margin for the centering
+		// tolerance: updateCenter() only recenters the window once it has drifted by more than a couple of
+		// tiles (CENTER_LIMIT), so the drawn window can trail the footprint by that much.
 		const Real footprintSpanX = footprintMaxX - footprintMinX;
 		const Real footprintSpanY = footprintMaxY - footprintMinY;
 		const Real footprintSpan = (footprintSpanX > footprintSpanY) ? footprintSpanX : footprintSpanY;
-		Int footprintTiles = (Int)(footprintSpan / MAP_XY_FACTOR) + 1 + VERTEX_BUFFER_TILE_LENGTH;
-		if (footprintTiles > mapExtent)
-			footprintTiles = mapExtent;
+		const Int centeringMarginTiles = 4;
+		const Int footprintTiles = (Int)(footprintSpan / MAP_XY_FACTOR) + centeringMarginTiles;
 
-		// Snap up to 1 + N * VERTEX_BUFFER_TILE_LENGTH to match the engine's tile-based draw sizes.
-		const Int zoomDrawSize = ((footprintTiles - 1 + VERTEX_BUFFER_TILE_LENGTH) / VERTEX_BUFFER_TILE_LENGTH) * VERTEX_BUFFER_TILE_LENGTH + 1;
+		// Snap up to the smallest tile-based draw size (1 + N * VERTEX_BUFFER_TILE_LENGTH) that still covers
+		// the footprint. Growing only to the required block count - rather than always adding a whole spare
+		// block - keeps this a no-op at normal zoom and avoids drawing an extra ring of terrain blocks.
+		Int blocks = (footprintTiles + VERTEX_BUFFER_TILE_LENGTH - 1) / VERTEX_BUFFER_TILE_LENGTH;
+		if (blocks < 1)
+			blocks = 1;
+		Int zoomDrawSize = 1 + blocks * VERTEX_BUFFER_TILE_LENGTH;
+		if (zoomDrawSize > mapExtent)
+			zoomDrawSize = mapExtent;
 		if (zoomDrawSize > dimensions.x)
 			dimensions.x = zoomDrawSize;
 		if (zoomDrawSize > dimensions.y)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -3789,6 +3789,10 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions) const
 		// ground far away, behind the camera, or not at all - cannot produce a degenerate draw size.
 		const Int mapExtent = (map->getXExtent() > map->getYExtent()) ? map->getXExtent() : map->getYExtent();
 		const Real worldBound = (Real)mapExtent * MAP_XY_FACTOR;
+		const Real worldMinX = cameraLocation.X - worldBound;
+		const Real worldMaxX = cameraLocation.X + worldBound;
+		const Real worldMinY = cameraLocation.Y - worldBound;
+		const Real worldMaxY = cameraLocation.Y + worldBound;
 
 		Real footprintMinX = cameraLocation.X, footprintMaxX = cameraLocation.X;
 		Real footprintMinY = cameraLocation.Y, footprintMaxY = cameraLocation.Y;
@@ -3800,25 +3804,25 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions) const
 				const Real xMod = (-i + 0.5f + viewportMin.X) * viewPlaneDist * viewPlaneScaleX;
 				const Real yMod = ( j - 0.5f - viewportMin.Y) * viewPlaneDist * viewPlaneScaleY;
 
-				Vector3 rayDirection(
+				const Vector3 rayDirection(
 					viewPlaneDist * cameraTransform[0][2] + xMod * cameraTransform[0][0] + yMod * cameraTransform[0][1],
 					viewPlaneDist * cameraTransform[1][2] + xMod * cameraTransform[1][0] + yMod * cameraTransform[1][1],
 					viewPlaneDist * cameraTransform[2][2] + xMod * cameraTransform[2][0] + yMod * cameraTransform[2][1]);
-				rayDirection.Normalize();
-				const Vector3 rayPoint = cameraLocation + rayDirection;
 
-				Real groundX = Vector3::Find_X_At_Z(groundZ, cameraLocation, rayPoint);
-				Real groundY = Vector3::Find_Y_At_Z(groundZ, cameraLocation, rayPoint);
+				// A ray's scale does not affect its intersection with the ground plane. Reuse one division
+				// for both coordinates instead of normalizing the ray and solving X and Y independently.
+				const Real rayScale = (groundZ - cameraLocation.Z) / rayDirection.Z;
+				Real groundX = cameraLocation.X + rayDirection.X * rayScale;
+				Real groundY = cameraLocation.Y + rayDirection.Y * rayScale;
 
-				// Clamp into [camera +/- worldBound]; the !(>=) form also rejects NaN from parallel rays.
-				if (!(groundX >= cameraLocation.X - worldBound))
-					groundX = cameraLocation.X - worldBound;
-				else if (groundX > cameraLocation.X + worldBound)
-					groundX = cameraLocation.X + worldBound;
-				if (!(groundY >= cameraLocation.Y - worldBound))
-					groundY = cameraLocation.Y - worldBound;
-				else if (groundY > cameraLocation.Y + worldBound)
-					groundY = cameraLocation.Y + worldBound;
+				// clamp() leaves NaN unchanged, so replace NaN from a parallel ray with the existing
+				// conservative fallback first. Infinite intersections are handled by clamp().
+				if (_isnan(groundX))
+					groundX = worldMinX;
+				if (_isnan(groundY))
+					groundY = worldMinY;
+				groundX = clamp(worldMinX, groundX, worldMaxX);
+				groundY = clamp(worldMinY, groundY, worldMaxY);
 
 				if (groundX < footprintMinX)
 					footprintMinX = groundX;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -3767,9 +3767,9 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions) const
 	// zooms out. The size is snapped to whole vertex-buffer tiles so the terrain reallocates only when a
 	// zoom threshold is crossed, and a single square size keeps it stable as the camera rotates.
 	//
-	// Only the user-controlled camera is grown this way; the scripted camera keeps the regular draw sizes
-	// (see above) and relies on terrain oversize.
-	const WorldHeightMap *map = m_isUserControlled ? TheTerrainRenderObject->getMap() : nullptr;
+	// This also applies to the scripted camera (for example the main menu shell map), whose view can reach
+	// past the regular draw window and would otherwise leave the ground uncovered.
+	const WorldHeightMap *map = TheTerrainRenderObject->getMap();
 	if (map)
 	{
 		const Matrix3D &cameraTransform = m_3DCamera->Get_Transform();

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -3741,13 +3741,112 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions) const
 		// and uses terrain oversize if it needs to enlarge.
 		dimensions.x = WorldHeightMap::NORMAL_DRAW_WIDTH;
 		dimensions.y = WorldHeightMap::NORMAL_DRAW_HEIGHT;
-		return true;
+	}
+	else
+	{
+		// TheSuperHackers @tweak xezon 31/12/2025 Increases visible terrain area when lowering the camera pitch.
+		// Note: The default camera pitch in Generals was 37.5, which we prefer to keep the normal draw size for.
+		dimensions.x = WorldHeightMap::LOW_ANGLE_DRAW_WIDTH;
+		dimensions.y = WorldHeightMap::LOW_ANGLE_DRAW_HEIGHT;
 	}
 
-	// TheSuperHackers @tweak xezon 31/12/2025 Increases visible terrain area when lowering the camera pitch.
-	// Note: The default camera pitch in Generals was 37.5, which we prefer to keep the normal draw size for.
-	dimensions.x = WorldHeightMap::LOW_ANGLE_DRAW_WIDTH;
-	dimensions.y = WorldHeightMap::LOW_ANGLE_DRAW_HEIGHT;
+	// TheSuperHackers @bugfix sailro 13/06/2026 Grow the terrain draw window to cover the visible ground
+	// when the camera is zoomed far out, for all maps.
+	//
+	// Terrain is only drawn within a window of tiles around the view center (the NORMAL/LOW_ANGLE sizes
+	// chosen above). When the camera is zoomed far out the visible ground reaches past that window, so the
+	// terrain there is not drawn and any map water shows through behind it. Many maps that have no real
+	// water still keep a map-sized "Default Water" polygon, which then makes the whole map look flooded.
+	// The legacy workaround was DrawEntireTerrain=Yes, which always draws the entire map and is very slow
+	// even at normal zoom (see TheSuperHackers/GeneralsGameCode#2743).
+	//
+	// Instead we size the window to the actual visible footprint: project the four view corners onto the
+	// ground plane (the same method updateCenter() uses to position the window) and grow the draw size just
+	// enough to span them. At normal zoom the footprint is smaller than the normal window, so this is a
+	// no-op and behavior is unchanged; the window only grows - bounded by the map extent - as the camera
+	// zooms out. The size is snapped to whole vertex-buffer tiles so the terrain reallocates only when a
+	// zoom threshold is crossed, and a single square size keeps it stable as the camera rotates.
+	//
+	// Only the user-controlled camera is grown this way; the scripted camera keeps the regular draw sizes
+	// (see above) and relies on terrain oversize.
+	const WorldHeightMap *map = m_isUserControlled ? TheTerrainRenderObject->getMap() : nullptr;
+	if (map)
+	{
+		const Matrix3D &cameraTransform = m_3DCamera->Get_Transform();
+		const Vector3 cameraLocation = m_3DCamera->Get_Position();
+		Vector2 viewPlaneMin, viewPlaneMax;
+		m_3DCamera->Get_View_Plane(viewPlaneMin, viewPlaneMax);
+		Vector2 viewportMin, viewportMax;
+		m_3DCamera->Get_Viewport(viewportMin, viewportMax);
+
+		const Real viewPlaneScaleX = viewPlaneMax.X - viewPlaneMin.X;
+		const Real viewPlaneScaleY = viewPlaneMax.Y - viewPlaneMin.Y;
+		const Real viewPlaneDist = -1.0f; // The view plane is always 1.0 from the camera, looking down -Z.
+		const Real groundZ = m_pos.z;
+
+		// Bound the projected corners to the map extent so a near horizontal corner ray - which meets the
+		// ground far away, behind the camera, or not at all - cannot produce a degenerate draw size.
+		const Int mapExtent = (map->getXExtent() > map->getYExtent()) ? map->getXExtent() : map->getYExtent();
+		const Real worldBound = (Real)mapExtent * MAP_XY_FACTOR;
+
+		Real footprintMinX = cameraLocation.X, footprintMaxX = cameraLocation.X;
+		Real footprintMinY = cameraLocation.Y, footprintMaxY = cameraLocation.Y;
+
+		for (Int i = 0; i < 2; ++i)
+		{
+			for (Int j = 0; j < 2; ++j)
+			{
+				const Real xMod = (-i + 0.5f + viewportMin.X) * viewPlaneDist * viewPlaneScaleX;
+				const Real yMod = ( j - 0.5f - viewportMin.Y) * viewPlaneDist * viewPlaneScaleY;
+
+				Vector3 rayDirection(
+					viewPlaneDist * cameraTransform[0][2] + xMod * cameraTransform[0][0] + yMod * cameraTransform[0][1],
+					viewPlaneDist * cameraTransform[1][2] + xMod * cameraTransform[1][0] + yMod * cameraTransform[1][1],
+					viewPlaneDist * cameraTransform[2][2] + xMod * cameraTransform[2][0] + yMod * cameraTransform[2][1]);
+				rayDirection.Normalize();
+				const Vector3 rayPoint = cameraLocation + rayDirection;
+
+				Real groundX = Vector3::Find_X_At_Z(groundZ, cameraLocation, rayPoint);
+				Real groundY = Vector3::Find_Y_At_Z(groundZ, cameraLocation, rayPoint);
+
+				// Clamp into [camera +/- worldBound]; the !(>=) form also rejects NaN from parallel rays.
+				if (!(groundX >= cameraLocation.X - worldBound))
+					groundX = cameraLocation.X - worldBound;
+				else if (groundX > cameraLocation.X + worldBound)
+					groundX = cameraLocation.X + worldBound;
+				if (!(groundY >= cameraLocation.Y - worldBound))
+					groundY = cameraLocation.Y - worldBound;
+				else if (groundY > cameraLocation.Y + worldBound)
+					groundY = cameraLocation.Y + worldBound;
+
+				if (groundX < footprintMinX)
+					footprintMinX = groundX;
+				if (groundX > footprintMaxX)
+					footprintMaxX = groundX;
+				if (groundY < footprintMinY)
+					footprintMinY = groundY;
+				if (groundY > footprintMaxY)
+					footprintMaxY = groundY;
+			}
+		}
+
+		// Use a single square size (the larger footprint dimension) so the window does not reallocate as the
+		// camera rotates, plus one tile block of margin to match the search padding updateCenter() applies.
+		const Real footprintSpanX = footprintMaxX - footprintMinX;
+		const Real footprintSpanY = footprintMaxY - footprintMinY;
+		const Real footprintSpan = (footprintSpanX > footprintSpanY) ? footprintSpanX : footprintSpanY;
+		Int footprintTiles = (Int)(footprintSpan / MAP_XY_FACTOR) + 1 + VERTEX_BUFFER_TILE_LENGTH;
+		if (footprintTiles > mapExtent)
+			footprintTiles = mapExtent;
+
+		// Snap up to 1 + N * VERTEX_BUFFER_TILE_LENGTH to match the engine's tile-based draw sizes.
+		const Int zoomDrawSize = ((footprintTiles - 1 + VERTEX_BUFFER_TILE_LENGTH) / VERTEX_BUFFER_TILE_LENGTH) * VERTEX_BUFFER_TILE_LENGTH + 1;
+		if (zoomDrawSize > dimensions.x)
+			dimensions.x = zoomDrawSize;
+		if (zoomDrawSize > dimensions.y)
+			dimensions.y = zoomDrawSize;
+	}
+
 	return true;
 }
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -3803,9 +3803,8 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions, Vector2 &drawCente
 		minimumSize.y = WorldHeightMap::LOW_ANGLE_DRAW_HEIGHT;
 	}
 
-	// Reserve the renderer's origin drift on both sides, plus half a cell per side for center rounding.
-	const Int centeringMargin = 2*HeightMapRenderObjClass::CENTER_LIMIT + 1;
-	const Int footprintTiles = (Int)ceil(WWMath::Sqrt(diameterSquared)/MAP_XY_FACTOR) + centeringMargin;
+	// CENTER_LIMIT permits two cells of origin drift per axis; nearest-cell centering adds half a cell.
+	const Int footprintTiles = (Int)ceil(WWMath::Sqrt(diameterSquared)/MAP_XY_FACTOR) + 5;
 	const Int blocks = (footprintTiles + VERTEX_BUFFER_TILE_LENGTH - 1)/VERTEX_BUFFER_TILE_LENGTH;
 	const Int drawSize = 1 + blocks*VERTEX_BUFFER_TILE_LENGTH;
 	dimensions.x = std::min(map->getXExtent(), std::max(minimumSize.x, drawSize));

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -3717,149 +3717,102 @@ void W3DView::Add_Camera_Shake (const Coord3D & position,float radius,float dura
 	CameraShakerSystem.Add_Camera_Shake(vpos,radius,duration,power);
 }
 
-bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions) const
+bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions, Vector2 &drawCenter) const
 {
-	if (TheGlobalData && TheGlobalData->m_drawEntireTerrain)
-	{
-		DEBUG_ASSERTCRASH(TheTerrainRenderObject != nullptr, ("TheTerrainRenderObject is null"));
-
-		if (const WorldHeightMap *heightMap = TheTerrainRenderObject->getMap())
-		{
-			dimensions.x = heightMap->getXExtent();
-			dimensions.y = heightMap->getYExtent();
-			return true;
-		}
-
+	const WorldHeightMap *map = TheTerrainRenderObject->getMap();
+	if (!map)
 		return false;
-	}
+
+	// A horizon-crossing or invalid projection has no finite footprint. Keep the map-sized fallback.
+	dimensions.x = map->getXExtent();
+	dimensions.y = map->getYExtent();
+	drawCenter.Set(0.0f, 0.0f);
+	if (TheGlobalData && TheGlobalData->m_drawEntireTerrain)
+		return true;
 
 	const Real cameraPitch = asin(fabs(m_3DCamera->Get_Forward_Dir().Z));
-
+	ICoord2D minimumSize;
 	if (cameraPitch > ViewDefaultLowPitchRadians || !m_isUserControlled)
 	{
-		// TheSuperHackers @info The scripted camera always uses the regular draw sizes
-		// and uses terrain oversize if it needs to enlarge.
-		dimensions.x = WorldHeightMap::NORMAL_DRAW_WIDTH;
-		dimensions.y = WorldHeightMap::NORMAL_DRAW_HEIGHT;
+		minimumSize.x = WorldHeightMap::NORMAL_DRAW_WIDTH;
+		minimumSize.y = WorldHeightMap::NORMAL_DRAW_HEIGHT;
 	}
 	else
 	{
 		// TheSuperHackers @tweak xezon 31/12/2025 Increases visible terrain area when lowering the camera pitch.
 		// Note: The default camera pitch in Generals was 37.5, which we prefer to keep the normal draw size for.
-		dimensions.x = WorldHeightMap::LOW_ANGLE_DRAW_WIDTH;
-		dimensions.y = WorldHeightMap::LOW_ANGLE_DRAW_HEIGHT;
+		minimumSize.x = WorldHeightMap::LOW_ANGLE_DRAW_WIDTH;
+		minimumSize.y = WorldHeightMap::LOW_ANGLE_DRAW_HEIGHT;
 	}
 
-	// TheSuperHackers @bugfix sailro 13/06/2026 Grow the terrain draw window to cover the visible ground
-	// when the camera is zoomed far out, for all maps.
-	//
-	// Terrain is only drawn within a window of tiles around the view center (the NORMAL/LOW_ANGLE sizes
-	// chosen above). When the camera is zoomed far out the visible ground reaches past that window, so the
-	// terrain there is not drawn and any map water shows through behind it. Many maps that have no real
-	// water still keep a map-sized "Default Water" polygon, which then makes the whole map look flooded.
-	// The legacy workaround was DrawEntireTerrain=Yes, which always draws the entire map and is very slow
-	// even at normal zoom (see TheSuperHackers/GeneralsGameCode#2743).
-	//
-	// Instead we size the window to the actual visible footprint: project the four view corners onto the
-	// ground plane (the same method updateCenter() uses to position the window) and grow the draw size just
-	// enough to span them. At normal zoom the footprint is smaller than the normal window, so this is a
-	// no-op and behavior is unchanged; the window only grows - bounded by the map extent - as the camera
-	// zooms out. The size is snapped to whole vertex-buffer tiles so the terrain reallocates only when a
-	// zoom threshold is crossed, and a single square size avoids swapping the draw dimensions as the
-	// camera rotates.
-	//
-	// This also applies to the scripted camera (for example the main menu shell map), whose view can reach
-	// past the regular draw window and would otherwise leave the ground uncovered.
-	const WorldHeightMap *map = TheTerrainRenderObject->getMap();
-	if (map)
+	// TheSuperHackers @bugfix sailro 06/09/2026 Cover the visible terrain without yaw-dependent buffer
+	// reallocations. The two cached terrain height limits also cover valleys and nearby higher ground.
+	const Matrix3D &cameraTransform = m_3DCamera->Get_Transform();
+	const Vector3 cameraLocation = m_3DCamera->Get_Position();
+	const Real groundZ[2] = {
+		TheTerrainRenderObject->getMinHeight(),
+		std::min(TheTerrainRenderObject->getMaxHeight(), cameraLocation.Z)
+	};
+	if (!cameraLocation.Is_Valid() || cameraLocation.Z <= groundZ[0])
+		return true;
+
+	Vector2 viewPlaneMin, viewPlaneMax;
+	m_3DCamera->Get_View_Plane(viewPlaneMin, viewPlaneMax);
+	const Int planeCount = groundZ[0] < groundZ[1] ? 2 : 1;
+	Vector3 corners[8];
+	Vector2 footprintMin, footprintMax;
+	for (Int i = 0; i < 4; ++i)
 	{
-		const Matrix3D &cameraTransform = m_3DCamera->Get_Transform();
-		const Vector3 cameraLocation = m_3DCamera->Get_Position();
-		Vector2 viewPlaneMin, viewPlaneMax;
-		m_3DCamera->Get_View_Plane(viewPlaneMin, viewPlaneMax);
-		Vector2 viewportMin, viewportMax;
-		m_3DCamera->Get_Viewport(viewportMin, viewportMax);
+		const Vector3 ray((i & 1) ? viewPlaneMax.X : viewPlaneMin.X,
+			(i & 2) ? viewPlaneMax.Y : viewPlaneMin.Y, -1.0f);
+		const Real rayZ = cameraTransform[2][0]*ray.X + cameraTransform[2][1]*ray.Y - cameraTransform[2][2];
+		if (!(rayZ < 0.0f))
+			return true;
 
-		const Real viewPlaneScaleX = viewPlaneMax.X - viewPlaneMin.X;
-		const Real viewPlaneScaleY = viewPlaneMax.Y - viewPlaneMin.Y;
-		const Real viewPlaneDist = -1.0f; // The view plane is always 1.0 from the camera, looking down -Z.
-		const Real groundZ = m_pos.z;
-
-		// Bound the projected corners to the map extent so a near horizontal corner ray - which meets the
-		// ground far away, behind the camera, or not at all - cannot produce a degenerate draw size.
-		const Int mapExtent = (map->getXExtent() > map->getYExtent()) ? map->getXExtent() : map->getYExtent();
-		const Real worldBound = (Real)mapExtent * MAP_XY_FACTOR;
-		const Real worldMinX = cameraLocation.X - worldBound;
-		const Real worldMaxX = cameraLocation.X + worldBound;
-		const Real worldMinY = cameraLocation.Y - worldBound;
-		const Real worldMaxY = cameraLocation.Y + worldBound;
-
-		Real footprintMinX = cameraLocation.X, footprintMaxX = cameraLocation.X;
-		Real footprintMinY = cameraLocation.Y, footprintMaxY = cameraLocation.Y;
-
-		for (Int i = 0; i < 2; ++i)
+		const Real inverseRayZ = 1.0f/rayZ;
+		for (Int plane = 0; plane < planeCount; ++plane)
 		{
-			for (Int j = 0; j < 2; ++j)
-			{
-				const Real xMod = (-i + 0.5f + viewportMin.X) * viewPlaneDist * viewPlaneScaleX;
-				const Real yMod = ( j - 0.5f - viewportMin.Y) * viewPlaneDist * viewPlaneScaleY;
-
-				const Vector3 rayDirection(
-					viewPlaneDist * cameraTransform[0][2] + xMod * cameraTransform[0][0] + yMod * cameraTransform[0][1],
-					viewPlaneDist * cameraTransform[1][2] + xMod * cameraTransform[1][0] + yMod * cameraTransform[1][1],
-					viewPlaneDist * cameraTransform[2][2] + xMod * cameraTransform[2][0] + yMod * cameraTransform[2][1]);
-
-				// A ray's scale does not affect its intersection with the ground plane. Reuse one division
-				// for both coordinates instead of normalizing the ray and solving X and Y independently.
-				const Real rayScale = (groundZ - cameraLocation.Z) / rayDirection.Z;
-				Real groundX = cameraLocation.X + rayDirection.X * rayScale;
-				Real groundY = cameraLocation.Y + rayDirection.Y * rayScale;
-
-				// clamp() leaves NaN unchanged, so replace NaN from a parallel ray with the existing
-				// conservative fallback first. Infinite intersections are handled by clamp().
-				if (_isnan(groundX))
-					groundX = worldMinX;
-				if (_isnan(groundY))
-					groundY = worldMinY;
-				groundX = clamp(worldMinX, groundX, worldMaxX);
-				groundY = clamp(worldMinY, groundY, worldMaxY);
-
-				if (groundX < footprintMinX)
-					footprintMinX = groundX;
-				if (groundX > footprintMaxX)
-					footprintMaxX = groundX;
-				if (groundY < footprintMinY)
-					footprintMinY = groundY;
-				if (groundY > footprintMaxY)
-					footprintMaxY = groundY;
-			}
+			Vector3 &corner = corners[plane*4 + i];
+			corner = ray * ((groundZ[plane] - cameraLocation.Z)*inverseRayZ);
+			if (!corner.Is_Valid())
+				return true;
+			const Vector2 offset(
+				cameraTransform[0][0]*corner.X + cameraTransform[0][1]*corner.Y + cameraTransform[0][2]*corner.Z,
+				cameraTransform[1][0]*corner.X + cameraTransform[1][1]*corner.Y + cameraTransform[1][2]*corner.Z);
+			if (i == 0 && plane == 0)
+				footprintMin = footprintMax = offset;
+			footprintMin.X = std::min(footprintMin.X, offset.X);
+			footprintMin.Y = std::min(footprintMin.Y, offset.Y);
+			footprintMax.X = std::max(footprintMax.X, offset.X);
+			footprintMax.Y = std::max(footprintMax.Y, offset.Y);
 		}
-
-		// Use a single square size (the larger footprint dimension) so the window covers the footprint at
-		// any camera yaw without swapping its X and Y extents. Add a small margin for the centering
-		// tolerance: updateCenter() only recenters the window once it has drifted by more than a couple of
-		// tiles (CENTER_LIMIT), so the drawn window can trail the footprint by that much.
-		const Real footprintSpanX = footprintMaxX - footprintMinX;
-		const Real footprintSpanY = footprintMaxY - footprintMinY;
-		const Real footprintSpan = (footprintSpanX > footprintSpanY) ? footprintSpanX : footprintSpanY;
-		const Int centeringMarginTiles = 4;
-		const Int footprintTiles = (Int)(footprintSpan / MAP_XY_FACTOR) + centeringMarginTiles;
-
-		// Snap up to the smallest tile-based draw size (1 + N * VERTEX_BUFFER_TILE_LENGTH) that still covers
-		// the footprint. Growing only to the required block count - rather than always adding a whole spare
-		// block - keeps this a no-op at normal zoom and avoids drawing an extra ring of terrain blocks.
-		Int blocks = (footprintTiles + VERTEX_BUFFER_TILE_LENGTH - 1) / VERTEX_BUFFER_TILE_LENGTH;
-		if (blocks < 1)
-			blocks = 1;
-		Int zoomDrawSize = 1 + blocks * VERTEX_BUFFER_TILE_LENGTH;
-		if (zoomDrawSize > mapExtent)
-			zoomDrawSize = mapExtent;
-		if (zoomDrawSize > dimensions.x)
-			dimensions.x = zoomDrawSize;
-		if (zoomDrawSize > dimensions.y)
-			dimensions.y = zoomDrawSize;
 	}
 
+	// The maximum pairwise XY distance bounds every rotated span. Compute it in camera space to avoid
+	// yaw-dependent rounding at allocation thresholds; remove the height difference between planes.
+	Real diameterSquared = 0.0f;
+	const Real worldBound = std::max(map->getXExtent(), map->getYExtent())*MAP_XY_FACTOR;
+	for (Int i = 0; i < planeCount*4; ++i)
+	{
+		for (Int j = 0; j < i; ++j)
+		{
+			const Vector3 delta = corners[i] - corners[j];
+			const Real deltaZ = groundZ[i/4] - groundZ[j/4];
+			const Real distanceSquared = delta.Length2() - deltaZ*deltaZ;
+			if (!(distanceSquared < worldBound*worldBound))
+				return true;
+			diameterSquared = std::max(diameterSquared, distanceSquared);
+		}
+	}
+
+	// CENTER_LIMIT permits two cells of origin drift per axis; nearest-cell centering adds half a cell.
+	const Int footprintTiles = (Int)ceil(WWMath::Sqrt(diameterSquared)/MAP_XY_FACTOR) + 5;
+	const Int blocks = (footprintTiles + VERTEX_BUFFER_TILE_LENGTH - 1)/VERTEX_BUFFER_TILE_LENGTH;
+	const Int drawSize = 1 + blocks*VERTEX_BUFFER_TILE_LENGTH;
+	dimensions.x = std::min(map->getXExtent(), std::max(minimumSize.x, drawSize));
+	dimensions.y = std::min(map->getYExtent(), std::max(minimumSize.y, drawSize));
+	drawCenter.Set(cameraLocation.X + (footprintMin.X + footprintMax.X)*0.5f,
+		cameraLocation.Y + (footprintMin.Y + footprintMax.Y)*0.5f);
 	return true;
 }
 
@@ -3868,8 +3821,9 @@ void W3DView::updateTerrain()
 	DEBUG_ASSERTCRASH(TheTerrainRenderObject != nullptr, ("TheTerrainRenderObject is null"));
 
 	ICoord2D drawSize;
-
-	if (getDesiredTerrainDrawSize(drawSize))
+	Vector2 drawCenter;
+	const bool hasDrawCenter = getDesiredTerrainDrawSize(drawSize, drawCenter);
+	if (hasDrawCenter)
 	{
 		TheTerrainRenderObject->setTerrainDrawSize(drawSize.x, drawSize.y);
 	}
@@ -3877,7 +3831,7 @@ void W3DView::updateTerrain()
 	RefRenderObjListIterator *it = W3DDisplay::m_3DScene->createLightsIterator();
 
 	const Vector3 cameraPivot(m_pos.x, m_pos.y, m_pos.z);
-	TheTerrainRenderObject->updateCenter(m_3DCamera, &cameraPivot, it);
+	TheTerrainRenderObject->updateCenter(m_3DCamera, &cameraPivot, it, hasDrawCenter ? &drawCenter : nullptr);
 
 	if (it)
 	{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -3730,25 +3730,10 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions, Vector2 &drawCente
 	if (TheGlobalData && TheGlobalData->m_drawEntireTerrain)
 		return true;
 
-	const Real cameraPitch = asin(fabs(m_3DCamera->Get_Forward_Dir().Z));
-	ICoord2D minimumSize;
-	if (cameraPitch > ViewDefaultLowPitchRadians || !m_isUserControlled)
-	{
-		minimumSize.x = WorldHeightMap::NORMAL_DRAW_WIDTH;
-		minimumSize.y = WorldHeightMap::NORMAL_DRAW_HEIGHT;
-	}
-	else
-	{
-		// TheSuperHackers @tweak xezon 31/12/2025 Increases visible terrain area when lowering the camera pitch.
-		// Note: The default camera pitch in Generals was 37.5, which we prefer to keep the normal draw size for.
-		minimumSize.x = WorldHeightMap::LOW_ANGLE_DRAW_WIDTH;
-		minimumSize.y = WorldHeightMap::LOW_ANGLE_DRAW_HEIGHT;
-	}
-
 	// TheSuperHackers @bugfix sailro 06/09/2026 Cover the visible terrain without yaw-dependent buffer
 	// reallocations. The two cached terrain height limits also cover valleys and nearby higher ground.
 	const Matrix3D &cameraTransform = m_3DCamera->Get_Transform();
-	const Vector3 cameraLocation = m_3DCamera->Get_Position();
+	const Vector3 cameraLocation = cameraTransform.Get_Translation();
 	const Real groundZ[2] = {
 		TheTerrainRenderObject->getMinHeight(),
 		std::min(TheTerrainRenderObject->getMaxHeight(), cameraLocation.Z)
@@ -3781,10 +3766,8 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions, Vector2 &drawCente
 				cameraTransform[1][0]*corner.X + cameraTransform[1][1]*corner.Y + cameraTransform[1][2]*corner.Z);
 			if (i == 0 && plane == 0)
 				footprintMin = footprintMax = offset;
-			footprintMin.X = std::min(footprintMin.X, offset.X);
-			footprintMin.Y = std::min(footprintMin.Y, offset.Y);
-			footprintMax.X = std::max(footprintMax.X, offset.X);
-			footprintMax.Y = std::max(footprintMax.Y, offset.Y);
+			footprintMin.Update_Min(offset);
+			footprintMax.Update_Max(offset);
 		}
 	}
 
@@ -3805,8 +3788,24 @@ bool W3DView::getDesiredTerrainDrawSize(ICoord2D &dimensions, Vector2 &drawCente
 		}
 	}
 
-	// CENTER_LIMIT permits two cells of origin drift per axis; nearest-cell centering adds half a cell.
-	const Int footprintTiles = (Int)ceil(WWMath::Sqrt(diameterSquared)/MAP_XY_FACTOR) + 5;
+	const Real cameraPitch = asin(fabs(cameraTransform[2][2]));
+	ICoord2D minimumSize;
+	if (cameraPitch > ViewDefaultLowPitchRadians || !m_isUserControlled)
+	{
+		minimumSize.x = WorldHeightMap::NORMAL_DRAW_WIDTH;
+		minimumSize.y = WorldHeightMap::NORMAL_DRAW_HEIGHT;
+	}
+	else
+	{
+		// TheSuperHackers @tweak xezon 31/12/2025 Increases visible terrain area when lowering the camera pitch.
+		// Note: The default camera pitch in Generals was 37.5, which we prefer to keep the normal draw size for.
+		minimumSize.x = WorldHeightMap::LOW_ANGLE_DRAW_WIDTH;
+		minimumSize.y = WorldHeightMap::LOW_ANGLE_DRAW_HEIGHT;
+	}
+
+	// Reserve the renderer's origin drift on both sides, plus half a cell per side for center rounding.
+	const Int centeringMargin = 2*HeightMapRenderObjClass::CENTER_LIMIT + 1;
+	const Int footprintTiles = (Int)ceil(WWMath::Sqrt(diameterSquared)/MAP_XY_FACTOR) + centeringMargin;
 	const Int blocks = (footprintTiles + VERTEX_BUFFER_TILE_LENGTH - 1)/VERTEX_BUFFER_TILE_LENGTH;
 	const Int drawSize = 1 + blocks*VERTEX_BUFFER_TILE_LENGTH;
 	dimensions.x = std::min(map->getXExtent(), std::max(minimumSize.x, drawSize));


### PR DESCRIPTION
## Problem

With the default settings (`DrawEntireTerrain=No`) the terrain is only drawn within a window of tiles around the view center. At high camera zoom this window no longer covers the visible ground, so any map water renders *behind* it. Many maps that have no real water still keep a map-sized **"Default Water"** polygon, which then makes the whole map look flooded when the camera is zoomed out.

The legacy workaround was `DrawEntireTerrain=Yes`, but that always draws the entire map and is very slow even at normal zoom (#2743).

## Fix

Size the normal draw window to the actual **visible footprint** instead of a fixed tile count:

- Project the four view corners onto the ground plane (the same method `updateCenter()` already uses to position the window).
- Grow the draw size just enough to span them, **bounded by the map extent** and **snapped to whole vertex-buffer tiles**, so the terrain only reallocates when a zoom threshold is crossed.
- Use a single square size so the window stays stable as the camera rotates (no reallocation on yaw).
- Near-horizontal / parallel corner rays (which meet the ground far away, behind the camera, or not at all) are clamped to the map extent, so they cannot produce a degenerate or `NaN` draw size.

At normal zoom the footprint is smaller than the normal window, so this is a **no-op** and behavior is unchanged; the window only grows as the camera zooms out. It works for **all maps**.

This change lives in the default `DrawEntireTerrain=No` path. It does **not** modify the `DrawEntireTerrain` path, so it does not by itself resolve #2743 — it removes the need for that slow workaround in the common case.

## Before / After

**Before** — zoomed out on a no-water map, the terrain window ends and the map's default water polygon fills the rest of the view:

![before](https://raw.githubusercontent.com/sailro/GameClient/pr-terrain-zoom-media/before-water-bug.jpg)

**After** — the draw window covers the visible ground, so the sand renders all the way out (same scene type, patched build):

![after](https://raw.githubusercontent.com/sailro/GameClient/pr-terrain-zoom-media/after-sandy-siege.jpg)

**After** on a stock map (Whiteout) — the real lake still renders correctly and the terrain fills the view (the black wedge top-left is genuinely off-map, past the terrain border at extreme zoom):

![after-whiteout](https://raw.githubusercontent.com/sailro/GameClient/pr-terrain-zoom-media/after-whiteout.jpg)

## Testing

- Built Release / Win32 and tested in skirmish (Zero Hour).
- At maximum camera zoom-out: no water bleed-through on no-water maps, and the real water on stock maps still renders correctly.
- Performance stays smooth at all zoom levels across multiple maps (no `DrawEntireTerrain=Yes`-style degradation).

## AI disclosure

Per the contribution guidelines: the code in this PR was written with the help of an LLM (GitHub Copilot CLI) and then reviewed, iterated on, and verified by a human. The approach — projecting the view footprint the same way `updateCenter()` does, tile snapping, and map-extent / `NaN` bounding — was chosen deliberately, and the change was validated in-game across several maps and zoom levels. The diff is intentionally small and self-contained: one file, only the draw-size calculation in `updateTerrain()`.

cc @xezon
