### PR TITLE
tweak(gui): Decouple GUI window-move animations from the render frame rate

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -184,7 +184,7 @@ private:
 	AnimateWindowList m_winMustFinishList;			///< A list of AnimationWindows that we do care about
 	Bool m_needsUpdate;													///< If we're done animating all our monitored windows, then this will be false
 	Bool m_reverse;															///< Are we in a reverse state?
-	Real m_updateAccumulator;										///< Carries fractional base-rate steps between updates
+	Real m_frameAccumulator;										///< Carries fractional base-rate frames between updates
 	ProcessAnimateWindowSlideFromRight *m_slideFromRight;			///< Holds the process in which the windows slide from the right
 	ProcessAnimateWindowSlideFromRightFast *m_slideFromRightFast;
 	ProcessAnimateWindowSlideFromTop *m_slideFromTop;					///< Holds the process in which the windows slide from the Top

--- a/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -178,10 +178,13 @@ public:
 	Bool isReversed();										///< Returns whether or not we're in our reversed state.
 	Bool isEmpty();
 private:
+	void step();															///< Runs a single base-rate step of all registered window animations
+
 	AnimateWindowList	m_winList;								///< A list of AnimationWindows that we don't care if their finished animating
 	AnimateWindowList m_winMustFinishList;			///< A list of AnimationWindows that we do care about
 	Bool m_needsUpdate;													///< If we're done animating all our monitored windows, then this will be false
 	Bool m_reverse;															///< Are we in a reverse state?
+	Real m_updateAccumulator;										///< Carries fractional base-rate steps between updates
 	ProcessAnimateWindowSlideFromRight *m_slideFromRight;			///< Holds the process in which the windows slide from the right
 	ProcessAnimateWindowSlideFromRightFast *m_slideFromRightFast;
 	ProcessAnimateWindowSlideFromTop *m_slideFromTop;					///< Holds the process in which the windows slide from the Top

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -134,7 +134,7 @@ AnimateWindowManager::AnimateWindowManager()
 	m_winList.clear();
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_updateAccumulator = 0.0f;
+	m_frameAccumulator = 0.0f;
 	m_winMustFinishList.clear();
 }
 AnimateWindowManager::~AnimateWindowManager()
@@ -161,7 +161,7 @@ void AnimateWindowManager::init()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_updateAccumulator = 0.0f;
+	m_frameAccumulator = 0.0f;
 }
 
 void AnimateWindowManager::reset()
@@ -171,24 +171,15 @@ void AnimateWindowManager::reset()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_updateAccumulator = 0.0f;
+	m_frameAccumulator = 0.0f;
 }
 
 // TheSuperHackers @tweak bobtista 27/06/2026 Decouple GUI window-move animations from the render frame rate
 void AnimateWindowManager::update()
 {
-	Real deltaSeconds = TheFramePacer->getUpdateTime();
-
-	// Clamp the delta so a long stall (load, alt-tab) cannot snap an animation to its end.
-	const Real maxCatchUpSeconds = 0.2f;
-	if (deltaSeconds > maxCatchUpSeconds)
-	{
-		deltaSeconds = maxCatchUpSeconds;
-	}
-
-	m_updateAccumulator += deltaSeconds * (Real)BaseFps;
-	Int steps = (Int)m_updateAccumulator;
-	m_updateAccumulator -= (Real)steps;
+	m_frameAccumulator += TheFramePacer->getBaseOverUpdateFpsRatio();
+	Int steps = (Int)m_frameAccumulator;
+	m_frameAccumulator -= (Real)steps;
 
 	while (steps-- > 0)
 	{

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -57,6 +57,7 @@
 #include "GameClient/GameWindow.h"
 #include "GameClient/Display.h"
 #include "GameClient/ProcessAnimateWindow.h"
+#include "Common/FramePacer.h"
 //-----------------------------------------------------------------------------
 // DEFINES ////////////////////////////////////////////////////////////////////
 //-----------------------------------------------------------------------------
@@ -133,6 +134,7 @@ AnimateWindowManager::AnimateWindowManager()
 	m_winList.clear();
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_updateAccumulator = 0.0f;
 	m_winMustFinishList.clear();
 }
 AnimateWindowManager::~AnimateWindowManager()
@@ -159,6 +161,7 @@ void AnimateWindowManager::init()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_updateAccumulator = 0.0f;
 }
 
 void AnimateWindowManager::reset()
@@ -168,9 +171,32 @@ void AnimateWindowManager::reset()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_updateAccumulator = 0.0f;
 }
 
+// TheSuperHackers @tweak bobtista 27/06/2026 Decouple GUI window-move animations from the render frame rate
 void AnimateWindowManager::update()
+{
+	Real deltaSeconds = TheFramePacer->getUpdateTime();
+
+	// Clamp the delta so a long stall (load, alt-tab) cannot snap an animation to its end.
+	const Real maxCatchUpSeconds = 0.2f;
+	if (deltaSeconds > maxCatchUpSeconds)
+	{
+		deltaSeconds = maxCatchUpSeconds;
+	}
+
+	m_updateAccumulator += deltaSeconds * (Real)BaseFps;
+	Int steps = (Int)m_updateAccumulator;
+	m_updateAccumulator -= (Real)steps;
+
+	while (steps-- > 0)
+	{
+		step();
+	}
+}
+
+void AnimateWindowManager::step()
 {
 
 	ProcessAnimateWindow *processAnim = nullptr;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -205,15 +205,15 @@ void Shell::update()
 
 		}
 
-		// Update the animate window manager
-		m_animateWindowManager->update();
-
 		m_schemeManager->update();
 
 		// mark last time we ran the updates
 		lastUpdate = now;
 
 	}
+
+	// TheSuperHackers @tweak bobtista 08/07/2026 Update the animate window manager every frame, it paces itself now
+	m_animateWindowManager->update();
 
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -212,7 +212,6 @@ void Shell::update()
 
 	}
 
-	// TheSuperHackers @tweak bobtista 08/07/2026 Update the animate window manager every frame, it paces itself now
 	m_animateWindowManager->update();
 
 }

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -184,7 +184,7 @@ private:
 	AnimateWindowList m_winMustFinishList;			///< A list of AnimationWindows that we do care about
 	Bool m_needsUpdate;													///< If we're done animating all our monitored windows, then this will be false
 	Bool m_reverse;															///< Are we in a reverse state?
-	Real m_updateAccumulator;										///< Carries fractional base-rate steps between updates
+	Real m_frameAccumulator;										///< Carries fractional base-rate frames between updates
 	ProcessAnimateWindowSlideFromRight *m_slideFromRight;			///< Holds the process in which the windows slide from the right
 	ProcessAnimateWindowSlideFromRightFast *m_slideFromRightFast;
 	ProcessAnimateWindowSlideFromTop *m_slideFromTop;					///< Holds the process in which the windows slide from the Top

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -178,10 +178,13 @@ public:
 	Bool isReversed();										///< Returns whether or not we're in our reversed state.
 	Bool isEmpty();
 private:
+	void step();															///< Runs a single base-rate step of all registered window animations
+
 	AnimateWindowList	m_winList;								///< A list of AnimationWindows that we don't care if their finished animating
 	AnimateWindowList m_winMustFinishList;			///< A list of AnimationWindows that we do care about
 	Bool m_needsUpdate;													///< If we're done animating all our monitored windows, then this will be false
 	Bool m_reverse;															///< Are we in a reverse state?
+	Real m_updateAccumulator;										///< Carries fractional base-rate steps between updates
 	ProcessAnimateWindowSlideFromRight *m_slideFromRight;			///< Holds the process in which the windows slide from the right
 	ProcessAnimateWindowSlideFromRightFast *m_slideFromRightFast;
 	ProcessAnimateWindowSlideFromTop *m_slideFromTop;					///< Holds the process in which the windows slide from the Top

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -134,7 +134,7 @@ AnimateWindowManager::AnimateWindowManager()
 	m_winList.clear();
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_updateAccumulator = 0.0f;
+	m_frameAccumulator = 0.0f;
 	m_winMustFinishList.clear();
 }
 AnimateWindowManager::~AnimateWindowManager()
@@ -161,7 +161,7 @@ void AnimateWindowManager::init()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_updateAccumulator = 0.0f;
+	m_frameAccumulator = 0.0f;
 }
 
 void AnimateWindowManager::reset()
@@ -171,24 +171,15 @@ void AnimateWindowManager::reset()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_updateAccumulator = 0.0f;
+	m_frameAccumulator = 0.0f;
 }
 
 // TheSuperHackers @tweak bobtista 27/06/2026 Decouple GUI window-move animations from the render frame rate
 void AnimateWindowManager::update()
 {
-	Real deltaSeconds = TheFramePacer->getUpdateTime();
-
-	// Clamp the delta so a long stall (load, alt-tab) cannot snap an animation to its end.
-	const Real maxCatchUpSeconds = 0.2f;
-	if (deltaSeconds > maxCatchUpSeconds)
-	{
-		deltaSeconds = maxCatchUpSeconds;
-	}
-
-	m_updateAccumulator += deltaSeconds * (Real)BaseFps;
-	Int steps = (Int)m_updateAccumulator;
-	m_updateAccumulator -= (Real)steps;
+	m_frameAccumulator += TheFramePacer->getBaseOverUpdateFpsRatio();
+	Int steps = (Int)m_frameAccumulator;
+	m_frameAccumulator -= (Real)steps;
 
 	while (steps-- > 0)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -57,6 +57,7 @@
 #include "GameClient/GameWindow.h"
 #include "GameClient/Display.h"
 #include "GameClient/ProcessAnimateWindow.h"
+#include "Common/FramePacer.h"
 //-----------------------------------------------------------------------------
 // DEFINES ////////////////////////////////////////////////////////////////////
 //-----------------------------------------------------------------------------
@@ -133,6 +134,7 @@ AnimateWindowManager::AnimateWindowManager()
 	m_winList.clear();
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_updateAccumulator = 0.0f;
 	m_winMustFinishList.clear();
 }
 AnimateWindowManager::~AnimateWindowManager()
@@ -159,6 +161,7 @@ void AnimateWindowManager::init()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_updateAccumulator = 0.0f;
 }
 
 void AnimateWindowManager::reset()
@@ -168,9 +171,32 @@ void AnimateWindowManager::reset()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_updateAccumulator = 0.0f;
 }
 
+// TheSuperHackers @tweak bobtista 27/06/2026 Decouple GUI window-move animations from the render frame rate
 void AnimateWindowManager::update()
+{
+	Real deltaSeconds = TheFramePacer->getUpdateTime();
+
+	// Clamp the delta so a long stall (load, alt-tab) cannot snap an animation to its end.
+	const Real maxCatchUpSeconds = 0.2f;
+	if (deltaSeconds > maxCatchUpSeconds)
+	{
+		deltaSeconds = maxCatchUpSeconds;
+	}
+
+	m_updateAccumulator += deltaSeconds * (Real)BaseFps;
+	Int steps = (Int)m_updateAccumulator;
+	m_updateAccumulator -= (Real)steps;
+
+	while (steps-- > 0)
+	{
+		step();
+	}
+}
+
+void AnimateWindowManager::step()
 {
 
 	ProcessAnimateWindow *processAnim = nullptr;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -205,15 +205,15 @@ void Shell::update()
 
 		}
 
-		// Update the animate window manager
-		m_animateWindowManager->update();
-
 		m_schemeManager->update();
 
 		// mark last time we ran the updates
 		lastUpdate = now;
 
 	}
+
+	// TheSuperHackers @tweak bobtista 08/07/2026 Update the animate window manager every frame, it paces itself now
+	m_animateWindowManager->update();
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -212,7 +212,6 @@ void Shell::update()
 
 	}
 
-	// TheSuperHackers @tweak bobtista 08/07/2026 Update the animate window manager every frame, it paces itself now
 	m_animateWindowManager->update();
 
 }


### PR DESCRIPTION
Addresses #2832, Similar to 2056, which decoupled the `GameWindowTransitions.`  

## Problem
Control bar, diplomacy/communicator panels slide animations go too fast when you increase render FPS 

## Approach
`AnimateWindowManager::update()` now paces itself with `TheFramePacer->getBaseOverUpdateFpsRatio()`: it accumulates base-rate (30 fps) frames and runs that many steps, carrying the fractional remainder between updates. `Shell::update` now pumps the manager every frame instead of through its 30 Hz gate, since the manager paces itself.

## TODO:
[x] Testing
[x] Replicate to Generals
