### PR TITLE
Fix #2452: Per-object cooldown for under-attack radar alarm

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -64,7 +64,7 @@
 #endif
 
 #ifndef PRESERVE_RADAR_WARNING_SUPPRESSION
-#define PRESERVE_RADAR_WARNING_SUPPRESSION (1)
+#define PRESERVE_RADAR_WARNING_SUPPRESSION (0) // Per-object cooldown in tryUnderAttackEvent supersedes this map-wide suppression.
 #endif
 
 #ifndef PRESERVE_STRUCTURE_STEALTH_DURING_REPAIR

--- a/Core/GameEngine/Include/Common/Radar.h
+++ b/Core/GameEngine/Include/Common/Radar.h
@@ -117,6 +117,7 @@ protected:
 	Object *m_object;				///< the object
 	RadarObject *m_next;		///< next radar object
 	Color m_color;					///< color to draw for this object on the radar
+	UnsignedInt m_lastUnderAttackAlarmFrame;	///< last logic frame this object's under-attack alarm fired
 
 };
 

--- a/Core/GameEngine/Source/Common/System/Radar.cpp
+++ b/Core/GameEngine/Source/Common/System/Radar.cpp
@@ -100,6 +100,7 @@ RadarObject::RadarObject()
 	m_object = nullptr;
 	m_next = nullptr;
 	m_color = GameMakeColor( 255, 255, 255, 255 );
+	m_lastUnderAttackAlarmFrame = 0xFFFFFFFF;
 
 }
 
@@ -1046,8 +1047,20 @@ void Radar::tryUnderAttackEvent( const Object *obj )
 	if( obj == nullptr )
 		return;
 
+	// Per-object cooldown: each unit can alarm at most once per suppression window.
+	// This prevents a single object (e.g. a supply plane) from re-triggering the alarm
+	// every time the global event window expires.
+	const UnsignedInt framesBetweenAlarms = LOGICFRAMES_PER_SECOND * 10;
+	UnsignedInt currentFrame = TheGameLogic->getFrame();
+	RadarObject *radarData = obj->friend_getRadarData();
+	if( radarData && currentFrame - radarData->m_lastUnderAttackAlarmFrame < framesBetweenAlarms )
+		return;
+
 	// try to create the event
 	Bool eventCreated = tryEvent( RADAR_EVENT_UNDER_ATTACK, obj->getPosition() );
+
+	if( eventCreated && radarData )
+		radarData->m_lastUnderAttackAlarmFrame = currentFrame;
 
 	// if event created, do some more feedback
 	if( eventCreated )


### PR DESCRIPTION
## Summary

Fixes #2452.

PR #2368 correctly fixed the broken 2-D squared-distance formula in `Radar::tryEvent`. A side effect was that the 10-second suppression window became area-local (250 world units), so simultaneous attacks on cargo planes at different map locations each triggered their own alarm — causing the reported spam.

PR #2540 worked around this by adding `PRESERVE_RADAR_WARNING_SUPPRESSION`, which forces map-wide 10-second suppression for all `RADAR_EVENT_UNDER_ATTACK` events. This restores retail noise levels but introduces a new problem: a cargo plane alarm suppresses a legitimate *base under attack* warning for the same 10-second window, even though the two events are in completely different locations.

### This fix

Adds a `m_lastUnderAttackAlarmFrame` field to `RadarObject` (initialized to `0xFFFFFFFF` so unsigned subtraction safely yields "never fired"). In `Radar::tryUnderAttackEvent`, the per-object frame is checked **before** calling `tryEvent`: if this specific object has already alarmed within the last 10 seconds, the call is skipped entirely.

`PRESERVE_RADAR_WARNING_SUPPRESSION` is set to `0`. The original area-based (250-unit radius) suppression in `tryEvent` handles the case of multiple nearby units being attacked simultaneously.

**Result:**
- A single supply plane being continuously shot at alarms at most once per 10 seconds (per object).
- A base under attack at a different map location alarms independently — it has its own `RadarObject` and its own cooldown.
- The global radar event slot is no longer used as a cross-object suppression mechanism for under-attack events.

## Files changed

- `Core/GameEngine/Include/Common/GameDefines.h` — `PRESERVE_RADAR_WARNING_SUPPRESSION` → 0
- `Core/GameEngine/Include/Common/Radar.h` — add `m_lastUnderAttackAlarmFrame` to `RadarObject`
- `Core/GameEngine/Source/Common/System/Radar.cpp` — initialize field; add per-object cooldown check in `tryUnderAttackEvent`

## Test plan

- [ ] Supply plane is shot down — "unit under attack" alarm fires once, not repeatedly during the plane's destruction
- [ ] Multiple supply planes attacked simultaneously — each fires at most one alarm (not N alarms in rapid succession)
- [ ] Base under attack at the same time as a supply plane — **both** locations report an alarm, not just the first one
- [ ] Normal unit or structure under attack — alarm still fires as expected
- [ ] 10 seconds after an alarm, attacking the same unit again — alarm fires again (cooldown expired)