### PR TITLE
fix(heightmap): Prevent per-frame full terrain rebuild with DrawEntireTerrain

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1207,6 +1207,23 @@ void HeightMapRenderObjClass::setTerrainDrawSize(Int width, Int height)
 	else
 		height = std::min(height, m_map->getYExtent());
 
+	// TheSuperHackers @bugfix sailro 13/06/2026 Apply the StretchTerrain and DrawEntireTerrain size
+	// overrides here so the requested size can match the stored full-map draw size. Otherwise the normal
+	// size is requested every frame and never matches, rebuilding the whole terrain (vertices and
+	// lighting) every frame and badly degrading performance. DrawEntireTerrain takes precedence.
+	if (TheGlobalData && TheGlobalData->m_stretchTerrain)
+	{
+		width = WorldHeightMap::STRETCH_DRAW_WIDTH;
+		height = WorldHeightMap::STRETCH_DRAW_HEIGHT;
+	}
+	if (TheGlobalData && TheGlobalData->m_drawEntireTerrain)
+	{
+		width = m_map->getXExtent();
+		height = m_map->getYExtent();
+	}
+	width = std::min(width, m_map->getXExtent());
+	height = std::min(height, m_map->getYExtent());
+
 	if (width == m_map->getDrawWidth() && height == m_map->getDrawHeight())
 		return;
 
@@ -1672,6 +1689,17 @@ void HeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *c
 
 	if (m_x >= m_map->getXExtent() && m_y >= m_map->getYExtent())
   {
+		// TheSuperHackers @bugfix sailro 13/06/2026 The vertex grid already covers the whole terrain
+		// (small maps, or StretchTerrain/DrawEntireTerrain), so there is no scrolling to do. Still honor a
+		// pending full update here, otherwise lighting, texture or height changes would never be applied.
+		// This repaints only when an update is actually requested, not every frame.
+		if (m_needFullUpdate)
+		{
+			m_updating = true;
+			m_needFullUpdate = false;
+			updateBlock(0, 0, m_x-1, m_y-1, m_map, pLightsIterator);
+			m_updating = false;
+		}
 		return; // no need to center.
 	}
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1213,16 +1213,15 @@ void HeightMapRenderObjClass::setTerrainDrawSize(Int width, Int height)
 	// lighting) every frame and badly degrading performance. DrawEntireTerrain takes precedence.
 	if (TheGlobalData && TheGlobalData->m_stretchTerrain)
 	{
-		width = WorldHeightMap::STRETCH_DRAW_WIDTH;
-		height = WorldHeightMap::STRETCH_DRAW_HEIGHT;
+		width = std::min((Int)WorldHeightMap::STRETCH_DRAW_WIDTH, m_map->getXExtent());
+		height = std::min((Int)WorldHeightMap::STRETCH_DRAW_HEIGHT, m_map->getYExtent());
 	}
+
 	if (TheGlobalData && TheGlobalData->m_drawEntireTerrain)
 	{
 		width = m_map->getXExtent();
 		height = m_map->getYExtent();
 	}
-	width = std::min(width, m_map->getXExtent());
-	height = std::min(height, m_map->getYExtent());
 
 	if (width == m_map->getDrawWidth() && height == m_map->getDrawHeight())
 		return;


### PR DESCRIPTION
## Problem

With `DrawEntireTerrain=Yes` (and likewise `StretchTerrain=Yes`) the engine rebuilds the **entire** terrain — all vertex buffers and lighting — on **every single frame**, which is the massive performance degradation reported in #2743.

Root cause: there are two sources of truth for the terrain draw size.

- `WorldHeightMap::createDrawArea()` force-overrides the stored draw size to the **full map** when `DrawEntireTerrain=Yes` (or to the stretch size when `StretchTerrain=Yes`).
- `W3DView::updateTerrain()` calls `HeightMapRenderObjClass::setTerrainDrawSize()` with the **normal** draw size every frame (introduced by #2677).

`setTerrainDrawSize()` early-returns when the requested size equals the stored size, but the requested normal size never matches the stored full-map size. So every frame it re-runs `initHeightData()` + a full-map `updateBlock()`, and sets `m_needFullUpdate`, causing `updateCenter()` to do a second full-map update. Roughly two full terrain rebuilds per frame.

This regressed in #2677, which added the per-frame `setTerrainDrawSize()` call; before that, `updateTerrain()` only called `updateCenter()`.

## Fix

Two parts that work together:

1. **Stop the per-frame rebuild.** Resolve the effective draw size inside `setTerrainDrawSize()` the same way `createDrawArea()` does, by applying the `StretchTerrain` / `DrawEntireTerrain` overrides up front (same precedence: `DrawEntireTerrain` wins). The unchanged-check now matches, so the terrain is no longer reinitialized and rebuilt every frame.

2. **Keep event-driven repaints working.** That per-frame rebuild was, however, the *only* thing repainting the terrain when the vertex grid already covers the whole map: `HeightMapRenderObjClass::updateCenter()` early-returns in that case (small maps, `StretchTerrain` or `DrawEntireTerrain`) and so never reaches its `m_needFullUpdate` handling. Once the per-frame rebuild is removed, pending full updates requested by `staticLightingChanged()`, `ReAcquireResources()` after a device reset, time-of-day changes, or late texture loads would never be applied — leaving undrawn (black) and untextured (grey) tiles, most visibly on the shell map. `updateCenter()` now honors a pending `m_needFullUpdate` in that early-return path with a single full `updateBlock`, so those repaints still happen, but only when actually requested instead of every frame.

Steady-state behavior returns to a one-time full update plus the normal full-map draw (i.e. the pre-#2677 cost), while terrain still updates correctly on lighting, device-reset and texture changes. The change is scoped to `HeightMapRenderObjClass` (`terrainLOD == 7`); `FlatHeightMapRenderObjClass::setTerrainDrawSize`/`oversizeTerrain` are no-ops and are unaffected.

## Testing

- Built Release / Win32 and tested in Zero Hour with `DrawEntireTerrain=Yes`.
- **In-game (Whiteout):** smooth where the unpatched build was heavily laggy — the per-frame rebuild is gone.
- **Shell map / intro menu and in-game terrain:** renders correctly (no black holes, no untextured grey tiles), confirming lighting / device-reset / late-texture repaints still occur.
- Verified `DrawEntireTerrain=No` (default) is unaffected: the overrides only apply when the corresponding setting is on, and the new `updateCenter` branch only runs when the grid already covers the whole map.

## AI disclosure

Per the contribution guidelines: the code in this PR was written with the help of an LLM (GitHub Copilot CLI) and then reviewed, iterated on, and verified by a human. The root cause (two competing sources of truth for the draw size defeating the unchanged-check, regressed by #2677) was traced deliberately, and a first iteration that only fixed `setTerrainDrawSize()` was caught in testing to regress shell-map rendering — which led directly to the second part of the fix. The change was validated in-game (performance and rendering) with `DrawEntireTerrain=Yes`. The diff is intentionally small and self-contained: one file, two narrowly-scoped changes.

Fixes #2743

cc @xezon
