### PR TITLE
Fix skirmish AI buildability check passing wrong template (#2407)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -215,7 +215,12 @@ void AISkirmishPlayer::processBaseBuilding()
 				}
 				continue;
 			}
-			if (TheBuildAssistant->canMakeUnit(dozer, bldgPlan)!=CANMAKE_OK) {
+			// TheSuperHackers @bugfix mohamedelabbas1996 Pass the current build-list
+			// entry (curPlan) to canMakeUnit, not the accumulated candidate (bldgPlan,
+			// which is still null here). Using bldgPlan made the buildability check fail
+			// for entries relying on AutomaticallyBuild=Yes (or the default when the
+			// field is omitted), so the AI never selected them. Fixes issue #2407.
+			if (TheBuildAssistant->canMakeUnit(dozer, curPlan)!=CANMAKE_OK) {
 				if (info->isBuildable()) {
 					AsciiString bldgName = info->getTemplateName();
 					bldgName.concat(" - Dozer unable to build - money or technology missing.");

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -222,7 +222,12 @@ void AISkirmishPlayer::processBaseBuilding()
 				}
 				continue;
 			}
-			if (TheBuildAssistant->canMakeUnit(dozer, bldgPlan)!=CANMAKE_OK) {
+			// TheSuperHackers @bugfix mohamedelabbas1996 Pass the current build-list
+			// entry (curPlan) to canMakeUnit, not the accumulated candidate (bldgPlan,
+			// which is still null here). Using bldgPlan made the buildability check fail
+			// for entries relying on AutomaticallyBuild=Yes (or the default when the
+			// field is omitted), so the AI never selected them. Fixes issue #2407.
+			if (TheBuildAssistant->canMakeUnit(dozer, curPlan)!=CANMAKE_OK) {
 				if (info->isBuildable()) {
 					AsciiString bldgName = info->getTemplateName();
 					bldgName.concat(" - Dozer unable to build - money or technology missing.");


### PR DESCRIPTION
## Summary

Fixes #2407.

In `AISkirmishPlayer::processBaseBuilding()`, the build-list scan passes the **accumulated candidate** template `bldgPlan` to `TheBuildAssistant->canMakeUnit()` — but at that point in the loop `bldgPlan` is still `nullptr`. It should pass the **current entry's** template, `curPlan`.

Because the check ran against the wrong (null) template, the buildability gate rejected build-list entries that rely on `AutomaticallyBuild = Yes` (or the default value when the field is omitted, i.e. `m_automaticallyBuild = true`), so the skirmish AI never selected those structures to build.

## Change

`canMakeUnit(dozer, bldgPlan)` → `canMakeUnit(dozer, curPlan)` in the build-list loop, with an explanatory comment. Applied to both `Generals/` and `GeneralsMD/` (the issue affects both games).

## Notes

This is the first of the two interacting issues described in #2407 (the wrong-template buildability gate). The second (GLA rebuild-hole `bldg` shadowing) is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)