### PR TITLE
fix(gui): Pace whole-screen fade loop through the frame pacer

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1958,7 +1958,7 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 			{
 				TheDisplay->draw();
 				setFPMode();
-				Sleep(33);
+				TheFramePacer->update();
 			}
 
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2247,7 +2247,7 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 			{
 				TheDisplay->draw();
 				setFPMode();
-				Sleep(33);
+				TheFramePacer->update();
 			}
 
 		}


### PR DESCRIPTION
Follow-up to #2840.

The whole-screen fade loop in `GameLogic::tryStartNewGame` paced itself with a hardcoded `Sleep(33)`. This froze the frame pacer for the duration of the fade, so the frame-rate-decoupled transition step from #2056 (`getBaseOverUpdateFpsRatio()`) read a stale delta and advanced at a fixed, frame-rate-dependent rate.

This change replaces the delay with `TheFramePacer->update()`, which caps the framerate and measures real elapsed time. The fade now advances at a consistent rate, and the magic 33 ms delay is gone now that transition speed is variable.

## Todo
- [x] testing
- [x] replicate to Generals