### PR TITLE
unify(update): Parse template references in the AssistedTargetingUpdate module by name

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
@@ -46,8 +46,6 @@ public:
 	{
 		m_clipSize = 1;
 		m_weaponSlot = PRIMARY_WEAPON;
-    m_laserFromAssistedName.clear();
-    m_laserToTargetName.clear();
 	}
 
 	static void buildFieldParse(MultiIniFieldParse& p);

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
@@ -38,15 +38,16 @@ class AssistedTargetingUpdateModuleData : public UpdateModuleData
 public:
 	Int m_clipSize;
 	WeaponSlotType m_weaponSlot;
-	ThingTemplate *m_laserFromAssisted;
-	ThingTemplate *m_laserToTarget;
+
+	AsciiString m_laserFromAssistedName;
+	AsciiString m_laserToTargetName;
 
 	AssistedTargetingUpdateModuleData()
 	{
 		m_clipSize = 1;
 		m_weaponSlot = PRIMARY_WEAPON;
-		m_laserFromAssisted = nullptr;
-		m_laserToTarget = nullptr;
+    m_laserFromAssistedName.clear();
+    m_laserToTargetName.clear();
 	}
 
 	static void buildFieldParse(MultiIniFieldParse& p);
@@ -72,4 +73,7 @@ public:
 
 private:
 	void makeFeedbackLaser( const ThingTemplate *laserTemplate, const Object *from, const Object *to );
+
+	const ThingTemplate *m_laserFromAssisted;
+	const ThingTemplate *m_laserToTarget;
 };

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -49,7 +49,7 @@
 //-------------------------------------------------------------------------------------------------
 void AssistedTargetingUpdateModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  UpdateModuleData::buildFieldParse(p);
+	UpdateModuleData::buildFieldParse(p);
 	static const FieldParse dataFieldParse[] =
 	{
 		{ "AssistingClipSize",		INI::parseInt,		nullptr, offsetof( AssistedTargetingUpdateModuleData, m_clipSize ) },
@@ -58,14 +58,15 @@ void AssistedTargetingUpdateModuleData::buildFieldParse(MultiIniFieldParse& p)
 		{ "LaserToTarget",				INI::parseAsciiString,				nullptr, offsetof( AssistedTargetingUpdateModuleData, m_laserToTargetName ) },
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 AssistedTargetingUpdate::AssistedTargetingUpdate( Thing *thing, const ModuleData* moduleData ) : UpdateModule( thing, moduleData )
 {
-	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
+	m_laserFromAssisted = nullptr;
+	m_laserToTarget = nullptr;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -137,6 +138,11 @@ void AssistedTargetingUpdate::makeFeedbackLaser( const ThingTemplate *laserTempl
 //-------------------------------------------------------------------------------------------------
 UpdateSleepTime AssistedTargetingUpdate::update()
 {
+	const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
+
+	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
+	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
+
 	return UPDATE_SLEEP_FOREVER;
 }
 
@@ -174,8 +180,11 @@ void AssistedTargetingUpdate::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void AssistedTargetingUpdate::loadPostProcess()
 {
+	const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
+
+	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
+	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
 
 	// extend base class
 	UpdateModule::loadPostProcess();
-
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -54,8 +54,8 @@ void AssistedTargetingUpdateModuleData::buildFieldParse(MultiIniFieldParse& p)
 	{
 		{ "AssistingClipSize",		INI::parseInt,		nullptr, offsetof( AssistedTargetingUpdateModuleData, m_clipSize ) },
 		{ "AssistingWeaponSlot",	INI::parseLookupList,	TheWeaponSlotTypeNamesLookupList, offsetof( AssistedTargetingUpdateModuleData, m_weaponSlot ) },
-		{ "LaserFromAssisted",		INI::parseThingTemplate,				nullptr, offsetof( AssistedTargetingUpdateModuleData, m_laserFromAssisted ) },
-		{ "LaserToTarget",				INI::parseThingTemplate,				nullptr, offsetof( AssistedTargetingUpdateModuleData, m_laserToTarget ) },
+		{ "LaserFromAssisted",		INI::parseAsciiString,				nullptr, offsetof( AssistedTargetingUpdateModuleData, m_laserFromAssistedName ) },
+		{ "LaserToTarget",				INI::parseAsciiString,				nullptr, offsetof( AssistedTargetingUpdateModuleData, m_laserToTargetName ) },
 		{ nullptr, nullptr, nullptr, 0 }
 	};
   p.add(dataFieldParse);
@@ -100,10 +100,10 @@ void AssistedTargetingUpdate::assistAttack( const Object *requestingObject, Obje
 	me->setWeaponLock( md->m_weaponSlot, LOCKED_TEMPORARILY );
 	me->getAI()->aiAttackObject( victimObject, md->m_clipSize, CMD_FROM_AI );
 
-	if( md->m_laserFromAssisted )
-		makeFeedbackLaser( md->m_laserFromAssisted, requestingObject, me );
-	if( md->m_laserToTarget )
-		makeFeedbackLaser( md->m_laserToTarget, me, victimObject );
+	if( m_laserFromAssisted )
+		makeFeedbackLaser( m_laserFromAssisted, requestingObject, me );
+	if( m_laserToTarget )
+		makeFeedbackLaser( m_laserToTarget, me, victimObject );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
@@ -46,8 +46,6 @@ public:
 	{
 		m_clipSize = 1;
 		m_weaponSlot = PRIMARY_WEAPON;
-    m_laserFromAssistedName.clear();
-    m_laserToTargetName.clear();
 	}
 
 	static void buildFieldParse(MultiIniFieldParse& p);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
@@ -39,8 +39,8 @@ public:
 	Int m_clipSize;
 	WeaponSlotType m_weaponSlot;
 
-  AsciiString m_laserFromAssistedName;
-  AsciiString m_laserToTargetName;
+	AsciiString m_laserFromAssistedName;
+	AsciiString m_laserToTargetName;
 
 	AssistedTargetingUpdateModuleData()
 	{
@@ -76,6 +76,4 @@ private:
 
 	const ThingTemplate *m_laserFromAssisted;
 	const ThingTemplate *m_laserToTarget;
-
-
 };

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -119,9 +119,6 @@ void AssistedTargetingUpdate::makeFeedbackLaser( const ThingTemplate *laserTempl
 	if( !laser )
 		return;
 
-	// Give it a good basis in reality to ensure it can draw when on screen.
-	laser->setPosition(from->getPosition());
-
 	Drawable *draw = laser->getDrawable();
 	static const NameKeyType key_LaserUpdate = NAMEKEY( "LaserUpdate" );
 	LaserUpdate *update = (LaserUpdate*)draw->findClientUpdateModule( key_LaserUpdate );
@@ -130,6 +127,9 @@ void AssistedTargetingUpdate::makeFeedbackLaser( const ThingTemplate *laserTempl
 		TheGameLogic->destroyObject( laser );
 		return;
 	}
+
+	// Give it a good basis in reality to ensure it can draw when on screen.
+	laser->setPosition(from->getPosition());
 
 	update->initLaser( getObject(), to, from->getPosition(), to->getPosition(), "" );
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -101,7 +101,6 @@ void AssistedTargetingUpdate::assistAttack( const Object *requestingObject, Obje
 	me->setWeaponLock( md->m_weaponSlot, LOCKED_TEMPORARILY );
 	me->getAI()->aiAttackObject( victimObject, md->m_clipSize, CMD_FROM_AI );
 
-
 	if( m_laserFromAssisted )
 		makeFeedbackLaser( m_laserFromAssisted, requestingObject, me );
 	if( m_laserToTarget )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -49,7 +49,7 @@
 //-------------------------------------------------------------------------------------------------
 void AssistedTargetingUpdateModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  UpdateModuleData::buildFieldParse(p);
+	UpdateModuleData::buildFieldParse(p);
 	static const FieldParse dataFieldParse[] =
 	{
 		{ "AssistingClipSize",		INI::parseInt,		nullptr, offsetof( AssistedTargetingUpdateModuleData, m_clipSize ) },
@@ -58,7 +58,7 @@ void AssistedTargetingUpdateModuleData::buildFieldParse(MultiIniFieldParse& p)
 		{ "LaserToTarget",				INI::parseAsciiString,				nullptr, offsetof( AssistedTargetingUpdateModuleData, m_laserToTargetName ) },
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -138,14 +138,10 @@ void AssistedTargetingUpdate::makeFeedbackLaser( const ThingTemplate *laserTempl
 //-------------------------------------------------------------------------------------------------
 UpdateSleepTime AssistedTargetingUpdate::update()
 {
-
-  const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
+	const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
 
 	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
-
-
 	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
-
 
 	return UPDATE_SLEEP_FOREVER;
 }
@@ -184,12 +180,11 @@ void AssistedTargetingUpdate::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void AssistedTargetingUpdate::loadPostProcess()
 {
-  const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
+	const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
 
 	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
 	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
 
 	// extend base class
 	UpdateModule::loadPostProcess();
-
 }


### PR DESCRIPTION
This change improves the way in which the `AssistedTargetingUpdate` module parses template reference fields in Generals by standardising the logic with Zero Hour.

As a result, the respective objects can be defined in any order, whereas previously e.g. the `PatriotBinaryDataStream` would have to be defined before any reference within an `AssistedTargetingUpdate ` module (otherwise the `LaserFromAssisted` and `LaserToTarget` fields would be left unassigned).

### Before

✅ Valid
```ini
Object PatriotBinaryDataStream
  ; ...
End

Object AmericaPatriotBattery
  Behavior = AssistedTargetingUpdate ModuleTag_XX
    LaserFromAssisted = PatriotBinaryDataStream
    LaserToTarget = PatriotBinaryDataStream
  End
End
```

❌ Invalid
```ini
Object AmericaPatriotBattery
  Behavior = AssistedTargetingUpdate ModuleTag_XX
    LaserFromAssisted = PatriotBinaryDataStream
    LaserToTarget = PatriotBinaryDataStream
  End
End

Object PatriotBinaryDataStream
  ; ...
End
```

### After

✅ Valid
```ini
Object PatriotBinaryDataStream
  ; ...
End

Object AmericaPatriotBattery
  Behavior = AssistedTargetingUpdate ModuleTag_XX
    LaserFromAssisted = PatriotBinaryDataStream
    LaserToTarget = PatriotBinaryDataStream
  End
End
```

✅ Valid
```ini
Object AmericaPatriotBattery
  Behavior = AssistedTargetingUpdate ModuleTag_XX
    LaserFromAssisted = PatriotBinaryDataStream
    LaserToTarget = PatriotBinaryDataStream
  End
End

Object PatriotBinaryDataStream
  ; ...
End
```