### PR TITLE
 chore: Prevent conflict between clang-format and MSVC by wrapping inline assembly blocks in curly braces

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -336,8 +336,10 @@ WWINLINE long WWMath::Float_To_Long(double f)
 {
 #if defined(_MSC_VER) && defined(_M_IX86)
 	long retval;
-	__asm fld	qword ptr [f]
-	__asm fistp dword ptr [retval]
+	__asm {
+		fld	qword ptr [f]
+		fistp dword ptr [retval]
+	}
 	return retval;
 #else
 	return (long) f;

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -58,20 +58,24 @@ class ProfileFastCS
 		#define ts_lock _emit 0xF0
 		DASSERT(((unsigned)&nFlag % 4) == 0);
 
-		__asm mov ebx, [nFlag]
-		__asm ts_lock
-		__asm bts dword ptr [ebx], 0
-		__asm jc The_Bit_Was_Previously_Set_So_Try_Again
+		__asm {
+			mov ebx, [nFlag]
+			ts_lock
+			bts dword ptr [ebx], 0
+			jc The_Bit_Was_Previously_Set_So_Try_Again
+		}
 		return;
 
 	The_Bit_Was_Previously_Set_So_Try_Again:
     // can't use SwitchToThread() here because Win9X doesn't have it!
     if (testEvent)
 		  ::WaitForSingleObject(testEvent,1);
-		__asm mov ebx, [nFlag]
-		__asm ts_lock
-		__asm bts dword ptr [ebx], 0
-		__asm jc  The_Bit_Was_Previously_Set_So_Try_Again
+		__asm {
+			mov ebx, [nFlag]
+			ts_lock
+			bts dword ptr [ebx], 0
+			jc  The_Bit_Was_Previously_Set_So_Try_Again
+		}
 	}
 
 	void ThreadSafeClearFlag()


### PR DESCRIPTION
When running `clang-format` on the codebase, it collapses consecutive unbraced inline `__asm` statements onto a single line. 
If a standard C++ statement (such as `return`) immediately follows, it also gets merged onto that same line.

This PR prepares the codebase for the upcoming formatting baseline pass by isolating the inline assembly instructions into standard braced blocks (__asm { ... }).

When running the updated clang-format recursively across the entire repository (Core/, Generals/, GeneralsMD/, and scripts/), these are the only two files that required syntax adjustments to compile successfully on both modern VS2022 and legacy VC6 toolchains. This avoids adding //clang-format off.