### PR TITLE
bugfix(textureloader): Lift hardcoded texture aspect ratio limit of 1:8 to allow loading all textures with modern gpu

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -373,7 +373,7 @@ void TextureLoader::Validate_Texture_Size
 	}
 
 	unsigned poweroftwodepth = 1;
-	while (poweroftwodepth< depth)
+	while (poweroftwodepth < depth)
 	{
 		poweroftwodepth <<= 1;
 	}
@@ -391,18 +391,22 @@ void TextureLoader::Validate_Texture_Size
 		poweroftwodepth=dx8caps.MaxVolumeExtent;
 	}
 
-	if (poweroftwowidth>poweroftwoheight)
+	const int maxTextureAspectRatio = dx8caps.MaxTextureAspectRatio;
+	if (maxTextureAspectRatio != 0)
 	{
-		while (poweroftwowidth/poweroftwoheight>8)
+		if (poweroftwowidth>poweroftwoheight)
 		{
-			poweroftwoheight*=2;
+			while (poweroftwowidth/poweroftwoheight > maxTextureAspectRatio)
+			{
+				poweroftwoheight*=2;
+			}
 		}
-	}
-	else
-	{
-		while (poweroftwoheight/poweroftwowidth>8)
+		else
 		{
-			poweroftwowidth*=2;
+			while (poweroftwoheight/poweroftwowidth > maxTextureAspectRatio)
+			{
+				poweroftwowidth*=2;
+			}
 		}
 	}
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -391,7 +391,7 @@ void TextureLoader::Validate_Texture_Size
 		poweroftwodepth=dx8caps.MaxVolumeExtent;
 	}
 
-	const int maxTextureAspectRatio = dx8caps.MaxTextureAspectRatio;
+	const unsigned maxTextureAspectRatio = dx8caps.MaxTextureAspectRatio;
 	if (maxTextureAspectRatio != 0)
 	{
 		if (poweroftwowidth>poweroftwoheight)


### PR DESCRIPTION
* Fixes #1990
* Closes #2771

This change lifts the hardcoded texture aspect ratio limit of 1:8 to allow load all textures with modern gpu.

The 1:8 texture limit was a concern on gpu's 25 years ago. DX8 caps has a flag to test the aspect ratio limit. With the limit lifted, the Binary Stream texture (1:16 aspect) of Lotus and Patriots renders normally.