### PR TITLE
perf(pathfinder): Skip redundant path-exists check in Pathfinder::checkForAdjust()

### DIFF
--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5385,18 +5385,15 @@ Bool Pathfinder::checkForAdjust(Object *obj, const LocomotorSet& locomotorSet, B
 	}
 	if (checkDestination(obj, cellX, cellY, layer, iRadius, center)) {
 		adjustCoordToCell(cellX, cellY,  center, adjustDest, cellP->getLayer());
-		Bool pathExists;
 		Bool adjustedPathExists;
 		if (obj->isKindOf(KINDOF_AIRCRAFT)) {
-			pathExists = true;
 			adjustedPathExists = true;
 		}	else {
-			pathExists = clientSafeQuickDoesPathExist( locomotorSet, obj->getPosition(), dest);
-			adjustedPathExists = clientSafeQuickDoesPathExist( locomotorSet, obj->getPosition(), &adjustDest);
-			if (!pathExists) {
-				if (clientSafeQuickDoesPathExist( locomotorSet, dest, &adjustDest))	{
- 					adjustedPathExists = true;
-				}
+			Bool pathExists = clientSafeQuickDoesPathExist( locomotorSet, obj->getPosition(), dest);
+			if (!pathExists && clientSafeQuickDoesPathExist( locomotorSet, dest, &adjustDest)) {
+				adjustedPathExists = true;
+			} else {
+				adjustedPathExists = clientSafeQuickDoesPathExist( locomotorSet, obj->getPosition(), &adjustDest);
 			}
 		}
 		if ( adjustedPathExists	) {


### PR DESCRIPTION
In `Pathfinder::checkForAdjust` there could be an unnecessary computation of `adjustedPathExists` because it could be overwritten later.

The gain is minor: `adjustedPathExists` takes around 200 +- 150 ns, but can be called many times in an update frame