### PR TITLE
feat(object): Implement KINDOF_NO_ATTACK_WARNING to suppress alarm events on object attacks

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -27,6 +27,10 @@
 #define PRESERVE_BUILDING_RESUMPTION_DELAY (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
 #endif
 
+#ifndef PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
+#define PRESERVE_CARGO_PLANE_ATTACK_WARNINGS (0)
+#endif
+
 #ifndef PRESERVE_CHINOOK_PASSENGER_DUMPING
 #define PRESERVE_CHINOOK_PASSENGER_DUMPING (1)
 #endif

--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -27,10 +27,6 @@
 #define PRESERVE_BUILDING_RESUMPTION_DELAY (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
 #endif
 
-#ifndef PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
-#define PRESERVE_CARGO_PLANE_ATTACK_WARNINGS (0)
-#endif
-
 #ifndef PRESERVE_CHINOOK_PASSENGER_DUMPING
 #define PRESERVE_CHINOOK_PASSENGER_DUMPING (1)
 #endif

--- a/Generals/Code/GameEngine/Include/Common/KindOf.h
+++ b/Generals/Code/GameEngine/Include/Common/KindOf.h
@@ -171,6 +171,8 @@ enum KindOfType CPP_11(: Int)
 	KINDOF_DEMOTRAP,								///< Added strictly only for disarming purposes. They don't act like mines which have rendering and selection implications!
 	KINDOF_CONSERVATIVE_BUILDING,		///< Conservative structures aren't considered part of your base for sneak attack boundary calculations...
 	KINDOF_IGNORE_DOCKING_BONES,		///< Structure will not look up docking bones. Patch 1.03 hack.
+	// TheSuperHackers @info TSH Kindofs
+	KINDOF_NO_ATTACK_WARNING,				///< does not trigger the under attack radar/EVA warning when damaged (e.g. cargo planes)
 
 	KINDOF_COUNT,										// total number of kindofs
 	KINDOF_FIRST = 0,

--- a/Generals/Code/GameEngine/Include/Common/KindOf.h
+++ b/Generals/Code/GameEngine/Include/Common/KindOf.h
@@ -171,7 +171,9 @@ enum KindOfType CPP_11(: Int)
 	KINDOF_DEMOTRAP,								///< Added strictly only for disarming purposes. They don't act like mines which have rendering and selection implications!
 	KINDOF_CONSERVATIVE_BUILDING,		///< Conservative structures aren't considered part of your base for sneak attack boundary calculations...
 	KINDOF_IGNORE_DOCKING_BONES,		///< Structure will not look up docking bones. Patch 1.03 hack.
-	// TheSuperHackers @info TSH Kindofs
+
+	// TheSuperHackers @info New kinds for Mods
+
 	KINDOF_NO_ATTACK_WARNING,				///< does not trigger the under attack radar/EVA warning when damaged (e.g. cargo planes)
 
 	KINDOF_COUNT,										// total number of kindofs

--- a/Generals/Code/GameEngine/Include/Common/KindOf.h
+++ b/Generals/Code/GameEngine/Include/Common/KindOf.h
@@ -174,7 +174,7 @@ enum KindOfType CPP_11(: Int)
 
 	// TheSuperHackers @info New kinds for Mods
 
-	KINDOF_NO_ATTACK_WARNING,				///< does not trigger the under attack radar/EVA warning when damaged (e.g. cargo planes)
+	KINDOF_NO_ATTACK_WARNING,				///< does not trigger the under attack radar/EVA warning when taking damage
 
 	KINDOF_COUNT,										// total number of kindofs
 	KINDOF_FIRST = 0,

--- a/Generals/Code/GameEngine/Source/Common/System/KindOf.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/KindOf.cpp
@@ -161,6 +161,7 @@ const char* const KindOfMaskType::s_bitNameList[] =
 	"DEMOTRAP",
 	"CONSERVATIVE_BUILDING",
 	"IGNORE_DOCKING_BONES",
+	"NO_ATTACK_WARNING",
 
 	nullptr
 };

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1769,11 +1769,8 @@ void Object::attemptDamage( DamageInfo *damageInfo )
 			damageInfo->in.m_damageType != DAMAGE_HEALING &&
 			!BitIsSet(damageInfo->in.m_sourcePlayerMask, getControllingPlayer()->getPlayerMask()) &&
 			m_radarData != nullptr &&
-			isLocallyControlled()
-#if !PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
-			&& getTemplate()->getName() != "AmericaJetCargoPlane"
-#endif
-			)
+			isLocallyControlled() &&
+			!isKindOf( KINDOF_NO_ATTACK_WARNING ) )
 		TheRadar->tryUnderAttackEvent( this );
 
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1770,9 +1770,9 @@ void Object::attemptDamage( DamageInfo *damageInfo )
 			!BitIsSet(damageInfo->in.m_sourcePlayerMask, getControllingPlayer()->getPlayerMask()) &&
 			m_radarData != nullptr &&
 			isLocallyControlled()
-			#if !PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
-				&& getTemplate()->getName() != "AmericaJetCargoPlane"
-			#endif
+#if !PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
+			&& getTemplate()->getName() != "AmericaJetCargoPlane"
+#endif
 			)
 		TheRadar->tryUnderAttackEvent( this );
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1769,7 +1769,11 @@ void Object::attemptDamage( DamageInfo *damageInfo )
 			damageInfo->in.m_damageType != DAMAGE_HEALING &&
 			!BitIsSet(damageInfo->in.m_sourcePlayerMask, getControllingPlayer()->getPlayerMask()) &&
 			m_radarData != nullptr &&
-			isLocallyControlled() )
+			isLocallyControlled()
+			#if !PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
+				&& getTemplate()->getName() != "AmericaJetCargoPlane"
+			#endif
+			)
 		TheRadar->tryUnderAttackEvent( this );
 
 }

--- a/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
@@ -173,6 +173,7 @@ enum KindOfType CPP_11(: Int)
 	KINDOF_IGNORE_DOCKING_BONES,		///< Structure will not look up docking bones. Patch 1.03 hack.
 	// TheSuperHackers @info TSH Kindofs
 	KINDOF_NO_ATTACK_WARNING,				///< does not trigger the under attack radar/EVA warning when damaged (e.g. cargo planes)
+	KINDOF_UNUSED_1,		///< padding to keep KINDOF_COUNT off other BitFlags counts, replace with the next new kindof
 
 	KINDOF_COUNT,										// total number of kindofs
 	KINDOF_FIRST = 0,

--- a/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
@@ -171,6 +171,8 @@ enum KindOfType CPP_11(: Int)
 	KINDOF_DEMOTRAP,								///< Added strictly only for disarming purposes. They don't act like mines which have rendering and selection implications!
 	KINDOF_CONSERVATIVE_BUILDING,		///< Conservative structures aren't considered part of your base for sneak attack boundary calculations...
 	KINDOF_IGNORE_DOCKING_BONES,		///< Structure will not look up docking bones. Patch 1.03 hack.
+	// TheSuperHackers @info TSH Kindofs
+	KINDOF_NO_ATTACK_WARNING,				///< does not trigger the under attack radar/EVA warning when damaged (e.g. cargo planes)
 
 	KINDOF_COUNT,										// total number of kindofs
 	KINDOF_FIRST = 0,

--- a/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
@@ -171,9 +171,10 @@ enum KindOfType CPP_11(: Int)
 	KINDOF_DEMOTRAP,								///< Added strictly only for disarming purposes. They don't act like mines which have rendering and selection implications!
 	KINDOF_CONSERVATIVE_BUILDING,		///< Conservative structures aren't considered part of your base for sneak attack boundary calculations...
 	KINDOF_IGNORE_DOCKING_BONES,		///< Structure will not look up docking bones. Patch 1.03 hack.
-	// TheSuperHackers @info TSH Kindofs
+
+	// TheSuperHackers @info New kinds for Mods
+
 	KINDOF_NO_ATTACK_WARNING,				///< does not trigger the under attack radar/EVA warning when damaged (e.g. cargo planes)
-	KINDOF_UNUSED_1,		///< padding to keep KINDOF_COUNT off other BitFlags counts, replace with the next new kindof
 
 	KINDOF_COUNT,										// total number of kindofs
 	KINDOF_FIRST = 0,

--- a/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
@@ -174,7 +174,7 @@ enum KindOfType CPP_11(: Int)
 
 	// TheSuperHackers @info New kinds for Mods
 
-	KINDOF_NO_ATTACK_WARNING,				///< does not trigger the under attack radar/EVA warning when damaged (e.g. cargo planes)
+	KINDOF_NO_ATTACK_WARNING,				///< does not trigger the under attack radar/EVA warning when taking damage
 
 	KINDOF_COUNT,										// total number of kindofs
 	KINDOF_FIRST = 0,

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/KindOf.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/KindOf.cpp
@@ -161,6 +161,7 @@ const char* const KindOfMaskType::s_bitNameList[] =
 	"DEMOTRAP",
 	"CONSERVATIVE_BUILDING",
 	"IGNORE_DOCKING_BONES",
+	"NO_ATTACK_WARNING",
 
 	nullptr
 };

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/KindOf.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/KindOf.cpp
@@ -162,6 +162,7 @@ const char* const KindOfMaskType::s_bitNameList[] =
 	"CONSERVATIVE_BUILDING",
 	"IGNORE_DOCKING_BONES",
 	"NO_ATTACK_WARNING",
+	"UNUSED_1",
 
 	nullptr
 };

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/KindOf.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/KindOf.cpp
@@ -162,7 +162,6 @@ const char* const KindOfMaskType::s_bitNameList[] =
 	"CONSERVATIVE_BUILDING",
 	"IGNORE_DOCKING_BONES",
 	"NO_ATTACK_WARNING",
-	"UNUSED_1",
 
 	nullptr
 };

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1969,11 +1969,8 @@ void Object::attemptDamage( DamageInfo *damageInfo )
 			getControllingPlayer() &&
 			!BitIsSet(damageInfo->in.m_sourcePlayerMask, getControllingPlayer()->getPlayerMask()) &&
 			m_radarData != nullptr &&
-			isLocallyControlled()
-#if !PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
-			&& getTemplate()->getName() != "AmericaJetCargoPlane"
-#endif
-			)
+			isLocallyControlled() &&
+			!isKindOf( KINDOF_NO_ATTACK_WARNING ) )
 		TheRadar->tryUnderAttackEvent( this );
 
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1969,7 +1969,11 @@ void Object::attemptDamage( DamageInfo *damageInfo )
 			getControllingPlayer() &&
 			!BitIsSet(damageInfo->in.m_sourcePlayerMask, getControllingPlayer()->getPlayerMask()) &&
 			m_radarData != nullptr &&
-			isLocallyControlled() )
+			isLocallyControlled()
+			#if !PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
+				&& getTemplate()->getName() != "AmericaJetCargoPlane"
+			#endif
+			)
 		TheRadar->tryUnderAttackEvent( this );
 
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1970,9 +1970,9 @@ void Object::attemptDamage( DamageInfo *damageInfo )
 			!BitIsSet(damageInfo->in.m_sourcePlayerMask, getControllingPlayer()->getPlayerMask()) &&
 			m_radarData != nullptr &&
 			isLocallyControlled()
-			#if !PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
-				&& getTemplate()->getName() != "AmericaJetCargoPlane"
-			#endif
+#if !PRESERVE_CARGO_PLANE_ATTACK_WARNINGS
+			&& getTemplate()->getName() != "AmericaJetCargoPlane"
+#endif
 			)
 		TheRadar->tryUnderAttackEvent( this );
 


### PR DESCRIPTION
This PR introduces the KINDOF_NO_ATTACK_WARNING flag. Assigning this KindOf to a unit prevents it from triggering EVA or Radar notifications for the player.