### PR TITLE
fix(update): Fix laser-to-target setup mistake in AssistedTargetingUpdate

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -145,7 +145,7 @@ UpdateSleepTime AssistedTargetingUpdate::update()
 	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
 
 
-	m_laserToTarget =TheThingFactory->findTemplate( d->m_laserFromAssistedName );
+	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
 
 
 	return UPDATE_SLEEP_FOREVER;
@@ -188,7 +188,7 @@ void AssistedTargetingUpdate::loadPostProcess()
   const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
 
 	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
-	m_laserToTarget =TheThingFactory->findTemplate( d->m_laserFromAssistedName );
+	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
 
 	// extend base class
 	UpdateModule::loadPostProcess();


### PR DESCRIPTION
This change fixes a copy-and-paste mistake in Zero Hour's `AssistedTargetingUpdate` module when reading template data, which causes the module's `LaserToTarget` field to use the value assigned to the `LaserFromAssisted` field.

This has no effect on retail games as all `LaserFromAssisted` and `LaserToTarget` fields share the same value regardless, as shown below.

```ini
Behavior = AssistedTargetingUpdate ModuleTag_XX
  LaserFromAssisted = PatriotBinaryDataStream ; Stream to draw from the requestor to me
  LaserToTarget = PatriotBinaryDataStream ; Stream to draw from me to the target
End
```