### PR TITLE
tweak(controlbar): Decouple the general promotion star blink from the render frame rate

### DIFF
--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -1029,7 +1029,7 @@ private:
 
 
 	Bool m_genStarFlash;
-	Real m_genStarFlashAccumSec;
+	Real m_genStarFlashTimeAccumulator; ///< Frame time accumulated within the current star blink cycle, in seconds
 	Int m_lastFlashedAtPointValue;
 
 	ICoord2D m_controlBarForegroundMarkerPos;

--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -1029,6 +1029,7 @@ private:
 
 
 	Bool m_genStarFlash;
+	Real m_genStarFlashAccumSec;
 	Int m_lastFlashedAtPointValue;
 
 	ICoord2D m_controlBarForegroundMarkerPos;

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -36,6 +36,7 @@
 #define DEFINE_RADIUSCURSOR_NAMES
 
 #include "Common/ActionManager.h"
+#include "Common/FramePacer.h"
 #include "Common/GameType.h"
 #include "Common/MultiplayerSettings.h"
 #include "Common/NameKeyGenerator.h"
@@ -904,6 +905,7 @@ ControlBar::ControlBar()
 	m_currContext = CB_CONTEXT_NONE;
 	m_defaultControlBarPosition.x = m_defaultControlBarPosition.y = 0;
 	m_genStarFlash = FALSE;
+	m_genStarFlashAccumSec = 0.0f;
 	m_genStarOff = nullptr;
 	m_genStarOn  = nullptr;
 	m_UIDirty    = FALSE;
@@ -1681,7 +1683,14 @@ const Image *ControlBar::getStarImage()
 		return nullptr;
 	}
 
-	if(TheGameLogic->getFrame()% LOGICFRAMES_PER_SECOND > LOGICFRAMES_PER_SECOND/2)
+	// TheSuperHackers @tweak bobtista 27/06/2026 Blink on a wall-clock cycle so the rate is independent of render frame rate and logic time scale.
+	m_genStarFlashAccumSec += TheFramePacer->getUpdateTime();
+	const Real blinkPeriodSec = 1.0f;
+	while( m_genStarFlashAccumSec >= blinkPeriodSec )
+	{
+		m_genStarFlashAccumSec -= blinkPeriodSec;
+	}
+	if( m_genStarFlashAccumSec >= blinkPeriodSec / 2 )
 	{
 		GadgetButtonSetEnabledImage(win, m_generalButtonHighlight);
 		return nullptr;

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -905,7 +905,7 @@ ControlBar::ControlBar()
 	m_currContext = CB_CONTEXT_NONE;
 	m_defaultControlBarPosition.x = m_defaultControlBarPosition.y = 0;
 	m_genStarFlash = FALSE;
-	m_genStarFlashAccumSec = 0.0f;
+	m_genStarFlashTimeAccumulator = 0.0f;
 	m_genStarOff = nullptr;
 	m_genStarOn  = nullptr;
 	m_UIDirty    = FALSE;
@@ -1684,13 +1684,13 @@ const Image *ControlBar::getStarImage()
 	}
 
 	// TheSuperHackers @tweak bobtista 27/06/2026 Blink on a wall-clock cycle so the rate is independent of render frame rate and logic time scale.
-	m_genStarFlashAccumSec += TheFramePacer->getUpdateTime();
-	const Real blinkPeriodSec = 1.0f;
-	while( m_genStarFlashAccumSec >= blinkPeriodSec )
+	m_genStarFlashTimeAccumulator += TheFramePacer->getUpdateTime();
+	const Real blinkPeriodSeconds = 1.0f;
+	while( m_genStarFlashTimeAccumulator >= blinkPeriodSeconds )
 	{
-		m_genStarFlashAccumSec -= blinkPeriodSec;
+		m_genStarFlashTimeAccumulator -= blinkPeriodSeconds;
 	}
-	if( m_genStarFlashAccumSec >= blinkPeriodSec / 2 )
+	if( m_genStarFlashTimeAccumulator >= blinkPeriodSeconds / 2 )
 	{
 		GadgetButtonSetEnabledImage(win, m_generalButtonHighlight);
 		return nullptr;


### PR DESCRIPTION
Addresses #2834, same idea as #2833 / #2056.

## Problem
The general's promote-button stars blink faster as you raise render FPS, because the blink is driven off the logic frame (`TheGameLogic->getFrame()`) and re-checked every render frame. The blink rate should be constant regardless of render FPS / logic time scale.

## Fix
ControlBar::getStarImage() now paces the star highlight off of TheFramePacer->getUpdateTime(), so the blink rate is constant regardless of render FPS / logic time scale. The star keeps blinking while the game is paused.

## TODO:
[x] Testing
[x] Replicate to Generals
