### PR TITLE
perf: Render ground-aligned particles without sorting

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/pointgr.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/pointgr.cpp
@@ -926,8 +926,14 @@ void PointGroupClass::Render(RenderInfoClass &rinfo)
 	DX8Wrapper::Set_Shader(Shader);
 	DX8Wrapper::Set_Texture(0,Texture);
 
+  // TheSuperHackers @perf stephanmeesters 27/06/2026
 	// Enable sorting if the primitives are translucent and alpha testing is not enabled.
-	const bool sort = (Shader.Get_Dst_Blend_Func() != ShaderClass::DSTBLEND_ZERO) && (Shader.Get_Alpha_Test() == ShaderClass::ALPHATEST_DISABLE) && (WW3D::Is_Sorting_Enabled());
+  // However, do not apply sorting for ground-aligned (i.e. non-billboard) particles.
+  // This is for performance reasons and because ground-aligned particles do not generally benefit from back-to-front sorting.
+	const bool sort = Billboard &&
+                    (Shader.Get_Dst_Blend_Func() != ShaderClass::DSTBLEND_ZERO) &&
+                    (Shader.Get_Alpha_Test() == ShaderClass::ALPHATEST_DISABLE) &&
+                    (WW3D::Is_Sorting_Enabled());
 
 	IndexBufferClass *indexbuffer;
 	int	verticesperprimitive;/// lorenzen fixed


### PR DESCRIPTION
A performance gain (about 8%) could be achieved in a busy scene, see animated gif below, by not sorting particles that are "ground-aligned". (tested in release mode, windowed, stats averaged in 60 secs window)

The reasoning is that ground-aligned particles generally do not have much benefit from back to front sorting, as they are effectively on the ground with nothing behind them, and other nearby ground-aligned particles are at about the same height.

In testing this actually appeared to resolve some rendering issues as ground particles would sometimes cut into nearby particles leaving hard edges (see the **before** image).

[sorting-renderer.webm](https://github.com/user-attachments/assets/16229ff0-aaa6-4af2-8cea-6071a4a2d814)

## Todo

- [ ] Do some more testing, in campaign etc