### PR TITLE
Fix #2778: Don't deselect units after right-click camera drag

### DIFF
--- a/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1103,7 +1103,8 @@ GameMessageDisposition SelectionTranslator::onRawMouseRightButtonUp(MAYBE_UNUSED
 	UnsignedInt currentTime = (UnsignedInt) msg->getArgument( 2 )->integer;
 
 	// right click behavior (not right drag)
-	if (TheMouse->isClick(&m_deselectFeedbackAnchor, &pixel, m_lastClick, currentTime))
+	bool cameraDidNotMove = cameraPos.lengthSqr() <= (Real)(TheMouse->m_dragTolerance3D * TheMouse->m_dragTolerance3D);
+	if (TheMouse->isClick(&m_deselectFeedbackAnchor, &pixel, m_lastClick, currentTime) && cameraDidNotMove)
 	{
 		//Added support to cancel the GUI command without deselecting the unit(s) involved
 		//when you right click.


### PR DESCRIPTION
## Summary

Fixes #2778.

When the player right-clicks and drags to pan the camera, releasing the mouse button was incorrectly triggering the deselect-all logic because `isClick()` only checks 2-D screen position and timing — it does not account for 3-D camera movement.

**Change:** In `onRawMouseRightButtonUp()`, added a `cameraDidNotMove` guard that compares the camera's 3-D position delta (already captured in `m_deselectDownCameraPosition` on button-down) against `TheMouse->m_dragTolerance3D`. If the camera moved more than the tolerance, the right-mouse-up is treated as the end of a drag, not a click, and the deselect is suppressed.

- `m_dragTolerance3D` defaults to `0`, meaning any measurable camera movement blocks the deselect. It can be tuned via the `Mouse.ini` `DragTolerance3D` field if needed.
- No behaviour change when the camera is stationary (normal right-click).

## Files changed

- `Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp`

## Test plan

- [ ] Right-click and hold, drag to pan the camera, release — units should remain selected
- [ ] Right-click without dragging — units should still deselect (normal behaviour)
- [ ] Right-click with an active GUI command — command cancels without deselect (pre-existing behaviour unchanged)