### PR TITLE
fix(gui): Stop game time clock from jittering horizontally

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -787,7 +787,6 @@ protected:
 	Color												m_gameTimeColor;
 	Color												m_gameTimeDropColor;
 	Int													m_gameTimeReservedWidth;
-	Int													m_gameTimeFrameReservedWidth;
 
 	struct PlayerInfoList
 	{

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -786,6 +786,8 @@ protected:
 	Coord2D												m_gameTimePosition;
 	Color												m_gameTimeColor;
 	Color												m_gameTimeDropColor;
+	Int													m_gameTimeReservedWidth;
+	Int													m_gameTimeFrameReservedWidth;
 
 	struct PlayerInfoList
 	{

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1168,7 +1168,6 @@ InGameUI::InGameUI()
 	m_gameTimeColor = GameMakeColor( 255, 255, 255, 255 );
 	m_gameTimeDropColor = GameMakeColor( 0, 0, 0, 255 );
 	m_gameTimeReservedWidth = 0;
-	m_gameTimeFrameReservedWidth = 0;
 
 	m_playerInfoListFont = "Tahoma";
 	m_playerInfoListPointSize = TheGlobalData->m_playerInfoListFontSize;
@@ -5970,8 +5969,7 @@ void InGameUI::refreshGameTimeResources()
 	Int maxDigitWidth = 0;
 	for (WideChar digit = L'0'; digit <= L'9'; ++digit)
 	{
-		UnicodeString digitString;
-		digitString.concat(digit);
+		WideChar digitString[2] = { digit, 0 };
 		m_gameTimeString->setText(digitString);
 		Int digitWidth = m_gameTimeString->getWidth();
 		if (digitWidth > maxDigitWidth)
@@ -5985,8 +5983,7 @@ void InGameUI::refreshGameTimeResources()
 	m_gameTimeString->setText(UnicodeString(L"."));
 	Int dotWidth = m_gameTimeString->getWidth();
 
-	m_gameTimeReservedWidth = 6 * maxDigitWidth + 2 * colonWidth;
-	m_gameTimeFrameReservedWidth = dotWidth + 2 * maxDigitWidth;
+	m_gameTimeReservedWidth = (6 * maxDigitWidth + 2 * colonWidth) + (dotWidth + 2 * maxDigitWidth);
 }
 
 void InGameUI::refreshPlayerInfoListResources()
@@ -6179,7 +6176,7 @@ void InGameUI::drawGameTime()
 
 	// TheSuperHackers @info this implicitly offsets the game timer from the right instead of left of the screen
 	// TheSuperHackers @fix bobtista 07/07/2026 Anchor timer left to reserved widths so it stops jittering; butt frame against its live right edge
-	int horizontalTimerOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeReservedWidth - m_gameTimeFrameReservedWidth;
+	int horizontalTimerOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeReservedWidth;
 	int horizontalFrameOffset = horizontalTimerOffset + m_gameTimeString->getWidth();
 
 	m_gameTimeString->draw(horizontalTimerOffset, m_gameTimePosition.y, m_gameTimeColor, m_gameTimeDropColor);

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1167,6 +1167,8 @@ InGameUI::InGameUI()
 	m_gameTimePosition.y = kHudAnchorY;
 	m_gameTimeColor = GameMakeColor( 255, 255, 255, 255 );
 	m_gameTimeDropColor = GameMakeColor( 0, 0, 0, 255 );
+	m_gameTimeReservedWidth = 0;
+	m_gameTimeFrameReservedWidth = 0;
 
 	m_playerInfoListFont = "Tahoma";
 	m_playerInfoListPointSize = TheGlobalData->m_playerInfoListFontSize;
@@ -5963,6 +5965,28 @@ void InGameUI::refreshGameTimeResources()
 	GameFont* gameTimeFont = TheWindowManager->winFindFont(m_gameTimeFont, adjustedGameTimeFontSize, m_gameTimeBold);
 	m_gameTimeString->setFont(gameTimeFont);
 	m_gameTimeFrameString->setFont(gameTimeFont);
+
+	// TheSuperHackers @fix bobtista 07/07/2026 Reserve widths from the widest digit so the clock does not jitter
+	Int maxDigitWidth = 0;
+	for (WideChar digit = L'0'; digit <= L'9'; ++digit)
+	{
+		UnicodeString digitString;
+		digitString.concat(digit);
+		m_gameTimeString->setText(digitString);
+		Int digitWidth = m_gameTimeString->getWidth();
+		if (digitWidth > maxDigitWidth)
+		{
+			maxDigitWidth = digitWidth;
+		}
+	}
+
+	m_gameTimeString->setText(UnicodeString(L":"));
+	Int colonWidth = m_gameTimeString->getWidth();
+	m_gameTimeString->setText(UnicodeString(L"."));
+	Int dotWidth = m_gameTimeString->getWidth();
+
+	m_gameTimeReservedWidth = 6 * maxDigitWidth + 2 * colonWidth;
+	m_gameTimeFrameReservedWidth = dotWidth + 2 * maxDigitWidth;
 }
 
 void InGameUI::refreshPlayerInfoListResources()
@@ -6154,8 +6178,9 @@ void InGameUI::drawGameTime()
     m_gameTimeFrameString->setText(gameTimeFrameString);
 
 	// TheSuperHackers @info this implicitly offsets the game timer from the right instead of left of the screen
-	int horizontalTimerOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeString->getWidth() - m_gameTimeFrameString->getWidth();
-	int horizontalFrameOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeFrameString->getWidth();
+	// TheSuperHackers @fix bobtista 07/07/2026 Anchor timer left to reserved widths so it stops jittering; butt frame against its live right edge
+	int horizontalTimerOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeReservedWidth - m_gameTimeFrameReservedWidth;
+	int horizontalFrameOffset = horizontalTimerOffset + m_gameTimeString->getWidth();
 
 	m_gameTimeString->draw(horizontalTimerOffset, m_gameTimePosition.y, m_gameTimeColor, m_gameTimeDropColor);
 	m_gameTimeFrameString->draw(horizontalFrameOffset, m_gameTimePosition.y, GameMakeColor(180,180,180,255), m_gameTimeDropColor);

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -800,6 +800,8 @@ protected:
 	Coord2D												m_gameTimePosition;
 	Color												m_gameTimeColor;
 	Color												m_gameTimeDropColor;
+	Int													m_gameTimeReservedWidth;
+	Int													m_gameTimeFrameReservedWidth;
 
 	struct PlayerInfoList
 	{

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -801,7 +801,6 @@ protected:
 	Color												m_gameTimeColor;
 	Color												m_gameTimeDropColor;
 	Int													m_gameTimeReservedWidth;
-	Int													m_gameTimeFrameReservedWidth;
 
 	struct PlayerInfoList
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1195,6 +1195,8 @@ InGameUI::InGameUI()
 	m_gameTimePosition.y = kHudAnchorY;
 	m_gameTimeColor = GameMakeColor( 255, 255, 255, 255 );
 	m_gameTimeDropColor = GameMakeColor( 0, 0, 0, 255 );
+	m_gameTimeReservedWidth = 0;
+	m_gameTimeFrameReservedWidth = 0;
 
 	m_playerInfoListFont = "Tahoma";
 	m_playerInfoListPointSize = TheGlobalData->m_playerInfoListFontSize;
@@ -6096,6 +6098,28 @@ void InGameUI::refreshGameTimeResources()
 	GameFont* gameTimeFont = TheWindowManager->winFindFont(m_gameTimeFont, adjustedGameTimeFontSize, m_gameTimeBold);
 	m_gameTimeString->setFont(gameTimeFont);
 	m_gameTimeFrameString->setFont(gameTimeFont);
+
+	// TheSuperHackers @fix bobtista 07/07/2026 Reserve widths from the widest digit so the clock does not jitter
+	Int maxDigitWidth = 0;
+	for (WideChar digit = L'0'; digit <= L'9'; ++digit)
+	{
+		UnicodeString digitString;
+		digitString.concat(digit);
+		m_gameTimeString->setText(digitString);
+		Int digitWidth = m_gameTimeString->getWidth();
+		if (digitWidth > maxDigitWidth)
+		{
+			maxDigitWidth = digitWidth;
+		}
+	}
+
+	m_gameTimeString->setText(UnicodeString(L":"));
+	Int colonWidth = m_gameTimeString->getWidth();
+	m_gameTimeString->setText(UnicodeString(L"."));
+	Int dotWidth = m_gameTimeString->getWidth();
+
+	m_gameTimeReservedWidth = 6 * maxDigitWidth + 2 * colonWidth;
+	m_gameTimeFrameReservedWidth = dotWidth + 2 * maxDigitWidth;
 }
 
 void InGameUI::refreshPlayerInfoListResources()
@@ -6287,8 +6311,9 @@ void InGameUI::drawGameTime()
     m_gameTimeFrameString->setText(gameTimeFrameString);
 
 	// TheSuperHackers @info this implicitly offsets the game timer from the right instead of left of the screen
-	int horizontalTimerOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeString->getWidth() - m_gameTimeFrameString->getWidth();
-	int horizontalFrameOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeFrameString->getWidth();
+	// TheSuperHackers @fix bobtista 07/07/2026 Anchor timer left to reserved widths so it stops jittering; butt frame against its live right edge
+	int horizontalTimerOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeReservedWidth - m_gameTimeFrameReservedWidth;
+	int horizontalFrameOffset = horizontalTimerOffset + m_gameTimeString->getWidth();
 
 	m_gameTimeString->draw(horizontalTimerOffset, m_gameTimePosition.y, m_gameTimeColor, m_gameTimeDropColor);
 	m_gameTimeFrameString->draw(horizontalFrameOffset, m_gameTimePosition.y, GameMakeColor(180,180,180,255), m_gameTimeDropColor);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1196,7 +1196,6 @@ InGameUI::InGameUI()
 	m_gameTimeColor = GameMakeColor( 255, 255, 255, 255 );
 	m_gameTimeDropColor = GameMakeColor( 0, 0, 0, 255 );
 	m_gameTimeReservedWidth = 0;
-	m_gameTimeFrameReservedWidth = 0;
 
 	m_playerInfoListFont = "Tahoma";
 	m_playerInfoListPointSize = TheGlobalData->m_playerInfoListFontSize;
@@ -6103,8 +6102,7 @@ void InGameUI::refreshGameTimeResources()
 	Int maxDigitWidth = 0;
 	for (WideChar digit = L'0'; digit <= L'9'; ++digit)
 	{
-		UnicodeString digitString;
-		digitString.concat(digit);
+		WideChar digitString[2] = { digit, 0 };
 		m_gameTimeString->setText(digitString);
 		Int digitWidth = m_gameTimeString->getWidth();
 		if (digitWidth > maxDigitWidth)
@@ -6118,8 +6116,7 @@ void InGameUI::refreshGameTimeResources()
 	m_gameTimeString->setText(UnicodeString(L"."));
 	Int dotWidth = m_gameTimeString->getWidth();
 
-	m_gameTimeReservedWidth = 6 * maxDigitWidth + 2 * colonWidth;
-	m_gameTimeFrameReservedWidth = dotWidth + 2 * maxDigitWidth;
+	m_gameTimeReservedWidth = (6 * maxDigitWidth + 2 * colonWidth) + (dotWidth + 2 * maxDigitWidth);
 }
 
 void InGameUI::refreshPlayerInfoListResources()
@@ -6312,7 +6309,7 @@ void InGameUI::drawGameTime()
 
 	// TheSuperHackers @info this implicitly offsets the game timer from the right instead of left of the screen
 	// TheSuperHackers @fix bobtista 07/07/2026 Anchor timer left to reserved widths so it stops jittering; butt frame against its live right edge
-	int horizontalTimerOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeReservedWidth - m_gameTimeFrameReservedWidth;
+	int horizontalTimerOffset = TheDisplay->getWidth() - (Int)m_gameTimePosition.x - m_gameTimeReservedWidth;
 	int horizontalFrameOffset = horizontalTimerOffset + m_gameTimeString->getWidth();
 
 	m_gameTimeString->draw(horizontalTimerOffset, m_gameTimePosition.y, m_gameTimeColor, m_gameTimeDropColor);


### PR DESCRIPTION
Addresses #2859

drawGameTime() positioned the top-right clock by subtracting live-measured text width every frame, right-anchored to the screen edge. With the proportional Tahoma font, digit widths change as the time ticks (and the .NN frame counter changes every frame), so the whole timer shifted a pixel or two each frame.

Reserve a fixed width per field from the widest digit and anchor the timer's left edge to it so the white clock no longer moves as digits change. The frame counter is butted against the timer's live right edge so the two stay adjacent.

TODO:
- [x] Test
- [x] Replicate to Generals
