### PR TITLE
bugfix(weapon): Sniper weapons can no longer fire upon empty Stinger Sites

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -79,6 +79,10 @@
 #define PRESERVE_UNRELIABLE_FIRESTORMS (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
 #endif
 
+#ifndef PRESERVE_SNIPING_EMPTY_STINGER_SITES
+#define PRESERVE_SNIPING_EMPTY_STINGER_SITES (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
+#endif
+
 #ifndef PRESERVE_RETAIL_SCRIPTED_CAMERA
 #define PRESERVE_RETAIL_SCRIPTED_CAMERA (1) // Retain scripted camera behavior present in retail Generals 1.08 and Zero Hour 1.04
 #endif

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpawnBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpawnBehavior.h
@@ -111,6 +111,7 @@ public:
 	virtual CanAttackResult getCanAnySlavesUseWeaponAgainstTarget( AbleToAttackType attackType, const Object *victim, const Coord3D *pos, CommandSourceType cmdSource ) = 0;
 	virtual Bool canAnySlavesAttack() = 0;
 	virtual void orderSlavesToGoIdle( CommandSourceType cmdSource ) = 0;
+	virtual Int getSlaveCount() const = 0;
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -160,6 +161,7 @@ public:
 	virtual CanAttackResult getCanAnySlavesUseWeaponAgainstTarget( AbleToAttackType attackType, const Object *victim, const Coord3D *pos, CommandSourceType cmdSource ) override;
 	virtual Bool canAnySlavesAttack() override;
 	virtual void orderSlavesToGoIdle( CommandSourceType cmdSource ) override;
+	virtual Int getSlaveCount() const override { return m_spawnCount; }
 
 	// **********************************************************************************************
 	// our own methods

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -586,12 +586,20 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 	// hmm.. must be shooting a firebase or such, if there is noone home to take the bullet, return 0!
 	if ( victimObj->isKindOf( KINDOF_STRUCTURE) && damageType == DAMAGE_SNIPER )
 	{
+#if PRESERVE_SNIPING_EMPTY_STINGER_SITES
+		if (victimObj->getContain())
+		{
+			if (victimObj->getContain()->getContainCount() == 0)
+				return 0.0f;
+		}
+#else
 		// TheSuperHackers @bugfix Stubbjax 22/06/2026 Only allow targeting Stinger Sites when they contain Soldiers.
 		const Bool hasOccupants = victimObj->getContain() && victimObj->getContain()->getContainCount() > 0;
 		const Bool hasSlaves = victimObj->getSpawnBehaviorInterface() && victimObj->getSpawnBehaviorInterface()->getSlaveCount() > 0;
 
 		if (!hasOccupants && !hasSlaves)
 			return 0.0f;
+#endif
 	}
 #endif
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -74,6 +74,7 @@
 #include "GameLogic/Module/AssistedTargetingUpdate.h"
 #include "GameLogic/Module/ProjectileStreamUpdate.h"
 #include "GameLogic/Module/PhysicsUpdate.h"
+#include "GameLogic/Module/SpawnBehavior.h"
 #include "GameLogic/TerrainLogic.h"
 
 #define RATIONALIZE_ATTACK_RANGE
@@ -580,6 +581,19 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 			return 0.0f;
 		}
 	}
+
+#if !RETAIL_COMPATIBLE_CRC
+	// hmm.. must be shooting a firebase or such, if there is noone home to take the bullet, return 0!
+	if ( victimObj->isKindOf( KINDOF_STRUCTURE) && damageType == DAMAGE_SNIPER )
+	{
+		// TheSuperHackers @bugfix Stubbjax 22/06/2026 Only allow targeting Stinger Sites when they contain Soldiers.
+		Bool hasOccupants = victimObj->getContain() && victimObj->getContain()->getContainCount() > 0;
+		Bool hasSlaves = victimObj->getSpawnBehaviorInterface() && victimObj->getSpawnBehaviorInterface()->getSlaveCount() > 0;
+
+		if (!hasOccupants && !hasSlaves)
+			return 0.0f;
+	}
+#endif
 
 // this stays, even if ALLOW_SURRENDER is not defed, since flashbangs still use 'em
 	if ( damageType == DAMAGE_SURRENDER || m_allowAttackGarrisonedBldgs )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -587,8 +587,8 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 	if ( victimObj->isKindOf( KINDOF_STRUCTURE) && damageType == DAMAGE_SNIPER )
 	{
 		// TheSuperHackers @bugfix Stubbjax 22/06/2026 Only allow targeting Stinger Sites when they contain Soldiers.
-		Bool hasOccupants = victimObj->getContain() && victimObj->getContain()->getContainCount() > 0;
-		Bool hasSlaves = victimObj->getSpawnBehaviorInterface() && victimObj->getSpawnBehaviorInterface()->getSlaveCount() > 0;
+		const Bool hasOccupants = victimObj->getContain() && victimObj->getContain()->getContainCount() > 0;
+		const Bool hasSlaves = victimObj->getSpawnBehaviorInterface() && victimObj->getSpawnBehaviorInterface()->getSlaveCount() > 0;
 
 		if (!hasOccupants && !hasSlaves)
 			return 0.0f;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpawnBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpawnBehavior.h
@@ -122,6 +122,7 @@ public:
 	virtual Bool areAllSlavesStealthed() const = 0;
 	virtual void revealSlaves() = 0;
 	virtual Bool doSlavesHaveFreedom() const = 0;
+	virtual Int getSlaveCount() const = 0;
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -177,6 +178,7 @@ public:
 	virtual Bool areAllSlavesStealthed() const override;
 	virtual void revealSlaves() override;
 	virtual Bool doSlavesHaveFreedom() const override { return getSpawnBehaviorModuleData()->m_slavesHaveFreeWill; }
+	virtual Int getSlaveCount() const override { return m_spawnCount; }
 
 	// **********************************************************************************************
 	// our own methods

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -609,8 +609,8 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
     }
 #else
 		// TheSuperHackers @bugfix Stubbjax 22/06/2026 Only allow targeting Stinger Sites when they contain Soldiers.
-		Bool hasOccupants = victimObj->getContain() && victimObj->getContain()->getContainCount() > 0;
-		Bool hasSlaves = victimObj->getSpawnBehaviorInterface() && victimObj->getSpawnBehaviorInterface()->getSlaveCount() > 0;
+		const Bool hasOccupants = victimObj->getContain() && victimObj->getContain()->getContainCount() > 0;
+		const Bool hasSlaves = victimObj->getSpawnBehaviorInterface() && victimObj->getSpawnBehaviorInterface()->getSlaveCount() > 0;
 
 		if (!hasOccupants && !hasSlaves)
 			return 0.0f;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -610,7 +610,7 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 		{
 			// TheSuperHackers @bugfix Stubbjax 22/06/2026 Only allow targeting Stinger Sites when they contain Soldiers.
 			SpawnBehaviorInterface* spawnInterface = victimObj->getSpawnBehaviorInterface();
-			if (spawnInterface && spawnInterface->getSlaveCount() == 0)
+			if (spawnInterface && spawnInterface->getSlaveCount() <= 0)
 				return 0.0f;
 		}
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -74,6 +74,7 @@
 #include "GameLogic/Module/AssistedTargetingUpdate.h"
 #include "GameLogic/Module/ProjectileStreamUpdate.h"
 #include "GameLogic/Module/PhysicsUpdate.h"
+#include "GameLogic/Module/SpawnBehavior.h"
 #include "GameLogic/TerrainLogic.h"
 
 #define RATIONALIZE_ATTACK_RANGE
@@ -604,6 +605,15 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
       if ( victimObj->getContain()->getContainCount() == 0 )
         return 0.0f;
     }
+#if !RETAIL_COMPATIBLE_CRC
+		else
+		{
+			// TheSuperHackers @bugfix Stubbjax 22/06/2026 Only allow targeting Stinger Sites when they contain Soldiers.
+			SpawnBehaviorInterface* spawnInterface = victimObj->getSpawnBehaviorInterface();
+			if (spawnInterface && spawnInterface->getSlaveCount() == 0)
+				return 0.0f;
+		}
+#endif
   }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -601,7 +601,7 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
   if ( victimObj->isKindOf( KINDOF_STRUCTURE) && damageType == DAMAGE_SNIPER )
   {
 
-#if RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_CRC || PRESERVE_SNIPING_EMPTY_STINGER_SITES
     if ( victimObj->getContain() )
     {
       if ( victimObj->getContain()->getContainCount() == 0 )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -600,19 +600,20 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
   // hmm.. must be shooting a firebase or such, if there is noone home to take the bullet, return 0!
   if ( victimObj->isKindOf( KINDOF_STRUCTURE) && damageType == DAMAGE_SNIPER )
   {
+
+#if RETAIL_COMPATIBLE_CRC
     if ( victimObj->getContain() )
     {
       if ( victimObj->getContain()->getContainCount() == 0 )
         return 0.0f;
     }
-#if !RETAIL_COMPATIBLE_CRC
-		else
-		{
-			// TheSuperHackers @bugfix Stubbjax 22/06/2026 Only allow targeting Stinger Sites when they contain Soldiers.
-			SpawnBehaviorInterface* spawnInterface = victimObj->getSpawnBehaviorInterface();
-			if (spawnInterface && spawnInterface->getSlaveCount() <= 0)
-				return 0.0f;
-		}
+#else
+		// TheSuperHackers @bugfix Stubbjax 22/06/2026 Only allow targeting Stinger Sites when they contain Soldiers.
+		Bool hasOccupants = victimObj->getContain() && victimObj->getContain()->getContainCount() > 0;
+		Bool hasSlaves = victimObj->getSpawnBehaviorInterface() && victimObj->getSpawnBehaviorInterface()->getSlaveCount() > 0;
+
+		if (!hasOccupants && !hasSlaves)
+			return 0.0f;
 #endif
   }
 


### PR DESCRIPTION
Fixes [#1590](https://github.com/TheSuperHackers/GeneralsGameCode/issues/2824) from the patch repository

This change prevents sniper weapons from being able to fire upon empty Stinger Sites. Behaviour is now consistent with occupied / empty Fire Bases.

~This change only applies to Zero Hour as the Generals implementation is different and it makes more sense to carry the fix there during the unification process.~

### Before

https://github.com/user-attachments/assets/b48eb15e-e8a2-4663-9d6a-86120fe19b8c

### After

https://github.com/user-attachments/assets/cdd75350-cea0-43d3-9372-86ae956f645e