### PR TITLE
refactor(basetype): Refactor functions of Coord3D, Region3D to take reference instead of pointer

### DIFF
--- a/Core/GameEngine/Source/Common/Audio/AudioEventRTS.cpp
+++ b/Core/GameEngine/Source/Common/Audio/AudioEventRTS.cpp
@@ -206,7 +206,7 @@ AudioEventRTS::AudioEventRTS( const AsciiString& eventName, const Coord3D *posit
 										m_delay(0.0f),
 										m_uninterruptible(FALSE)
 {
-	m_positionOfAudio.set( positionOfAudio );
+	m_positionOfAudio.set( *positionOfAudio );
 	m_attackName.clear();
 	m_decayName.clear();
 }
@@ -239,7 +239,7 @@ AudioEventRTS::AudioEventRTS( const AudioEventRTS& right )
 
 	if( m_ownerType == OT_Positional || m_ownerType == OT_Dead )
 	{
-		m_positionOfAudio.set( &right.m_positionOfAudio );
+		m_positionOfAudio.set( right.m_positionOfAudio );
 	}
 	else if( m_ownerType == OT_Drawable )
 	{
@@ -280,7 +280,7 @@ AudioEventRTS& AudioEventRTS::operator=( const AudioEventRTS& right )
 
 	if( m_ownerType == OT_Positional || m_ownerType == OT_Dead )
 	{
-		m_positionOfAudio.set( &right.m_positionOfAudio );
+		m_positionOfAudio.set( right.m_positionOfAudio );
 	}
 	else if( m_ownerType == OT_Drawable )
 	{
@@ -732,7 +732,7 @@ const Coord3D *AudioEventRTS::getCurrentPosition()
 	case OT_Object:
 		if (Object *obj = TheGameLogic->findObjectByID(m_objectID))
 		{
-			m_positionOfAudio.set( obj->getPosition() );
+			m_positionOfAudio.set( *obj->getPosition() );
 		}
 		else
 		{
@@ -743,7 +743,7 @@ const Coord3D *AudioEventRTS::getCurrentPosition()
 	case OT_Drawable:
 		if (Drawable *draw = TheGameClient->findDrawableByID(m_drawableID))
 		{
-			m_positionOfAudio.set( draw->getPosition() );
+			m_positionOfAudio.set( *draw->getPosition() );
 		}
 		else
 		{

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -302,7 +302,7 @@ void AudioManager::update()
 	//of making sure we only go a certain percentage towards the camera or the desired height, whichever occurs first.
 	Coord3D cameraPos = TheTacticalView->get3DCameraPosition();
 	Coord3D groundToCameraVector;
-	groundToCameraVector.set( &cameraPos );
+	groundToCameraVector.set( cameraPos );
 	groundToCameraVector.sub( &cameraPivot );
 	Real bestScaleFactor;
 
@@ -325,7 +325,7 @@ void AudioManager::update()
 
 	//Set the microphone to be the ground position adjusted for terrain plus the vector we just calculated.
 	Coord3D microphonePos;
-	microphonePos.set( &cameraPivot );
+	microphonePos.set( cameraPivot );
 	microphonePos.add( &groundToCameraVector );
 
 	//Viola! A properly placed microphone.

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -303,7 +303,7 @@ void AudioManager::update()
 	Coord3D cameraPos = TheTacticalView->get3DCameraPosition();
 	Coord3D groundToCameraVector;
 	groundToCameraVector.set( cameraPos );
-	groundToCameraVector.sub( &cameraPivot );
+	groundToCameraVector.sub( cameraPivot );
 	Real bestScaleFactor;
 
 	if( cameraPos.z <= desiredHeightAbs || groundToCameraVector.z <= 0.0f )
@@ -345,7 +345,7 @@ void AudioManager::update()
 	{
 		//How far away is the camera from the microphone?
 		Coord3D vector = cameraPos;
-		vector.sub( &microphonePos );
+		vector.sub( microphonePos );
 		Real dist = vector.length();
 
 		if( dist < minDist )

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -326,7 +326,7 @@ void AudioManager::update()
 	//Set the microphone to be the ground position adjusted for terrain plus the vector we just calculated.
 	Coord3D microphonePos;
 	microphonePos.set( cameraPivot );
-	microphonePos.add( &groundToCameraVector );
+	microphonePos.add( groundToCameraVector );
 
 	//Viola! A properly placed microphone.
 	setListenerPosition( &microphonePos, &lookTo );

--- a/Core/GameEngine/Source/Common/Audio/GameSounds.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameSounds.cpp
@@ -174,7 +174,7 @@ Bool SoundManager::canPlayNow( AudioEventRTS *event )
 		const Coord3D *pos = event->getCurrentPosition();
 		if (pos)
 		{
-			distance.sub(pos);
+			distance.sub(*pos);
 			if (distance.length() >= event->getAudioEventInfo()->m_maxDistance)
 			{
 #ifdef INTENSIVE_AUDIO_DEBUG

--- a/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -957,7 +957,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 		case GameMessage::MSG_RAW_MOUSE_RIGHT_BUTTON_UP:
 		{
 			Coord3D cameraPos = TheTacticalView->getPosition();
-			cameraPos.sub(&m_deselectDownCameraPosition);
+			cameraPos.sub(m_deselectDownCameraPosition);
 
 			ICoord2D pixel = msg->getArgument( 0 )->pixel;
 			UnsignedInt currentTime = (UnsignedInt) msg->getArgument( 2 )->integer;

--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1518,8 +1518,8 @@ const Coord3D *ParticleSystem::computeParticleVelocity( const Coord3D *pos )
 					up.x = 0.0;
 					up.y = 0.0;
 					up.z = 1.0;
-					perp.crossProduct( &up, &along, &perp );
-					up.crossProduct( &along, &perp, &up );
+					perp.crossProduct( up, along, perp );
+					up.crossProduct( along, perp, up );
 
 					// "speed" is in 'horizontal' plane, and "otherSpeed" is 'vertical'
 					newVel.x = speed * perp.x + otherSpeed * up.x;

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5451,8 +5451,8 @@ Bool Pathfinder::adjustToLandingDestination(Object *obj, Coord3D *dest)
 	TheTerrainLogic->getMaximumPathfindExtent(&extent);
 	// If the object is off the map & the goal is off the map, it is a scripted setup, so just
 	// go to the dest.
-	if (!extent.isInRegionNoZ(dest)) {
-		if (!extent.isInRegionNoZ(obj->getPosition())) {
+	if (!extent.isInRegionNoZ(*dest)) {
+		if (!extent.isInRegionNoZ(*obj->getPosition())) {
 			return true;
 		}
 	}

--- a/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2069,7 +2069,7 @@ bool GameLogic::onPlaceBeacon(MAYBE_UNUSED GameMessage *msg)
 	Coord3D pos = msg->getArgument( 0 )->location;
 	Region3D r;
 	TheTerrainLogic->getExtent(&r);
-	if (!r.isInRegionNoZ(&pos))
+	if (!r.isInRegionNoZ(pos))
 		pos = TheTerrainLogic->findClosestEdgePoint(&pos);
 	const ThingTemplate *thing = TheThingFactory->findTemplate( msgPlayer->getPlayerTemplate()->getBeaconTemplate() );
 

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -139,7 +139,7 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 	Coord3D lookPos = TheTacticalView->getPosition();
 	const Coord3D *mikePos = TheAudio->getListenerPosition();
 	Coord3D distanceVector = TheTacticalView->get3DCameraPosition();
-	distanceVector.sub( mikePos );
+	distanceVector.sub( *mikePos );
 
 	Int now = TheGameLogic->getFrame();
 	static Int lastCheck = now;
@@ -307,7 +307,7 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 			if( pos )
 			{
 				Coord3D vector = *microphonePos;
-				vector.sub( pos );
+				vector.sub( *pos );
 				dist = vector.length();
 				sprintf( distStr, "%d", REAL_TO_INT( dist ) );
 			}
@@ -2555,7 +2555,7 @@ Real MilesAudioManager::getEffectiveVolume(AudioEventRTS *event) const
 			if (pos)
 			{
 				Coord3D distance = m_listenerPosition;
-				distance.sub(pos);
+				distance.sub(*pos);
 				Real objMinDistance;
 				Real objMaxDistance;
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
@@ -290,7 +290,7 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 
 				//Get the length of the line
 				lineVector.set( lineEnd );
-				lineVector.sub( &lineStart );
+				lineVector.sub( lineStart );
 				Real lineLength = lineVector.length();
 
 				//Get the middle point (we'll use this to determine how far we are from
@@ -339,7 +339,7 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 
 				//Calculate the distance from midpoint for the start positions.
 				vector.set( lineMiddle );
-				vector.sub( &segmentStart );
+				vector.sub( segmentStart );
 				Real dist = vector.length();
 				Real scaledRadians = dist / halfLength * PI * 0.5f;
 				Real height = cos( scaledRadians );
@@ -348,7 +348,7 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 
 				//Now do the same thing for the end position.
 				vector.set( lineMiddle );
-				vector.sub( &segmentEnd );
+				vector.sub( segmentEnd );
 				dist = vector.length();
 				scaledRadians = dist / halfLength * PI * 0.5f;
 				height = cos( scaledRadians );

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
@@ -283,20 +283,20 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 
 				//Get the desired direct line
 				Coord3D lineStart, lineEnd, lineVector;
-				lineStart.set( update->getStartPos() );
-				lineEnd.set( update->getEndPos() );
+				lineStart.set( *update->getStartPos() );
+				lineEnd.set( *update->getEndPos() );
 				//This is critical -- in the case we have sloped lines (at the end, we'll fix it)
 //				lineEnd.z = lineStart.z;
 
 				//Get the length of the line
-				lineVector.set( &lineEnd );
+				lineVector.set( lineEnd );
 				lineVector.sub( &lineStart );
 				Real lineLength = lineVector.length();
 
 				//Get the middle point (we'll use this to determine how far we are from
 				//that to calculate our height -- middle point is the highest).
 				Coord3D lineMiddle;
-				lineMiddle.set( &lineStart );
+				lineMiddle.set( lineStart );
 				lineMiddle.add( &lineEnd );
 				lineMiddle.scale( 0.5 );
 
@@ -321,15 +321,15 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 
 				//Calculate our start segment position on the *ground*.
 				Coord3D segmentStart, segmentEnd, vector;
-				vector.set( &lineVector );
+				vector.set( lineVector );
 				vector.scale( startSegmentRatio );
-				segmentStart.set( &lineStart );
+				segmentStart.set( lineStart );
 				segmentStart.add( &vector );
 
 				//Calculate our end segment position on the *ground*.
-				vector.set( &lineVector );
+				vector.set( lineVector );
 				vector.scale( endSegmentRatio );
-				segmentEnd.set( &lineStart );
+				segmentEnd.set( lineStart );
 				segmentEnd.add( &vector );
 
 				//--------------------------------------------------------------------------------
@@ -338,7 +338,7 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 				//--------------------------------------------------------------------------------
 
 				//Calculate the distance from midpoint for the start positions.
-				vector.set( &lineMiddle );
+				vector.set( lineMiddle );
 				vector.sub( &segmentStart );
 				Real dist = vector.length();
 				Real scaledRadians = dist / halfLength * PI * 0.5f;
@@ -347,7 +347,7 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 				segmentStart.z += height;
 
 				//Now do the same thing for the end position.
-				vector.set( &lineMiddle );
+				vector.set( lineMiddle );
 				vector.sub( &segmentEnd );
 				dist = vector.length();
 				scaledRadians = dist / halfLength * PI * 0.5f;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
@@ -297,7 +297,7 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 				//that to calculate our height -- middle point is the highest).
 				Coord3D lineMiddle;
 				lineMiddle.set( lineStart );
-				lineMiddle.add( &lineEnd );
+				lineMiddle.add( lineEnd );
 				lineMiddle.scale( 0.5 );
 
 				//The half length is used to scale with the distance from middle to
@@ -324,13 +324,13 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 				vector.set( lineVector );
 				vector.scale( startSegmentRatio );
 				segmentStart.set( lineStart );
-				segmentStart.add( &vector );
+				segmentStart.add( vector );
 
 				//Calculate our end segment position on the *ground*.
 				vector.set( lineVector );
 				vector.scale( endSegmentRatio );
 				segmentEnd.set( lineStart );
-				segmentEnd.add( &vector );
+				segmentEnd.add( vector );
 
 				//--------------------------------------------------------------------------------
 				//Now at this point, we have our segment line in the level positions that we want.

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -1186,7 +1186,7 @@ void W3DTreeBuffer::unitMoved(Object *unit)
 				}
 				Coord3D delta;
 				delta.set(m_trees[treeNdx].location.X, m_trees[treeNdx].location.Y, m_trees[treeNdx].location.Z );
-				delta.sub(&pos);
+				delta.sub(pos);
 				if (radius*radius>delta.lengthSqr()) {
 					bool canTopple = unit->getCrusherLevel() > 1;
 					if (canTopple && m_treeTypes[m_trees[treeNdx].treeType].m_data->m_doTopple) {
@@ -1500,7 +1500,7 @@ void W3DTreeBuffer::pushAsideTree(DrawableID id, const Coord3D *pusherPos,
 			m_trees[i].pushAsideSource = pusherID;
 			Coord3D delta;
 			delta.set(m_trees[i].location.X, m_trees[i].location.Y, m_trees[i].location.Z);
-			delta.sub(pusherPos);
+			delta.sub(*pusherPos);
 
 			if (pusherDirection->x*delta.y - pusherDirection->y*delta.x > 0.0f) {
 				m_trees[i].pushAsideCos = -pusherDirection->y;

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -582,17 +582,17 @@ struct Region3D
 		}
 	}
 
-	Bool isInRegionNoZ( const Coord3D *query ) const
+	Bool isInRegionNoZ( const Coord3D &query ) const
 	{
-		return (lo.x < query->x) && (query->x < hi.x) &&
-					 (lo.y < query->y) && (query->y < hi.y);
+		return (lo.x < query.x) && (query.x < hi.x) &&
+					 (lo.y < query.y) && (query.y < hi.y);
 	}
 
-	Bool isInRegion( const Coord3D *query ) const
+	Bool isInRegion( const Coord3D &query ) const
 	{
-		return (lo.x < query->x) && (query->x < hi.x) &&
-					 (lo.y < query->y) && (query->y < hi.y) &&
-					 (lo.z < query->z) && (query->z < hi.z);
+		return (lo.x < query.x) && (query.x < hi.x) &&
+					 (lo.y < query.y) && (query.y < hi.y) &&
+					 (lo.z < query.z) && (query.z < hi.z);
 	}
 };
 

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -464,11 +464,11 @@ struct Coord3D
 		z += a->z;
 	}
 
-	void sub( const Coord3D *a )
+	void sub( const Coord3D &a )
 	{
-		x -= a->x;
-		y -= a->y;
-		z -= a->z;
+		x -= a.x;
+		y -= a.y;
+		z -= a.z;
 	}
 
 	void set( const Coord3D &a )

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -471,11 +471,11 @@ struct Coord3D
 		z -= a->z;
 	}
 
-	void set( const Coord3D *a )
+	void set( const Coord3D &a )
 	{
-		x = a->x;
-		y = a->y;
-		z = a->z;
+		x = a.x;
+		y = a.y;
+		z = a.z;
 	}
 
 	void set( Real ax, Real ay, Real az )

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -438,11 +438,11 @@ struct Coord3D
 		}
 	}
 
-	static void crossProduct( const Coord3D *a, const Coord3D *b, Coord3D *r )
+	static void crossProduct( const Coord3D &a, const Coord3D &b, Coord3D &r )
 	{
-		r->x = (a->y * b->z - a->z * b->y);
-		r->y = (a->z * b->x - a->x * b->z);
-		r->z = (a->x * b->y - a->y * b->x);
+		r.x = (a.y * b.z - a.z * b.y);
+		r.y = (a.z * b.x - a.x * b.z);
+		r.z = (a.x * b.y - a.y * b.x);
 	}
 
 	void zero()

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -457,11 +457,11 @@ struct Coord3D
 		return x == value && y == value && z == value;
 	}
 
-	void add( const Coord3D *a )
+	void add( const Coord3D &a )
 	{
-		x += a->x;
-		y += a->y;
-		z += a->z;
+		x += a.x;
+		y += a.y;
+		z += a.z;
 	}
 
 	void sub( const Coord3D &a )

--- a/Generals/Code/GameEngine/Source/Common/Bezier/BezFwdIterator.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Bezier/BezFwdIterator.cpp
@@ -111,9 +111,9 @@ const Coord3D& BezFwdIterator::getCurrent() const
 //-------------------------------------------------------------------------------------------------
 void BezFwdIterator::next()
 {
-	mCurrPoint.add(&mDq);
-	mDq.add(&mDDq);
-	mDDq.add(&mDDDq);
+	mCurrPoint.add(mDq);
+	mDq.add(mDDq);
+	mDDq.add(mDDDq);
 
 	++mStep;
 }

--- a/Generals/Code/GameEngine/Source/Common/Bezier/BezierSegment.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Bezier/BezierSegment.cpp
@@ -207,9 +207,9 @@ void BezierSegment::splitSegmentAtT(Real tValue, BezierSegment &outSeg1, BezierS
 	p1p2.scale(tValue);
 	p2p3.scale(tValue);
 
-	p0p1.add(&m_controlPoints[0]);
-	p1p2.add(&m_controlPoints[1]);
-	p2p3.add(&m_controlPoints[2]);
+	p0p1.add(m_controlPoints[0]);
+	p1p2.add(m_controlPoints[1]);
+	p2p3.add(m_controlPoints[2]);
 
 	Coord3D triLeft = { p1p2.x - p0p1.x,
 											p1p2.y - p0p1.y,
@@ -222,8 +222,8 @@ void BezierSegment::splitSegmentAtT(Real tValue, BezierSegment &outSeg1, BezierS
 	triLeft.scale(tValue);
 	triRight.scale(tValue);
 
-	triLeft.add(&p0p1);
-	triRight.add(&p1p2);
+	triLeft.add(p0p1);
+	triRight.add(p1p2);
 
 	outSeg1.m_controlPoints[0] = m_controlPoints[0];
 	outSeg1.m_controlPoints[1] = p0p1;

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2381,7 +2381,7 @@ void Player::doBountyForKill(const Object* killer, const Object* victim)
 		moneyString.format( TheGameText->fetch( "GUI:AddCash" ), bounty );
 		Coord3D pos;
 		pos.zero();
-		pos.add( killer->getPosition() );
+		pos.add( *killer->getPosition() );
 		pos.z += 10.0f; //add a little z to make it show up above the unit.
 		TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 255, 255, 0, 255 ) );
 	}

--- a/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -849,7 +849,7 @@ LegalBuildCode BuildAssistant::isLocationLegalToBuild( const Coord3D *worldPos,
 	/* You just can't never build off the map, regardless of options.  jba. */
 	Region3D mapExtent;
 	TheTerrainLogic->getMaximumPathfindExtent(&mapExtent);
-	if (!mapExtent.isInRegionNoZ(worldPos)) {
+	if (!mapExtent.isInRegionNoZ(*worldPos)) {
 		return LBC_RESTRICTED_TERRAIN;
 	}
 

--- a/Generals/Code/GameEngine/Source/Common/Thing/Thing.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/Thing.cpp
@@ -233,8 +233,8 @@ void Thing::setOrientation( Real angle )
 		u.y = Sin(angle);
 		u.z = 0.0f;
 
-		y.crossProduct( &z, &u, &y );
-		x.crossProduct( &y, &z, &x );
+		y.crossProduct( z, u, y );
+		x.crossProduct( y, z, x );
 
 		m_transform.Set(  x.x, y.x, z.x, pos.x,
 											x.y, y.y, z.y, pos.y,

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -1585,8 +1585,8 @@ void Drawable::calcPhysicsXformTreads( const Locomotor *locomotor, PhysicsXformI
 				up.normalize();
 
 				Coord3D prp;
-				prp.crossProduct( &v, &up, &prp );
-				normal.crossProduct( &prp, &v, &normal );
+				prp.crossProduct( v, up, prp );
+				normal.crossProduct( prp, v, normal );
 
 				// compute unit normal
 				normal.normalize();
@@ -3884,7 +3884,7 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod)
 			{
 				//Check if it's close enough to try playing (optimization)
 				Coord3D vector = *getPosition();
-				vector.sub( TheAudio->getListenerPosition() );
+				vector.sub( *TheAudio->getListenerPosition() );
 				Real distSqr = vector.lengthSqr();
 				if( distSqr < sqr( info->m_maxDistance ) )
 				{

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -660,14 +660,14 @@ Bool CommandButton::isValidToUseOn(const Object *sourceObj, const Object *target
 	Coord3D pos;
 	if( targetLocation )
 	{
-		pos.set( targetLocation );
+		pos.set( *targetLocation );
 	}
 
 	if( BitIsSet( m_options, NEED_TARGET_POS ) && !targetLocation )
 	{
 		if( targetObj )
 		{
-			pos.set( targetObj->getPosition() );
+			pos.set( *targetObj->getPosition() );
 		}
 		else
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -690,7 +690,7 @@ static void clampToMap(Coord3D *dest, PlayerType pt)
 	extent.hi.y -= PATHFIND_CELL_SIZE_F;
 	extent.lo.x += PATHFIND_CELL_SIZE_F;
 	extent.lo.y += PATHFIND_CELL_SIZE_F;
-	if (!extent.isInRegionNoZ(dest)) {
+	if (!extent.isInRegionNoZ(*dest)) {
 		// clamp to in region. [8/28/2003]
 		if (dest->x < extent.lo.x) {
 			dest->x = extent.lo.x;
@@ -1558,7 +1558,7 @@ void clampWaypointPosition( Coord3D &position, Int margin )
   mapExtent.lo.x += margin;
   mapExtent.lo.y += margin;
 
-	if ( mapExtent.isInRegionNoZ( &position ) == FALSE )
+	if ( mapExtent.isInRegionNoZ( position ) == FALSE )
   {
     if ( position.x > mapExtent.hi.x )
       position.x = mapExtent.hi.x;
@@ -2213,7 +2213,7 @@ void AIGroup::groupAttackPosition( const Coord3D *pos, Int maxShotsToFire, Comma
 		if( !pos )
 		{
 			//If you specify a nullptr position, it means you are attacking your own location.
-			attackPos.set( (*i)->getPosition() );
+			attackPos.set( *(*i)->getPosition() );
 		}
 
 		//This code allows garrisoned buildings to force attack a ground position

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -3829,7 +3829,7 @@ void AIFollowWaypointPathState::computeGoal(Bool useGroupOffsets)
 	}
 	Region3D extent;
 	TheTerrainLogic->getMaximumPathfindExtent(&extent);
-	if (!extent.isInRegionNoZ(&m_goalPosition)) {
+	if (!extent.isInRegionNoZ(m_goalPosition)) {
 		setAdjustsDestination(false); // moving off the map.
 		ai->getCurLocomotor()->setAllowInvalidPosition(true); // allow it to move off the map.
 		m_appendGoalPosition = true; // Moving off the map.

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1492,7 +1492,7 @@ void makeAlignToNormalMatrix( Real angle, const Coord3D& pos, const Coord3D& nor
 	DEBUG_ASSERTCRASH(fabs(x.x*z.x + x.y*z.y + x.z*z.z)<0.0001,("dot is not zero (%f)",fabs(x.x*z.x + x.y*z.y + x.z*z.z)));
 
 	// now computing the y vector is trivial.
-	y.crossProduct( &z, &x, &y );
+	y.crossProduct( z, x, y );
 	y.normalize();
 
 	mtx.Set(  x.x, y.x, z.x, pos.x,

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/BridgeBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/BridgeBehavior.cpp
@@ -760,7 +760,7 @@ UpdateSleepTime BridgeBehavior::update()
 				else if ( bridge && bridgeTemplate && bridgeInfo)//we have valid Terrain data for the bridge
 					getRandomSurfacePosition( bridgeTemplate, bridgeInfo, &pos );
 				else
-					pos.set( getObject()->getPosition() );
+					pos.set( *getObject()->getPosition() );
 
 
 				// launch the fx list
@@ -824,7 +824,7 @@ UpdateSleepTime BridgeBehavior::update()
 					if ( bridge && bridgeTemplate && bridgeInfo )//we have valid Terrain data for the bridge
 						getRandomSurfacePosition( bridgeTemplate, bridgeInfo, &pos );
 					else
-						pos.set( getObject()->getPosition() );
+						pos.set( *getObject()->getPosition() );
 
 					// launch the fx list
 					ObjectCreationList::create( (*oclIt).ocl, us, &pos, nullptr );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
@@ -831,7 +831,7 @@ void ParkingPlaceBehavior::unreserveDoorForExit( ExitDoorType exitDoor )
 void ParkingPlaceBehavior::setRallyPoint( const Coord3D *pos )
 {
 	m_heliRallyPointExists = TRUE;
-	m_heliRallyPoint.set( pos );
+	m_heliRallyPoint.set( *pos );
 	// nothing
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
@@ -870,7 +870,7 @@ void SpawnBehavior::computeAggregateStates()
 
 			spawnWeaponBonus = currentSpawn->getWeaponBonusCondition();
 
-			avgSpawnPos.add(currentSpawn->getPosition());
+			avgSpawnPos.add(*currentSpawn->getPosition());
 
 			BodyModuleInterface *body = currentSpawn->getBodyModule();
 			acrHealth    += body->getHealth();
@@ -942,7 +942,7 @@ void SpawnBehavior::computeAggregateStates()
 	// HEALTH BOX POSITION *****************************
 	// pick a centered, average spot to draw the health box
 	avgSpawnPos.scale(1.0f / spawnCount);
-	avgSpawnPos.sub(obj->getPosition());
+	avgSpawnPos.sub(*obj->getPosition());
 	obj->setHealthBoxOffset(avgSpawnPos);
 
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SalvageCrateCollide.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SalvageCrateCollide.cpp
@@ -205,7 +205,7 @@ void SalvageCrateCollide::doMoney( Object *other )
 		UnicodeString moneyString;
 		moneyString.format( TheGameText->fetch( "GUI:AddCash" ), money );
 		Coord3D pos;
-		pos.set( getObject()->getPosition() );
+		pos.set( *getObject()->getPosition() );
 		pos.z += 10.0f; //add a little z to make it show up above the unit.
 		Color color = other->getControllingPlayer()->getPlayerColor() | GameMakeColor( 0, 0, 0, 230 );
 		TheInGameUI->addFloatingText( moneyString, &pos, color );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
@@ -292,7 +292,7 @@ Bool GarrisonContain::calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3
 		return FALSE;
 	}
 
-	sourcePos->set( &(m_garrisonPoint[ conditionIndex ][ placeIndex ]) );
+	sourcePos->set( m_garrisonPoint[ conditionIndex ][ placeIndex ] );
 	return TRUE;
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1717,7 +1717,7 @@ void Object::reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPo
 
 		Region3D mapExtent;
 		TheTerrainLogic->getExtent(&mapExtent);
-		if (mapExtent.isInRegionNoZ(getPosition()))
+		if (mapExtent.isInRegionNoZ(*getPosition()))
 			m_privateStatus &= ~OFF_MAP;
 		else
 			m_privateStatus |= OFF_MAP;
@@ -2618,7 +2618,7 @@ void Object::friend_notifyOfNewMapBoundary()
 
 	Region3D mapExtent;
 	TheTerrainLogic->getExtent(&mapExtent);
-	if (mapExtent.isInRegionNoZ(getPosition()))
+	if (mapExtent.isInRegionNoZ(*getPosition()))
 		m_privateStatus &= ~OFF_MAP;
 	else
 		m_privateStatus |= OFF_MAP;
@@ -2934,7 +2934,7 @@ void Object::createVeterancyLevelFX(VeterancyLevel oldLevel, VeterancyLevel newL
 			Anim2DTemplate *animTemplate = TheAnim2DCollection->findTemplate( TheGlobalData->m_levelGainAnimationName );
 
 			Coord3D pos = *getPosition();
-			pos.add(&m_healthBoxOffset);
+			pos.add(m_healthBoxOffset);
 
 			TheInGameUI->addWorldAnimation( animTemplate,
 																			&pos,
@@ -3121,7 +3121,7 @@ void Object::getHealthBoxPosition(Coord3D& pos) const
 {
 	pos = *getPosition();
 	pos.z += getGeometryInfo().getMaxHeightAbovePosition() + 10;
-	pos.add(&m_healthBoxOffset);
+	pos.add(m_healthBoxOffset);
 
 	// this needs to get moved to the mobspawnerupdate
 	if (isKindOf(KINDOF_MOB_NEXUS)) // quicker idiot test

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -324,9 +324,9 @@ public:
 
 			Coord3D startPos = *primary;
 			Coord3D moveToPos = *secondary;
-			startPos.add( &offset );
+			startPos.add( offset );
 			//Also give our moveToPos the same offset to maintain perfect formation.
-			moveToPos.add( &offset );
+			moveToPos.add( offset );
 
 			Coord3D targetPos = *secondary;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -3964,7 +3964,7 @@ Bool PartitionManager::findPositionAround( const Coord3D *center,
 	TheTerrainLogic->getMaximumPathfindExtent(&extent);
 	// If the goal is off the map, it is a scripted setup, so just
 	// use the center.
-	if (!extent.isInRegionNoZ(center)) {
+	if (!extent.isInRegionNoZ(*center)) {
 		*result = *center;
 		return true;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/CashHackSpecialPower.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/CashHackSpecialPower.cpp
@@ -162,14 +162,14 @@ void CashHackSpecialPower::doSpecialPowerAtObject( Object *victim, UnsignedInt c
 			moneyString.format( TheGameText->fetch( "GUI:AddCash" ), cash );
 			Coord3D pos;
 			pos.zero();
-			pos.add( self->getPosition() );
+			pos.add( *self->getPosition() );
 			pos.z += 20.0f; //add a little z to make it show up above the unit.
 			TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 0, 255, 0, 255 ) );
 
 			//Display cash lost floating over the target
 			moneyString.format( TheGameText->fetch( "GUI:LoseCash" ), cash );
 			pos.zero();
-			pos.add( victim->getPosition() );
+			pos.add( *victim->getPosition() );
 			pos.z += 30.0f; //add a little z to make it show up above the unit.
 			TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 255, 0, 0, 255 ) );
 		}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
@@ -181,7 +181,7 @@ void OCLSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, 
 			ObjectCreationList::create( ocl, getObject(), &creationCoord, loc );
 			break;
 		case USE_OWNER_OBJECT:
-			creationCoord.set( loc );
+			creationCoord.set( *loc );
 			ObjectCreationList::create( ocl, getObject(), &creationCoord, loc, false );
 			break;
 		case CREATE_ABOVE_LOCATION:
@@ -213,7 +213,7 @@ void OCLSpecialPower::doSpecialPower( UnsignedInt commandOptions )
 		return;
 
 	Coord3D creationCoord;
-	creationCoord.set( getObject()->getPosition() );
+	creationCoord.set( *getObject()->getPosition() );
 
 	// call the base class action cause we are *EXTENDING* functionality
 	SpecialPowerModule::doSpecialPowerAtLocation( &creationCoord, INVALID_ANGLE, commandOptions );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -1658,10 +1658,10 @@ Bool AIUpdateInterface::computePath( PathfindServicesInterface *pathServices, Co
 	m_retryPath = false;
 	Region3D extent;
 	TheTerrainLogic->getMaximumPathfindExtent(&extent);
-	if (!extent.isInRegionNoZ(destination)) {
+	if (!extent.isInRegionNoZ(*destination)) {
 		// We're going off the map.
 		Coord3D pos = *getObject()->getPosition();
-		if (!extent.isInRegionNoZ(&pos))	{
+		if (!extent.isInRegionNoZ(pos))	{
 			// We're starting off the map.  Since we're off the map, we can't pathfind so just build a path.
 			return computeQuickPath(destination);
 		}
@@ -3841,7 +3841,7 @@ void AIUpdateInterface::privateGuardPosition( const Coord3D *pos, GuardMode guar
 		// Clip to playable area.
 		Region3D r;
 		TheTerrainLogic->getExtent(&r);
-		if (!r.isInRegionNoZ(&adjPos))
+		if (!r.isInRegionNoZ(adjPos))
 			adjPos = TheTerrainLogic->findClosestEdgePoint(&adjPos);
 	}
 	m_locationToGuard = adjPos;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cpp
@@ -297,7 +297,7 @@ UpdateSleepTime AssaultTransportAIUpdate::update()
 					else
 					{
 						//Increment the number of fighters and their position.
-						fighterCentroidPos.add( member->getPosition() );
+						fighterCentroidPos.add( *member->getPosition() );
 						fightingMembers++;
 
 						if( !ai->isMoving() )
@@ -343,14 +343,14 @@ UpdateSleepTime AssaultTransportAIUpdate::update()
 			//Calculate a vector from the target passed the fighters to be at a safe place
 			//to be as a transport.
 			Coord3D vector;
-			vector.set( &fighterCentroidPos );
-			vector.sub( &designatedTargetPos );
+			vector.set( fighterCentroidPos );
+			vector.sub( designatedTargetPos );
 			vector.normalize();
 			vector.scale( 150.0f );
 
 			Coord3D transportGoalPos;
-			transportGoalPos.set( &designatedTargetPos );
-			transportGoalPos.add( &vector );
+			transportGoalPos.set( designatedTargetPos );
+			transportGoalPos.add( vector );
 
 			Real distanceSqrd = ThePartitionManager->getDistanceSquared( transport, &transportGoalPos, FROM_CENTER_2D );
 			if( distanceSqrd > 40.0f * 40.0f )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -176,7 +176,7 @@ public:
 
 		Region3D mapRegion;
 		TheTerrainLogic->getExtentIncludingBorder( &mapRegion );
-		if (!mapRegion.isInRegionNoZ( owner->getPosition() ))
+		if (!mapRegion.isInRegionNoZ( *owner->getPosition() ))
 		{
 			TheGameLogic->destroyObject(owner);
 			return STATE_SUCCESS;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -215,9 +215,9 @@ UpdateSleepTime DeliverPayloadAIUpdate::update()
 					backwards.scale( 0.33f );
 
 					Coord3D strafePoint = *getTargetPos();
-					strafePoint.sub( &backwards );
+					strafePoint.sub( backwards );
 
-					strafePoint.add( &velocity );
+					strafePoint.add( velocity );
 					strafePoint.z = TheTerrainLogic->getGroundHeight( strafePoint.x, strafePoint.y );
 
 					// lock it just till the weapon is empty or the attack is "done"
@@ -305,8 +305,8 @@ void DeliverPayloadAIUpdate::deliverPayloadViaModuleData( const Coord3D *moveToP
 	//****************************************************
 
 	DeliverPayloadData dpData;
-	dpData.m_dropOffset.set( &data->m_dropOffset );
-	dpData.m_dropVariance.set( &data->m_dropVariance );
+	dpData.m_dropOffset.set( data->m_dropOffset );
+	dpData.m_dropVariance.set( data->m_dropVariance );
 	dpData.m_distToTarget						= data->m_maxDistanceToTarget;
 	dpData.m_maxAttempts						= data->m_maxNumberAttempts;
 	dpData.m_dropDelay							= data->m_dropDelay;
@@ -383,7 +383,7 @@ Bool DeliverPayloadAIUpdate::isOffMap() const
 	Region3D mapRegion;
 	TheTerrainLogic->getExtentIncludingBorder( &mapRegion );
 
-	if (!mapRegion.isInRegionNoZ( getObject()->getPosition() ))
+	if (!mapRegion.isInRegionNoZ( *getObject()->getPosition() ))
 		return true;
 
 	return false;
@@ -810,7 +810,7 @@ StateReturnType DeliveringState::update() // Kick a dude out every so often
 
 							Coord3D backPosition = *owner->getPhysics()->getVelocity();
 							backPosition.scale( -1.0f );
-							backPosition.add( payload->getPosition() );
+							backPosition.add( *payload->getPosition() );
 							payload->setPosition( &backPosition );
 						}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeployStyleAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeployStyleAIUpdate.cpp
@@ -116,7 +116,7 @@ void DeployStyleAIUpdate::aiDoCommand( const AICommandParms* parms )
 		switch( parms->m_cmd )
 		{
 			case AICMD_GUARD_POSITION:
-				m_position.set( &parms->m_pos );
+				m_position.set( parms->m_pos );
 				m_isGuardingPosition = TRUE;
 				//fall through (no break)
 			case AICMD_GUARD_OBJECT:
@@ -135,7 +135,7 @@ void DeployStyleAIUpdate::aiDoCommand( const AICommandParms* parms )
 				break;
 			case AICMD_ATTACK_POSITION:
 				m_isAttackPosition = TRUE;
-				m_position.set( &parms->m_pos );
+				m_position.set( parms->m_pos );
 				break;
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2010,7 +2010,7 @@ void DozerAIUpdate::newTask( DozerTask task, Object *target )
 		offset.set(position.x-target->getPosition()->x, position.y-target->getPosition()->y, 0);
 		offset.normalize();
 		offset.scale(5*PATHFIND_CELL_SIZE_F);
-		position.add(&offset); // move away from the dock point at the end of build.
+		position.add(offset); // move away from the dock point at the end of build.
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_END ].valid				= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_END ].location		= position;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -536,7 +536,7 @@ StateReturnType HackInternetState::update()
 				moneyString.format( TheGameText->fetch( "GUI:AddCash" ), amount );
 				Coord3D pos;
 				pos.zero();
-				pos.add( owner->getPosition() );
+				pos.add( *owner->getPosition() );
 				pos.z += 20.0f; //add a little z to make it show up above the unit.
 				TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 0, 255, 0, 255 ) );
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -357,7 +357,7 @@ void RailroadBehavior::onCollide( Object *other, const Coord3D *loc, const Coord
 
 	//figure out the relative slope between them and me
 	Coord3D delta = *theirLoc;
-	delta.sub( myLoc );
+	delta.sub( *myLoc );
 	delta.normalize();
 	Real dot = delta.x * myDir->x + delta.y * myDir->y + delta.z * myDir->z;
 
@@ -410,7 +410,7 @@ void RailroadBehavior::onCollide( Object *other, const Coord3D *loc, const Coord
 
 	const Coord3D up = {0,0,1};
 	Coord3D cross;
-	myDir->crossProduct( myDir, &up, &cross );
+	myDir->crossProduct( *myDir, up, cross );
 
 	delta.normalize();
 	Real deviationCOG = cross.x * delta.x + cross.y * delta.y + cross.z * delta.z;
@@ -581,7 +581,7 @@ void RailroadBehavior::loadTrackData()
 		trackPoint.m_isStation = scanner->getName().endsWith("Station");
 		trackPoint.m_isDisembark = scanner->getName().endsWith("Disembark");
 		trackPoint.m_isPingPong = FALSE;
-		trackPoint.m_position.set( scanner->getLocation() );
+		trackPoint.m_position.set( *scanner->getLocation() );
 		trackPoint.m_handle = scanner->getID();
 		track->push_back( trackPoint );
 	}
@@ -615,7 +615,7 @@ void RailroadBehavior::loadTrackData()
 				trackPoint.m_isStation = anotherWaypoint->getName().endsWith("Station");
 				trackPoint.m_isPingPong = scanner->getName().endsWith("PingPong");
 				trackPoint.m_isDisembark = scanner->getName().endsWith("Disembark");
-				trackPoint.m_position.set( anotherWaypoint->getLocation() );
+				trackPoint.m_position.set( *anotherWaypoint->getLocation() );
 				trackPoint.m_handle = scanner->getID();
 				track->push_back( trackPoint );
 
@@ -915,7 +915,7 @@ void RailroadBehavior::createCarriages()
 	Coord3D myHitchLoc  = *self->getPosition();
 	Coord3D hitchOffset = *self->getUnitDirectionVector2D();//copy that
 	hitchOffset.scale ( - maxRadius );// negative, since I want the back, not the front
-	myHitchLoc.add( & hitchOffset );
+	myHitchLoc.add( hitchOffset );
 
 
 	PartitionFilterIsValidCarriage pfivc(self, md);
@@ -1076,7 +1076,7 @@ void RailroadBehavior::hitchNewCarriagebyProximity( ObjectID locoID, TrainTrack 
 	Coord3D myHitchLoc  = *self->getPosition();
 	Coord3D hitchOffset = *self->getUnitDirectionVector2D();//copy that
 	hitchOffset.scale ( - maxRadius );// negative, since I want the back, not the front
-	myHitchLoc.add( & hitchOffset );
+	myHitchLoc.add( hitchOffset );
 
 	PartitionFilterIsValidCarriage pfivc(self, md);
 	PartitionFilter *filters[] = { &pfivc, nullptr };
@@ -1196,7 +1196,7 @@ void alignToTerrain( Real angle, const Coord3D& pos, const Coord3D& normal, Matr
 	DEBUG_ASSERTCRASH(fabs(x.x*z.x + x.y*z.y + x.z*z.z)<0.0001,("dot is not zero"));
 
 	// now computing the y vector is trivial.
-	y.crossProduct( &z, &x, &y );
+	y.crossProduct( z, x, y );
 	y.normalize();
 
 	mtx.Set(  x.x, y.x, z.x, pos.x,
@@ -1439,10 +1439,10 @@ void RailroadBehavior::FindPosByPathDistance( Coord3D *pos, const Real dist, con
 
 				Coord3D delta        = nextPoint->m_position;
 
-				delta.sub( &thisPointPos );
+				delta.sub( thisPointPos );
 				delta.normalize();
 				delta.scale( difference );
-				thisPointPos.add( &delta );
+				thisPointPos.add( delta );
 
 				*pos = thisPointPos;//copy out
 				return;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -160,7 +160,7 @@ Bool SupplyTruckAIUpdate::gainOneBox( Int remainingStock )
 		{
 			//figure out whether the best one is considerably far from the previous one (current position)
 			Coord3D delta = *getObject()->getPosition();
-			delta.sub( bestWarehouse->getPosition() );
+			delta.sub( *bestWarehouse->getPosition() );
 			if ( delta.length() > getWarehouseScanDistance()/4)
 			playDepleted = TRUE;
 		}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -1104,7 +1104,7 @@ Bool WorkerAIUpdate::gainOneBox( Int remainingStock )
 		{
 			//figure out whether the best one is considerably far from the previous one (current position)
 			Coord3D delta = *getObject()->getPosition();
-			delta.sub( bestWarehouse->getPosition() );
+			delta.sub( *bestWarehouse->getPosition() );
 			if ( delta.length() > getWarehouseScanDistance()/4)
 			playDepleted = TRUE;
 		}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AutoDepositUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AutoDepositUpdate.cpp
@@ -128,7 +128,7 @@ void AutoDepositUpdate::awardInitialCaptureBonus( Player *player )
 		UnicodeString moneyString;
 		moneyString.format( TheGameText->fetch( "GUI:AddCash" ), getAutoDepositUpdateModuleData()->m_initialCaptureBonus );
 		Coord3D pos;
-		pos.set( getObject()->getPosition() );
+		pos.set( *getObject()->getPosition() );
 		pos.z += 10.0f; //add a little z to make it show up above the unit.
 		Color color = player->getPlayerColor() | GameMakeColor( 0, 0, 0, 230 );
 		TheInGameUI->addFloatingText( moneyString, &pos, color );
@@ -168,7 +168,7 @@ UpdateSleepTime AutoDepositUpdate::update()
 			UnicodeString moneyString;
 			moneyString.format( TheGameText->fetch( "GUI:AddCash" ), getAutoDepositUpdateModuleData()->m_depositAmount );
 			Coord3D pos;
-			pos.set( getObject()->getPosition() );
+			pos.set( *getObject()->getPosition() );
 			pos.z += 10.0f; //add a little z to make it show up above the unit.
 			Color color = getObject()->getControllingPlayer()->getPlayerColor() | GameMakeColor( 0, 0, 0, 230 );
 			TheInGameUI->addFloatingText( moneyString, &pos, color );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
@@ -298,8 +298,8 @@ void LaserUpdate::initLaser( const Object *parent, const Coord3D *startPos, cons
 	//Important! Set the laser position to the average of both points or else
 	//it probably won't get rendered!!!
 	Coord3D avgPos;
-	avgPos.set( startPos );
-	avgPos.add( endPos );
+	avgPos.set( *startPos );
+	avgPos.add( *endPos );
 	avgPos.scale( 0.5 );
 	getDrawable()->setPosition( &avgPos );
 	Object *laser = getDrawable()->getObject();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MobMemberSlavedUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MobMemberSlavedUpdate.cpp
@@ -225,7 +225,7 @@ UpdateSleepTime MobMemberSlavedUpdate::update()
 			else
 			{
 				Coord3D goalDelta = *myAI->getGoalPosition();
-				goalDelta.sub( &nuPos );
+				goalDelta.sub( nuPos );
 
 				if ( goalDelta.length() > 5.0f * PATHFIND_CELL_SIZE_F )// only if I am not headed there already
 				{
@@ -357,7 +357,7 @@ void MobMemberSlavedUpdate::doCatchUpLogic( Coord3D *pos )
 	// recalc where we want to be if we wander around
 	Real randomDirection = GameLogicRandomValue( 0, 2*PI );
 	Real randomRadius = GameLogicRandomValue( 0, data->m_noNeedToCatchUpRadius );
-	nuPos.set(pos);
+	nuPos.set(*pos);
 	nuPos.x += randomRadius * Cos( randomDirection );
 	nuPos.y += randomRadius * Sin( randomDirection );
 	nuPos.z = TheTerrainLogic->getGroundHeight( nuPos.x, nuPos.y );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -251,8 +251,8 @@ void ParticleUplinkCannonUpdate::onObjectCreated()
 	}
 
 	m_specialPowerModule = obj->getSpecialPowerModule( data->m_specialPowerTemplate );
-	m_connectorNodePosition.set( obj->getPosition() );
-	m_laserOriginPosition.set( obj->getPosition() );
+	m_connectorNodePosition.set( *obj->getPosition() );
+	m_laserOriginPosition.set( *obj->getPosition() );
 
 	//Create instances of the sounds required.
 	m_powerupSound.setEventName( data->m_powerupSoundName );
@@ -284,9 +284,9 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 		m_startAttackFrame = TheGameLogic->getFrame();
 		m_laserStatus = LASERSTATUS_NONE;
 		m_manualTargetMode = true;
-		m_initialTargetPosition.set( targetPos );
-		m_overrideTargetDestination.set( targetPos );
-		m_currentTargetPosition.set( targetPos );
+		m_initialTargetPosition.set( *targetPos );
+		m_overrideTargetDestination.set( *targetPos );
+		m_currentTargetPosition.set( *targetPos );
 	}
 	else
 	{
@@ -294,7 +294,7 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 
 		//All computer controlled players have automatic control -- the "S" curve.
 		UnsignedInt now = TheGameLogic->getFrame();
-		m_initialTargetPosition.set( targetPos );
+		m_initialTargetPosition.set( *targetPos );
 		m_startAttackFrame = max( now, (UnsignedInt)1 );
 		m_laserStatus = LASERSTATUS_NONE;
 		setLogicalStatus( STATUS_READY_TO_FIRE );
@@ -483,8 +483,8 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 				Real cxHeight = height * data->m_swathOfDeathAmplitude;
 
 				Coord3D buildingToInitialTargetVector;
-				buildingToInitialTargetVector.set( &m_initialTargetPosition );
-				buildingToInitialTargetVector.sub( me->getPosition() );
+				buildingToInitialTargetVector.set( m_initialTargetPosition );
+				buildingToInitialTargetVector.sub( *me->getPosition() );
 				Real targetDistance = buildingToInitialTargetVector.length();
 
 				//Calculate the point position assuming the target position is on the x axis relative to the building.
@@ -533,7 +533,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 
 				//Calculate the distance from our current position to our target dest.
 				Coord3D vector = m_overrideTargetDestination;
-				vector.sub( &m_currentTargetPosition );
+				vector.sub( m_currentTargetPosition );
 				Real distance = vector.length();
 				if( distance < speed )
 				{
@@ -554,7 +554,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 			m_currentTargetPosition.z = TheTerrainLogic->getGroundHeight( m_currentTargetPosition.x, m_currentTargetPosition.y );
 
 			Coord3D orbitPosition;
-			orbitPosition.set( &m_currentTargetPosition );
+			orbitPosition.set( m_currentTargetPosition );
 			orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 
 			Real scorchRadius = 0.0f;
@@ -918,7 +918,7 @@ void ParticleUplinkCannonUpdate::createGroundToOrbitLaser( UnsignedInt growthFra
 				if( update )
 				{
 					Coord3D orbitPosition;
-					orbitPosition.set( &m_laserOriginPosition );
+					orbitPosition.set( m_laserOriginPosition );
 					orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 					update->initLaser( nullptr, &m_laserOriginPosition, &orbitPosition, growthFrames );
 				}
@@ -957,7 +957,7 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 				if( update )
 				{
 					Coord3D orbitPosition;
-					orbitPosition.set( &m_initialTargetPosition );
+					orbitPosition.set( m_initialTargetPosition );
 					orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 					update->initLaser( nullptr, &orbitPosition, &m_initialTargetPosition, growthFrames );
 				}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -937,7 +937,7 @@ void PhysicsBehavior::transferVelocityTo(PhysicsBehavior* that) const
 {
 	if (that != nullptr)
 	{
-		that->m_vel.add(&m_vel);
+		that->m_vel.add(m_vel);
 		that->m_velMag = INVALID_VEL_MAG;
 	}
 }
@@ -946,7 +946,7 @@ void PhysicsBehavior::transferVelocityTo(PhysicsBehavior* that) const
 void PhysicsBehavior::addVelocityTo( const Coord3D *vel)
 {
 	if (vel != nullptr)
-		m_vel.add( vel );
+		m_vel.add( *vel );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
@@ -307,9 +307,9 @@ Object* PointDefenseLaserUpdate::scanClosestTarget()
 				PhysicsBehavior *physics = other->getPhysics();
 				if( physics )
 				{
-					pos.set( physics->getVelocity() );
+					pos.set( *physics->getVelocity() );
 					pos.scale( data->m_velocityFactor );
-					pos.add( other->getPosition() );
+					pos.add( *other->getPosition() );
 
 					//Recalculate the distance.
 					fDist = sqrt( ThePartitionManager->getDistanceSquared( me, other, FROM_CENTER_2D ) );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SlavedUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SlavedUpdate.cpp
@@ -292,19 +292,19 @@ void SlavedUpdate::doAttackLogic( const Object *target )
 	{
 		//The distance is too far, so calculate the best allowable position.
 		Coord3D vector;
-		vector.set( targetPos );
-		vector.sub( master->getPosition() );
+		vector.set( *targetPos );
+		vector.sub( *master->getPosition() );
 		vector.normalize();
 		vector.scale( data->m_attackRange );
 
 		//Now that we have calculated the vector relative to me, add it to my position to get my goal.
-		attackPosition.set( master->getPosition() );
-		attackPosition.add( &vector );
+		attackPosition.set( *master->getPosition() );
+		attackPosition.add( vector );
 	}
 	else
 	{
 		//We are close enough, so use the target position -- easy!
-		attackPosition.set( targetPos );
+		attackPosition.set( *targetPos );
 	}
 
 	//Finally, if we have a wander distance, then randomly select a point within
@@ -355,19 +355,19 @@ void SlavedUpdate::doScoutLogic( const Coord3D *mastersDestination )
 	{
 		//The distance is too far, so calculate the best allowable position.
 		Coord3D vector;
-		vector.set( mastersDestination );
-		vector.sub( master->getPosition() );
+		vector.set( *mastersDestination );
+		vector.sub( *master->getPosition() );
 		vector.normalize();
 		vector.scale( data->m_scoutRange );
 
 		//Now that we have calculated the vector relative to me, add it to my position to get my goal.
-		scoutPosition.set( master->getPosition() );
-		scoutPosition.add( &vector );
+		scoutPosition.set( *master->getPosition() );
+		scoutPosition.add( vector );
 	}
 	else
 	{
 		//We are close enough, so use the target position -- easy!
-		scoutPosition.set( mastersDestination );
+		scoutPosition.set( *mastersDestination );
 	}
 
 	//Finally, if we have a wander distance, then randomly select a point within
@@ -478,7 +478,7 @@ void SlavedUpdate::doRepairLogic()
 			locomotor->setUsePreciseZPos( closeEnoughForZPrecision );
 		}
 		Coord3D pos;
-		pos.set( master->getPosition() );
+		pos.set( *master->getPosition() );
 		Real altitude = GameLogicRandomValueReal( data->m_repairMinAltitude, data->m_repairMaxAltitude );
 		pos.z += altitude;
 		ai->aiMoveToPosition( &pos, CMD_FROM_AI );
@@ -623,11 +623,11 @@ void SlavedUpdate::setRepairState( RepairStates repairState )
 						//Get the bone position
 						if( draw->getPristineBonePositions( data->m_weldingFXBone.str(), 0, &pos, nullptr, 1 ) )
 						{
-							pos.add( obj->getPosition() );
+							pos.add( *obj->getPosition() );
 						}
 						else
 						{
-							pos.set( obj->getPosition() );
+							pos.set( *obj->getPosition() );
 						}
 
 						weldingSys->setPosition( &pos );
@@ -670,7 +670,7 @@ void SlavedUpdate::moveToNewRepairSpot()
 	{
 		//Allow me to wander away from the pinnedPosition.
 		Real randomDirection = GameLogicRandomValue( 0, 2*PI );
-		m_guardPointOffset.set( master->getPosition() );
+		m_guardPointOffset.set( *master->getPosition() );
 		m_guardPointOffset.x += data->m_repairRange * Cos( randomDirection );
 		m_guardPointOffset.y += data->m_repairRange * Sin( randomDirection );
 		m_guardPointOffset.z = TheTerrainLogic->getGroundHeight( m_guardPointOffset.x, m_guardPointOffset.y );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1008,7 +1008,7 @@ Bool SpecialAbilityUpdate::initLaser(Object* specialObject, Object* target )
 	if( !getObject()->getSingleLogicalBonePosition( data->m_specialObjectAttachToBoneName.str(), &startPos, nullptr ) )
 	{
 		//If we can't find the bone, then set it to our current position.
-		startPos.set( getObject()->getPosition() );
+		startPos.set( *getObject()->getPosition() );
 	}
 
 	Coord3D endPos;
@@ -1373,13 +1373,13 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
 					UnicodeString moneyString;
 					moneyString.format( TheGameText->fetch( "GUI:AddCash" ), cash );
 					Coord3D pos;
-					pos.set( object->getPosition() );
+					pos.set( *object->getPosition() );
 					pos.z += 20.0f; //add a little z to make it show up above the unit.
 					TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 0, 255, 0, 255 ) );
 
 					//Display cash lost floating over the target
 					moneyString.format( TheGameText->fetch( "GUI:LoseCash" ), cash );
-					pos.set( target->getPosition() );
+					pos.set( *target->getPosition() );
 					pos.z += 30.0f; //add a little z to make it show up above the unit.
 					TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 255, 0, 0, 255 ) );
 				}
@@ -1604,23 +1604,23 @@ void SpecialAbilityUpdate::finishAbility()
 	if( data->m_fleeRangeAfterCompletion && validTarget )
 	{
 		Coord3D pos;
-		pos.set( getObject()->getPosition() );
+		pos.set( *getObject()->getPosition() );
 
 		AIUpdateInterface *ai = getObject()->getAIUpdateInterface();
 		if( ai )
 		{
 			Coord3D dir;
-			dir.set( getObject()->getUnitDirectionVector2D() );
+			dir.set( *getObject()->getUnitDirectionVector2D() );
 			dir.normalize();
 			dir.scale( data->m_fleeRangeAfterCompletion );
 
 			if( data->m_flipObjectAfterUnpacking || data->m_flipObjectAfterPacking )
 			{
-				pos.add( &dir );
+				pos.add( dir );
 			}
 			else
 			{
-				pos.sub( &dir );
+				pos.sub( dir );
 			}
 			// Now check for mines.  Normally we are fleeing from a bomb we just planted.
 			// It is not good to run back towards the previous mine we just planted about
@@ -1638,7 +1638,7 @@ void SpecialAbilityUpdate::finishAbility()
 						dir.normalize();
 						dir.scale(data->m_fleeRangeAfterCompletion);
 						pos = *mine->getPosition();
-						pos.add(&dir);
+						pos.add(dir);
 					}
 				}
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
@@ -575,7 +575,7 @@ void setWakeupIfInRange( Object *obj, void *userData)
 	Coord3D srcpos = *obj->getPosition();
 	Coord3D dstpos = *victim->getPosition();
 
-	srcpos.sub(&dstpos);
+	srcpos.sub(dstpos);
 	if (srcpos.length() > vision)
 		return;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
@@ -281,7 +281,7 @@ UpdateSleepTime TensileFormationUpdate::update()
 	Real steepness = 1.0f - normal.z;
 	slope.scale( 0.3f + steepness);
 
-	m_inertia.add( &slope );
+	m_inertia.add( slope );
 
 	Real friction = 0.95f;
 	m_inertia.scale( friction );
@@ -313,7 +313,7 @@ UpdateSleepTime TensileFormationUpdate::update()
 
 			Coord3D tensor = m_links[ t ].tensor;
 
-			desiredPos.sub( &tensor );
+			desiredPos.sub( tensor );
 
 			//Coord3D desiredPos = { theirPos->x - m_links[ t ].tensor.x, theirPos->y - m_links[ t ].tensor.y, theirPos->z - m_links[ t ].tensor.z };
 
@@ -322,7 +322,7 @@ UpdateSleepTime TensileFormationUpdate::update()
 			newPos.z = MIN( m_lowestSlideElevation, TheTerrainLogic->getGroundHeight(newPos.x, newPos.y) );//rest on surface here
 
 			tensor.normalize();
-			tensorSum.add( &tensor );
+			tensorSum.add( tensor );
 
 		}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/WaveGuideUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/WaveGuideUpdate.cpp
@@ -722,8 +722,8 @@ void WaveGuideUpdate::doDamage()
 								u.y = Sin( angle + modData->m_bridgeParticleAngleFudge );
 								u.z = 0.0f;
 
-								y.crossProduct( &z, &u, &y );
-								x.crossProduct( &y, &z, &x );
+								y.crossProduct( z, u, y );
+								x.crossProduct( y, z, x );
 
 								transform.Set(  x.x, y.x, z.x, obj->getPosition()->x,
 																x.y, y.y, z.y, obj->getPosition()->y,

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -870,7 +870,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		}
 		else
 		{
-			targetPos.set( victimPos );
+			targetPos.set( *victimPos );
 		}
 		Real reAngle = getWeaponRecoilAmount();
 		Real reDir = reAngle != 0.0f ? (atan2(victimPos->y - sourcePos->y, victimPos->x - sourcePos->x)) : 0.0f;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
@@ -280,12 +280,12 @@ void W3DWaypointBuffer::drawWaypoints(RenderInfoClass &rinfo)
 							wayOutPoint.normalize();
 							wayOutPoint.scale( 99999.9f );
 							Real wayOutLength = wayOutPoint.length();
-							wayOutPoint.add(&naturalRallyPoint);
+							wayOutPoint.add(naturalRallyPoint);
 
 
 							//if the rallypoint is closer to the wayoutpoint than it is to the natural rally point then we definitely do not wrap
 							Coord3D rallyToWayOutDelta = wayOutPoint;
-							rallyToWayOutDelta.sub(rallyPoint);
+							rallyToWayOutDelta.sub(*rallyPoint);
 							if ( (100.0f + rallyToWayOutDelta.length()) > wayOutLength)
 							{
 
@@ -293,7 +293,7 @@ void W3DWaypointBuffer::drawWaypoints(RenderInfoClass &rinfo)
 								wayOutPoint.normalize();// a normal shooting straight out the door
 								//next comes the delta between the NRP and the RP
 								Coord3D NRPToRPDelta = naturalRallyPoint;
-								NRPToRPDelta.sub(rallyPoint);
+								NRPToRPDelta.sub(*rallyPoint);
 								NRPToRPDelta.normalize();
 								Real dot = NRPToRPDelta.x * wayOutPoint.x + NRPToRPDelta.y * wayOutPoint.y;
 								if (dot > 0)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ChinookAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ChinookAIUpdate.h
@@ -104,7 +104,7 @@ public:
 	const ChinookAIUpdateModuleData* friend_getData() const { return getChinookAIUpdateModuleData(); }
 	void friend_setFlightStatus(ChinookFlightStatus a) { m_flightStatus = a; }
 
-	void recordOriginalPosition( const Coord3D &pos ) { m_originalPos.set( &pos ); }
+	void recordOriginalPosition( const Coord3D &pos ) { m_originalPos.set( pos ); }
 	const Coord3D* getOriginalPosition() const { return &m_originalPos; }
 
 	virtual Int getUpgradedSupplyBoost() const override;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Bezier/BezFwdIterator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Bezier/BezFwdIterator.cpp
@@ -111,9 +111,9 @@ const Coord3D& BezFwdIterator::getCurrent() const
 //-------------------------------------------------------------------------------------------------
 void BezFwdIterator::next()
 {
-	mCurrPoint.add(&mDq);
-	mDq.add(&mDDq);
-	mDDq.add(&mDDDq);
+	mCurrPoint.add(mDq);
+	mDq.add(mDDq);
+	mDDq.add(mDDDq);
 
 	++mStep;
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/Bezier/BezierSegment.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Bezier/BezierSegment.cpp
@@ -207,9 +207,9 @@ void BezierSegment::splitSegmentAtT(Real tValue, BezierSegment &outSeg1, BezierS
 	p1p2.scale(tValue);
 	p2p3.scale(tValue);
 
-	p0p1.add(&m_controlPoints[0]);
-	p1p2.add(&m_controlPoints[1]);
-	p2p3.add(&m_controlPoints[2]);
+	p0p1.add(m_controlPoints[0]);
+	p1p2.add(m_controlPoints[1]);
+	p2p3.add(m_controlPoints[2]);
 
 	Coord3D triLeft = { p1p2.x - p0p1.x,
 											p1p2.y - p0p1.y,
@@ -222,8 +222,8 @@ void BezierSegment::splitSegmentAtT(Real tValue, BezierSegment &outSeg1, BezierS
 	triLeft.scale(tValue);
 	triRight.scale(tValue);
 
-	triLeft.add(&p0p1);
-	triRight.add(&p1p2);
+	triLeft.add(p0p1);
+	triRight.add(p1p2);
 
 	outSeg1.m_controlPoints[0] = m_controlPoints[0];
 	outSeg1.m_controlPoints[1] = p0p1;

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -1464,7 +1464,7 @@ inline Bool isPointOnMap( const Coord3D  *testPos )
 {
 	Region3D mapRegion;
 	TheTerrainLogic->getExtent( &mapRegion );
-	return mapRegion.isInRegionNoZ( testPos );
+	return mapRegion.isInRegionNoZ( *testPos );
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2483,7 +2483,7 @@ void Player::doBountyForKill(const Object* killer, const Object* victim)
 		moneyString.format( TheGameText->fetch( "GUI:AddCash" ), bounty );
 		Coord3D pos;
 		pos.zero();
-		pos.add( killer->getPosition() );
+		pos.add( *killer->getPosition() );
 		pos.z += 10.0f; //add a little z to make it show up above the unit.
 		TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 255, 255, 0, 255 ) );
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -922,7 +922,7 @@ LegalBuildCode BuildAssistant::isLocationLegalToBuild( const Coord3D *worldPos,
 	/* You just can't never build off the map, regardless of options.  jba. */
 	Region3D mapExtent;
 	TheTerrainLogic->getMaximumPathfindExtent(&mapExtent);
-	if (!mapExtent.isInRegionNoZ(worldPos)) {
+	if (!mapExtent.isInRegionNoZ(*worldPos)) {
 		return LBC_RESTRICTED_TERRAIN;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/Thing.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/Thing.cpp
@@ -233,8 +233,8 @@ void Thing::setOrientation( Real angle )
 		u.y = Sin(angle);
 		u.z = 0.0f;
 
-		y.crossProduct( &z, &u, &y );
-		x.crossProduct( &y, &z, &x );
+		y.crossProduct( z, u, y );
+		x.crossProduct( y, z, x );
 
 		m_transform.Set(  x.x, y.x, z.x, pos.x,
 											x.y, y.y, z.y, pos.y,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -4469,7 +4469,7 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 			  {
 				  //Check if it's close enough to try playing (optimization)
 				  Coord3D vector = *getPosition();
-				  vector.sub( TheAudio->getListenerPosition() );
+				  vector.sub( *TheAudio->getListenerPosition() );
 				  Real distSqr = vector.lengthSqr();
 				  if( distSqr < sqr( info->m_maxDistance ) )
 				  {

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -1737,8 +1737,8 @@ void Drawable::calcPhysicsXformTreads( const Locomotor *locomotor, PhysicsXformI
 				up.normalize();
 
 				Coord3D prp;
-				prp.crossProduct( &v, &up, &prp );
-				normal.crossProduct( &prp, &v, &normal );
+				prp.crossProduct( v, up, prp );
+				normal.crossProduct( prp, v, normal );
 
 				// compute unit normal
 				normal.normalize();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -660,14 +660,14 @@ Bool CommandButton::isValidToUseOn(const Object *sourceObj, const Object *target
 	Coord3D pos;
 	if( targetLocation )
 	{
-		pos.set( targetLocation );
+		pos.set( *targetLocation );
 	}
 
 	if( BitIsSet( m_options, NEED_TARGET_POS ) && !targetLocation )
 	{
 		if( targetObj )
 		{
-			pos.set( targetObj->getPosition() );
+			pos.set( *targetObj->getPosition() );
 		}
 		else
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -690,7 +690,7 @@ static void clampToMap(Coord3D *dest, PlayerType pt)
 	extent.hi.y -= PATHFIND_CELL_SIZE_F;
 	extent.lo.x += PATHFIND_CELL_SIZE_F;
 	extent.lo.y += PATHFIND_CELL_SIZE_F;
-	if (!extent.isInRegionNoZ(dest)) {
+	if (!extent.isInRegionNoZ(*dest)) {
 		// clamp to in region. [8/28/2003]
 		if (dest->x < extent.lo.x) {
 			dest->x = extent.lo.x;
@@ -1568,7 +1568,7 @@ void clampWaypointPosition( Coord3D &position, Int margin )
   mapExtent.lo.x += margin;
   mapExtent.lo.y += margin;
 
-	if ( mapExtent.isInRegionNoZ( &position ) == FALSE )
+	if ( mapExtent.isInRegionNoZ( position ) == FALSE )
   {
     if ( position.x > mapExtent.hi.x )
       position.x = mapExtent.hi.x;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -2276,7 +2276,7 @@ void AIGroup::groupAttackPosition( const Coord3D *pos, Int maxShotsToFire, Comma
 		if( !pos )
 		{
 			//If you specify a nullptr position, it means you are attacking your own location.
-			attackPos.set( (*i)->getPosition() );
+			attackPos.set( *(*i)->getPosition() );
 		}
 
 		//This code allows garrisoned buildings to force attack a ground position

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -2077,7 +2077,7 @@ Bool AIPlayer::calcClosestConstructionZoneLocation( const ThingTemplate *constru
 	if( valid )
 	{
 		//We succeeded in calculating the best position.
-		location->set( &newPos );
+		location->set( newPos );
     success = TRUE;
 	}
 	else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -3932,9 +3932,9 @@ void AIFollowWaypointPathState::computeGoal(Bool useGroupOffsets)
 	Region3D extent;
 	TheTerrainLogic->getMaximumPathfindExtent(&extent);
 
-	if (extent.isInRegionNoZ(&dest)) {
+	if (extent.isInRegionNoZ(dest)) {
 		// The waypoint is on the map.  Check & see if the adjusted position is off map [8/28/2003]
-		if (!extent.isInRegionNoZ(&m_goalPosition)) {
+		if (!extent.isInRegionNoZ(m_goalPosition)) {
 			// clamp to in region. [8/28/2003]
 			if (m_goalPosition.x < extent.lo.x+PATHFIND_CELL_SIZE_F) {
 				m_goalPosition.x = extent.lo.x+PATHFIND_CELL_SIZE_F;
@@ -3951,7 +3951,7 @@ void AIFollowWaypointPathState::computeGoal(Bool useGroupOffsets)
 		}
 	}
 
-	if (!extent.isInRegionNoZ(&m_goalPosition)) {
+	if (!extent.isInRegionNoZ(m_goalPosition)) {
 		setAdjustsDestination(false); // moving off the map.
 		ai->getCurLocomotor()->setAllowInvalidPosition(true); // allow it to move off the map.
 		m_appendGoalPosition = true; // Moving off the map.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1492,7 +1492,7 @@ void makeAlignToNormalMatrix( Real angle, const Coord3D& pos, const Coord3D& nor
 	DEBUG_ASSERTCRASH(fabs(x.x*z.x + x.y*z.y + x.z*z.z)<0.0001,("dot is not zero (%f)",fabs(x.x*z.x + x.y*z.y + x.z*z.z)));
 
 	// now computing the y vector is trivial.
-	y.crossProduct( &z, &x, &y );
+	y.crossProduct( z, x, y );
 	y.normalize();
 
 	mtx.Set(  x.x, y.x, z.x, pos.x,

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/BridgeBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/BridgeBehavior.cpp
@@ -760,7 +760,7 @@ UpdateSleepTime BridgeBehavior::update()
 				else if ( bridge && bridgeTemplate && bridgeInfo)//we have valid Terrain data for the bridge
 					getRandomSurfacePosition( bridgeTemplate, bridgeInfo, &pos );
 				else
-					pos.set( getObject()->getPosition() );
+					pos.set( *getObject()->getPosition() );
 
 
 				// launch the fx list
@@ -824,7 +824,7 @@ UpdateSleepTime BridgeBehavior::update()
 					if ( bridge && bridgeTemplate && bridgeInfo )//we have valid Terrain data for the bridge
 						getRandomSurfacePosition( bridgeTemplate, bridgeInfo, &pos );
 					else
-						pos.set( getObject()->getPosition() );
+						pos.set( *getObject()->getPosition() );
 
 					// launch the fx list
 					ObjectCreationList::create( (*oclIt).ocl, us, &pos, nullptr, INVALID_ANGLE );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
@@ -561,7 +561,7 @@ void FlightDeckBehavior::calcPPInfo( ObjectID id, PPInfo *info )
 
 		//Cache the runway's takeoff distance used by JetAIUpdate for calculating lift.
 		Coord3D vector = info->runwayStart;
-		vector.sub( &info->runwayEnd );
+		vector.sub( info->runwayEnd );
 		info->runwayTakeoffDist = vector.length();
 
 		for (std::vector<RunwayInfo>::iterator it = m_runways.begin(); it != m_runways.end(); ++it)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
@@ -874,7 +874,7 @@ Bool FlightDeckBehavior::calcBestParkingAssignment( ObjectID id, Coord3D *pos, I
 
 			if( pos )
 			{
-				pos->set( &myIt->m_prep );
+				pos->set( myIt->m_prep );
 			}
 			break;
 		}
@@ -942,7 +942,7 @@ Bool FlightDeckBehavior::calcBestParkingAssignment( ObjectID id, Coord3D *pos, I
 					checkForPlaneInWay = TRUE;
 					if( pos )
 					{
-						pos->set( &thatIt->m_prep );
+						pos->set( thatIt->m_prep );
 					}
 				}
 			}
@@ -952,7 +952,7 @@ Bool FlightDeckBehavior::calcBestParkingAssignment( ObjectID id, Coord3D *pos, I
  				checkForPlaneInWay = FALSE;
 				if( pos )
 				{
-					pos->set( &myIt->m_prep ); //reset the original position.
+					pos->set( myIt->m_prep ); //reset the original position.
 					bestIt = m_spaces.end();
 				}
 			}
@@ -1400,13 +1400,13 @@ void FlightDeckBehavior::aiDoCommand(const AICommandParms* parms)
 		{
 			case AICMD_GUARD_POSITION:
 				m_designatedTarget = INVALID_ID;
-				m_designatedPosition.set( &parms->m_pos );
+				m_designatedPosition.set( parms->m_pos );
 				m_designatedCommand = parms->m_cmd;
 				propagateOrdersToPlanes();
 				break;
 			case AICMD_ATTACK_POSITION:
 				m_designatedTarget = INVALID_ID;
-				m_designatedPosition.set( &parms->m_pos );
+				m_designatedPosition.set( parms->m_pos );
 				m_designatedCommand = parms->m_cmd;
 				propagateOrdersToPlanes();
 				break;
@@ -1419,7 +1419,7 @@ void FlightDeckBehavior::aiDoCommand(const AICommandParms* parms)
 				break;
 			case AICMD_ATTACKMOVE_TO_POSITION:
 				m_designatedTarget = INVALID_ID;
-				m_designatedPosition.set( &parms->m_pos );
+				m_designatedPosition.set( parms->m_pos );
 				m_designatedCommand = parms->m_cmd;
 				propagateOrdersToPlanes();
 				break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
@@ -398,7 +398,7 @@ void ParkingPlaceBehavior::calcPPInfo( ObjectID id, PPInfo *info )
 
 		//Cache the runway's takeoff distance used by JetAIUpdate for calculating lift.
 		Coord3D vector = info->runwayStart;
-		vector.sub( &info->runwayEnd );
+		vector.sub( info->runwayEnd );
 		info->runwayTakeoffDist = vector.length();
 
 		for (std::vector<RunwayInfo>::iterator it = m_runways.begin(); it != m_runways.end(); ++it)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
@@ -903,7 +903,7 @@ void ParkingPlaceBehavior::unreserveDoorForExit( ExitDoorType exitDoor )
 void ParkingPlaceBehavior::setRallyPoint( const Coord3D *pos )
 {
 	m_heliRallyPointExists = TRUE;
-	m_heliRallyPoint.set( pos );
+	m_heliRallyPoint.set( *pos );
 	// nothing
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
@@ -986,7 +986,7 @@ void SpawnBehavior::computeAggregateStates()
 	// HEALTH BOX POSITION *****************************
 	// pick a centered, average spot to draw the health box
 	avgSpawnPos.scale(1.0f / spawnCount);
-	avgSpawnPos.sub(obj->getPosition());
+	avgSpawnPos.sub(*obj->getPosition());
 	obj->setHealthBoxOffset(avgSpawnPos);
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
@@ -914,7 +914,7 @@ void SpawnBehavior::computeAggregateStates()
 
 			spawnWeaponBonus = currentSpawn->getWeaponBonusCondition();
 
-			avgSpawnPos.add(currentSpawn->getPosition());
+			avgSpawnPos.add(*currentSpawn->getPosition());
 
 			BodyModuleInterface *body = currentSpawn->getBodyModule();
 			acrHealth    += body->getHealth();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SabotageSupplyCenterCrateCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SabotageSupplyCenterCrateCollide.cpp
@@ -161,13 +161,13 @@ Bool SabotageSupplyCenterCrateCollide::executeCrateBehavior( Object *other )
 			UnicodeString moneyString;
 			moneyString.format( TheGameText->fetch( "GUI:AddCash" ), cash );
 			Coord3D pos;
-			pos.set( obj->getPosition() );
+			pos.set( *obj->getPosition() );
 			pos.z += 20.0f; //add a little z to make it show up above the unit.
 			TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 0, 255, 0, 255 ) );
 
 			//Display cash lost floating over the target
 			moneyString.format( TheGameText->fetch( "GUI:LoseCash" ), cash );
-			pos.set( other->getPosition() );
+			pos.set( *other->getPosition() );
 			pos.z += 30.0f; //add a little z to make it show up above the unit.
 			TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 255, 0, 0, 255 ) );
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SabotageSupplyDropzoneCrateCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SabotageSupplyDropzoneCrateCollide.cpp
@@ -171,13 +171,13 @@ Bool SabotageSupplyDropzoneCrateCollide::executeCrateBehavior( Object *other )
 			UnicodeString moneyString;
 			moneyString.format( TheGameText->fetch( "GUI:AddCash" ), cash );
 			Coord3D pos;
-			pos.set( obj->getPosition() );
+			pos.set( *obj->getPosition() );
 			pos.z += 20.0f; //add a little z to make it show up above the unit.
 			TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 0, 255, 0, 255 ) );
 
 			//Display cash lost floating over the target
 			moneyString.format( TheGameText->fetch( "GUI:LoseCash" ), cash );
-			pos.set( other->getPosition() );
+			pos.set( *other->getPosition() );
 			pos.z += 30.0f; //add a little z to make it show up above the unit.
 			TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 255, 0, 0, 255 ) );
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SalvageCrateCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SalvageCrateCollide.cpp
@@ -252,7 +252,7 @@ void SalvageCrateCollide::doMoney( Object *other )
 		UnicodeString moneyString;
 		moneyString.format( TheGameText->fetch( "GUI:AddCash" ), money );
 		Coord3D pos;
-		pos.set( getObject()->getPosition() );
+		pos.set( *getObject()->getPosition() );
 		pos.z += 10.0f; //add a little z to make it show up above the unit.
 		Color color = other->getControllingPlayer()->getPlayerColor() | GameMakeColor( 0, 0, 0, 230 );
 		TheInGameUI->addFloatingText( moneyString, &pos, color );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
@@ -300,7 +300,7 @@ Bool GarrisonContain::calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3
 		return FALSE;
 	}
 
-	sourcePos->set( &(m_garrisonPoint[ conditionIndex ][ placeIndex ]) );
+	sourcePos->set( m_garrisonPoint[ conditionIndex ][ placeIndex ] );
 	return TRUE;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3237,7 +3237,7 @@ void Object::createVeterancyLevelFX(VeterancyLevel oldLevel, VeterancyLevel newL
 			Anim2DTemplate *animTemplate = TheAnim2DCollection->findTemplate( TheGlobalData->m_levelGainAnimationName );
 
 			Coord3D pos = *getPosition();
-			pos.add(&m_healthBoxOffset);
+			pos.add(m_healthBoxOffset);
 
 			TheInGameUI->addWorldAnimation( animTemplate,
 																			&pos,
@@ -3453,7 +3453,7 @@ void Object::getHealthBoxPosition(Coord3D& pos) const
 {
 	pos = *getPosition();
 	pos.z += getGeometryInfo().getMaxHeightAbovePosition() + 10;
-	pos.add(&m_healthBoxOffset);
+	pos.add(m_healthBoxOffset);
 
 	// this needs to get moved to the mobspawnerupdate
 	if (isKindOf(KINDOF_MOB_NEXUS)) // quicker idiot test

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1877,7 +1877,7 @@ void Object::reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPo
 
 		Region3D mapExtent;
 		TheTerrainLogic->getExtent(&mapExtent);
-		if (mapExtent.isInRegionNoZ(getPosition()))
+		if (mapExtent.isInRegionNoZ(*getPosition()))
 			m_privateStatus &= ~OFF_MAP;
 		else
 			m_privateStatus |= OFF_MAP;
@@ -2906,7 +2906,7 @@ void Object::friend_notifyOfNewMapBoundary()
 
 	Region3D mapExtent;
 	TheTerrainLogic->getExtent(&mapExtent);
-	if (mapExtent.isInRegionNoZ(getPosition()))
+	if (mapExtent.isInRegionNoZ(*getPosition()))
 		m_privateStatus &= ~OFF_MAP;
 	else
 		m_privateStatus |= OFF_MAP;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1926,7 +1926,7 @@ void Object::attemptDamage( DamageInfo *damageInfo )
 
 			// Set up the shockwave force to use apply on object
 			Coord3D shockWaveForce;
-			shockWaveForce.set( &damageInfo->in.m_shockWaveVector );
+			shockWaveForce.set( damageInfo->in.m_shockWaveVector );
 			shockWaveForce.normalize();
 			shockWaveForce.scale( damageInfo->in.m_shockWaveAmount * shockTaperMult );
 			shockWaveForce.z = shockWaveForce.length(); // Apply up force equal to the lateral force for dramatic effect

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -333,9 +333,9 @@ public:
 
 			Coord3D startPos = *primary;
 			Coord3D moveToPos = *secondary;
-			startPos.add( &offset );
+			startPos.add( offset );
 			//Also give our moveToPos the same offset to maintain perfect formation.
-			moveToPos.add( &offset );
+			moveToPos.add( offset );
 
 			Coord3D targetPos = *secondary;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -3974,7 +3974,7 @@ Bool PartitionManager::findPositionAround( const Coord3D *center,
 	TheTerrainLogic->getMaximumPathfindExtent(&extent);
 	// If the goal is off the map, it is a scripted setup, so just
 	// use the center.
-	if (!extent.isInRegionNoZ(center)) {
+	if (!extent.isInRegionNoZ(*center)) {
 		*result = *center;
 		return true;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/CashHackSpecialPower.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/CashHackSpecialPower.cpp
@@ -162,14 +162,14 @@ void CashHackSpecialPower::doSpecialPowerAtObject( Object *victim, UnsignedInt c
 			moneyString.format( TheGameText->fetch( "GUI:AddCash" ), cash );
 			Coord3D pos;
 			pos.zero();
-			pos.add( self->getPosition() );
+			pos.add( *self->getPosition() );
 			pos.z += 20.0f; //add a little z to make it show up above the unit.
 			TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 0, 255, 0, 255 ) );
 
 			//Display cash lost floating over the target
 			moneyString.format( TheGameText->fetch( "GUI:LoseCash" ), cash );
 			pos.zero();
-			pos.add( victim->getPosition() );
+			pos.add( *victim->getPosition() );
 			pos.z += 30.0f; //add a little z to make it show up above the unit.
 			TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 255, 0, 0, 255 ) );
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
@@ -207,7 +207,7 @@ void OCLSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, 
 			ObjectCreationList::create( ocl, getObject(), &creationCoord, &targetCoord, angle );
 			break;
 		case USE_OWNER_OBJECT:
-			creationCoord.set( &targetCoord );
+			creationCoord.set( targetCoord );
 			ObjectCreationList::create( ocl, getObject(), &creationCoord, &targetCoord, angle, false );
 			break;
 		case CREATE_ABOVE_LOCATION:
@@ -239,7 +239,7 @@ void OCLSpecialPower::doSpecialPower( UnsignedInt commandOptions )
 		return;
 
 	Coord3D creationCoord;
-	creationCoord.set( getObject()->getPosition() );
+	creationCoord.set( *getObject()->getPosition() );
 
 	// call the base class action cause we are *EXTENDING* functionality
 	SpecialPowerModule::doSpecialPowerAtLocation( &creationCoord, INVALID_ANGLE, commandOptions );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -1679,10 +1679,10 @@ Bool AIUpdateInterface::computePath( PathfindServicesInterface *pathServices, Co
 	m_retryPath = false;
 	Region3D extent;
 	TheTerrainLogic->getMaximumPathfindExtent(&extent);
-	if (!extent.isInRegionNoZ(destination)) {
+	if (!extent.isInRegionNoZ(*destination)) {
 		// We're going off the map.
 		Coord3D pos = *getObject()->getPosition();
-		if (!extent.isInRegionNoZ(&pos))	{
+		if (!extent.isInRegionNoZ(pos))	{
 			// We're starting off the map.  Since we're off the map, we can't pathfind so just build a path.
 			return computeQuickPath(destination);
 		}
@@ -4056,7 +4056,7 @@ void AIUpdateInterface::privateGuardPosition( const Coord3D *pos, GuardMode guar
 		// Clip to playable area.
 		Region3D r;
 		TheTerrainLogic->getExtent(&r);
-		if (!r.isInRegionNoZ(&adjPos))
+		if (!r.isInRegionNoZ(adjPos))
 			adjPos = TheTerrainLogic->findClosestEdgePoint(&adjPos);
 	}
 	m_locationToGuard = adjPos;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -1977,7 +1977,7 @@ Bool AIUpdateInterface::computeAttackPath( PathfindServicesInterface *pathServic
 				// If the move is a short distance, just do a find closest path to our current
 				// position.  This will unstack us if we are on top of another unit. jba.
 				Coord3D objPos = *getObject()->getPosition();
-				goal.sub(&objPos);
+				goal.sub(objPos);
 				if (goal.length()<3*PATHFIND_CELL_SIZE_F) {
 					destroyPath();
 					TheAI->pathfinder()->adjustDestination(getObject(), m_locomotorSet, &objPos);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cpp
@@ -343,13 +343,13 @@ UpdateSleepTime AssaultTransportAIUpdate::update()
 			//Calculate a vector from the target passed the fighters to be at a safe place
 			//to be as a transport.
 			Coord3D vector;
-			vector.set( &fighterCentroidPos );
+			vector.set( fighterCentroidPos );
 			vector.sub( &designatedTargetPos );
 			vector.normalize();
 			vector.scale( 150.0f );
 
 			Coord3D transportGoalPos;
-			transportGoalPos.set( &designatedTargetPos );
+			transportGoalPos.set( designatedTargetPos );
 			transportGoalPos.add( &vector );
 
 			Real distanceSqrd = ThePartitionManager->getDistanceSquared( transport, &transportGoalPos, FROM_CENTER_2D );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cpp
@@ -344,7 +344,7 @@ UpdateSleepTime AssaultTransportAIUpdate::update()
 			//to be as a transport.
 			Coord3D vector;
 			vector.set( fighterCentroidPos );
-			vector.sub( &designatedTargetPos );
+			vector.sub( designatedTargetPos );
 			vector.normalize();
 			vector.scale( 150.0f );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cpp
@@ -297,7 +297,7 @@ UpdateSleepTime AssaultTransportAIUpdate::update()
 					else
 					{
 						//Increment the number of fighters and their position.
-						fighterCentroidPos.add( member->getPosition() );
+						fighterCentroidPos.add( *member->getPosition() );
 						fightingMembers++;
 
 						if( !ai->isMoving() )
@@ -350,7 +350,7 @@ UpdateSleepTime AssaultTransportAIUpdate::update()
 
 			Coord3D transportGoalPos;
 			transportGoalPos.set( designatedTargetPos );
-			transportGoalPos.add( &vector );
+			transportGoalPos.add( vector );
 
 			Real distanceSqrd = ThePartitionManager->getDistanceSquared( transport, &transportGoalPos, FROM_CENTER_2D );
 			if( distanceSqrd > 40.0f * 40.0f )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -169,7 +169,7 @@ public:
 
 		Region3D mapRegion;
 		TheTerrainLogic->getExtentIncludingBorder( &mapRegion );
-		if( !mapRegion.isInRegionNoZ( owner->getPosition() ) )
+		if( !mapRegion.isInRegionNoZ( *owner->getPosition() ) )
 		{
 			TheGameLogic->destroyObject(owner);
 			return STATE_SUCCESS;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -218,7 +218,7 @@ UpdateSleepTime DeliverPayloadAIUpdate::update()
 					Coord3D strafePoint = *getTargetPos();
 					strafePoint.sub( backwards );
 
-					strafePoint.add( &velocity );
+					strafePoint.add( velocity );
 					strafePoint.z = TheTerrainLogic->getGroundHeight( strafePoint.x, strafePoint.y );
 
 					// lock it just till the weapon is empty or the attack is "done"
@@ -836,7 +836,7 @@ StateReturnType DeliveringState::update() // Kick a dude out every so often
 
 							Coord3D backPosition = *owner->getPhysics()->getVelocity();
 							backPosition.scale( -1.0f );
-							backPosition.add( payload->getPosition() );
+							backPosition.add( *payload->getPosition() );
 							payload->setPosition( &backPosition );
 						}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -384,7 +384,7 @@ Bool DeliverPayloadAIUpdate::isOffMap() const
 	Region3D mapRegion;
 	TheTerrainLogic->getExtentIncludingBorder( &mapRegion );
 
-	if (!mapRegion.isInRegionNoZ( getObject()->getPosition() ))
+	if (!mapRegion.isInRegionNoZ( *getObject()->getPosition() ))
 		return true;
 
 	return false;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -306,8 +306,8 @@ void DeliverPayloadAIUpdate::deliverPayloadViaModuleData( const Coord3D *moveToP
 	//****************************************************
 
 	DeliverPayloadData dpData;
-	dpData.m_dropOffset.set( &data->m_dropOffset );
-	dpData.m_dropVariance.set( &data->m_dropVariance );
+	dpData.m_dropOffset.set( data->m_dropOffset );
+	dpData.m_dropVariance.set( data->m_dropVariance );
 	dpData.m_distToTarget						= data->m_maxDistanceToTarget;
 	dpData.m_maxAttempts						= data->m_maxNumberAttempts;
 	dpData.m_dropDelay							= data->m_dropDelay;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -216,7 +216,7 @@ UpdateSleepTime DeliverPayloadAIUpdate::update()
 					backwards.scale( 0.33f );
 
 					Coord3D strafePoint = *getTargetPos();
-					strafePoint.sub( &backwards );
+					strafePoint.sub( backwards );
 
 					strafePoint.add( &velocity );
 					strafePoint.z = TheTerrainLogic->getGroundHeight( strafePoint.x, strafePoint.y );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2015,7 +2015,7 @@ void DozerAIUpdate::newTask( DozerTask task, Object *target )
 		offset.set(position.x-target->getPosition()->x, position.y-target->getPosition()->y, 0);
 		offset.normalize();
 		offset.scale(5*PATHFIND_CELL_SIZE_F);
-		position.add(&offset); // move away from the dock point at the end of build.
+		position.add(offset); // move away from the dock point at the end of build.
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_END ].valid				= TRUE;
 		m_dockPoint[ task ][ DOZER_DOCK_POINT_END ].location		= position;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -551,7 +551,7 @@ StateReturnType HackInternetState::update()
 					moneyString.format( TheGameText->fetch( "GUI:AddCash" ), amount );
 					Coord3D pos;
 					pos.zero();
-					pos.add( owner->getPosition() );
+					pos.add( *owner->getPosition() );
 					pos.z += 20.0f; //add a little z to make it show up above the unit.
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -868,7 +868,7 @@ public:
 			ParkingPlaceBehaviorInterface::PPInfo ppinfo;
 			pp->calcPPInfo( jet->getID(), &ppinfo );
 			Coord3D vector = ppinfo.runwayEnd;
-			vector.sub( jet->getPosition() );
+			vector.sub( *jet->getPosition() );
 			Real dist = vector.length();
 
 			Real ratio = 1.0f - (dist / ppinfo.runwayTakeoffDist);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -576,7 +576,7 @@ void RailroadBehavior::loadTrackData()
 		trackPoint.m_isStation = scanner->getName().endsWith("Station");
 		trackPoint.m_isDisembark = scanner->getName().endsWith("Disembark");
 		trackPoint.m_isPingPong = FALSE;
-		trackPoint.m_position.set( scanner->getLocation() );
+		trackPoint.m_position.set( *scanner->getLocation() );
 		trackPoint.m_handle = scanner->getID();
 		track->push_back( trackPoint );
 	}
@@ -610,7 +610,7 @@ void RailroadBehavior::loadTrackData()
 				trackPoint.m_isStation = anotherWaypoint->getName().endsWith("Station");
 				trackPoint.m_isPingPong = scanner->getName().endsWith("PingPong");
 				trackPoint.m_isDisembark = scanner->getName().endsWith("Disembark");
-				trackPoint.m_position.set( anotherWaypoint->getLocation() );
+				trackPoint.m_position.set( *anotherWaypoint->getLocation() );
 				trackPoint.m_handle = scanner->getID();
 				track->push_back( trackPoint );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -955,7 +955,7 @@ void RailroadBehavior::createCarriages()
 	Coord3D myHitchLoc  = *self->getPosition();
 	Coord3D hitchOffset = *self->getUnitDirectionVector2D();//copy that
 	hitchOffset.scale ( - maxRadius );// negative, since I want the back, not the front
-	myHitchLoc.add( & hitchOffset );
+	myHitchLoc.add( hitchOffset );
 
 
 	PartitionFilterIsValidCarriage pfivc(self, md);
@@ -1116,7 +1116,7 @@ void RailroadBehavior::hitchNewCarriagebyProximity( ObjectID locoID, TrainTrack 
 	Coord3D myHitchLoc  = *self->getPosition();
 	Coord3D hitchOffset = *self->getUnitDirectionVector2D();//copy that
 	hitchOffset.scale ( - maxRadius );// negative, since I want the back, not the front
-	myHitchLoc.add( & hitchOffset );
+	myHitchLoc.add( hitchOffset );
 
 	PartitionFilterIsValidCarriage pfivc(self, md);
 	PartitionFilter *filters[] = { &pfivc, nullptr };
@@ -1487,7 +1487,7 @@ void RailroadBehavior::FindPosByPathDistance( Coord3D *pos, const Real dist, con
 				delta.sub( thisPointPos );
 				delta.normalize();
 				delta.scale( difference );
-				thisPointPos.add( &delta );
+				thisPointPos.add( delta );
 
 				*pos = thisPointPos;//copy out
 				return;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -352,7 +352,7 @@ void RailroadBehavior::onCollide( Object *other, const Coord3D *loc, const Coord
 
 	//figure out the relative slope between them and me
 	Coord3D delta = *theirLoc;
-	delta.sub( myLoc );
+	delta.sub( *myLoc );
 	delta.normalize();
 	Real dot = delta.x * myDir->x + delta.y * myDir->y + delta.z * myDir->z;
 
@@ -1484,7 +1484,7 @@ void RailroadBehavior::FindPosByPathDistance( Coord3D *pos, const Real dist, con
 
 				Coord3D delta        = nextPoint->m_position;
 
-				delta.sub( &thisPointPos );
+				delta.sub( thisPointPos );
 				delta.normalize();
 				delta.scale( difference );
 				thisPointPos.add( &delta );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -405,7 +405,7 @@ void RailroadBehavior::onCollide( Object *other, const Coord3D *loc, const Coord
 
 	const Coord3D up = {0,0,1};
 	Coord3D cross;
-	myDir->crossProduct( myDir, &up, &cross );
+	myDir->crossProduct( *myDir, up, cross );
 
 	delta.normalize();
 	Real deviationCOG = cross.x * delta.x + cross.y * delta.y + cross.z * delta.z;
@@ -1236,7 +1236,7 @@ void alignToTerrain( Real angle, const Coord3D& pos, const Coord3D& normal, Matr
 	DEBUG_ASSERTCRASH(fabs(x.x*z.x + x.y*z.y + x.z*z.z)<0.0001,("dot is not zero"));
 
 	// now computing the y vector is trivial.
-	y.crossProduct( &z, &x, &y );
+	y.crossProduct( z, x, y );
 	y.normalize();
 
 	mtx.Set(  x.x, y.x, z.x, pos.x,

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -166,7 +166,7 @@ Bool SupplyTruckAIUpdate::gainOneBox( Int remainingStock )
 		{
 			//figure out whether the best one is considerably far from the previous one (current position)
 			Coord3D delta = *getObject()->getPosition();
-			delta.sub( bestWarehouse->getPosition() );
+			delta.sub( *bestWarehouse->getPosition() );
 			if ( delta.length() > getWarehouseScanDistance()/4)
 			playDepleted = TRUE;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -1104,7 +1104,7 @@ Bool WorkerAIUpdate::gainOneBox( Int remainingStock )
 		{
 			//figure out whether the best one is considerably far from the previous one (current position)
 			Coord3D delta = *getObject()->getPosition();
-			delta.sub( bestWarehouse->getPosition() );
+			delta.sub( *bestWarehouse->getPosition() );
 			if ( delta.length() > getWarehouseScanDistance()/4)
 			playDepleted = TRUE;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AutoDepositUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AutoDepositUpdate.cpp
@@ -129,7 +129,7 @@ void AutoDepositUpdate::awardInitialCaptureBonus( Player *player )
 		UnicodeString moneyString;
 		moneyString.format( TheGameText->fetch( "GUI:AddCash" ), getAutoDepositUpdateModuleData()->m_initialCaptureBonus );
 		Coord3D pos;
-		pos.set( getObject()->getPosition() );
+		pos.set( *getObject()->getPosition() );
 		pos.z += 10.0f; //add a little z to make it show up above the unit.
 		Color color = player->getPlayerColor() | GameMakeColor( 0, 0, 0, 230 );
 		TheInGameUI->addFloatingText( moneyString, &pos, color );
@@ -180,7 +180,7 @@ UpdateSleepTime AutoDepositUpdate::update()
 			  UnicodeString moneyString;
 			  moneyString.format( TheGameText->fetch( "GUI:AddCash" ), moneyAmount );
 			  Coord3D pos;
-			  pos.set( getObject()->getPosition() );
+			  pos.set( *getObject()->getPosition() );
 			  pos.z += 10.0f; //add a little z to make it show up above the unit.
 
         if ( owner->isKindOf( KINDOF_STRUCTURE ) )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -357,7 +357,7 @@ void EMPUpdate::doDisableAttack()
 			Coord3D coord;
 			coord.set( *intendedVictim->getPosition() );
 			//Subtract this object (distance from missile to victim's previous position)
-			coord.sub( pos );
+			coord.sub( *pos );
 
 			Real lengthSqr = coord.lengthSqr();
 			if( lengthSqr <= radius * 2.0f || lengthSqr <= 40.0f * 40.0f )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -355,7 +355,7 @@ void EMPUpdate::doDisableAttack()
 		{
 			//Victim position
 			Coord3D coord;
-			coord.set( intendedVictim->getPosition() );
+			coord.set( *intendedVictim->getPosition() );
 			//Subtract this object (distance from missile to victim's previous position)
 			coord.sub( pos );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
@@ -131,7 +131,7 @@ void LaserUpdate::updateStartPos()
 			//      create a nasty assert.
 			//TheGameClient->destroyDrawable( getDrawable() );
 
-			m_startPos.set( parentDrawable->getPosition() );
+			m_startPos.set( *parentDrawable->getPosition() );
 			DEBUG_CRASH( ("LaserUpdate::updateStartPos() -- Drawable %s is expecting to find a bone %s but can't. Defaulting to position of drawable.",
 				parentDrawable->getTemplate()->getName().str(), m_parentBoneName.str() ) );
 
@@ -404,7 +404,7 @@ void LaserUpdate::initLaser( const Object *parent, const Object *target, const C
 	Coord3D posToUse;
 	if( parent == nullptr )
 	{
-		posToUse.set( startPos );
+		posToUse.set( *startPos );
 		posToUse.add( endPos );
 		posToUse.scale( 0.5 );
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
@@ -405,7 +405,7 @@ void LaserUpdate::initLaser( const Object *parent, const Object *target, const C
 	if( parent == nullptr )
 	{
 		posToUse.set( *startPos );
-		posToUse.add( endPos );
+		posToUse.add( *endPos );
 		posToUse.scale( 0.5 );
 	}
 	else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MobMemberSlavedUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MobMemberSlavedUpdate.cpp
@@ -357,7 +357,7 @@ void MobMemberSlavedUpdate::doCatchUpLogic( Coord3D *pos )
 	// recalc where we want to be if we wander around
 	Real randomDirection = GameLogicRandomValue( 0, 2*PI );
 	Real randomRadius = GameLogicRandomValue( 0, data->m_noNeedToCatchUpRadius );
-	nuPos.set(pos);
+	nuPos.set(*pos);
 	nuPos.x += randomRadius * Cos( randomDirection );
 	nuPos.y += randomRadius * Sin( randomDirection );
 	nuPos.z = TheTerrainLogic->getGroundHeight( nuPos.x, nuPos.y );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MobMemberSlavedUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MobMemberSlavedUpdate.cpp
@@ -225,7 +225,7 @@ UpdateSleepTime MobMemberSlavedUpdate::update()
 			else
 			{
 				Coord3D goalDelta = *myAI->getGoalPosition();
-				goalDelta.sub( &nuPos );
+				goalDelta.sub( nuPos );
 
 				if ( goalDelta.length() > 5.0f * PATHFIND_CELL_SIZE_F )// only if I am not headed there already
 				{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -253,8 +253,8 @@ void ParticleUplinkCannonUpdate::onObjectCreated()
 	}
 
 	m_specialPowerModule = obj->getSpecialPowerModule( data->m_specialPowerTemplate );
-	m_connectorNodePosition.set( obj->getPosition() );
-	m_laserOriginPosition.set( obj->getPosition() );
+	m_connectorNodePosition.set( *obj->getPosition() );
+	m_laserOriginPosition.set( *obj->getPosition() );
 
 	//Create instances of the sounds required.
 	m_powerupSound.setEventName( data->m_powerupSoundName );
@@ -289,9 +289,9 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 #if !RETAIL_COMPATIBLE_CRC
 		m_scriptedWaypointMode = FALSE;
 #endif
-		m_initialTargetPosition.set( targetPos );
-		m_overrideTargetDestination.set( targetPos );
-		m_currentTargetPosition.set( targetPos );
+		m_initialTargetPosition.set( *targetPos );
+		m_overrideTargetDestination.set( *targetPos );
+		m_currentTargetPosition.set( *targetPos );
 	}
 	else if( way )
 	{
@@ -299,7 +299,7 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 		UnsignedInt now = TheGameLogic->getFrame();
 
 		Coord3D pos;
-		pos.set( way->getLocation() );
+		pos.set( *way->getLocation() );
 
 		m_startAttackFrame = max( now, (UnsignedInt)1 );
 #if !RETAIL_COMPATIBLE_CRC
@@ -309,8 +309,8 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 		m_laserStatus = LASERSTATUS_NONE;
 		setLogicalStatus( STATUS_READY_TO_FIRE );
 		m_specialPowerModule->setReadyFrame( now );
-		m_initialTargetPosition.set( &pos );
-		m_currentTargetPosition.set( &pos );
+		m_initialTargetPosition.set( pos );
+		m_currentTargetPosition.set( pos );
 
 		Int linkCount = way->getNumLinks();
 		Int which = GameLogicRandomValue( 0, linkCount-1 );
@@ -318,7 +318,7 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 		if( next )
 		{
 			m_nextDestWaypointID = next->getID();
-			m_overrideTargetDestination.set( next->getLocation() );
+			m_overrideTargetDestination.set( *next->getLocation() );
 		}
 		else
 		{
@@ -335,17 +335,17 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 		Coord3D pos;
 		if( targetPos )
 		{
-			pos.set( targetPos );
+			pos.set( *targetPos );
 		}
 		else if( targetObj )
 		{
-			pos.set( targetObj->getPosition() );
+			pos.set( *targetObj->getPosition() );
 		}
 #if !RETAIL_COMPATIBLE_CRC
 		m_manualTargetMode = FALSE;
 		m_scriptedWaypointMode = FALSE;
 #endif
-		m_initialTargetPosition.set( &pos );
+		m_initialTargetPosition.set( pos );
 		m_startAttackFrame = max( now, (UnsignedInt)1 );
 		m_laserStatus = LASERSTATUS_NONE;
 		setLogicalStatus( STATUS_READY_TO_FIRE );
@@ -535,7 +535,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 				Real cxHeight = height * data->m_swathOfDeathAmplitude;
 
 				Coord3D buildingToInitialTargetVector;
-				buildingToInitialTargetVector.set( &m_initialTargetPosition );
+				buildingToInitialTargetVector.set( m_initialTargetPosition );
 				buildingToInitialTargetVector.sub( me->getPosition() );
 				Real targetDistance = buildingToInitialTargetVector.length();
 
@@ -606,7 +606,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 							if ( way )
 							{
 								m_nextDestWaypointID = way->getID();
-								m_overrideTargetDestination.set(way->getLocation());
+								m_overrideTargetDestination.set(*way->getLocation());
 							}
 							else
 							{
@@ -629,7 +629,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 			m_currentTargetPosition.z = TheTerrainLogic->getGroundHeight( m_currentTargetPosition.x, m_currentTargetPosition.y );
 
 			Coord3D orbitPosition;
-			orbitPosition.set( &m_currentTargetPosition );
+			orbitPosition.set( m_currentTargetPosition );
 			orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 
 			Real scorchRadius = 0.0f;
@@ -1003,7 +1003,7 @@ void ParticleUplinkCannonUpdate::createGroundToOrbitLaser( UnsignedInt growthFra
 				if( update )
 				{
 					Coord3D orbitPosition;
-					orbitPosition.set( &m_laserOriginPosition );
+					orbitPosition.set( m_laserOriginPosition );
 					orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 					update->initLaser( nullptr, nullptr, &m_laserOriginPosition, &orbitPosition, "", growthFrames );
 				}
@@ -1042,7 +1042,7 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 				if( update )
 				{
 					Coord3D orbitPosition;
-					orbitPosition.set( &m_initialTargetPosition );
+					orbitPosition.set( m_initialTargetPosition );
 					orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 					update->initLaser( nullptr, nullptr, &orbitPosition, &m_initialTargetPosition, "", growthFrames );
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -536,7 +536,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 
 				Coord3D buildingToInitialTargetVector;
 				buildingToInitialTargetVector.set( m_initialTargetPosition );
-				buildingToInitialTargetVector.sub( me->getPosition() );
+				buildingToInitialTargetVector.sub( *me->getPosition() );
 				Real targetDistance = buildingToInitialTargetVector.length();
 
 				//Calculate the point position assuming the target position is on the x axis relative to the building.
@@ -584,7 +584,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 
 				//Calculate the distance from our current position to our target dest.
 				Coord3D vector = m_overrideTargetDestination;
-				vector.sub( &m_currentTargetPosition );
+				vector.sub( m_currentTargetPosition );
 				Real distance = vector.length();
 				if( distance < speed )
 				{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1062,7 +1062,7 @@ void PhysicsBehavior::transferVelocityTo(PhysicsBehavior* that) const
 {
 	if (that != nullptr)
 	{
-		that->m_vel.add(&m_vel);
+		that->m_vel.add(m_vel);
 		that->m_velMag = INVALID_VEL_MAG;
 	}
 }
@@ -1071,7 +1071,7 @@ void PhysicsBehavior::transferVelocityTo(PhysicsBehavior* that) const
 void PhysicsBehavior::addVelocityTo( const Coord3D *vel)
 {
 	if (vel != nullptr)
-		m_vel.add( vel );
+		m_vel.add( *vel );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
@@ -314,7 +314,7 @@ Object* PointDefenseLaserUpdate::scanClosestTarget()
 				{
 					pos.set( *physics->getVelocity() );
 					pos.scale( data->m_velocityFactor );
-					pos.add( other->getPosition() );
+					pos.add( *other->getPosition() );
 
 					//Recalculate the distance.
 					fDist = sqrt( ThePartitionManager->getDistanceSquared( me, other, FROM_CENTER_2D ) );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
@@ -312,7 +312,7 @@ Object* PointDefenseLaserUpdate::scanClosestTarget()
 				PhysicsBehavior *physics = other->getPhysics();
 				if( physics )
 				{
-					pos.set( physics->getVelocity() );
+					pos.set( *physics->getVelocity() );
 					pos.scale( data->m_velocityFactor );
 					pos.add( other->getPosition() );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SlavedUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SlavedUpdate.cpp
@@ -304,7 +304,7 @@ void SlavedUpdate::doAttackLogic( const Object *target )
 
 		//Now that we have calculated the vector relative to me, add it to my position to get my goal.
 		attackPosition.set( *master->getPosition() );
-		attackPosition.add( &vector );
+		attackPosition.add( vector );
 	}
 	else
 	{
@@ -367,7 +367,7 @@ void SlavedUpdate::doScoutLogic( const Coord3D *mastersDestination )
 
 		//Now that we have calculated the vector relative to me, add it to my position to get my goal.
 		scoutPosition.set( *master->getPosition() );
-		scoutPosition.add( &vector );
+		scoutPosition.add( vector );
 	}
 	else
 	{
@@ -628,7 +628,7 @@ void SlavedUpdate::setRepairState( RepairStates repairState )
 						//Get the bone position
 						if( draw->getPristineBonePositions( data->m_weldingFXBone.str(), 0, &pos, nullptr, 1 ) )
 						{
-							pos.add( obj->getPosition() );
+							pos.add( *obj->getPosition() );
 						}
 						else
 						{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SlavedUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SlavedUpdate.cpp
@@ -298,7 +298,7 @@ void SlavedUpdate::doAttackLogic( const Object *target )
 		//The distance is too far, so calculate the best allowable position.
 		Coord3D vector;
 		vector.set( *targetPos );
-		vector.sub( master->getPosition() );
+		vector.sub( *master->getPosition() );
 		vector.normalize();
 		vector.scale( data->m_attackRange );
 
@@ -361,7 +361,7 @@ void SlavedUpdate::doScoutLogic( const Coord3D *mastersDestination )
 		//The distance is too far, so calculate the best allowable position.
 		Coord3D vector;
 		vector.set( *mastersDestination );
-		vector.sub( master->getPosition() );
+		vector.sub( *master->getPosition() );
 		vector.normalize();
 		vector.scale( data->m_scoutRange );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SlavedUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SlavedUpdate.cpp
@@ -297,19 +297,19 @@ void SlavedUpdate::doAttackLogic( const Object *target )
 	{
 		//The distance is too far, so calculate the best allowable position.
 		Coord3D vector;
-		vector.set( targetPos );
+		vector.set( *targetPos );
 		vector.sub( master->getPosition() );
 		vector.normalize();
 		vector.scale( data->m_attackRange );
 
 		//Now that we have calculated the vector relative to me, add it to my position to get my goal.
-		attackPosition.set( master->getPosition() );
+		attackPosition.set( *master->getPosition() );
 		attackPosition.add( &vector );
 	}
 	else
 	{
 		//We are close enough, so use the target position -- easy!
-		attackPosition.set( targetPos );
+		attackPosition.set( *targetPos );
 	}
 
 	//Finally, if we have a wander distance, then randomly select a point within
@@ -360,19 +360,19 @@ void SlavedUpdate::doScoutLogic( const Coord3D *mastersDestination )
 	{
 		//The distance is too far, so calculate the best allowable position.
 		Coord3D vector;
-		vector.set( mastersDestination );
+		vector.set( *mastersDestination );
 		vector.sub( master->getPosition() );
 		vector.normalize();
 		vector.scale( data->m_scoutRange );
 
 		//Now that we have calculated the vector relative to me, add it to my position to get my goal.
-		scoutPosition.set( master->getPosition() );
+		scoutPosition.set( *master->getPosition() );
 		scoutPosition.add( &vector );
 	}
 	else
 	{
 		//We are close enough, so use the target position -- easy!
-		scoutPosition.set( mastersDestination );
+		scoutPosition.set( *mastersDestination );
 	}
 
 	//Finally, if we have a wander distance, then randomly select a point within
@@ -483,7 +483,7 @@ void SlavedUpdate::doRepairLogic()
 			locomotor->setUsePreciseZPos( closeEnoughForZPrecision );
 		}
 		Coord3D pos;
-		pos.set( master->getPosition() );
+		pos.set( *master->getPosition() );
 		Real altitude = GameLogicRandomValueReal( data->m_repairMinAltitude, data->m_repairMaxAltitude );
 		pos.z += altitude;
 		ai->aiMoveToPosition( &pos, CMD_FROM_AI );
@@ -632,7 +632,7 @@ void SlavedUpdate::setRepairState( RepairStates repairState )
 						}
 						else
 						{
-							pos.set( obj->getPosition() );
+							pos.set( *obj->getPosition() );
 						}
 
 						weldingSys->setPosition( &pos );
@@ -675,7 +675,7 @@ void SlavedUpdate::moveToNewRepairSpot()
 	{
 		//Allow me to wander away from the pinnedPosition.
 		Real randomDirection = GameLogicRandomValue( 0, 2*PI );
-		m_guardPointOffset.set( master->getPosition() );
+		m_guardPointOffset.set( *master->getPosition() );
 		m_guardPointOffset.x += data->m_repairRange * Cos( randomDirection );
 		m_guardPointOffset.y += data->m_repairRange * Sin( randomDirection );
 		m_guardPointOffset.z = TheTerrainLogic->getGroundHeight( m_guardPointOffset.x, m_guardPointOffset.y );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1790,7 +1790,7 @@ void SpecialAbilityUpdate::finishAbility()
 			}
 			else
 			{
-				pos.sub( &dir );
+				pos.sub( dir );
 			}
 			// Now check for mines.  Normally we are fleeing from a bomb we just planted.
 			// It is not good to run back towards the previous mine we just planted about

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1786,7 +1786,7 @@ void SpecialAbilityUpdate::finishAbility()
 
 			if( data->m_flipObjectAfterUnpacking || data->m_flipObjectAfterPacking )
 			{
-				pos.add( &dir );
+				pos.add( dir );
 			}
 			else
 			{
@@ -1808,7 +1808,7 @@ void SpecialAbilityUpdate::finishAbility()
 						dir.normalize();
 						dir.scale(data->m_fleeRangeAfterCompletion);
 						pos = *mine->getPosition();
-						pos.add(&dir);
+						pos.add(dir);
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1123,7 +1123,7 @@ Bool SpecialAbilityUpdate::initLaser(Object* specialObject, Object* target )
   if( !getObject()->getSingleLogicalBonePosition( data->m_specialObjectAttachToBoneName.str(), &startPos, nullptr ) )
   {
     //If we can't find the bone, then set it to our current position.
-    startPos.set( getObject()->getPosition() );
+    startPos.set( *getObject()->getPosition() );
   }
 
   Coord3D endPos;
@@ -1519,13 +1519,13 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
           UnicodeString moneyString;
           moneyString.format( TheGameText->fetch( "GUI:AddCash" ), cash );
           Coord3D pos;
-          pos.set( object->getPosition() );
+          pos.set( *object->getPosition() );
           pos.z += 20.0f; //add a little z to make it show up above the unit.
           TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 0, 255, 0, 255 ) );
 
           //Display cash lost floating over the target
           moneyString.format( TheGameText->fetch( "GUI:LoseCash" ), cash );
-          pos.set( target->getPosition() );
+          pos.set( *target->getPosition() );
           pos.z += 30.0f; //add a little z to make it show up above the unit.
           TheInGameUI->addFloatingText( moneyString, &pos, GameMakeColor( 255, 0, 0, 255 ) );
         }
@@ -1775,13 +1775,13 @@ void SpecialAbilityUpdate::finishAbility()
   if( data->m_fleeRangeAfterCompletion && validTarget )
   {
     Coord3D pos;
-    pos.set( getObject()->getPosition() );
+    pos.set( *getObject()->getPosition() );
 
     AIUpdateInterface *ai = getObject()->getAIUpdateInterface();
     if( ai )
     {
       Coord3D dir;
-      dir.set( getObject()->getUnitDirectionVector2D() );
+      dir.set( *getObject()->getUnitDirectionVector2D() );
 			dir.scale( data->m_fleeRangeAfterCompletion );
 
 			if( data->m_flipObjectAfterUnpacking || data->m_flipObjectAfterPacking )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipDeploymentUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipDeploymentUpdate.cpp
@@ -205,7 +205,7 @@ Bool SpectreGunshipDeploymentUpdate::initiateIntentToDoSpecialPower(const Specia
 
       // HERE WE NEED TO CREATE THE POINT FURTHER OFF THE MAP SO WE CANT SEE THE LAME HOVER AND ACCELERATE BEHAVIOR
     Coord3D deltaToCreationPoint = m_initialTargetPosition;
-    deltaToCreationPoint.sub( &creationCoord );
+    deltaToCreationPoint.sub( creationCoord );
     Real distanceFromTarget = deltaToCreationPoint.length();
     deltaToCreationPoint.normalize();
     deltaToCreationPoint.x *= ( distanceFromTarget + data->m_gunshipOrbitRadius );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipDeploymentUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipDeploymentUpdate.cpp
@@ -150,13 +150,13 @@ Bool SpectreGunshipDeploymentUpdate::initiateIntentToDoSpecialPower(const Specia
 
 	if( !BitIsSet( commandOptions, COMMAND_FIRED_BY_SCRIPT ) )
 	{
-/******CHANGE*******/		m_initialTargetPosition.set( targetPos );
+/******CHANGE*******/		m_initialTargetPosition.set( *targetPos );
 	}
 	else
 	{
 		UnsignedInt now = TheGameLogic->getFrame();
 		m_specialPowerModule->setReadyFrame( now );
-/******CHANGE*******/   	m_initialTargetPosition.set( targetPos );
+/******CHANGE*******/   	m_initialTargetPosition.set( *targetPos );
 //		setLogicalStatus( GUNSHIPDEPLOY_STATUS_INSERTING );
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
@@ -406,7 +406,7 @@ UpdateSleepTime SpectreGunshipUpdate::update()
 
         //perigee is the point in the orbital arc nearest the satellite being captured
         Coord3D perigee = *gunship->getPosition();
-        perigee.sub( &m_initialTargetPosition );
+        perigee.sub( m_initialTargetPosition );
         perigee.z = zero;
         Real distanceToTarget = perigee.length();
         perigee.normalize();
@@ -442,7 +442,7 @@ UpdateSleepTime SpectreGunshipUpdate::update()
 
         //Constrain Target Override to the targeting radius
         Coord3D overrideTargetDelta = m_initialTargetPosition;
-        overrideTargetDelta.sub( &m_overrideTargetDestination );
+        overrideTargetDelta.sub( m_overrideTargetDestination );
         if ( overrideTargetDelta.length() > constraintRadius )
         {
           overrideTargetDelta.normalize();
@@ -626,7 +626,7 @@ UpdateSleepTime SpectreGunshipUpdate::update()
 
 
             Coord3D delta = m_positionToShootAt;
-            delta.sub( &m_gattlingTargetPosition );
+            delta.sub( m_gattlingTargetPosition );
             Real dist = delta.length();
             if ( dist < data->m_strafingIncrement )
             {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
@@ -638,7 +638,7 @@ UpdateSleepTime SpectreGunshipUpdate::update()
               m_okToFireHowitzerCounter = ZERO;
               delta.normalize();
               delta.scale( data->m_strafingIncrement );
-              m_gattlingTargetPosition.add( &delta );
+              m_gattlingTargetPosition.add( delta );
             }
 
 
@@ -793,7 +793,7 @@ void SpectreGunshipUpdate::disengageAndDepartAO( Object *gunship )
     Real mapSize = 99999.0f;
     exitPoint.x *= mapSize;
     exitPoint.y *= mapSize;
-    exitPoint.add( gunship->getPosition() );
+    exitPoint.add( *gunship->getPosition() );
 
     shipAI->aiMoveToPosition( &exitPoint, CMD_FROM_AI );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
@@ -306,7 +306,7 @@ Bool SpectreGunshipUpdate::isPointOffMap( const Coord3D& testPos ) const
 	Region3D mapRegion;
 	TheTerrainLogic->getExtentIncludingBorder( &mapRegion );
 
-	if (!mapRegion.isInRegionNoZ( &testPos ))
+	if (!mapRegion.isInRegionNoZ( testPos ))
 		return true;
 
 	return false;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
@@ -177,7 +177,7 @@ void SpectreGunshipUpdate::onObjectCreated()
 	}
 
 	m_specialPowerModule = obj->getSpecialPowerModule( data->m_specialPowerTemplate );
-  m_satellitePosition.set( obj->getPosition() );
+  m_satellitePosition.set( *obj->getPosition() );
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -193,15 +193,15 @@ Bool SpectreGunshipUpdate::initiateIntentToDoSpecialPower(const SpecialPowerTemp
 
 	if( !BitIsSet( commandOptions, COMMAND_FIRED_BY_SCRIPT ) )
 	{
-		m_initialTargetPosition.set( targetPos );
-		m_overrideTargetDestination.set( targetPos );
-    m_gattlingTargetPosition.set( targetPos );
+		m_initialTargetPosition.set( *targetPos );
+		m_overrideTargetDestination.set( *targetPos );
+    m_gattlingTargetPosition.set( *targetPos );
 	}
 	else
 	{
 		UnsignedInt now = TheGameLogic->getFrame();
 		m_specialPowerModule->setReadyFrame( now );
-   	m_initialTargetPosition.set( targetPos );
+   	m_initialTargetPosition.set( *targetPos );
 		setLogicalStatus( GUNSHIP_STATUS_INSERTING );
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
@@ -846,7 +846,7 @@ void setWakeupIfInRange( Object *obj, void *userData)
 	Coord3D srcpos = *obj->getPosition();
 	Coord3D dstpos = *victim->getPosition();
 
-	srcpos.sub(&dstpos);
+	srcpos.sub(dstpos);
 	if (srcpos.length() > vision)
 		return;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
@@ -281,7 +281,7 @@ UpdateSleepTime TensileFormationUpdate::update()
 	Real steepness = 1.0f - normal.z;
 	slope.scale( 0.3f + steepness);
 
-	m_inertia.add( &slope );
+	m_inertia.add( slope );
 
 	Real friction = 0.95f;
 	m_inertia.scale( friction );
@@ -322,7 +322,7 @@ UpdateSleepTime TensileFormationUpdate::update()
 			newPos.z = MIN( m_lowestSlideElevation, TheTerrainLogic->getGroundHeight(newPos.x, newPos.y) );//rest on surface here
 
 			tensor.normalize();
-			tensorSum.add( &tensor );
+			tensorSum.add( tensor );
 
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
@@ -313,7 +313,7 @@ UpdateSleepTime TensileFormationUpdate::update()
 
 			Coord3D tensor = m_links[ t ].tensor;
 
-			desiredPos.sub( &tensor );
+			desiredPos.sub( tensor );
 
 			//Coord3D desiredPos = { theirPos->x - m_links[ t ].tensor.x, theirPos->y - m_links[ t ].tensor.y, theirPos->z - m_links[ t ].tensor.z };
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/WaveGuideUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/WaveGuideUpdate.cpp
@@ -722,8 +722,8 @@ void WaveGuideUpdate::doDamage()
 								u.y = Sin( angle + modData->m_bridgeParticleAngleFudge );
 								u.z = 0.0f;
 
-								y.crossProduct( &z, &u, &y );
-								x.crossProduct( &y, &z, &x );
+								y.crossProduct( z, u, y );
+								x.crossProduct( y, z, x );
 
 								transform.Set(  x.x, y.x, z.x, obj->getPosition()->x,
 																x.y, y.y, z.y, obj->getPosition()->y,

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1472,7 +1472,7 @@ void WeaponTemplate::dealDamageInternal(ObjectID sourceID, ObjectID victimID, co
 			if( curVictim && source )
 			{
 				damageDirection.set( *curVictim->getPosition() );
-				damageDirection.sub( source->getPosition() );
+				damageDirection.sub( *source->getPosition() );
 			}
 
 			Real allowedAngle = getRadiusDamageAngle();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -902,7 +902,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		}
 		else
 		{
-			targetPos.set( victimPos );
+			targetPos.set( *victimPos );
 		}
 		Real reAngle = getWeaponRecoilAmount();
 		Real reDir = reAngle != 0.0f ? (atan2(victimPos->y - sourcePos->y, victimPos->x - sourcePos->x)) : 0.0f;
@@ -1020,7 +1020,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 				//adjust the laser's position to prevent it from hitting the ground.
 				if( victimObj )
 				{
-					projectileDestination.set( victimObj->getPosition() );
+					projectileDestination.set( *victimObj->getPosition() );
 				}
 				firingWeapon->createLaser( sourceObj, victimObj, &projectileDestination );
 			}
@@ -1471,7 +1471,7 @@ void WeaponTemplate::dealDamageInternal(ObjectID sourceID, ObjectID victimID, co
 			damageDirection.zero();
 			if( curVictim && source )
 			{
-				damageDirection.set( curVictim->getPosition() );
+				damageDirection.set( *curVictim->getPosition() );
 				damageDirection.sub( source->getPosition() );
 			}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
@@ -253,7 +253,7 @@ void W3DWaypointBuffer::drawWaypoints(RenderInfoClass &rinfo)
               {
 
                 Coord3D delta = *obj->getPosition();
-                delta.sub( enemy->getPosition() );
+                delta.sub( *enemy->getPosition() );
                 if ( delta.length() <= obj->getVisionRange() ) // is listening outpost close enough to do this?
                 {
 
@@ -386,7 +386,7 @@ void W3DWaypointBuffer::drawWaypoints(RenderInfoClass &rinfo)
 
 							//if the rallypoint is closer to the wayoutpoint than it is to the natural rally point then we definitely do not wrap
 							Coord3D rallyToWayOutDelta = wayOutPoint;
-							rallyToWayOutDelta.sub(rallyPoint);
+							rallyToWayOutDelta.sub(*rallyPoint);
 							if ( (100.0f + rallyToWayOutDelta.length()) > wayOutLength)
 							{
 
@@ -394,7 +394,7 @@ void W3DWaypointBuffer::drawWaypoints(RenderInfoClass &rinfo)
 								wayOutPoint.normalize();// a normal shooting straight out the door
 								//next comes the delta between the NRP and the RP
 								Coord3D NRPToRPDelta = naturalRallyPoint;
-								NRPToRPDelta.sub(rallyPoint);
+								NRPToRPDelta.sub(*rallyPoint);
 								NRPToRPDelta.normalize();
 								Real dot = NRPToRPDelta.x * wayOutPoint.x + NRPToRPDelta.y * wayOutPoint.y;
 								if (dot > 0)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
@@ -381,7 +381,7 @@ void W3DWaypointBuffer::drawWaypoints(RenderInfoClass &rinfo)
 							wayOutPoint.normalize();
 							wayOutPoint.scale( 99999.9f );
 							Real wayOutLength = wayOutPoint.length();
-							wayOutPoint.add(&naturalRallyPoint);
+							wayOutPoint.add(naturalRallyPoint);
 
 
 							//if the rallypoint is closer to the wayoutpoint than it is to the natural rally point then we definitely do not wrap

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/RulerTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/RulerTool.cpp
@@ -120,7 +120,7 @@ void RulerTool::mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorld
 	} else { //m_rulerType == RULER_LINE
 		Coord3D diff;
 		diff.set(cpt);
-		diff.sub(&m_downPt3d);
+		diff.sub(m_downPt3d);
 		m_savedLength = diff.length();
 		RulerOptions::setWidth(m_savedLength);
 		pView->doRulerFeedback(RULER_LINE);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/RulerTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/RulerTool.cpp
@@ -119,7 +119,7 @@ void RulerTool::mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorld
 		pView->Invalidate();
 	} else { //m_rulerType == RULER_LINE
 		Coord3D diff;
-		diff.set(&cpt);
+		diff.set(cpt);
 		diff.sub(&m_downPt3d);
 		m_savedLength = diff.length();
 		RulerOptions::setWidth(m_savedLength);


### PR DESCRIPTION
This change refactors functions of Coord3D, Region3D to take reference instead of pointer.

This is more consistent with how standard C++ operator functions look (`operator=(const Coord3D&)`). And it clarifies that it expects non-null values.

Affected functions are:

* Coord3D::set
* Coord3D::add
* Coord3D::sub
* Coord3D::crossProduct
* Coord3D::isInRegion
* Coord3D::isInRegionNoZ

Applied by hand.

## TODO

- [x] Run against replays