### PR TITLE
bugfix(logic): Restore retail compatibility after change in CountermeasuresBehavior::calculateCountermeasureToDivertTo

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/CountermeasuresBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/CountermeasuresBehavior.cpp
@@ -159,8 +159,8 @@ ObjectID CountermeasuresBehavior::calculateCountermeasureToDivertTo( const Objec
 	Real closestFlareDist = 1e15f;
 	Object *closestFlare = nullptr;
 
-	const int volleySize = data->m_volleySize;
-	int volleyFlaresCounted = 0;
+	const UnsignedInt volleySize = max(data->m_volleySize, 1u);
+	UnsignedInt volleyFlaresCounted = 0;
 
 	//Flares are pushed to the front of the list, but we only want to acquire the "newest" of the flares, therefore
 	//Start at the end of the list and go towards the beginning.
@@ -182,9 +182,13 @@ ObjectID CountermeasuresBehavior::calculateCountermeasureToDivertTo( const Objec
 			// The non retail behaviour corrects the code to iterate through all flares in the volley
 			break;
 #else
-			volleyFlaresCounted++;
+			++volleyFlaresCounted;
 #endif
 		}
+
+#if RETAIL_COMPATIBLE_CRC
+		++volleyFlaresCounted;
+#endif
 	}
 
 	if( closestFlare )


### PR DESCRIPTION
* Follow up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/1367

#1367 did a small bug fix + refactor but inadvertently introduced a small change to the game logic with retail compatibility. The old implementation would increment the `volleyFlaresCounted` on each iteration, but the new implementation doesn't.

Replay [23-49-43_2v2_hitlr98_122_Alphax01_Alphax02.zip](https://github.com/user-attachments/files/29114728/23-49-43_2v2_hitlr98_122_Alphax01_Alphax02.zip) mismatches because of that change. This PR fixes the mismatch.

---

```cpp
#if RETAIL_COMPATIBLE_CRC
	++volleyFlaresCounted;
#endif
```
This is the crucial part of this change. The other changes were not necessary to fix the mismatch.