### PR TITLE
refactor(sortingrenderer): Replace custom doubly linked list with std::list in SortingNodeStruct

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -265,7 +265,10 @@ void SortingRendererClass::Insert_Triangles(
 		}
 		++node;
 	}
-	if (node == sorted_list.end()) sorted_list.push_back(state);
+	if (node == sorted_list.end())
+	{
+		sorted_list.push_back(state);
+	}
 
 #ifdef WWDEBUG
 	unsigned short* indices=nullptr;
@@ -720,5 +723,8 @@ void SortingRendererClass::Insert_VolumeParticle(
 		}
 		++node;
 	}
-	if (node == sorted_list.end()) sorted_list.push_back(state);
+	if (node == sorted_list.end())
+	{
+		sorted_list.push_back(state);
+	}
 }

--- a/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -167,8 +167,9 @@ public:
 	unsigned short vertex_count;			// Number of vertices used in vb
 };
 
-static std::list<SortingNodeStruct*> sorted_list;
-static std::list<SortingNodeStruct*> clean_list;
+typedef std::list<SortingNodeStruct*> SortingNodeStructList;
+static SortingNodeStructList sorted_list;
+static SortingNodeStructList clean_list;
 static unsigned total_sorting_vertices;
 
 static SortingNodeStruct* Get_Sorting_Struct()
@@ -245,31 +246,6 @@ void SortingRendererClass::Insert_Triangles(
 	WWASSERT(vertex_buffer);
 	WWASSERT(state->vertex_count<=vertex_buffer->Get_Vertex_Count());
 
-	D3DXMATRIX mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
-	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
-	D3DXVECTOR4 transformed_vec;
-	D3DXVec3Transform(
-		&transformed_vec,
-		&vec,
-		&mtx);
-	state->transformed_center=Vector3(transformed_vec[0],transformed_vec[1],transformed_vec[2]);
-
-
-	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
-
-	std::list<SortingNodeStruct*>::iterator node = sorted_list.begin();
-	while (node != sorted_list.end()) {
-		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
-			sorted_list.insert(node, state);
-			break;
-		}
-		++node;
-	}
-	if (node == sorted_list.end())
-	{
-		sorted_list.push_back(state);
-	}
-
 #ifdef WWDEBUG
 	unsigned short* indices=nullptr;
 	SortingIndexBufferClass* index_buffer=static_cast<SortingIndexBufferClass*>(state->sorting_state.index_buffer);
@@ -288,6 +264,28 @@ void SortingRendererClass::Insert_Triangles(
 		WWASSERT(idx3<state->vertex_count);
 	}
 #endif // WWDEBUG
+
+	D3DXMATRIX mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
+	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
+	D3DXVECTOR4 transformed_vec;
+	D3DXVec3Transform(
+		&transformed_vec,
+		&vec,
+		&mtx);
+	state->transformed_center=Vector3(transformed_vec[0],transformed_vec[1],transformed_vec[2]);
+
+
+	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
+
+	for (SortingNodeStructList::iterator node = sorted_list.begin(); node != sorted_list.end(); ++node)
+	{
+		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
+			sorted_list.insert(node, state);
+			return;
+		}
+	}
+
+	sorted_list.push_back(state);
 }
 
 // ----------------------------------------------------------------------------
@@ -715,16 +713,13 @@ void SortingRendererClass::Insert_VolumeParticle(
 
 	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
 
-	std::list<SortingNodeStruct*>::iterator node = sorted_list.begin();
-	while (node != sorted_list.end()) {
+	for (SortingNodeStructList::iterator node = sorted_list.begin(); node != sorted_list.end(); ++node)
+	{
 		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
 			sorted_list.insert(node, state);
-			break;
+			return;
 		}
-		++node;
 	}
-	if (node == sorted_list.end())
-	{
-		sorted_list.push_back(state);
-	}
+
+	sorted_list.push_back(state);
 }

--- a/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -242,11 +242,37 @@ void SortingRendererClass::Insert_Triangles(
 	state->min_vertex_index=min_vertex_index;
 	state->vertex_count=vertex_count;
 
+	D3DXMATRIX mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
+	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
+	D3DXVECTOR4 transformed_vec;
+	D3DXVec3Transform(
+		&transformed_vec,
+		&vec,
+		&mtx);
+	state->transformed_center=Vector3(transformed_vec[0],transformed_vec[1],transformed_vec[2]);
+
+
+	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
+
+	SortingNodeStructList::iterator node;
+	for (node = sorted_list.begin(); node != sorted_list.end(); ++node)
+	{
+		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
+			sorted_list.insert(node, state);
+			break;
+		}
+	}
+
+	if (node == sorted_list.end())
+	{
+		sorted_list.push_back(state);
+	}
+
+#ifdef WWDEBUG
 	SortingVertexBufferClass* vertex_buffer=static_cast<SortingVertexBufferClass*>(state->sorting_state.vertex_buffers[0]);
 	WWASSERT(vertex_buffer);
 	WWASSERT(state->vertex_count<=vertex_buffer->Get_Vertex_Count());
 
-#ifdef WWDEBUG
 	unsigned short* indices=nullptr;
 	SortingIndexBufferClass* index_buffer=static_cast<SortingIndexBufferClass*>(state->sorting_state.index_buffer);
 	WWASSERT(index_buffer);
@@ -264,28 +290,6 @@ void SortingRendererClass::Insert_Triangles(
 		WWASSERT(idx3<state->vertex_count);
 	}
 #endif // WWDEBUG
-
-	D3DXMATRIX mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
-	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
-	D3DXVECTOR4 transformed_vec;
-	D3DXVec3Transform(
-		&transformed_vec,
-		&vec,
-		&mtx);
-	state->transformed_center=Vector3(transformed_vec[0],transformed_vec[1],transformed_vec[2]);
-
-
-	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
-
-	for (SortingNodeStructList::iterator node = sorted_list.begin(); node != sorted_list.end(); ++node)
-	{
-		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
-			sorted_list.insert(node, state);
-			return;
-		}
-	}
-
-	sorted_list.push_back(state);
 }
 
 // ----------------------------------------------------------------------------
@@ -713,13 +717,17 @@ void SortingRendererClass::Insert_VolumeParticle(
 
 	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
 
-	for (SortingNodeStructList::iterator node = sorted_list.begin(); node != sorted_list.end(); ++node)
+	SortingNodeStructList::iterator node;
+	for (node = sorted_list.begin(); node != sorted_list.end(); ++node)
 	{
 		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
 			sorted_list.insert(node, state);
-			return;
+			break;
 		}
 	}
 
-	sorted_list.push_back(state);
+	if (node == sorted_list.end())
+	{
+		sorted_list.push_back(state);
+	}
 }

--- a/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -251,22 +251,7 @@ void SortingRendererClass::Insert_Triangles(
 		&mtx);
 	state->transformed_center=Vector3(transformed_vec[0],transformed_vec[1],transformed_vec[2]);
 
-
-	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
-
-	SortingNodeStructList::iterator node;
-	for (node = sorted_list.begin(); node != sorted_list.end(); ++node)
-	{
-		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
-			sorted_list.insert(node, state);
-			break;
-		}
-	}
-
-	if (node == sorted_list.end())
-	{
-		sorted_list.push_back(state);
-	}
+	Insert_To_Sorted_List(state);
 
 #ifdef WWDEBUG
 	SortingVertexBufferClass* vertex_buffer=static_cast<SortingVertexBufferClass*>(state->sorting_state.vertex_buffers[0]);
@@ -333,6 +318,23 @@ static unsigned overlapping_polygon_count;
 static unsigned overlapping_vertex_count;
 static const unsigned MAX_OVERLAPPING_NODES=4096;
 static SortingNodeStruct* overlapping_nodes[MAX_OVERLAPPING_NODES];
+
+// ----------------------------------------------------------------------------
+
+void SortingRendererClass::Insert_To_Sorted_List(SortingNodeStruct *state)
+{
+	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
+
+	for (SortingNodeStructList::iterator node = sorted_list.begin(); node != sorted_list.end(); ++node)
+	{
+		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
+			sorted_list.insert(node, state);
+			return;
+		}
+	}
+
+	sorted_list.push_back(state);
+}
 
 // ----------------------------------------------------------------------------
 
@@ -715,19 +717,5 @@ void SortingRendererClass::Insert_VolumeParticle(
 
 	//THE TRANSFORMED CENTER[2] IS THE ZBUFFER DEPTH
 
-	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
-
-	SortingNodeStructList::iterator node;
-	for (node = sorted_list.begin(); node != sorted_list.end(); ++node)
-	{
-		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
-			sorted_list.insert(node, state);
-			break;
-		}
-	}
-
-	if (node == sorted_list.end())
-	{
-		sorted_list.push_back(state);
-	}
+	Insert_To_Sorted_List(state);
 }

--- a/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -49,6 +49,7 @@
 #include "statistics.h"
 #include <wwprofile.h>
 #include <algorithm>
+#include <list>
 
 
 bool SortingRendererClass::_EnableTriangleDraw=true;
@@ -150,7 +151,7 @@ void Sort(TempIndexStruct *begin, TempIndexStruct *end)
 
 // ----------------------------------------------------------------------------
 
-class SortingNodeStruct : public DLNodeClass<SortingNodeStruct>
+class SortingNodeStruct
 {
 	W3DMPO_CODE(SortingNodeStruct)
 
@@ -166,20 +167,18 @@ public:
 	unsigned short vertex_count;			// Number of vertices used in vb
 };
 
-static DLListClass<SortingNodeStruct> sorted_list;
-static DLListClass<SortingNodeStruct> clean_list;
+static std::list<SortingNodeStruct*> sorted_list;
+static std::list<SortingNodeStruct*> clean_list;
 static unsigned total_sorting_vertices;
 
 static SortingNodeStruct* Get_Sorting_Struct()
 {
-
-	SortingNodeStruct* state=clean_list.Head();
-	if (state) {
-		state->Remove();
+	if (!clean_list.empty()) {
+		SortingNodeStruct* state = clean_list.front();
+		clean_list.pop_front();
 		return state;
 	}
-	state=W3DNEW SortingNodeStruct();
-	return state;
+	return W3DNEW SortingNodeStruct();
 }
 
 // ----------------------------------------------------------------------------
@@ -258,18 +257,15 @@ void SortingRendererClass::Insert_Triangles(
 
 	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
 
-	SortingNodeStruct* node=sorted_list.Head();
-	while (node) {
-		if (state->transformed_center.Z>node->transformed_center.Z) {
-			if (sorted_list.Head()==sorted_list.Tail())
-				sorted_list.Add_Head(state);
-			else
-				state->Insert_Before(node);
+	std::list<SortingNodeStruct*>::iterator node = sorted_list.begin();
+	while (node != sorted_list.end()) {
+		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
+			sorted_list.insert(node, state);
 			break;
 		}
-		node=node->Succ();
+		++node;
 	}
-	if (!node) sorted_list.Add_Tail(state);
+	if (node == sorted_list.end()) sorted_list.push_back(state);
 
 #ifdef WWDEBUG
 	unsigned short* indices=nullptr;
@@ -577,7 +573,7 @@ void SortingRendererClass::Flush_Sorting_Pool()
 	for (unsigned node_id=0;node_id<overlapping_node_count;++node_id) {
 		SortingNodeStruct* state=overlapping_nodes[node_id];
 		Release_Refs(state);
-		clean_list.Add_Head(state);
+		clean_list.push_front(state);
 	}
 	overlapping_node_count=0;
 	overlapping_polygon_count=0;
@@ -597,8 +593,9 @@ void SortingRendererClass::Flush()
 	DX8Wrapper::Get_Transform(D3DTS_VIEW,old_view);
 	DX8Wrapper::Get_Transform(D3DTS_WORLD,old_world);
 
-	while (SortingNodeStruct* state=sorted_list.Head()) {
-		state->Remove();
+	while (!sorted_list.empty()) {
+		SortingNodeStruct* state = sorted_list.front();
+		sorted_list.pop_front();
 
 		if ((state->sorting_state.index_buffer_type==BUFFER_TYPE_SORTING || state->sorting_state.index_buffer_type==BUFFER_TYPE_DYNAMIC_SORTING) &&
 			(state->sorting_state.vertex_buffer_types[0]==BUFFER_TYPE_SORTING || state->sorting_state.vertex_buffer_types[0]==BUFFER_TYPE_DYNAMIC_SORTING)) {
@@ -609,7 +606,7 @@ void SortingRendererClass::Flush()
 			DX8Wrapper::Draw_Triangles(state->start_index,state->polygon_count,state->min_vertex_index,state->vertex_count);
 			DX8Wrapper::Release_Render_State();
 			Release_Refs(state);
-			clean_list.Add_Head(state);
+			clean_list.push_front(state);
 		}
 	}
 
@@ -635,22 +632,20 @@ void SortingRendererClass::Flush()
 
 void SortingRendererClass::Deinit()
 {
-	SortingNodeStruct *head = nullptr;
-
 	//
 	//	Flush the sorted list
 	//
-	while ((head = sorted_list.Head ()) != nullptr) {
-		sorted_list.Remove_Head ();
-		delete head;
+	while (!sorted_list.empty()) {
+		delete sorted_list.front();
+		sorted_list.pop_front();
 	}
 
 	//
 	//	Flush the clean list
 	//
-	while ((head = clean_list.Head ()) != nullptr) {
-		clean_list.Remove_Head ();
-		delete head;
+	while (!clean_list.empty()) {
+		delete clean_list.front();
+		clean_list.pop_front();
 	}
 
 	delete[] temp_index_array;
@@ -717,16 +712,13 @@ void SortingRendererClass::Insert_VolumeParticle(
 
 	/// @todo lorenzen sez use a bucket sort here... and stop copying so much data so many times
 
-	SortingNodeStruct* node=sorted_list.Head();
-	while (node) {
-		if (state->transformed_center.Z>node->transformed_center.Z) {
-			if (sorted_list.Head()==sorted_list.Tail())
-				sorted_list.Add_Head(state);
-			else
-				state->Insert_Before(node);
+	std::list<SortingNodeStruct*>::iterator node = sorted_list.begin();
+	while (node != sorted_list.end()) {
+		if (state->transformed_center.Z > (*node)->transformed_center.Z) {
+			sorted_list.insert(node, state);
 			break;
 		}
-		node=node->Succ();
+		++node;
 	}
-	if (!node) sorted_list.Add_Tail(state);
+	if (node == sorted_list.end()) sorted_list.push_back(state);
 }

--- a/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.h
@@ -28,6 +28,7 @@ class SortingRendererClass
 	static bool _EnableTriangleDraw;
 
 	static void Flush_Sorting_Pool();
+	static void Insert_To_Sorted_List(SortingNodeStruct* state);
 	static void Insert_To_Sorting_Pool(SortingNodeStruct* state);
 
 public:


### PR DESCRIPTION
For the sorting renderer, this changes `DLListClass` and its nodes `DLNodeClass` with the `std::list` equivalent.

Tested on a custom map to verify that transparent particle rendering stays the same.

In the sorting renderer a doubly linked list is used for insertion sort in `Insert_Triangles`. In a follow-up I have some code ready to optimize the insertion of particles.