### PR TITLE
Fix #2834: Frame-rate-independent general promotion star blink

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1681,7 +1681,8 @@ const Image *ControlBar::getStarImage()
 		return nullptr;
 	}
 
-	if(TheGameLogic->getFrame()% LOGICFRAMES_PER_SECOND > LOGICFRAMES_PER_SECOND/2)
+	// TheSuperHackers @bugfix Use wall-clock time so blink rate is frame-rate independent.
+	if(timeGetTime() % 1000 > 500)
 	{
 		GadgetButtonSetEnabledImage(win, m_generalButtonHighlight);
 		return nullptr;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1681,7 +1681,8 @@ const Image *ControlBar::getStarImage()
 		return nullptr;
 	}
 
-	if(TheGameLogic->getFrame()% LOGICFRAMES_PER_SECOND > LOGICFRAMES_PER_SECOND/2)
+	// TheSuperHackers @bugfix Use wall-clock time so blink rate is frame-rate independent.
+	if(timeGetTime() % 1000 > 500)
 	{
 		GadgetButtonSetEnabledImage(win, m_generalButtonHighlight);
 		return nullptr;


### PR DESCRIPTION
## Summary

Fixes #2834.

The general promotion star button used `TheGameLogic->getFrame() % LOGICFRAMES_PER_SECOND > LOGICFRAMES_PER_SECOND / 2` to drive its blink animation. At high FPS (e.g. uncapped or 144 Hz), logic frames advance faster than real time, causing the button to blink far too rapidly and become visually distracting.

**Change:** Replaced the frame-based blink condition with `timeGetTime() % 1000 > 500` in both `Generals` and `GeneralsMD` `ControlBar.cpp`. This gives a steady, wall-clock 1 Hz blink (500 ms on / 500 ms off) that is completely independent of game speed or frame rate.

## Files changed

- `Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp`
- `GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp`

## Test plan

- [ ] Earn a general promotion at high FPS (uncapped or 144 Hz+) — star button should blink at ~1 Hz, not rapidly
- [ ] Confirm the star still blinks (not permanently on or off)
- [ ] Confirm behaviour is identical in both the base game and Zero Hour builds