### PR TITLE
bugfix(gamelogic): Map player index to slot index for CRC validation

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/PlayerList.h
+++ b/Generals/Code/GameEngine/Include/Common/PlayerList.h
@@ -52,6 +52,7 @@
 class DataChunkInput;
 struct DataChunkInfo;
 class DataChunkOutput;
+class GameInfo;
 class Player;
 class Team;
 class TeamFactory;
@@ -150,6 +151,8 @@ public:
 	*/
 	PlayerMaskType getPlayersWithRelationship( Int srcPlayerIndex, UnsignedInt allowedRelationships );
 
+	Int getSlotIndex(Int playerIndex) const;
+
 protected:
 
 	// snapshot methods
@@ -158,10 +161,13 @@ protected:
 	virtual void loadPostProcess() override;
 
 private:
+	void assignSlotIndices(const GameInfo& gameInfo);
+	void setSlotIndex(Int playerIndex, Int slotIndex);
 
 	Player				*m_local;
 	Int						m_playerCount;
 	Player				*m_players[MAX_PLAYER_COUNT];
+	Int						m_slotIndices[MAX_PLAYER_COUNT];
 
 };
 

--- a/Generals/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
@@ -58,8 +58,8 @@
 #include "GameLogic/Object.h"
 #endif
 #include "GameLogic/SidesList.h"
+#include "GameNetwork/GameInfo.h"
 #include "GameNetwork/NetworkDefs.h"
-
 
 //-----------------------------------------------------------------------------
 /*extern*/ PlayerList *ThePlayerList = nullptr;
@@ -226,6 +226,10 @@ void PlayerList::newGame()
 		p->setDefaultTeam();
 	}
 
+	if (TheGameInfo)
+	{
+		assignSlotIndices(*TheGameInfo);
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -236,6 +240,8 @@ void PlayerList::init()
 
 	for (int i = 1; i < MAX_PLAYER_COUNT; i++)
 		m_players[i]->init(nullptr);
+
+	std::fill(m_slotIndices, m_slotIndices + ARRAY_SIZE(m_slotIndices), -1);
 
 	// call setLocalPlayer so that becomingLocalPlayer() gets called appropriately
 	setLocalPlayer(m_players[0]);
@@ -383,7 +389,6 @@ Player *PlayerList::getEachPlayerFromMask( PlayerMaskType& maskToAdjust )
 	return nullptr; // mask not found
 }
 
-
 //-------------------------------------------------------------------------------------------------
 PlayerMaskType PlayerList::getPlayersWithRelationship( Int srcPlayerIndex, UnsignedInt allowedRelationships )
 {
@@ -482,3 +487,42 @@ void PlayerList::loadPostProcess()
 
 }
 
+//-----------------------------------------------------------------------------
+void PlayerList::setSlotIndex(Int playerIndex, Int slotIndex)
+{
+	if (playerIndex >= 0 && playerIndex < ARRAY_SIZE(m_slotIndices))
+	{
+		m_slotIndices[playerIndex] = slotIndex;
+	}
+}
+
+//-----------------------------------------------------------------------------
+Int PlayerList::getSlotIndex(Int playerIndex) const
+{
+	if (playerIndex >= 0 && playerIndex < ARRAY_SIZE(m_slotIndices))
+	{
+		return m_slotIndices[playerIndex];
+	}
+
+	return -1;
+}
+
+//-----------------------------------------------------------------------------
+void PlayerList::assignSlotIndices(const GameInfo& gameInfo)
+{
+	AsciiString playerName;
+
+	for (Int i = 0; i < MAX_SLOTS; ++i)
+	{
+		const GameSlot* slot = gameInfo.getConstSlot(i);
+		if (!slot || !slot->isOccupied())
+			continue;
+
+		playerName.format("player%d", i);
+
+		if (Player* player = findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(playerName)))
+		{
+			setSlotIndex(player->getPlayerIndex(), i);
+		}
+	}
+}

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2345,7 +2345,8 @@ void GameLogic::processCommandList( CommandList *list )
 				{
 					// TheSuperHackers @bugfix Caball009 14/06/2026 Check if player is still connected,
 					// to avoid spurious mismatches at low CRC intervals, e.g. every frame.
-					if (!TheNetwork->isPlayerConnected(it->first))
+					const Int slotIndex = ThePlayerList->getSlotIndex(it->first);
+					if (slotIndex >= 0 && !TheNetwork->isPlayerConnected(slotIndex))
 						continue;
 
 					const UnsignedInt crc = it->second;

--- a/GeneralsMD/Code/GameEngine/Include/Common/PlayerList.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/PlayerList.h
@@ -52,6 +52,7 @@
 class DataChunkInput;
 struct DataChunkInfo;
 class DataChunkOutput;
+class GameInfo;
 class Player;
 class Team;
 class TeamFactory;
@@ -150,6 +151,8 @@ public:
 	*/
 	PlayerMaskType getPlayersWithRelationship( Int srcPlayerIndex, UnsignedInt allowedRelationships );
 
+	Int getSlotIndex(Int playerIndex) const;
+
 protected:
 
 	// snapshot methods
@@ -158,10 +161,13 @@ protected:
 	virtual void loadPostProcess() override;
 
 private:
+	void assignSlotIndices(const GameInfo& gameInfo);
+	void setSlotIndex(Int playerIndex, Int slotIndex);
 
 	Player				*m_local;
 	Int						m_playerCount;
 	Player				*m_players[MAX_PLAYER_COUNT];
+	Int						m_slotIndices[MAX_PLAYER_COUNT];
 
 };
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
@@ -58,8 +58,8 @@
 #include "GameLogic/Object.h"
 #endif
 #include "GameLogic/SidesList.h"
+#include "GameNetwork/GameInfo.h"
 #include "GameNetwork/NetworkDefs.h"
-
 
 //-----------------------------------------------------------------------------
 /*extern*/ PlayerList *ThePlayerList = nullptr;
@@ -226,6 +226,10 @@ void PlayerList::newGame()
 		p->setDefaultTeam();
 	}
 
+	if (TheGameInfo)
+	{
+		assignSlotIndices(*TheGameInfo);
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -236,6 +240,8 @@ void PlayerList::init()
 
 	for (int i = 1; i < MAX_PLAYER_COUNT; i++)
 		m_players[i]->init(nullptr);
+
+	std::fill(m_slotIndices, m_slotIndices + ARRAY_SIZE(m_slotIndices), -1);
 
 	// call setLocalPlayer so that becomingLocalPlayer() gets called appropriately
 	setLocalPlayer(m_players[0]);
@@ -383,7 +389,6 @@ Player *PlayerList::getEachPlayerFromMask( PlayerMaskType& maskToAdjust )
 	return nullptr; // mask not found
 }
 
-
 //-------------------------------------------------------------------------------------------------
 PlayerMaskType PlayerList::getPlayersWithRelationship( Int srcPlayerIndex, UnsignedInt allowedRelationships )
 {
@@ -482,3 +487,42 @@ void PlayerList::loadPostProcess()
 
 }
 
+//-----------------------------------------------------------------------------
+void PlayerList::setSlotIndex(Int playerIndex, Int slotIndex)
+{
+	if (playerIndex >= 0 && playerIndex < ARRAY_SIZE(m_slotIndices))
+	{
+		m_slotIndices[playerIndex] = slotIndex;
+	}
+}
+
+//-----------------------------------------------------------------------------
+Int PlayerList::getSlotIndex(Int playerIndex) const
+{
+	if (playerIndex >= 0 && playerIndex < ARRAY_SIZE(m_slotIndices))
+	{
+		return m_slotIndices[playerIndex];
+	}
+
+	return -1;
+}
+
+//-----------------------------------------------------------------------------
+void PlayerList::assignSlotIndices(const GameInfo& gameInfo)
+{
+	AsciiString playerName;
+
+	for (Int i = 0; i < MAX_SLOTS; ++i)
+	{
+		const GameSlot* slot = gameInfo.getConstSlot(i);
+		if (!slot || !slot->isOccupied())
+			continue;
+
+		playerName.format("player%d", i);
+
+		if (Player* player = findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(playerName)))
+		{
+			setSlotIndex(player->getPlayerIndex(), i);
+		}
+	}
+}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2671,7 +2671,8 @@ void GameLogic::processCommandList( CommandList *list )
 				{
 					// TheSuperHackers @bugfix Caball009 14/06/2026 Check if player is still connected,
 					// to avoid spurious mismatches at low CRC intervals, e.g. every frame.
-					if (!TheNetwork->isPlayerConnected(it->first))
+					const Int slotIndex = ThePlayerList->getSlotIndex(it->first);
+					if (slotIndex >= 0 && !TheNetwork->isPlayerConnected(slotIndex))
 						continue;
 
 					const UnsignedInt crc = it->second;


### PR DESCRIPTION
* Follow-up for PR: https://github.com/TheSuperHackers/GeneralsGameCode/pull/2796

## Description
A recent bugfix intended to prevent spurious mismatches from disconnected players has inadvertently disabled CRC mismatch detection for all active players. This allows games to completely desync (e.g., destroyed buildings on one client but not on the other) without the game ever raising the "Mismatch" error screen or halting the match.

This was discovered during a GeneralsX test running a LAN game between Mac and Linux. The main base on one side had been completely destroyed, while on the other side it still had about 30% life remaining, yet no mismatch error was triggered and the game continued to run smoothly in a completely desynchronized state.

## Root Cause
The issue stems from the commit by `Caball009` on `14/06/2026` in `GameLogic::processCommandList` (`GameLogic.cpp`):

```cpp
if (!TheNetwork->isPlayerConnected(it->first))
    continue;
```

In the `m_cachedCRCs` map, the key (`it->first`) is the **Player Index** (e.g., 3, 4). However, the `TheNetwork->isPlayerConnected()` function expects a **Network Slot Index** (e.g., 0, 1). 

Because the `PlayerIndex` does not match the `SlotIndex`, the function checks the connection status of invalid or empty network slots, returning `FALSE` for all human players. Consequently, the loop `continue`s for every CRC, skipping the `referenceCRC != crc` check entirely.

## Changes
To correctly determine if the player is connected, we must first map their `PlayerIndex` back to their `SlotIndex` by ~matching the network display name, similar to how it is handled when receiving the CRC in `GameLogicDispatch::onLogicCrc`~ using the same method as used in `RecorderClass::handleCRCMessage`:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/b3f3a9a8544be405b96dade91e2523218f1f5b27/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp#L993-L1000

This fix correctly maps the `PlayerIndex` to the `SlotIndex` before evaluating `isPlayerConnected()`, restoring proper CRC mismatch detection for active players while retaining the intent of ignoring disconnected players.
