### PR TITLE
bugfix(dozeraiupdate): Fix issue where builders could resume completed tasks after being disabled

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Module.h
+++ b/Generals/Code/GameEngine/Include/Common/Module.h
@@ -248,6 +248,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 	virtual void onCapture( Player *oldOwner, Player *newOwner ) { }
+	virtual void onDisabledEdge( Bool nowDisabled ) { }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -141,6 +141,7 @@ public:
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requrested task
 	virtual void cancelTask( DozerTask task ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine
@@ -242,6 +243,7 @@ public:
 	virtual void newTask( DozerTask task, Object *target ) override;	///< set a desire to do the requrested task
 	virtual void cancelTask( DozerTask task ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void setPreviousTask(DozerTask task) override;					///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -212,6 +212,7 @@ public:
 	virtual const DozerAIInterface* getDozerAIInterface() const override {return this;}
 
 	virtual void onDelete() override;
+	virtual void onDisabledEdge(Bool nowDisabled) override;
 
 	//
 	// module data methods ... this is LAME, multiple inheritance off an interface with replicated

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -139,7 +139,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requrested task
-	virtual void cancelTask( DozerTask task ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
@@ -242,7 +242,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object *target ) override;	///< set a desire to do the requrested task
-	virtual void cancelTask( DozerTask task ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;					///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -139,7 +139,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requrested task
-	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) = 0;	///< cancel this task from the queue, if it's the current task the dozer will stop working on it. Can remember the cancelled task for resumption.
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -143,6 +143,7 @@ public:
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
+	virtual void clearPreviousTask() = 0;										///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) = 0;					///< set a dozer task as successfully completed
@@ -246,6 +247,7 @@ public:
 	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;					///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
+	virtual void clearPreviousTask() override;									///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -141,9 +141,6 @@ public:
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requrested task
 	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) = 0;	///< cancel this task from the queue, if it's the current task the dozer will stop working on it. Can remember the cancelled task for resumption.
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
-	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
-	virtual void clearPreviousTask() = 0;										///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) = 0;					///< set a dozer task as successfully completed
@@ -245,9 +242,6 @@ public:
 	virtual void newTask( DozerTask task, Object *target ) override;	///< set a desire to do the requrested task
 	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void setPreviousTask(DozerTask task) override;					///< set the previous task
-	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
-	virtual void clearPreviousTask() override;									///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed
@@ -282,6 +276,10 @@ protected:
 
 	virtual void privateRepair( Object *obj, CommandSourceType cmdSource ) override;	///< repair the target
 	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource ) override;  ///< resume construction on obj
+
+	virtual void setPreviousTask(DozerTask task);					///< set the previous task
+	virtual void resumePreviousTask();									///< resume the previous task if there was one
+	virtual void clearPreviousTask();									///< clear the previous task
 
 	struct DozerTaskInfo
 	{

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -157,9 +157,6 @@ public:
 	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requrested task
 	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;	///< cancel this task from the queue, if it's the current task the dozer will stop working on it. Can remember the cancelled task for resumption.
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
-	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
-	virtual void clearPreviousTask() override;									///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed
@@ -266,6 +263,10 @@ protected:
 	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource ) override;  ///< resume construction on obj
 	virtual void privateDock( Object *obj, CommandSourceType cmdSource ) override;
 	virtual void privateIdle(CommandSourceType cmdSource) override;						///< Enter idle state.
+
+	virtual void setPreviousTask(DozerTask task);				///< set the previous task
+	virtual void resumePreviousTask();									///< resume the previous task if there was one
+	virtual void clearPreviousTask();									///< clear the previous task
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -159,6 +159,7 @@ public:
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
+	virtual void clearPreviousTask() override;									///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -132,6 +132,7 @@ public:
 
 	// Dozer side
 	virtual void onDelete() override;
+	virtual void onDisabledEdge(Bool nowDisabled) override;
 
 	virtual Real getRepairHealthPerSecond() const override;	///< get health to repair per second
 	virtual Real getBoredTime() const override;							///< how long till we're bored

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -155,7 +155,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requrested task
-	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;	///< cancel this task from the queue, if it's the current task the dozer will stop working on it. Can remember the cancelled task for resumption.
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -155,7 +155,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requrested task
-	virtual void cancelTask( DozerTask task ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -156,6 +156,7 @@ public:
 	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requrested task
 	virtual void cancelTask( DozerTask task ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1985,10 +1985,6 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 				sound.setPosition( getPosition() );
 				TheAudio->addAudioEvent( &sound );
 			}
-
-			DozerAIInterface* dozerAI = getAI() ? getAI()->getDozerAIInterface() : nullptr;
-			if (dozerAI)
-				dozerAI->setPreviousTask(dozerAI->getCurrentTask());
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1985,6 +1985,10 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 				sound.setPosition( getPosition() );
 				TheAudio->addAudioEvent( &sound );
 			}
+
+			DozerAIInterface* dozerAI = getAI() ? getAI()->getDozerAIInterface() : nullptr;
+			if (dozerAI)
+				dozerAI->setPreviousTask(dozerAI->getCurrentTask());
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3415,6 +3415,10 @@ void Object::friend_adjustPowerForPlayer( Bool incoming )
 //-------------------------------------------------------------------------------------------------
 void Object::onDisabledEdge(Bool becomingDisabled)
 {
+	// rip through the behavior modules and call the onDisabledEdge for any modules that care
+	for( BehaviorModule **module = m_behaviors; *module; ++module )
+		(*module)->onDisabledEdge( becomingDisabled );
+
 	Player* controller = getControllingPlayer();
 	// can be called during game teardown, thus controller can be null
 	if (controller)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2087,7 +2087,7 @@ void DozerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2099,6 +2099,11 @@ void DozerAIUpdate::resumePreviousTask()
 			newTask(m_previousTask, target);
 	}
 
+	clearPreviousTask();
+}
+
+void DozerAIUpdate::clearPreviousTask()
+{
 	m_previousTask = DOZER_TASK_INVALID;
 	m_previousTaskInfo = DozerTaskInfo();
 }
@@ -2159,8 +2164,7 @@ void DozerAIUpdate::internalTaskComplete( DozerTask task )
 	m_task[ task ].m_targetObjectID = INVALID_ID;
 	m_task[ task ].m_taskOrderFrame = 0;
 
-	m_previousTask = DOZER_TASK_INVALID;
-	m_previousTaskInfo = DozerTaskInfo();
+	clearPreviousTask();
 
 	// remove dock point info for this task
 	for( Int i = 0; i < DOZER_NUM_DOCK_POINTS; i++ )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2045,8 +2045,10 @@ void DozerAIUpdate::newTask( DozerTask task, Object *target )
 	* re-evaluate what it wants to do if it was working on the task being
 	* cancelled */
 //-------------------------------------------------------------------------------------------------
-void DozerAIUpdate::cancelTask( DozerTask task )
+void DozerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 {
+	if (rememberTask)
+		setPreviousTask(task);
 
 	// clear the order
 	internalCancelTask( task );
@@ -2327,15 +2329,12 @@ void DozerAIUpdate::onDisabledEdge(Bool nowDisabled)
 		{
 			// TheSuperHackers @info We want to explicitly define what types to resume from as some types
 			// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
-			Bool attemptToResumeTask = getObject()->isDisabledByType(DISABLED_EMP) ||
+			Bool rememberTask = getObject()->isDisabledByType(DISABLED_EMP) ||
 				getObject()->isDisabledByType(DISABLED_HACKED) ||
 				getObject()->isDisabledByType(DISABLED_SUBDUED) ||
 				getObject()->isDisabledByType(DISABLED_UNDERPOWERED);
 
-			if (attemptToResumeTask)
-				setPreviousTask(getCurrentTask());
-
-			cancelTask(getCurrentTask());
+			cancelTask(getCurrentTask(), rememberTask);
 		}
 	}
 	else

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2015,7 +2015,13 @@ void DozerAIUpdate::newTask( DozerTask task, Object *target )
 		// multiple dozers/workers to double up on construction efforts
 		//
 		if( task == DOZER_TASK_BUILD )
+		{
+			// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
+			if (target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+				return;
+
 			target->setBuilder( me );
+		}
 
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].valid			= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].location	= position;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2088,7 +2088,7 @@ void DozerAIUpdate::resumePreviousTask()
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
 		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-			newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
+			newTask(m_previousTask, target);
 	}
 
 	m_previousTask = DOZER_TASK_INVALID;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2063,6 +2063,8 @@ void DozerAIUpdate::cancelAllTasks()
 	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
 		internalCancelTask((DozerTask)task);
 
+	clearPreviousTask();
+
 	m_dozerMachine->resetToDefaultState();
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2526,7 +2526,7 @@ void DozerAIUpdate::xfer( Xfer *xfer )
 	xfer->xferSnapshot(m_dozerMachine);
 	xfer->xferUser(&m_currentTask, sizeof(m_currentTask));
 
-	if (currentVersion >= 2)
+	if (version >= 2)
 	{
 		xfer->xferUser(&m_previousTask, sizeof(m_previousTask));
 		xfer->xferUser(&m_previousTaskInfo, sizeof(m_previousTaskInfo));

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2087,7 +2087,7 @@ void DozerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (target && target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+		if (target && !target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			return;
 
 		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2049,6 +2049,8 @@ void DozerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 {
 	if (rememberTask)
 		setPreviousTask(task);
+	else
+		clearPreviousTask();
 
 	// clear the order
 	internalCancelTask( task );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2087,13 +2087,12 @@ void DozerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (target && !target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-			return;
-
-		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
-		m_previousTask = DOZER_TASK_INVALID;
-		m_previousTaskInfo = DozerTaskInfo();
+		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+			newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
 	}
+
+	m_previousTask = DOZER_TASK_INVALID;
+	m_previousTaskInfo = DozerTaskInfo();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2084,7 +2084,6 @@ void DozerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_INVALID)
 		return;
 
-	// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2090,6 +2090,12 @@ void DozerAIUpdate::resumePreviousTask()
 		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
+	else if (m_previousTask == DOZER_TASK_REPAIR)
+	{
+		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
+		if (target)
+			newTask(m_previousTask, target);
+	}
 
 	m_previousTask = DOZER_TASK_INVALID;
 	m_previousTaskInfo = DozerTaskInfo();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2092,7 +2092,7 @@ void DozerAIUpdate::resumePreviousTask()
 		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
-	else if (m_previousTask == DOZER_TASK_REPAIR)
+	else if (m_previousTask == DOZER_TASK_REPAIR || m_previousTask == DOZER_TASK_FORTIFY)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
 		if (target)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2015,13 +2015,7 @@ void DozerAIUpdate::newTask( DozerTask task, Object *target )
 		// multiple dozers/workers to double up on construction efforts
 		//
 		if( task == DOZER_TASK_BUILD )
-		{
-			// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
-			if (target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
-				return;
-
 			target->setBuilder( me );
-		}
 
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].valid			= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].location	= position;
@@ -2087,8 +2081,16 @@ void DozerAIUpdate::setPreviousTask(DozerTask task)
 //-------------------------------------------------------------------------------------------------
 void DozerAIUpdate::resumePreviousTask()
 {
-	if (m_previousTask != DOZER_TASK_INVALID)
+	if (m_previousTask == DOZER_TASK_INVALID)
+		return;
+
+	// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
+	if (m_previousTask == DOZER_TASK_BUILD)
 	{
+		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
+		if (target && target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+			return;
+
 		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
 		m_previousTask = DOZER_TASK_INVALID;
 		m_previousTaskInfo = DozerTaskInfo();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2071,6 +2071,18 @@ void DozerAIUpdate::cancelAllTasks()
 }
 
 //-------------------------------------------------------------------------------------------------
+/** Set the previous task so that we may return to it if we become temporarily incapacitated */
+//-------------------------------------------------------------------------------------------------
+void DozerAIUpdate::setPreviousTask(DozerTask task)
+{
+	if (task == DOZER_TASK_INVALID)
+		return;
+
+	m_previousTask = task;
+	m_previousTaskInfo = m_task[task];
+}
+
+//-------------------------------------------------------------------------------------------------
 /** Attempt to resume the previous task */
 //-------------------------------------------------------------------------------------------------
 void DozerAIUpdate::resumePreviousTask()
@@ -2163,9 +2175,6 @@ void DozerAIUpdate::internalCancelTask( DozerTask task )
 
 	// call the single method that gets called for completing and canceling tasks
 	internalTaskCompleteOrCancelled( task );
-
-	m_previousTask = task;
-	m_previousTaskInfo = m_task[task];
 
 	// remove the info for this task
 	m_task[ task ].m_targetObjectID = INVALID_ID;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2318,6 +2318,35 @@ void DozerAIUpdate::onDelete()
 	}
 }
 
+void DozerAIUpdate::onDisabledEdge(Bool nowDisabled)
+{
+	if (nowDisabled)
+	{
+		// Have to say goodbye to the thing we might be building or repairing so someone else can do it.
+		if (getCurrentTask() != DOZER_TASK_INVALID)
+		{
+			// TheSuperHackers @info We want to explicitly define what types to resume from as some types
+			// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
+			Bool attemptToResumeTask = getObject()->isDisabledByType(DISABLED_EMP) ||
+				getObject()->isDisabledByType(DISABLED_HACKED) ||
+				getObject()->isDisabledByType(DISABLED_SUBDUED) ||
+				getObject()->isDisabledByType(DISABLED_UNDERPOWERED);
+
+			if (attemptToResumeTask)
+				setPreviousTask(getCurrentTask());
+
+			cancelTask(getCurrentTask());
+		}
+	}
+	else
+	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Stubbjax 17/11/2025 Resume previous task when re-enabled.
+		resumePreviousTask();
+#endif
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Get the most recently issued task */
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2062,10 +2062,10 @@ void DozerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 
 void DozerAIUpdate::cancelAllTasks()
 {
+	clearPreviousTask();
+
 	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
 		internalCancelTask((DozerTask)task);
-
-	clearPreviousTask();
 
 	m_dozerMachine->resetToDefaultState();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2078,6 +2078,8 @@ void DozerAIUpdate::setPreviousTask(DozerTask task)
 	if (task == DOZER_TASK_INVALID)
 		return;
 
+	DEBUG_ASSERTCRASH(m_previousTask == DOZER_TASK_INVALID, ("Dozer already remembers a previous task"));
+
 	m_previousTask = task;
 	m_previousTaskInfo = m_task[task];
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -711,6 +711,18 @@ void WorkerAIUpdate::cancelAllTasks()
 }
 
 //-------------------------------------------------------------------------------------------------
+/** Set the previous task so that we may return to it if we become temporarily incapacitated */
+//-------------------------------------------------------------------------------------------------
+void WorkerAIUpdate::setPreviousTask(DozerTask task)
+{
+	if (task == DOZER_TASK_INVALID)
+		return;
+
+	m_previousTask = task;
+	m_previousTaskInfo = m_task[task];
+}
+
+//-------------------------------------------------------------------------------------------------
 /** Attempt to resume the previous task */
 //-------------------------------------------------------------------------------------------------
 void WorkerAIUpdate::resumePreviousTask()
@@ -803,9 +815,6 @@ void WorkerAIUpdate::internalCancelTask( DozerTask task )
 
 	// call the single method that gets called for completing and canceling tasks
 	internalTaskCompleteOrCancelled( task );
-
-	m_previousTask = task;
-	m_previousTaskInfo = m_task[task];
 
 	// remove the info for this task
 	m_task[ task ].m_targetObjectID = INVALID_ID;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -727,13 +727,12 @@ void WorkerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (target && !target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-			return;
-
-		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
-		m_previousTask = DOZER_TASK_INVALID;
-		m_previousTaskInfo = DozerTaskInfo();
+		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+			newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
 	}
+
+	m_previousTask = DOZER_TASK_INVALID;
+	m_previousTaskInfo = DozerTaskInfo();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -724,7 +724,6 @@ void WorkerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_INVALID)
 		return;
 
-	// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -703,6 +703,8 @@ void WorkerAIUpdate::cancelAllTasks()
 	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
 		internalCancelTask((DozerTask)task);
 
+	clearPreviousTask();
+
 	m_dozerMachine->resetToDefaultState();
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -730,6 +730,12 @@ void WorkerAIUpdate::resumePreviousTask()
 		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
+	else if (m_previousTask == DOZER_TASK_REPAIR)
+	{
+		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
+		if (target)
+			newTask(m_previousTask, target);
+	}
 
 	m_previousTask = DOZER_TASK_INVALID;
 	m_previousTaskInfo = DozerTaskInfo();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -727,7 +727,7 @@ void WorkerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (target && target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+		if (target && !target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			return;
 
 		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -728,7 +728,7 @@ void WorkerAIUpdate::resumePreviousTask()
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
 		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-			newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
+			newTask(m_previousTask, target);
 	}
 
 	m_previousTask = DOZER_TASK_INVALID;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -644,13 +644,7 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 		// multiple dozers/workers to double up on construction efforts
 		//
 		if( task == DOZER_TASK_BUILD )
-		{
-			// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
-			if (target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
-				return;
-
 			target->setBuilder( me );
-		}
 
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].valid			= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].location	= position;
@@ -727,8 +721,16 @@ void WorkerAIUpdate::setPreviousTask(DozerTask task)
 //-------------------------------------------------------------------------------------------------
 void WorkerAIUpdate::resumePreviousTask()
 {
-	if (m_previousTask != DOZER_TASK_INVALID)
+	if (m_previousTask == DOZER_TASK_INVALID)
+		return;
+
+	// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
+	if (m_previousTask == DOZER_TASK_BUILD)
 	{
+		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
+		if (target && target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+			return;
+
 		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
 		m_previousTask = DOZER_TASK_INVALID;
 		m_previousTaskInfo = DozerTaskInfo();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -644,7 +644,13 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 		// multiple dozers/workers to double up on construction efforts
 		//
 		if( task == DOZER_TASK_BUILD )
+		{
+			// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
+			if (target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+				return;
+
 			target->setBuilder( me );
+		}
 
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].valid			= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].location	= position;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -689,6 +689,8 @@ void WorkerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 {
 	if (rememberTask)
 		setPreviousTask(task);
+	else
+		clearPreviousTask();
 
 	// clear the order
 	internalCancelTask( task );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -1478,7 +1478,7 @@ void WorkerAIUpdate::xfer( Xfer *xfer )
 	xfer->xferSnapshot(m_dozerMachine);
 	xfer->xferUser(&m_currentTask, sizeof(m_currentTask));
 
-	if (currentVersion >= 2)
+	if (version >= 2)
 	{
 		xfer->xferUser(&m_previousTask, sizeof(m_previousTask));
 		xfer->xferUser(&m_previousTaskInfo, sizeof(m_previousTaskInfo));

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -732,7 +732,7 @@ void WorkerAIUpdate::resumePreviousTask()
 		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
-	else if (m_previousTask == DOZER_TASK_REPAIR)
+	else if (m_previousTask == DOZER_TASK_REPAIR || m_previousTask == DOZER_TASK_FORTIFY)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
 		if (target)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -727,7 +727,7 @@ void WorkerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -685,8 +685,10 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 	* re-evaluate what it wants to do if it was working on the task being
 	* cancelled */
 //-------------------------------------------------------------------------------------------------
-void WorkerAIUpdate::cancelTask( DozerTask task )
+void WorkerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 {
+	if (rememberTask)
+		setPreviousTask(task);
 
 	// clear the order
 	internalCancelTask( task );
@@ -955,15 +957,12 @@ void WorkerAIUpdate::onDisabledEdge(Bool nowDisabled)
 		{
 			// TheSuperHackers @info We want to explicitly define what types to resume from as some types
 			// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
-			Bool attemptToResumeTask = getObject()->isDisabledByType(DISABLED_EMP) ||
+			Bool rememberTask = getObject()->isDisabledByType(DISABLED_EMP) ||
 				getObject()->isDisabledByType(DISABLED_HACKED) ||
 				getObject()->isDisabledByType(DISABLED_SUBDUED) ||
 				getObject()->isDisabledByType(DISABLED_UNDERPOWERED);
 
-			if (attemptToResumeTask)
-				setPreviousTask(getCurrentTask());
-
-			cancelTask(getCurrentTask());
+			cancelTask(getCurrentTask(), rememberTask);
 		}
 	}
 	else

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -946,6 +946,35 @@ void WorkerAIUpdate::onDelete()
 	}
 }
 
+void WorkerAIUpdate::onDisabledEdge(Bool nowDisabled)
+{
+	if (nowDisabled)
+	{
+		// Have to say goodbye to the thing we might be building or repairing so someone else can do it.
+		if (getCurrentTask() != DOZER_TASK_INVALID)
+		{
+			// TheSuperHackers @info We want to explicitly define what types to resume from as some types
+			// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
+			Bool attemptToResumeTask = getObject()->isDisabledByType(DISABLED_EMP) ||
+				getObject()->isDisabledByType(DISABLED_HACKED) ||
+				getObject()->isDisabledByType(DISABLED_SUBDUED) ||
+				getObject()->isDisabledByType(DISABLED_UNDERPOWERED);
+
+			if (attemptToResumeTask)
+				setPreviousTask(getCurrentTask());
+
+			cancelTask(getCurrentTask());
+		}
+	}
+	else
+	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Stubbjax 17/11/2025 Resume previous task when re-enabled.
+		resumePreviousTask();
+#endif
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Get the most recently issued task */
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -739,6 +739,11 @@ void WorkerAIUpdate::resumePreviousTask()
 			newTask(m_previousTask, target);
 	}
 
+	clearPreviousTask();
+}
+
+void WorkerAIUpdate::clearPreviousTask()
+{
 	m_previousTask = DOZER_TASK_INVALID;
 	m_previousTaskInfo = DozerTaskInfo();
 }
@@ -799,8 +804,7 @@ void WorkerAIUpdate::internalTaskComplete( DozerTask task )
 	m_task[ task ].m_targetObjectID = INVALID_ID;
 	m_task[ task ].m_taskOrderFrame = 0;
 
-	m_previousTask = DOZER_TASK_INVALID;
-	m_previousTaskInfo = DozerTaskInfo();
+	clearPreviousTask();
 
 	// remove dock point info for this task
 	for( Int i = 0; i < DOZER_NUM_DOCK_POINTS; i++ )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -702,10 +702,10 @@ void WorkerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 
 void WorkerAIUpdate::cancelAllTasks()
 {
+	clearPreviousTask();
+
 	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
 		internalCancelTask((DozerTask)task);
-
-	clearPreviousTask();
 
 	m_dozerMachine->resetToDefaultState();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -718,6 +718,8 @@ void WorkerAIUpdate::setPreviousTask(DozerTask task)
 	if (task == DOZER_TASK_INVALID)
 		return;
 
+	DEBUG_ASSERTCRASH(m_previousTask == DOZER_TASK_INVALID, ("Worker already remembers a previous task"));
+
 	m_previousTask = task;
 	m_previousTaskInfo = m_task[task];
 }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -141,9 +141,6 @@ public:
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requested task
 	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) = 0;	///< cancel this task from the queue, if it's the current task the dozer will stop working on it. Can remember the cancelled task for resumption.
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
-	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
-  virtual void clearPreviousTask() = 0;										///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) = 0;					///< set a dozer task as successfully completed
@@ -245,9 +242,6 @@ public:
 	virtual void newTask( DozerTask task, Object *target ) override;	///< set a desire to do the requested task
 	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void setPreviousTask(DozerTask task) override;					///< set the previous task
-	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
-	virtual void clearPreviousTask() override;									///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed
@@ -282,6 +276,10 @@ protected:
 
 	virtual void privateRepair( Object *obj, CommandSourceType cmdSource ) override;	///< repair the target
 	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource ) override;  ///< resume construction on obj
+
+	virtual void setPreviousTask(DozerTask task);					///< set the previous task
+	virtual void resumePreviousTask();									///< resume the previous task if there was one
+	virtual void clearPreviousTask();									///< clear the previous task
 
 	struct DozerTaskInfo
 	{

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -139,7 +139,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requested task
-	virtual void cancelTask( DozerTask task ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
@@ -242,7 +242,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object *target ) override;	///< set a desire to do the requested task
-	virtual void cancelTask( DozerTask task ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;					///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -143,6 +143,7 @@ public:
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
+  virtual void clearPreviousTask() = 0;										///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) = 0;					///< set a dozer task as successfully completed
@@ -246,6 +247,7 @@ public:
 	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;					///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
+	virtual void clearPreviousTask() override;									///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -141,6 +141,7 @@ public:
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requested task
 	virtual void cancelTask( DozerTask task ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine
@@ -242,6 +243,7 @@ public:
 	virtual void newTask( DozerTask task, Object *target ) override;	///< set a desire to do the requested task
 	virtual void cancelTask( DozerTask task ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void setPreviousTask(DozerTask task) override;					///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -212,6 +212,7 @@ public:
 	virtual const DozerAIInterface* getDozerAIInterface() const override {return this;}
 
 	virtual void onDelete() override;
+	virtual void onDisabledEdge(Bool nowDisabled) override;
 
 	//
 	// module data methods ... this is LAME, multiple inheritance off an interface with replicated

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -139,7 +139,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requested task
-	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) = 0;	///< cancel this task from the queue, if it's the current task the dozer will stop working on it. Can remember the cancelled task for resumption.
 	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) = 0;						///< set the previous task
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -135,6 +135,7 @@ public:
 
 	// Dozer side
 	virtual void onDelete() override;
+	virtual void onDisabledEdge(Bool nowDisabled) override;
 
 	virtual Real getRepairHealthPerSecond() const override;	///< get health to repair per second
 	virtual Real getBoredTime() const override;							///< how long till we're bored

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -162,6 +162,7 @@ public:
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
+  virtual void clearPreviousTask() override;									///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -159,6 +159,7 @@ public:
 	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requested task
 	virtual void cancelTask( DozerTask task ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -158,7 +158,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requested task
-	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;	///< cancel this task from the queue, if it's the current task the dozer will stop working on it. Can remember the cancelled task for resumption.
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -160,9 +160,6 @@ public:
 	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requested task
 	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;	///< cancel this task from the queue, if it's the current task the dozer will stop working on it. Can remember the cancelled task for resumption.
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
-	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
-  virtual void clearPreviousTask() override;									///< clear the previous task
 
 	// internal methods to manage behavior from within the dozer state machine
 	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed
@@ -272,6 +269,10 @@ protected:
 	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource ) override;  ///< resume construction on obj
 	virtual void privateDock( Object *obj, CommandSourceType cmdSource ) override;
 	virtual void privateIdle(CommandSourceType cmdSource) override;						///< Enter idle state.
+
+	virtual void setPreviousTask(DozerTask task);				///< set the previous task
+	virtual void resumePreviousTask();									///< resume the previous task if there was one
+	virtual void clearPreviousTask();									///< clear the previous task
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -158,7 +158,7 @@ public:
 
 	// task actions
 	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requested task
-	virtual void cancelTask( DozerTask task ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelTask( DozerTask task, Bool rememberTask = false ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
 	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void setPreviousTask(DozerTask task) override;				///< set the previous task
 	virtual void resumePreviousTask() override;									///< resume the previous task if there was one

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3908,36 +3908,6 @@ void Object::onDisabledEdge(Bool becomingDisabled)
 	for( BehaviorModule **module = m_behaviors; *module; ++module )
 		(*module)->onDisabledEdge( becomingDisabled );
 
-	DozerAIInterface *dozerAI = getAI() ? getAI()->getDozerAIInterface() : nullptr;
-	if (dozerAI)
-	{
-		if (becomingDisabled)
-		{
-			// Have to say goodbye to the thing we might be building or repairing so someone else can do it.
-			if (dozerAI->getCurrentTask() != DOZER_TASK_INVALID)
-			{
-				// TheSuperHackers @info We want to explicitly define what types to resume from as some types
-				// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
-				Bool attemptToResumeTask = isDisabledByType(DISABLED_EMP) ||
-					isDisabledByType(DISABLED_HACKED) ||
-					isDisabledByType(DISABLED_SUBDUED) ||
-					isDisabledByType(DISABLED_UNDERPOWERED);
-
-				if (attemptToResumeTask)
-					dozerAI->setPreviousTask(dozerAI->getCurrentTask());
-
-				dozerAI->cancelTask(dozerAI->getCurrentTask());
-			}
-		}
-		else
-		{
-#if !RETAIL_COMPATIBLE_CRC
-			// TheSuperHackers @bugfix Stubbjax 17/11/2025 Resume previous task when re-enabled.
-			dozerAI->resumePreviousTask();
-#endif
-		}
-	}
-
 	Player* controller = getControllingPlayer();
 	// can be called during game teardown, thus controller can be null
 	if (controller)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2196,6 +2196,10 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 				sound.setPosition( getPosition() );
 				TheAudio->addAudioEvent( &sound );
 			}
+
+			DozerAIInterface* dozerAI = getAI() ? getAI()->getDozerAIInterface() : nullptr;
+			if (dozerAI)
+				dozerAI->setPreviousTask(dozerAI->getCurrentTask());
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2196,10 +2196,6 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 				sound.setPosition( getPosition() );
 				TheAudio->addAudioEvent( &sound );
 			}
-
-			DozerAIInterface* dozerAI = getAI() ? getAI()->getDozerAIInterface() : nullptr;
-			if (dozerAI)
-				dozerAI->setPreviousTask(dozerAI->getCurrentTask());
 		}
 	}
 
@@ -3919,7 +3915,19 @@ void Object::onDisabledEdge(Bool becomingDisabled)
 		{
 			// Have to say goodbye to the thing we might be building or repairing so someone else can do it.
 			if (dozerAI->getCurrentTask() != DOZER_TASK_INVALID)
+			{
+				// TheSuperHackers @info We want to explicitly define what types to resume from as some types
+				// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
+				Bool attemptToResumeTask = isDisabledByType(DISABLED_EMP) ||
+					isDisabledByType(DISABLED_HACKED) ||
+					isDisabledByType(DISABLED_SUBDUED) ||
+					isDisabledByType(DISABLED_UNDERPOWERED);
+
+				if (attemptToResumeTask)
+					dozerAI->setPreviousTask(dozerAI->getCurrentTask());
+
 				dozerAI->cancelTask(dozerAI->getCurrentTask());
+			}
 		}
 		else
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2076,6 +2076,18 @@ void DozerAIUpdate::cancelAllTasks()
 }
 
 //-------------------------------------------------------------------------------------------------
+/** Set the previous task so that we may return to it if we become temporarily incapacitated */
+//-------------------------------------------------------------------------------------------------
+void DozerAIUpdate::setPreviousTask(DozerTask task)
+{
+	if (task == DOZER_TASK_INVALID)
+		return;
+
+	m_previousTask = task;
+	m_previousTaskInfo = m_task[task];
+}
+
+//-------------------------------------------------------------------------------------------------
 /** Attempt to resume the previous task */
 //-------------------------------------------------------------------------------------------------
 void DozerAIUpdate::resumePreviousTask()
@@ -2168,9 +2180,6 @@ void DozerAIUpdate::internalCancelTask( DozerTask task )
 
 	// call the single method that gets called for completing and canceling tasks
 	internalTaskCompleteOrCancelled( task );
-
-	m_previousTask = task;
-	m_previousTaskInfo = m_task[task];
 
 	// remove the info for this task
 	m_task[ task ].m_targetObjectID = INVALID_ID;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2054,6 +2054,8 @@ void DozerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 {
 	if (rememberTask)
 		setPreviousTask(task);
+	else
+		clearPreviousTask();
 
 	// clear the order
 	internalCancelTask( task );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2092,7 +2092,7 @@ void DozerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (target && target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+		if (target && !target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			return;
 
 		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2050,8 +2050,10 @@ void DozerAIUpdate::newTask( DozerTask task, Object *target )
 	* re-evaluate what it wants to do if it was working on the task being
 	* cancelled */
 //-------------------------------------------------------------------------------------------------
-void DozerAIUpdate::cancelTask( DozerTask task )
+void DozerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 {
+	if (rememberTask)
+		setPreviousTask(task);
 
 	// clear the order
 	internalCancelTask( task );
@@ -2332,15 +2334,12 @@ void DozerAIUpdate::onDisabledEdge(Bool nowDisabled)
 		{
 			// TheSuperHackers @info We want to explicitly define what types to resume from as some types
 			// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
-			Bool attemptToResumeTask = getObject()->isDisabledByType(DISABLED_EMP) ||
+			Bool rememberTask = getObject()->isDisabledByType(DISABLED_EMP) ||
 				getObject()->isDisabledByType(DISABLED_HACKED) ||
 				getObject()->isDisabledByType(DISABLED_SUBDUED) ||
 				getObject()->isDisabledByType(DISABLED_UNDERPOWERED);
 
-			if (attemptToResumeTask)
-				setPreviousTask(getCurrentTask());
-
-			cancelTask(getCurrentTask());
+			cancelTask(getCurrentTask(), rememberTask);
 		}
 	}
 	else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2020,13 +2020,7 @@ void DozerAIUpdate::newTask( DozerTask task, Object *target )
 		// multiple dozers/workers to double up on construction efforts
 		//
 		if( task == DOZER_TASK_BUILD )
-		{
-			// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
-			if (target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
-				return;
-
 			target->setBuilder( me );
-		}
 
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].valid			= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].location	= position;
@@ -2092,8 +2086,16 @@ void DozerAIUpdate::setPreviousTask(DozerTask task)
 //-------------------------------------------------------------------------------------------------
 void DozerAIUpdate::resumePreviousTask()
 {
-	if (m_previousTask != DOZER_TASK_INVALID)
+	if (m_previousTask == DOZER_TASK_INVALID)
+		return;
+
+	// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
+	if (m_previousTask == DOZER_TASK_BUILD)
 	{
+		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
+		if (target && target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+			return;
+
 		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
 		m_previousTask = DOZER_TASK_INVALID;
 		m_previousTaskInfo = DozerTaskInfo();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2092,13 +2092,12 @@ void DozerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (target && !target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-			return;
-
-		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
-		m_previousTask = DOZER_TASK_INVALID;
-		m_previousTaskInfo = DozerTaskInfo();
+		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+			newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
 	}
+
+	m_previousTask = DOZER_TASK_INVALID;
+	m_previousTaskInfo = DozerTaskInfo();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2089,7 +2089,6 @@ void DozerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_INVALID)
 		return;
 
-	// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2097,7 +2097,7 @@ void DozerAIUpdate::resumePreviousTask()
 		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
-	else if (m_previousTask == DOZER_TASK_REPAIR)
+	else if (m_previousTask == DOZER_TASK_REPAIR || m_previousTask == DOZER_TASK_FORTIFY)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
 		if (target)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2092,7 +2092,7 @@ void DozerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2104,8 +2104,13 @@ void DozerAIUpdate::resumePreviousTask()
 			newTask(m_previousTask, target);
 	}
 
-	m_previousTask = DOZER_TASK_INVALID;
-	m_previousTaskInfo = DozerTaskInfo();
+	clearPreviousTask();
+}
+
+void DozerAIUpdate::clearPreviousTask()
+{
+  m_previousTask = DOZER_TASK_INVALID;
+  m_previousTaskInfo = DozerTaskInfo();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -2164,8 +2169,7 @@ void DozerAIUpdate::internalTaskComplete( DozerTask task )
 	m_task[ task ].m_targetObjectID = INVALID_ID;
 	m_task[ task ].m_taskOrderFrame = 0;
 
-	m_previousTask = DOZER_TASK_INVALID;
-	m_previousTaskInfo = DozerTaskInfo();
+	clearPreviousTask();
 
 	// remove dock point info for this task
 	for( Int i = 0; i < DOZER_NUM_DOCK_POINTS; i++ )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2093,7 +2093,7 @@ void DozerAIUpdate::resumePreviousTask()
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
 		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-			newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
+			newTask(m_previousTask, target);
 	}
 
 	m_previousTask = DOZER_TASK_INVALID;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2538,7 +2538,7 @@ void DozerAIUpdate::xfer( Xfer *xfer )
 	xfer->xferSnapshot(m_dozerMachine);
 	xfer->xferUser(&m_currentTask, sizeof(m_currentTask));
 
-	if (currentVersion >= 2)
+	if (version >= 2)
 	{
 		xfer->xferUser(&m_previousTask, sizeof(m_previousTask));
 		xfer->xferUser(&m_previousTaskInfo, sizeof(m_previousTaskInfo));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2323,6 +2323,35 @@ void DozerAIUpdate::onDelete()
 	}
 }
 
+void DozerAIUpdate::onDisabledEdge(Bool nowDisabled)
+{
+	if (nowDisabled)
+	{
+		// Have to say goodbye to the thing we might be building or repairing so someone else can do it.
+		if (getCurrentTask() != DOZER_TASK_INVALID)
+		{
+			// TheSuperHackers @info We want to explicitly define what types to resume from as some types
+			// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
+			Bool attemptToResumeTask = getObject()->isDisabledByType(DISABLED_EMP) ||
+				getObject()->isDisabledByType(DISABLED_HACKED) ||
+				getObject()->isDisabledByType(DISABLED_SUBDUED) ||
+				getObject()->isDisabledByType(DISABLED_UNDERPOWERED);
+
+			if (attemptToResumeTask)
+				setPreviousTask(getCurrentTask());
+
+			cancelTask(getCurrentTask());
+		}
+	}
+	else
+	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Stubbjax 17/11/2025 Resume previous task when re-enabled.
+		resumePreviousTask();
+#endif
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Get the most recently issued task */
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2095,6 +2095,12 @@ void DozerAIUpdate::resumePreviousTask()
 		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
+	else if (m_previousTask == DOZER_TASK_REPAIR)
+	{
+		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
+		if (target)
+			newTask(m_previousTask, target);
+	}
 
 	m_previousTask = DOZER_TASK_INVALID;
 	m_previousTaskInfo = DozerTaskInfo();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2020,7 +2020,13 @@ void DozerAIUpdate::newTask( DozerTask task, Object *target )
 		// multiple dozers/workers to double up on construction efforts
 		//
 		if( task == DOZER_TASK_BUILD )
+		{
+			// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
+			if (target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+				return;
+
 			target->setBuilder( me );
+		}
 
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].valid			= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].location	= position;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2068,6 +2068,8 @@ void DozerAIUpdate::cancelAllTasks()
 	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
 		internalCancelTask((DozerTask)task);
 
+	clearPreviousTask();
+
 	m_dozerMachine->resetToDefaultState();
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2067,10 +2067,10 @@ void DozerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 
 void DozerAIUpdate::cancelAllTasks()
 {
+	clearPreviousTask();
+
 	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
 		internalCancelTask((DozerTask)task);
-
-	clearPreviousTask();
 
 	m_dozerMachine->resetToDefaultState();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2083,6 +2083,8 @@ void DozerAIUpdate::setPreviousTask(DozerTask task)
 	if (task == DOZER_TASK_INVALID)
 		return;
 
+	DEBUG_ASSERTCRASH(m_previousTask == DOZER_TASK_INVALID, ("Dozer already remembers a previous task"));
+
 	m_previousTask = task;
 	m_previousTaskInfo = m_task[task];
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -711,6 +711,18 @@ void WorkerAIUpdate::cancelAllTasks()
 }
 
 //-------------------------------------------------------------------------------------------------
+/** Set the previous task so that we may return to it if we become temporarily incapacitated */
+//-------------------------------------------------------------------------------------------------
+void WorkerAIUpdate::setPreviousTask(DozerTask task)
+{
+	if (task == DOZER_TASK_INVALID)
+		return;
+
+	m_previousTask = task;
+	m_previousTaskInfo = m_task[task];
+}
+
+//-------------------------------------------------------------------------------------------------
 /** Attempt to resume the previous task */
 //-------------------------------------------------------------------------------------------------
 void WorkerAIUpdate::resumePreviousTask()
@@ -803,9 +815,6 @@ void WorkerAIUpdate::internalCancelTask( DozerTask task )
 
 	// call the single method that gets called for completing and canceling tasks
 	internalTaskCompleteOrCancelled( task );
-
-	m_previousTask = task;
-	m_previousTaskInfo = m_task[task];
 
 	// remove the info for this task
 	m_task[ task ].m_targetObjectID = INVALID_ID;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -727,13 +727,12 @@ void WorkerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (target && !target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-			return;
-
-		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
-		m_previousTask = DOZER_TASK_INVALID;
-		m_previousTaskInfo = DozerTaskInfo();
+		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+			newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
 	}
+
+	m_previousTask = DOZER_TASK_INVALID;
+	m_previousTaskInfo = DozerTaskInfo();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -724,7 +724,6 @@ void WorkerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_INVALID)
 		return;
 
-	// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -703,6 +703,8 @@ void WorkerAIUpdate::cancelAllTasks()
 	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
 		internalCancelTask((DozerTask)task);
 
+	clearPreviousTask();
+
 	m_dozerMachine->resetToDefaultState();
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -730,6 +730,12 @@ void WorkerAIUpdate::resumePreviousTask()
 		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
+	else if (m_previousTask == DOZER_TASK_REPAIR)
+	{
+		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
+		if (target)
+			newTask(m_previousTask, target);
+	}
 
 	m_previousTask = DOZER_TASK_INVALID;
 	m_previousTaskInfo = DozerTaskInfo();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -727,7 +727,7 @@ void WorkerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (target && target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+		if (target && !target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			return;
 
 		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -728,7 +728,7 @@ void WorkerAIUpdate::resumePreviousTask()
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
 		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-			newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
+			newTask(m_previousTask, target);
 	}
 
 	m_previousTask = DOZER_TASK_INVALID;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -644,13 +644,7 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 		// multiple dozers/workers to double up on construction efforts
 		//
 		if( task == DOZER_TASK_BUILD )
-		{
-			// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
-			if (target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
-				return;
-
 			target->setBuilder( me );
-		}
 
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].valid			= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].location	= position;
@@ -727,8 +721,16 @@ void WorkerAIUpdate::setPreviousTask(DozerTask task)
 //-------------------------------------------------------------------------------------------------
 void WorkerAIUpdate::resumePreviousTask()
 {
-	if (m_previousTask != DOZER_TASK_INVALID)
+	if (m_previousTask == DOZER_TASK_INVALID)
+		return;
+
+	// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
+	if (m_previousTask == DOZER_TASK_BUILD)
 	{
+		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
+		if (target && target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+			return;
+
 		newTask(m_previousTask, TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID));
 		m_previousTask = DOZER_TASK_INVALID;
 		m_previousTaskInfo = DozerTaskInfo();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -1488,7 +1488,7 @@ void WorkerAIUpdate::xfer( Xfer *xfer )
 	xfer->xferSnapshot(m_dozerMachine);
 	xfer->xferUser(&m_currentTask, sizeof(m_currentTask));
 
-	if (currentVersion >= 2)
+	if (version >= 2)
 	{
 		xfer->xferUser(&m_previousTask, sizeof(m_previousTask));
 		xfer->xferUser(&m_previousTaskInfo, sizeof(m_previousTaskInfo));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -644,7 +644,13 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 		// multiple dozers/workers to double up on construction efforts
 		//
 		if( task == DOZER_TASK_BUILD )
+		{
+			// TheSuperHackers @bugfix Stubbjax 15/06/2026 Ignore the build task if the building is already complete.
+			if (target->getConstructionPercent() == CONSTRUCTION_COMPLETE)
+				return;
+
 			target->setBuilder( me );
+		}
 
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].valid			= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_START ].location	= position;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -689,6 +689,8 @@ void WorkerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 {
 	if (rememberTask)
 		setPreviousTask(task);
+	else
+		clearPreviousTask();
 
 	// clear the order
 	internalCancelTask( task );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -732,7 +732,7 @@ void WorkerAIUpdate::resumePreviousTask()
 		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
-	else if (m_previousTask == DOZER_TASK_REPAIR)
+	else if (m_previousTask == DOZER_TASK_REPAIR || m_previousTask == DOZER_TASK_FORTIFY)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
 		if (target)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -727,7 +727,7 @@ void WorkerAIUpdate::resumePreviousTask()
 	if (m_previousTask == DOZER_TASK_BUILD)
 	{
 		Object* target = TheGameLogic->findObjectByID(m_previousTaskInfo.m_targetObjectID);
-		if (!target || target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+		if (target && target->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 			newTask(m_previousTask, target);
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -685,8 +685,10 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 	* re-evaluate what it wants to do if it was working on the task being
 	* cancelled */
 //-------------------------------------------------------------------------------------------------
-void WorkerAIUpdate::cancelTask( DozerTask task )
+void WorkerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 {
+	if (rememberTask)
+		setPreviousTask(task);
 
 	// clear the order
 	internalCancelTask( task );
@@ -955,15 +957,12 @@ void WorkerAIUpdate::onDisabledEdge(Bool nowDisabled)
 		{
 			// TheSuperHackers @info We want to explicitly define what types to resume from as some types
 			// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
-			Bool attemptToResumeTask = getObject()->isDisabledByType(DISABLED_EMP) ||
+			Bool rememberTask = getObject()->isDisabledByType(DISABLED_EMP) ||
 				getObject()->isDisabledByType(DISABLED_HACKED) ||
 				getObject()->isDisabledByType(DISABLED_SUBDUED) ||
 				getObject()->isDisabledByType(DISABLED_UNDERPOWERED);
 
-			if (attemptToResumeTask)
-				setPreviousTask(getCurrentTask());
-
-			cancelTask(getCurrentTask());
+			cancelTask(getCurrentTask(), rememberTask);
 		}
 	}
 	else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -946,6 +946,35 @@ void WorkerAIUpdate::onDelete()
 	}
 }
 
+void WorkerAIUpdate::onDisabledEdge(Bool nowDisabled)
+{
+	if (nowDisabled)
+	{
+		// Have to say goodbye to the thing we might be building or repairing so someone else can do it.
+		if (getCurrentTask() != DOZER_TASK_INVALID)
+		{
+			// TheSuperHackers @info We want to explicitly define what types to resume from as some types
+			// are undesirable (e.g. DISABLED_HELD via entering/exiting a container).
+			Bool attemptToResumeTask = getObject()->isDisabledByType(DISABLED_EMP) ||
+				getObject()->isDisabledByType(DISABLED_HACKED) ||
+				getObject()->isDisabledByType(DISABLED_SUBDUED) ||
+				getObject()->isDisabledByType(DISABLED_UNDERPOWERED);
+
+			if (attemptToResumeTask)
+				setPreviousTask(getCurrentTask());
+
+			cancelTask(getCurrentTask());
+		}
+	}
+	else
+	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Stubbjax 17/11/2025 Resume previous task when re-enabled.
+		resumePreviousTask();
+#endif
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Get the most recently issued task */
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -739,6 +739,11 @@ void WorkerAIUpdate::resumePreviousTask()
 			newTask(m_previousTask, target);
 	}
 
+	clearPreviousTask();
+}
+
+void WorkerAIUpdate::clearPreviousTask()
+{
 	m_previousTask = DOZER_TASK_INVALID;
 	m_previousTaskInfo = DozerTaskInfo();
 }
@@ -799,8 +804,7 @@ void WorkerAIUpdate::internalTaskComplete( DozerTask task )
 	m_task[ task ].m_targetObjectID = INVALID_ID;
 	m_task[ task ].m_taskOrderFrame = 0;
 
-	m_previousTask = DOZER_TASK_INVALID;
-	m_previousTaskInfo = DozerTaskInfo();
+	clearPreviousTask();
 
 	// remove dock point info for this task
 	for( Int i = 0; i < DOZER_NUM_DOCK_POINTS; i++ )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -702,10 +702,10 @@ void WorkerAIUpdate::cancelTask( DozerTask task, Bool rememberTask )
 
 void WorkerAIUpdate::cancelAllTasks()
 {
+	clearPreviousTask();
+
 	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
 		internalCancelTask((DozerTask)task);
-
-	clearPreviousTask();
 
 	m_dozerMachine->resetToDefaultState();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -718,6 +718,8 @@ void WorkerAIUpdate::setPreviousTask(DozerTask task)
 	if (task == DOZER_TASK_INVALID)
 		return;
 
+	DEBUG_ASSERTCRASH(m_previousTask == DOZER_TASK_INVALID, ("Worker already remembers a previous task"));
+
 	m_previousTask = task;
 	m_previousTaskInfo = m_task[task];
 }


### PR DESCRIPTION
This change fixes an issue introduced by #1870 that allows builders to resume an already completed task after being disabled.

When assigning a new build task to a builder, if the target building is an already-completed building, then the new task is ignored.

### Before

https://github.com/user-attachments/assets/11a5f45f-091e-4ee6-9f6f-5633141895ec

### After

https://github.com/user-attachments/assets/0a51a7cb-7364-41a3-96bf-8ec8f4ce45fb