### PR TITLE
refactor(pathfinder): Simplify implementation of spiral cell search in Pathfinder::adjustDestination()

### DIFF
--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5543,48 +5543,40 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 		layer = TheTerrainLogic->getLayerForDestination(groupDest);
 	}
 
-	Int limit = MAX_ADJUSTMENT_CELL_COUNT;
-	Int i, j;
-	i = cell.x;
-	j = cell.y;
+	Int i = cell.x;
+	Int j = cell.y;
+	// Check the center cell
 	if (checkForAdjust(obj, locomotorSet, isHuman, i,j, layer, iRadius, center, dest, groupDest)) {
 		return true;
 	}
 
-	Int delta=1;
-	Int count;
+	// TheSuperHackers @info Expanding clockwise spiral search around center cell C. Each full lap walks right→down→left→up.
+	// After every pair of directions (right+down, then left+up) length of the segment grows by 1.
+	//
+	//    6  7  8  9
+	//    5  C  1  10
+	//    4  3  2  11
+	//    <------  12
+	//
+	Int limit = MAX_ADJUSTMENT_CELL_COUNT;
+	Int segmentLength = 1;
+	const ICoord2D directions[4] = { {1, 0}, {0, 1}, {-1, 0}, {0, -1} };
 	while (limit>0) {
-		for (count = delta; count>0; count--) {
-			i++;
-			limit--;
-			if (checkForAdjust(obj, locomotorSet, isHuman, i,j, layer, iRadius, center, dest, groupDest)) {
-				return true;
-			}
-		}
-		for (count = delta; count>0; count--) {
-			j++;
-			limit--;
-			if (checkForAdjust(obj, locomotorSet, isHuman, i,j, layer, iRadius, center, dest, groupDest)) {
-				return true;
-			}
-		}
-		delta++;
-		for (count = delta; count>0; count--) {
-			i--;
-			limit--;
-			if (checkForAdjust(obj, locomotorSet, isHuman, i,j, layer, iRadius, center, dest, groupDest)) {
-				return true;
-			}
-		}
-		for (count = delta; count>0; count--) {
-			j--;
-			limit--;
-			if (checkForAdjust(obj, locomotorSet, isHuman, i,j, layer, iRadius, center, dest, groupDest)) {
-				return true;
-			}
-		}
-		delta++;
+	 	for (Int dir = 0; dir < 4; dir++) {
+	 		for (Int count = segmentLength; count>0; count--) {
+	 			i+=directions[dir].x;
+	 			j+=directions[dir].y;
+	 			limit--;
+	 			if (checkForAdjust(obj, locomotorSet, isHuman, i, j, layer, iRadius, center, dest, groupDest)) {
+	 				return true;
+	 			}
+	 		}
+	 		if (dir & 1) {
+	 			segmentLength++;
+	 		}
+	 	}
 	}
+
 	if (groupDest) {
 		// Didn't work, so just do simple adjust.
 		return(adjustDestination(obj, locomotorSet, dest, nullptr));

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5562,19 +5562,19 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 	Int segmentLength = 1;
 	const ICoord2D directions[4] = { {1, 0}, {0, 1}, {-1, 0}, {0, -1} };
 	while (limit>0) {
-	 	for (Int dir = 0; dir < 4; dir++) {
-	 		for (Int count = segmentLength; count>0; count--) {
-	 			i+=directions[dir].x;
-	 			j+=directions[dir].y;
-	 			limit--;
-	 			if (checkForAdjust(obj, locomotorSet, isHuman, i, j, layer, iRadius, center, dest, groupDest)) {
-	 				return true;
-	 			}
-	 		}
-	 		if (dir & 1) {
-	 			segmentLength++;
-	 		}
-	 	}
+		for (Int dir = 0; dir < 4; dir++) {
+			for (Int count = segmentLength; count>0; count--) {
+				i+=directions[dir].x;
+				j+=directions[dir].y;
+				limit--;
+				if (checkForAdjust(obj, locomotorSet, isHuman, i, j, layer, iRadius, center, dest, groupDest)) {
+					return true;
+				}
+			}
+			if (dir & 1) {
+				segmentLength++;
+			}
+		}
 	}
 
 	if (groupDest) {

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5550,13 +5550,13 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 		return true;
 	}
 
-	// TheSuperHackers @info Expanding clockwise spiral search around center cell C. Each full lap walks right→down→left→up.
-	// After every pair of directions (right+down, then left+up) length of the segment grows by 1.
+	// TheSuperHackers @info Expanding counter-clockwise spiral search around center cell C. Each full lap walks right->up->left->down.
+	// After every pair of directions (right+up, then left+down) length of the segment grows by 1.
 	//
-	//    6  7  8  9
-	//    5  C  1  10
-	//    4  3  2  11
 	//    <------  12
+	//    4  3  2  11
+	//    5  C  1  10
+	//    6  7  8  9
 	//
 	Int limit = MAX_ADJUSTMENT_CELL_COUNT;
 	Int segmentLength = 1;


### PR DESCRIPTION
* Relates to #2296

This change simplifies code in `Pathfinder::adjustDestination` and adds information about the way that path finding cells are searched.

As noted in linked item `MAX_ADJUSTMENT_CELL_COUNT = 400` is the current limit for the amount of `checkForAdjust` calls, which can get expensive. And actually there is a minor bug because limit is only checked in the outer while loop it can overshoot that target, so at most we will see around 420 checks.