### PR TITLE
feat(gui): Implement user option to scale the game window transition speed

### DIFF
--- a/Core/GameEngine/Include/Common/OptionPreferences.h
+++ b/Core/GameEngine/Include/Common/OptionPreferences.h
@@ -129,4 +129,6 @@ public:
 	Real getResolutionFontAdjustment();
 
 	Bool getShowMoneyPerMinute() const;
+
+	Real getMenuTransitionSpeed();
 };

--- a/Core/GameEngine/Include/Common/OptionPreferences.h
+++ b/Core/GameEngine/Include/Common/OptionPreferences.h
@@ -130,5 +130,5 @@ public:
 
 	Bool getShowMoneyPerMinute() const;
 
-	Real getMenuTransitionSpeed();
+	Real getMenuTransitionSpeed() const;
 };

--- a/Core/GameEngine/Include/Common/OptionPreferences.h
+++ b/Core/GameEngine/Include/Common/OptionPreferences.h
@@ -130,5 +130,5 @@ public:
 
 	Bool getShowMoneyPerMinute() const;
 
-	Real getGameWindowTransitionSpeed() const;
+	Real getGameWindowTransitionSpeedMultiplier() const;
 };

--- a/Core/GameEngine/Include/Common/OptionPreferences.h
+++ b/Core/GameEngine/Include/Common/OptionPreferences.h
@@ -130,5 +130,5 @@ public:
 
 	Bool getShowMoneyPerMinute() const;
 
-	Real getMenuTransitionSpeed() const;
+	Real getGameWindowTransitionSpeed() const;
 };

--- a/Core/GameEngine/Source/Common/OptionPreferences.cpp
+++ b/Core/GameEngine/Source/Common/OptionPreferences.cpp
@@ -885,7 +885,7 @@ Bool OptionPreferences::getShowMoneyPerMinute() const
 	return FALSE;
 }
 
-Real OptionPreferences::getMenuTransitionSpeed()
+Real OptionPreferences::getMenuTransitionSpeed() const
 {
 	OptionPreferences::const_iterator it = find("MenuTransitionSpeed");
 	if (it == end())

--- a/Core/GameEngine/Source/Common/OptionPreferences.cpp
+++ b/Core/GameEngine/Source/Common/OptionPreferences.cpp
@@ -885,14 +885,12 @@ Bool OptionPreferences::getShowMoneyPerMinute() const
 	return FALSE;
 }
 
-Real OptionPreferences::getGameWindowTransitionSpeed() const
+Real OptionPreferences::getGameWindowTransitionSpeedMultiplier() const
 {
-	OptionPreferences::const_iterator it = find("GameWindowTransitionSpeed");
+	OptionPreferences::const_iterator it = find("GameWindowTransitionSpeedMultiplier");
 	if (it == end())
 		return 1.0f;
 
 	Real speed = (Real) atof(it->second.str());
-	if (speed <= 0.0f)
-		return 1.0f;
-	return min(speed, 1000.0f);
+	return clamp(1.0f, speed, 1000.0f);
 }

--- a/Core/GameEngine/Source/Common/OptionPreferences.cpp
+++ b/Core/GameEngine/Source/Common/OptionPreferences.cpp
@@ -885,12 +885,14 @@ Bool OptionPreferences::getShowMoneyPerMinute() const
 	return FALSE;
 }
 
-Real OptionPreferences::getMenuTransitionSpeed() const
+Real OptionPreferences::getGameWindowTransitionSpeed() const
 {
-	OptionPreferences::const_iterator it = find("MenuTransitionSpeed");
+	OptionPreferences::const_iterator it = find("GameWindowTransitionSpeed");
 	if (it == end())
 		return 1.0f;
 
 	Real speed = (Real) atof(it->second.str());
-	return clamp(0.1f, speed, 10.0f);
+	if (speed <= 0.0f)
+		return 1.0f;
+	return min(speed, 1000.0f);
 }

--- a/Core/GameEngine/Source/Common/OptionPreferences.cpp
+++ b/Core/GameEngine/Source/Common/OptionPreferences.cpp
@@ -884,3 +884,13 @@ Bool OptionPreferences::getShowMoneyPerMinute() const
 	}
 	return FALSE;
 }
+
+Real OptionPreferences::getMenuTransitionSpeed()
+{
+	OptionPreferences::const_iterator it = find("MenuTransitionSpeed");
+	if (it == end())
+		return 1.0f;
+
+	Real speed = (Real) atof(it->second.str());
+	return clamp(0.1f, speed, 10.0f);
+}

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -275,8 +275,8 @@ void TransitionGroup::update()
 	// TheSuperHackers @tweak bobtista GUI transition timing is now decoupled from the render update.
 	// Step every integer frame between the old and new accumulator value so discrete-state-machine
 	// transitions cannot skip a state when the render frame rate dips below the base rate.
-	// TheSuperHackers @feature bobtista 28/06/2026 Scale by the user menu transition speed preference.
-	const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio() * TheGlobalData->m_menuTransitionSpeed;
+	// TheSuperHackers @feature bobtista 28/06/2026 Scale by the user game window transition speed preference.
+	const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio() * TheGlobalData->m_gameWindowTransitionSpeed;
 	const Int prevFrame = (Int)m_currentFrame;
 	m_currentFrame += m_directionMultiplier * timeScale;
 	const Int newFrame = (Int)m_currentFrame;

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -276,7 +276,7 @@ void TransitionGroup::update()
 	// Step every integer frame between the old and new accumulator value so discrete-state-machine
 	// transitions cannot skip a state when the render frame rate dips below the base rate.
 	// TheSuperHackers @feature bobtista 28/06/2026 Scale by the user game window transition speed preference.
-	const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio() * TheGlobalData->m_gameWindowTransitionSpeed;
+	const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio() * TheGlobalData->m_gameWindowTransitionSpeedMultiplier;
 	const Int prevFrame = (Int)m_currentFrame;
 	m_currentFrame += m_directionMultiplier * timeScale;
 	const Int newFrame = (Int)m_currentFrame;

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -56,6 +56,7 @@
 #include "GameClient/GameWindow.h"
 #include "GameClient/GameWindowManager.h"
 #include "Common/FramePacer.h"
+#include "Common/GlobalData.h"
 //-----------------------------------------------------------------------------
 // DEFINES ////////////////////////////////////////////////////////////////////
 //-----------------------------------------------------------------------------
@@ -274,7 +275,8 @@ void TransitionGroup::update()
 	// TheSuperHackers @tweak bobtista GUI transition timing is now decoupled from the render update.
 	// Step every integer frame between the old and new accumulator value so discrete-state-machine
 	// transitions cannot skip a state when the render frame rate dips below the base rate.
-	const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio();
+	// TheSuperHackers @feature bobtista 28/06/2026 Scale by the user menu transition speed preference.
+	const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio() * TheGlobalData->m_menuTransitionSpeed;
 	const Int prevFrame = (Int)m_currentFrame;
 	m_currentFrame += m_directionMultiplier * timeScale;
 	const Int newFrame = (Int)m_currentFrame;

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -426,8 +426,8 @@ public:
 	Bool m_showMoneyPerMinute;
 	Bool m_allowMoneyPerMinuteForPlayer;
 
-	// TheSuperHackers @feature bobtista 28/06/2026 user-configurable speed multiplier for menu window transitions
-	Real m_menuTransitionSpeed;
+	// TheSuperHackers @feature bobtista 28/06/2026 user-configurable speed multiplier for game window transitions
+	Real m_gameWindowTransitionSpeed;
 
 	Real m_shakeSubtleIntensity;			///< Intensity for shaking a camera with SHAKE_SUBTLE
 	Real m_shakeNormalIntensity;			///< Intensity for shaking a camera with SHAKE_NORMAL

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -427,7 +427,7 @@ public:
 	Bool m_allowMoneyPerMinuteForPlayer;
 
 	// TheSuperHackers @feature bobtista 28/06/2026 user-configurable speed multiplier for game window transitions
-	Real m_gameWindowTransitionSpeed;
+	Real m_gameWindowTransitionSpeedMultiplier;
 
 	Real m_shakeSubtleIntensity;			///< Intensity for shaking a camera with SHAKE_SUBTLE
 	Real m_shakeNormalIntensity;			///< Intensity for shaking a camera with SHAKE_NORMAL

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -426,6 +426,9 @@ public:
 	Bool m_showMoneyPerMinute;
 	Bool m_allowMoneyPerMinuteForPlayer;
 
+	// TheSuperHackers @feature bobtista 28/06/2026 user-configurable speed multiplier for menu window transitions
+	Real m_menuTransitionSpeed;
+
 	Real m_shakeSubtleIntensity;			///< Intensity for shaking a camera with SHAKE_SUBTLE
 	Real m_shakeNormalIntensity;			///< Intensity for shaking a camera with SHAKE_NORMAL
 	Real m_shakeStrongIntensity;			///< Intensity for shaking a camera with SHAKE_STRONG

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -956,7 +956,7 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
-	m_menuTransitionSpeed = 1.0f;
+	m_gameWindowTransitionSpeed = 1.0f;
 
 	m_debugShowGraphicalFramerate = FALSE;
 
@@ -1219,7 +1219,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_gameTimeFontSize = optionPref.getGameTimeFontSize();
 	TheWritableGlobalData->m_playerInfoListFontSize = optionPref.getPlayerInfoListFontSize();
 	TheWritableGlobalData->m_showMoneyPerMinute = optionPref.getShowMoneyPerMinute();
-	TheWritableGlobalData->m_menuTransitionSpeed = optionPref.getMenuTransitionSpeed();
+	TheWritableGlobalData->m_gameWindowTransitionSpeed = optionPref.getGameWindowTransitionSpeed();
 
 	TheWritableGlobalData->m_antiAliasLevel = optionPref.getAntiAliasing();
 	TheWritableGlobalData->m_textureFilteringMode = optionPref.getTextureFilterMode();

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -956,6 +956,8 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
+	m_menuTransitionSpeed = 1.0f;
+
 	m_debugShowGraphicalFramerate = FALSE;
 
 	// By default, show all asserts.
@@ -1217,6 +1219,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_gameTimeFontSize = optionPref.getGameTimeFontSize();
 	TheWritableGlobalData->m_playerInfoListFontSize = optionPref.getPlayerInfoListFontSize();
 	TheWritableGlobalData->m_showMoneyPerMinute = optionPref.getShowMoneyPerMinute();
+	TheWritableGlobalData->m_menuTransitionSpeed = optionPref.getMenuTransitionSpeed();
 
 	TheWritableGlobalData->m_antiAliasLevel = optionPref.getAntiAliasing();
 	TheWritableGlobalData->m_textureFilteringMode = optionPref.getTextureFilterMode();

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -956,7 +956,7 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
-	m_gameWindowTransitionSpeed = 1.0f;
+	m_gameWindowTransitionSpeedMultiplier = 1.0f;
 
 	m_debugShowGraphicalFramerate = FALSE;
 
@@ -1219,7 +1219,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_gameTimeFontSize = optionPref.getGameTimeFontSize();
 	TheWritableGlobalData->m_playerInfoListFontSize = optionPref.getPlayerInfoListFontSize();
 	TheWritableGlobalData->m_showMoneyPerMinute = optionPref.getShowMoneyPerMinute();
-	TheWritableGlobalData->m_gameWindowTransitionSpeed = optionPref.getGameWindowTransitionSpeed();
+	TheWritableGlobalData->m_gameWindowTransitionSpeedMultiplier = optionPref.getGameWindowTransitionSpeedMultiplier();
 
 	TheWritableGlobalData->m_antiAliasLevel = optionPref.getAntiAliasing();
 	TheWritableGlobalData->m_textureFilteringMode = optionPref.getTextureFilterMode();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -820,6 +820,16 @@ static void saveOptions()
 	}
 
 	//-------------------------------------------------------------------------------------------------
+	// Set Game Window Transition Speed Multiplier
+	{
+		Real speed = pref->getGameWindowTransitionSpeedMultiplier();
+		AsciiString prefString;
+		prefString.format("%g", speed);
+		(*pref)["GameWindowTransitionSpeedMultiplier"] = prefString;
+		TheWritableGlobalData->m_gameWindowTransitionSpeedMultiplier = speed;
+	}
+
+	//-------------------------------------------------------------------------------------------------
 	// Resolution
 	//
 	// TheSuperHackers @bugfix xezon 12/06/2025 Now performs the resolution change at the very end of

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -428,7 +428,7 @@ public:
 	Bool m_allowMoneyPerMinuteForPlayer;
 
 	// TheSuperHackers @feature bobtista 28/06/2026 user-configurable speed multiplier for game window transitions
-	Real m_gameWindowTransitionSpeed;
+	Real m_gameWindowTransitionSpeedMultiplier;
 
 	Real m_shakeSubtleIntensity;			///< Intensity for shaking a camera with SHAKE_SUBTLE
 	Real m_shakeNormalIntensity;			///< Intensity for shaking a camera with SHAKE_NORMAL

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -427,6 +427,9 @@ public:
 	Bool m_showMoneyPerMinute;
 	Bool m_allowMoneyPerMinuteForPlayer;
 
+	// TheSuperHackers @feature bobtista 28/06/2026 user-configurable speed multiplier for menu window transitions
+	Real m_menuTransitionSpeed;
+
 	Real m_shakeSubtleIntensity;			///< Intensity for shaking a camera with SHAKE_SUBTLE
 	Real m_shakeNormalIntensity;			///< Intensity for shaking a camera with SHAKE_NORMAL
 	Real m_shakeStrongIntensity;			///< Intensity for shaking a camera with SHAKE_STRONG

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -427,8 +427,8 @@ public:
 	Bool m_showMoneyPerMinute;
 	Bool m_allowMoneyPerMinuteForPlayer;
 
-	// TheSuperHackers @feature bobtista 28/06/2026 user-configurable speed multiplier for menu window transitions
-	Real m_menuTransitionSpeed;
+	// TheSuperHackers @feature bobtista 28/06/2026 user-configurable speed multiplier for game window transitions
+	Real m_gameWindowTransitionSpeed;
 
 	Real m_shakeSubtleIntensity;			///< Intensity for shaking a camera with SHAKE_SUBTLE
 	Real m_shakeNormalIntensity;			///< Intensity for shaking a camera with SHAKE_NORMAL

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -963,6 +963,8 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
+	m_menuTransitionSpeed = 1.0f;
+
 	m_debugShowGraphicalFramerate = FALSE;
 
 	// By default, show all asserts.
@@ -1224,6 +1226,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_gameTimeFontSize = optionPref.getGameTimeFontSize();
 	TheWritableGlobalData->m_playerInfoListFontSize = optionPref.getPlayerInfoListFontSize();
 	TheWritableGlobalData->m_showMoneyPerMinute = optionPref.getShowMoneyPerMinute();
+	TheWritableGlobalData->m_menuTransitionSpeed = optionPref.getMenuTransitionSpeed();
 
 	TheWritableGlobalData->m_antiAliasLevel = optionPref.getAntiAliasing();
 	TheWritableGlobalData->m_textureFilteringMode = optionPref.getTextureFilterMode();

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -963,7 +963,7 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
-	m_gameWindowTransitionSpeed = 1.0f;
+	m_gameWindowTransitionSpeedMultiplier = 1.0f;
 
 	m_debugShowGraphicalFramerate = FALSE;
 
@@ -1226,7 +1226,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_gameTimeFontSize = optionPref.getGameTimeFontSize();
 	TheWritableGlobalData->m_playerInfoListFontSize = optionPref.getPlayerInfoListFontSize();
 	TheWritableGlobalData->m_showMoneyPerMinute = optionPref.getShowMoneyPerMinute();
-	TheWritableGlobalData->m_gameWindowTransitionSpeed = optionPref.getGameWindowTransitionSpeed();
+	TheWritableGlobalData->m_gameWindowTransitionSpeedMultiplier = optionPref.getGameWindowTransitionSpeedMultiplier();
 
 	TheWritableGlobalData->m_antiAliasLevel = optionPref.getAntiAliasing();
 	TheWritableGlobalData->m_textureFilteringMode = optionPref.getTextureFilterMode();

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -963,7 +963,7 @@ GlobalData::GlobalData()
 	m_showMoneyPerMinute = FALSE;
 	m_allowMoneyPerMinuteForPlayer = FALSE;
 
-	m_menuTransitionSpeed = 1.0f;
+	m_gameWindowTransitionSpeed = 1.0f;
 
 	m_debugShowGraphicalFramerate = FALSE;
 
@@ -1226,7 +1226,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_gameTimeFontSize = optionPref.getGameTimeFontSize();
 	TheWritableGlobalData->m_playerInfoListFontSize = optionPref.getPlayerInfoListFontSize();
 	TheWritableGlobalData->m_showMoneyPerMinute = optionPref.getShowMoneyPerMinute();
-	TheWritableGlobalData->m_menuTransitionSpeed = optionPref.getMenuTransitionSpeed();
+	TheWritableGlobalData->m_gameWindowTransitionSpeed = optionPref.getGameWindowTransitionSpeed();
 
 	TheWritableGlobalData->m_antiAliasLevel = optionPref.getAntiAliasing();
 	TheWritableGlobalData->m_textureFilteringMode = optionPref.getTextureFilterMode();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -845,6 +845,16 @@ static void saveOptions()
 	}
 
 	//-------------------------------------------------------------------------------------------------
+	// Set Game Window Transition Speed Multiplier
+	{
+		Real speed = pref->getGameWindowTransitionSpeedMultiplier();
+		AsciiString prefString;
+		prefString.format("%g", speed);
+		(*pref)["GameWindowTransitionSpeedMultiplier"] = prefString;
+		TheWritableGlobalData->m_gameWindowTransitionSpeedMultiplier = speed;
+	}
+
+	//-------------------------------------------------------------------------------------------------
 	// Resolution
 	//
 	// TheSuperHackers @bugfix xezon 12/06/2025 Now performs the resolution change at the very end of


### PR DESCRIPTION
Closes #2839

This change adds a `GameWindowTransitionSpeedMultiplier` option (in `Options.ini`) that scales the speed of menu/window transition animations, as requested following #2056. Defaults to `1.0` (unchanged behavior); values range from `1.0` (1×) to `1000.0` (1000× faster).

The multiplier is applied to the existing frame-rate-decoupled time step from #2056, so transitions still step through every state and never skip.

## Todo
- [x] testing
- [x] replicate to Generals
