### PR TITLE
bugfix(gameengine): Prevent logic time accumulation while the game is halted

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -705,6 +705,13 @@ Bool GameEngine::canUpdateRegularGameLogic(UnsignedInt logicTimeQueryFlags)
 	}
 	else
 	{
+		// TheSuperHackers @bugfix bobtista 08/07/2026 Return early when the logic time scale fps is zero,
+		// otherwise the accumulator banks the paused duration and replays it at render rate after unpausing.
+		if (logicTimeScaleFps <= 0)
+		{
+			return false;
+		}
+
 		// TheSuperHackers @tweak xezon 06/08/2025
 		// The logic time step is now decoupled from the render update.
 		const Real targetFrameTime = 1.0f / logicTimeScaleFps;

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -690,6 +690,12 @@ Bool GameEngine::canUpdateNetworkGameLogic()
 Bool GameEngine::canUpdateRegularGameLogic(UnsignedInt logicTimeQueryFlags)
 {
 	const Int logicTimeScaleFps = TheFramePacer->getActualLogicTimeScaleFps(logicTimeQueryFlags);
+
+	if (logicTimeScaleFps <= 0)
+	{
+		return false;
+	}
+
 	const Int maxRenderFps = TheFramePacer->getActualFramesPerSecondLimit();
 
 #if defined(_ALLOW_DEBUG_CHEATS_IN_RELEASE)
@@ -705,13 +711,6 @@ Bool GameEngine::canUpdateRegularGameLogic(UnsignedInt logicTimeQueryFlags)
 	}
 	else
 	{
-		// TheSuperHackers @bugfix bobtista 08/07/2026 Return early when the logic time scale fps is zero,
-		// otherwise the accumulator banks the paused duration and replays it at render rate after unpausing.
-		if (logicTimeScaleFps <= 0)
-		{
-			return false;
-		}
-
 		// TheSuperHackers @tweak xezon 06/08/2025
 		// The logic time step is now decoupled from the render update.
 		const Real targetFrameTime = 1.0f / logicTimeScaleFps;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -857,6 +857,12 @@ Bool GameEngine::canUpdateNetworkGameLogic()
 Bool GameEngine::canUpdateRegularGameLogic(UnsignedInt logicTimeQueryFlags)
 {
 	const Int logicTimeScaleFps = TheFramePacer->getActualLogicTimeScaleFps(logicTimeQueryFlags);
+
+	if (logicTimeScaleFps <= 0)
+	{
+		return false;
+	}
+
 	const Int maxRenderFps = TheFramePacer->getActualFramesPerSecondLimit();
 
 #if defined(_ALLOW_DEBUG_CHEATS_IN_RELEASE)
@@ -872,13 +878,6 @@ Bool GameEngine::canUpdateRegularGameLogic(UnsignedInt logicTimeQueryFlags)
 	}
 	else
 	{
-		// TheSuperHackers @bugfix bobtista 08/07/2026 Return early when the logic time scale fps is zero,
-		// otherwise the accumulator banks the paused duration and replays it at render rate after unpausing.
-		if (logicTimeScaleFps <= 0)
-		{
-			return false;
-		}
-
 		// TheSuperHackers @tweak xezon 06/08/2025
 		// The logic time step is now decoupled from the render update.
 		const Real targetFrameTime = 1.0f / logicTimeScaleFps;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -872,6 +872,13 @@ Bool GameEngine::canUpdateRegularGameLogic(UnsignedInt logicTimeQueryFlags)
 	}
 	else
 	{
+		// TheSuperHackers @bugfix bobtista 08/07/2026 Return early when the logic time scale fps is zero,
+		// otherwise the accumulator banks the paused duration and replays it at render rate after unpausing.
+		if (logicTimeScaleFps <= 0)
+		{
+			return false;
+		}
+
 		// TheSuperHackers @tweak xezon 06/08/2025
 		// The logic time step is now decoupled from the render update.
 		const Real targetFrameTime = 1.0f / logicTimeScaleFps;


### PR DESCRIPTION
* Fixes #2864
* Follow up for #2803
* Follow up for #2707

Since #2803 the update no longer passes `FramePacer::IgnoreHaltedGame`, so `getActualLogicTimeScaleFps` returns 0 while the game is paused. That makes `targetFrameTime` infinite, and `m_logicTimeAccumulator` banks the entire pause duration, which then drains at render rate after unpausing — the game runs at 2x for about as long as it was paused.

Now returns early when the logic time scale fps is 0, leaving the accumulator untouched while the game is halted, so the game resumes at normal speed.

Todo:
- [x] Test pause/unpause with render fps 60 and logic time scale 30
- [x] Replicate to Generals