### PR TITLE
tweak(drawable): Decouple police car light time step from render update

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DPoliceCarDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DPoliceCarDraw.cpp
@@ -103,6 +103,7 @@ W3DPoliceCarDraw::~W3DPoliceCarDraw()
 void W3DPoliceCarDraw::doDrawModule(const Matrix3D* transformMtx)
 {
 	const Real floatAmt = 8.0f;
+
 	// TheSuperHackers @tweak bobtista 24/06/2026 The police car light animation time step is now decoupled from the render update.
 	const Real animAmt = 0.25f * TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DPoliceCarDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DPoliceCarDraw.cpp
@@ -30,8 +30,8 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include <stdlib.h>
 
-#include "Common/STLTypedefs.h"
 #include "Common/FramePacer.h"
+#include "Common/STLTypedefs.h"
 #include "Common/Thing.h"
 #include "Common/Xfer.h"
 #include "GameClient/Drawable.h"

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DPoliceCarDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DPoliceCarDraw.cpp
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 
 #include "Common/STLTypedefs.h"
+#include "Common/FramePacer.h"
 #include "Common/Thing.h"
 #include "Common/Xfer.h"
 #include "GameClient/Drawable.h"
@@ -102,7 +103,8 @@ W3DPoliceCarDraw::~W3DPoliceCarDraw()
 void W3DPoliceCarDraw::doDrawModule(const Matrix3D* transformMtx)
 {
 	const Real floatAmt = 8.0f;
-	const Real animAmt = 0.25;
+	// TheSuperHackers @tweak bobtista 24/06/2026 The police car light animation time step is now decoupled from the render update.
+	const Real animAmt = 0.25f * TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
 
 	// get pointers to our render objects that we'll need
 	RenderObjClass* policeCarRenderObj = getRenderObject();


### PR DESCRIPTION
Resolves #2828 

The police car light bar animation and its blinking dynamic light are advanced by a fixed m_curFrame += 0.25 increment in W3DPoliceCarDraw::doDrawModule, which runs once per render frame. This makes the blink rate scale with render frame rate.

This change scales the per-frame increment by TheFramePacer->getActualLogicTimeScaleOverFpsRatio(), following the same pattern already applied to the stealth opacity fade, tint envelope, tree sway, and water movement. The animation now advances at the logic rate regardless of render frame rate.

This is a render-only change. m_curFrame is not part of crc()/xfer(), so there is no effect on logic, replays, or CRC determinism.

### Testing: 
[x]Police car light bar blinks at a consistent rate with various render FPS