### PR TITLE
refactor(network): Remove dynamic allocations for NetPacket

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
+++ b/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
@@ -134,27 +134,28 @@ protected:
 template<typename NetPacketType, typename SmallNetPacketType>
 class NetCommandMsgT : public NetCommandMsg
 {
-	virtual size_t getSizeForNetPacket() const override
+public:
+	virtual size_t getSizeForNetPacket() const final
 	{
 		return NetPacketType::getSize(*this);
 	}
 
-	virtual size_t copyBytesForNetPacket(UnsignedByte* buffer, const NetCommandRef& ref) const override
+	virtual size_t copyBytesForNetPacket(UnsignedByte* buffer, const NetCommandRef& ref) const final
 	{
 		return NetPacketType::copyBytes(buffer, ref);
 	}
 
-	virtual size_t getSizeForSmallNetPacket(const Select* select = nullptr) const override
+	virtual size_t getSizeForSmallNetPacket(const Select* select = nullptr) const final
 	{
 		return SmallNetPacketType::getSize(*this, select);
 	}
 
-	virtual size_t copyBytesForSmallNetPacket(UnsignedByte* buffer, const NetCommandRef& ref, const Select* select = nullptr) const override
+	virtual size_t copyBytesForSmallNetPacket(UnsignedByte* buffer, const NetCommandRef& ref, const Select* select = nullptr) const final
 	{
 		return SmallNetPacketType::copyBytes(buffer, ref, select);
 	}
 
-	virtual size_t readMessageData(NetCommandRef& ref, NetPacketBuf buf) const override
+	virtual size_t readMessageData(NetCommandRef& ref, NetPacketBuf buf) const final
 	{
 		return SmallNetPacketType::CommandData::readMessage(ref, buf);
 	}

--- a/Core/GameEngine/Include/GameNetwork/NetPacket.h
+++ b/Core/GameEngine/Include/GameNetwork/NetPacket.h
@@ -62,7 +62,7 @@ public:
 	NetCommandList *getCommandList();
 
 	static NetCommandRef *ConstructNetCommandMsgFromRawData(const UnsignedByte *data, UnsignedInt dataLength);
-	static NetPacketList ConstructBigCommandPacketList(NetCommandRef *ref);
+	static NetCommandList *ConstructBigCommandList(NetCommandRef *ref);
 
 	UnsignedByte *getData();
 	Int getLength();

--- a/Core/GameEngine/Include/GameNetwork/NetPacket.h
+++ b/Core/GameEngine/Include/GameNetwork/NetPacket.h
@@ -40,18 +40,12 @@ be specialized code.
 #include "Common/MessageStream.h"
 #include "Common/GameMemory.h"
 
-class NetPacket;
-
-typedef std::list<NetPacket *> NetPacketList;
-typedef std::list<NetPacket *>::iterator NetPacketListIter;
-
-class NetPacket : public MemoryPoolObject
+class NetPacket
 {
-	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetPacket, "NetPacket")
 public:
 	NetPacket();
-	NetPacket(TransportMessage *msg);
-	//virtual ~NetPacket();
+	NetPacket(const TransportMessage& msg);
+	~NetPacket();
 
 	void init();
 	void reset();

--- a/Core/GameEngine/Include/GameNetwork/NetPacket.h
+++ b/Core/GameEngine/Include/GameNetwork/NetPacket.h
@@ -63,10 +63,6 @@ public:
 	UnsignedInt getAddr();
 	UnsignedShort getPort();
 
-	// This function returns the size of the command without any compression, repetition, etc.
-	// i.e. All of the required fields are taken into account when returning the size.
-	static UnsignedInt GetBufferSizeNeededForCommand(NetCommandMsg *msg);
-
 protected:
 	Bool isAckRepeat(NetCommandRef *msg);
 	Bool isAckBothRepeat(NetCommandRef *msg);

--- a/Core/GameEngine/Source/Common/System/GameMemoryInitPools_Generals.inl
+++ b/Core/GameEngine/Source/Common/System/GameMemoryInitPools_Generals.inl
@@ -522,7 +522,6 @@ static PoolSizeRec PoolSizes[] =
 	{ "Campaign", 32, 32 },
 	{ "Mission", 32, 32 },
 	{ "ModalWindow", 32, 32 },
-	{ "NetPacket", 32, 32 },
 	{ "AISideInfo", 32, 32 },
 	{ "AISideBuildList", 32, 32 },
 	{ "MetaMapRec", 256, 32 },

--- a/Core/GameEngine/Source/Common/System/GameMemoryInitPools_GeneralsMD.inl
+++ b/Core/GameEngine/Source/Common/System/GameMemoryInitPools_GeneralsMD.inl
@@ -518,7 +518,6 @@ static PoolSizeRec PoolSizes[] =
 	{ "Campaign", 32, 32 },
 	{ "Mission", 88, 32 },
 	{ "ModalWindow", 32, 32 },
-	{ "NetPacket", 32, 32 },
 	{ "AISideInfo", 32, 32 },
 	{ "AISideBuildList", 32, 32 },
 	{ "MetaMapRec", 256, 32 },

--- a/Core/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Connection.cpp
@@ -152,8 +152,9 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 			// the message doesn't fit in a single packet, need to split it up.
 			if (NetCommandList* list = NetPacket::ConstructBigCommandList(tempref)) {
 				for (NetCommandRef* ref1 = list->getFirstMessage(); ref1 != nullptr; ref1 = ref1->getNext()) {
-					NetCommandRef* ref2 = m_netCommandList->addMessage(ref1->getCommand());
-					ref2->setRelay(relay);
+					if (NetCommandRef* ref2 = m_netCommandList->addMessage(ref1->getCommand())) {
+						ref2->setRelay(relay);
+					}
 				}
 
 				deleteInstance(list);

--- a/Core/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Connection.cpp
@@ -150,40 +150,25 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 		packet->reset();
 
 		NetCommandRef *tempref = NEW_NETCOMMANDREF(msg);
+		if (packet.addCommand(tempref)) {
+			deleteInstance(tempref);
+			tempref = nullptr;
+		} else {
+			tempref->setRelay(relay);
 
-		Bool msgFits = packet->addCommand(tempref);
-		deleteInstance(tempref); // delete the temporary reference.
-		tempref = nullptr;
-
-		if (!msgFits) {
-			NetCommandRef *origref = NEW_NETCOMMANDREF(msg);
-			origref->setRelay(relay);
 			// the message doesn't fit in a single packet, need to split it up.
-			NetPacketList packetList = NetPacket::ConstructBigCommandPacketList(origref);
-			NetPacketListIter tempPacketPtr = packetList.begin();
-
-			while (tempPacketPtr != packetList.end()) {
-				NetPacket *tempPacket = (*tempPacketPtr);
-
-				NetCommandList *list = tempPacket->getCommandList();
-				NetCommandRef *ref1 = list->getFirstMessage();
-				while (ref1 != nullptr) {
-					NetCommandRef *ref2 = m_netCommandList->addMessage(ref1->getCommand());
+			if (NetCommandList* list = NetPacket::ConstructBigCommandList(tempref)) {
+				for (NetCommandRef* ref1 = list->getFirstMessage(); ref1 != nullptr; ref1 = ref1->getNext()) {
+					NetCommandRef* ref2 = m_netCommandList->addMessage(ref1->getCommand());
 					ref2->setRelay(relay);
-
-					ref1 = ref1->getNext();
 				}
-
-				deleteInstance(tempPacket);
-				tempPacket = nullptr;
-				++tempPacketPtr;
 
 				deleteInstance(list);
 				list = nullptr;
 			}
 
-			deleteInstance(origref);
-			origref = nullptr;
+			deleteInstance(tempref);
+			tempref = nullptr;
 
 			return;
 		}

--- a/Core/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Connection.cpp
@@ -131,23 +131,16 @@ User * Connection::getUser() {
  * The relay mostly has to do with the packet router.
  */
 void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
-	static NetPacket *packet = nullptr;
-
-	// this is done so we don't have to allocate and delete a packet every time we send a message.
-	if (packet == nullptr) {
-		packet = newInstance(NetPacket);
-	}
-
-
 	if (m_isQuitting)
 		return;
 
 	if (m_netCommandList != nullptr) {
+		NetPacket packet;
+
 		// check to see if this command will fit in a packet.  If not, we need to split it up.
 		// we are splitting up the command here so that the retry logic will not try to
 		// resend the ENTIRE command (i.e. multiple packets work of data) and only do the retry
 		// one wrapper command at a time.
-		packet->reset();
 
 		NetCommandRef *tempref = NEW_NETCOMMANDREF(msg);
 		if (packet.addCommand(tempref)) {
@@ -255,9 +248,8 @@ UnsignedInt Connection::doSend() {
 	NetCommandRef *msg = m_netCommandList->getFirstMessage();
 
 	while ((msg != nullptr) && couldQueue) {
-		NetPacket *packet = newInstance(NetPacket);
-		packet->init();
-		packet->setAddress(m_user->GetIPAddr(), m_user->GetPort());
+		NetPacket packet;
+		packet.setAddress(m_user->GetIPAddr(), m_user->GetPort());
 
 		Bool notDone = TRUE;
 
@@ -268,7 +260,7 @@ UnsignedInt Connection::doSend() {
 			time_t timeLastSent = msg->getTimeLastSent();
 
 			if (((curtime - timeLastSent) > m_retryTime) || (timeLastSent == -1)) {
-				notDone = packet->addCommand(msg);
+				notDone = packet.addCommand(msg);
 				if (notDone) {
 					// the msg command was added to the packet.
 					if (CommandRequiresAck(msg->getCommand())) {
@@ -293,14 +285,12 @@ UnsignedInt Connection::doSend() {
 		++numpackets;
 
 		/// @todo Make the act of giving the transport object a packet to send more efficient.  Make the transport take a NetPacket object rather than the raw data, thus avoiding an extra memcpy.
-		if (packet->getNumCommands() > 0) {
+		if (packet.getNumCommands() > 0) {
 			// If the packet actually has any information to give, give it to the transport object
 			// for transmission.
-			couldQueue = m_transport->queueSend(packet->getAddr(), packet->getPort(), packet->getData(), packet->getLength());
+			couldQueue = m_transport->queueSend(packet.getAddr(), packet.getPort(), packet.getData(), packet.getLength());
 			m_lastTimeSent = curtime;
 		}
-
-		deleteInstance(packet); // delete the packet now that we're done with it.
 	}
 
 	return numpackets;

--- a/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -459,20 +459,18 @@ void ConnectionManager::destroyGameMessages() {
  * assumption that a command will only be relayed once.
  */
 void ConnectionManager::doRelay() {
-	NetPacket *packet = nullptr;
-
 	for (size_t i = 0; i < ARRAY_SIZE(m_transport->m_inBuffer); ++i) {
 		if (m_transport->m_inBuffer[i].length > 0) {
 			// This transport buffer has yet to be processed.
 
 			// make a NetPacket out of this data so it can be broken up into individual commands.
-			packet = newInstance(NetPacket)(&(m_transport->m_inBuffer[i]));
+			NetPacket packet(m_transport->m_inBuffer[i]);
 
-			//DEBUG_LOG(("ConnectionManager::doRelay() - got a packet with %d commands", packet->getNumCommands()));
-			//LOGBUFFER( packet->getData(), packet->getLength() );
+			//DEBUG_LOG(("ConnectionManager::doRelay() - got a packet with %d commands", packet.getNumCommands()));
+			//LOGBUFFER( packet.getData(), packet.getLength() );
 
 			// Get the command list from the packet.
-			NetCommandList *cmdList = packet->getCommandList();
+			NetCommandList *cmdList = packet.getCommandList();
 
 			// Iterate through the commands in this packet and send them to the proper connections.
 			for (NetCommandRef* cmd = cmdList->getFirstMessage(); cmd; cmd = cmd->getNext()) {
@@ -486,10 +484,6 @@ void ConnectionManager::doRelay() {
 					sendRemoteCommand(cmd);
 				}
 			}
-
-			// Delete this packet since we won't be needing it anymore.
-			deleteInstance(packet);
-			packet = nullptr;
 
 			deleteInstance(cmdList);
 			cmdList = nullptr;
@@ -510,10 +504,6 @@ void ConnectionManager::doRelay() {
 			sendRemoteCommand(cmd);
 		}
 	}
-
-	// Delete this packet since we won't be needing it anymore.
-	deleteInstance(packet);
-	packet = nullptr;
 
 	deleteInstance(cmdList);
 	cmdList = nullptr;

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -90,7 +90,6 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	ref->getCommand()->copyBytesForNetPacket(bigPacketData, *ref);
 
 	NetCommandList* commandList = newInstance(NetCommandList);
-	commandList->init();
 
 	// create the wrapper command message we'll be using.
 	NetWrapperCommandMsg *wrapperMsg = newInstance(NetWrapperCommandMsg);
@@ -167,13 +166,14 @@ NetPacket::NetPacket() {
 /**
  * Constructor given raw transport data.
  */
-NetPacket::NetPacket(TransportMessage *msg) {
+NetPacket::NetPacket(const TransportMessage& msg) {
 	init();
-	m_packetLen = msg->length;
-	memcpy(m_packet, msg->data, MAX_PACKET_SIZE);
+
+	m_packetLen = msg.length;
+	memcpy(m_packet, msg.data, MAX_PACKET_SIZE);
 	m_numCommands = -1;
-	m_addr = msg->addr;
-	m_port = msg->port;
+	m_addr = msg.addr;
+	m_port = msg.port;
 }
 
 /**

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -89,8 +89,6 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	// create the buffer for the huge message and fill the buffer with that message.
 	ref->getCommand()->copyBytesForNetPacket(bigPacketData, *ref);
 
-	NetCommandList* commandList = newInstance(NetCommandList);
-
 	// create the wrapper command message we'll be using.
 	NetWrapperCommandMsg *wrapperMsg = newInstance(NetWrapperCommandMsg);
 	// get the amount of space needed for the wrapper message, not including the wrapped command data.
@@ -101,6 +99,8 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	if ((bufferSize % commandSizePerPacket) > 0) {
 		++numChunks;
 	}
+
+	NetCommandList* commandList = newInstance(NetCommandList);
 
 	UnsignedInt currentChunk = 0;
 	UnsignedInt bigPacketCurrentOffset = 0;

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -71,7 +71,8 @@ NetCommandRef *NetPacket::ConstructNetCommandMsgFromRawData(const UnsignedByte *
 	return ref;
 }
 
-NetPacketList NetPacket::ConstructBigCommandPacketList(NetCommandRef *ref) {
+NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
+{
 	// if we don't have a unique command ID, then the wrapped command cannot
 	// be identified.  Therefore don't allow commands without a unique ID to
 	// be wrapped.
@@ -79,18 +80,17 @@ NetPacketList NetPacket::ConstructBigCommandPacketList(NetCommandRef *ref) {
 
 	if (!DoesCommandRequireACommandID(msg->getNetCommandType())) {
 		DEBUG_CRASH(("Trying to wrap a command that doesn't have a unique command ID"));
-		return NetPacketList();
+		return nullptr;
 	}
 
 	UnsignedInt bufferSize = GetBufferSizeNeededForCommand(msg);  // need to implement.  I have a drinking problem.
-	UnsignedByte *bigPacketData = nullptr;
-
-	NetPacketList packetList;
+	UnsignedByte* bigPacketData = NEW UnsignedByte[bufferSize];
 
 	// create the buffer for the huge message and fill the buffer with that message.
-	UnsignedInt bigPacketCurrentOffset = 0;
-	bigPacketData = NEW UnsignedByte[bufferSize];
 	ref->getCommand()->copyBytesForNetPacket(bigPacketData, *ref);
+
+	NetCommandList* commandList = newInstance(NetCommandList);
+	commandList->init();
 
 	// create the wrapper command message we'll be using.
 	NetWrapperCommandMsg *wrapperMsg = newInstance(NetWrapperCommandMsg);
@@ -102,55 +102,49 @@ NetPacketList NetPacket::ConstructBigCommandPacketList(NetCommandRef *ref) {
 	if ((bufferSize % commandSizePerPacket) > 0) {
 		++numChunks;
 	}
+
 	UnsignedInt currentChunk = 0;
+	UnsignedInt bigPacketCurrentOffset = 0;
 
-	// create the packets and the wrapper messages.
 	while (currentChunk < numChunks) {
-		NetPacket *packet = newInstance(NetPacket);
-
-		UnsignedInt dataSizeThisPacket = commandSizePerPacket;
-		if ((bufferSize - bigPacketCurrentOffset) < dataSizeThisPacket) {
-			dataSizeThisPacket = bufferSize - bigPacketCurrentOffset;
+		UnsignedInt dataSizeThisChunk = commandSizePerPacket;
+		if ((bufferSize - bigPacketCurrentOffset) < dataSizeThisChunk) {
+			dataSizeThisChunk = bufferSize - bigPacketCurrentOffset;
 		}
-		NetCommandDataChunk bigPacket(dataSizeThisPacket);
-		memcpy(bigPacket.data(), bigPacketData + bigPacketCurrentOffset, bigPacket.size());
+
+		NetCommandDataChunk chunkData(dataSizeThisChunk);
+		memcpy(chunkData.data(), bigPacketData + bigPacketCurrentOffset, chunkData.size());
 
 		if (DoesCommandRequireACommandID(wrapperMsg->getNetCommandType())) {
 			wrapperMsg->setID(GenerateNextCommandID());
 		}
+
 		wrapperMsg->setPlayerID(msg->getPlayerID());
 		wrapperMsg->setExecutionFrame(msg->getExecutionFrame());
 
 		wrapperMsg->setChunkNumber(currentChunk);
 		wrapperMsg->setNumChunks(numChunks);
 		wrapperMsg->setDataOffset(bigPacketCurrentOffset);
-		wrapperMsg->setData(bigPacket);
+		wrapperMsg->setData(chunkData);
 		wrapperMsg->setTotalDataLength(bufferSize);
 		wrapperMsg->setWrappedCommandID(msg->getID());
 
-		bigPacketCurrentOffset += dataSizeThisPacket;
+		bigPacketCurrentOffset += dataSizeThisChunk;
 
-		NetCommandRef *ref = NEW_NETCOMMANDREF(wrapperMsg);
-		ref->setRelay(ref->getRelay());
+		NetCommandRef* chunkRef = NEW_NETCOMMANDREF(wrapperMsg);
+		chunkRef->setRelay(ref->getRelay());
 
-		if (packet->addCommand(ref) == FALSE) {
-			DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::BeginBigCommandPacketList - failed to add a wrapper command to the packet")); // I still have a drinking problem.
-		}
-
-		packetList.push_back(packet);
-
-		deleteInstance(ref);
-		ref = nullptr;
-
+		commandList->addMessage(chunkRef);
 		++currentChunk;
 	}
+
 	wrapperMsg->detach();
 	wrapperMsg = nullptr;
 
 	delete[] bigPacketData;
 	bigPacketData = nullptr;
 
-	return packetList;
+	return commandList;
 }
 
 UnsignedInt NetPacket::GetBufferSizeNeededForCommand(NetCommandMsg *msg) {

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -83,7 +83,7 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 		return nullptr;
 	}
 
-	UnsignedInt bufferSize = GetBufferSizeNeededForCommand(msg);  // need to implement.  I have a drinking problem.
+	UnsignedInt bufferSize = msg->getSizeForNetPacket();
 	UnsignedByte* bigPacketData = NEW UnsignedByte[bufferSize];
 
 	// create the buffer for the huge message and fill the buffer with that message.
@@ -92,7 +92,7 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	// create the wrapper command message we'll be using.
 	NetWrapperCommandMsg *wrapperMsg = newInstance(NetWrapperCommandMsg);
 	// get the amount of space needed for the wrapper message, not including the wrapped command data.
-	UnsignedInt wrapperSize = GetBufferSizeNeededForCommand(wrapperMsg);
+	UnsignedInt wrapperSize = static_cast<NetCommandMsg*>(wrapperMsg)->getSizeForNetPacket();
 	UnsignedInt commandSizePerPacket = MAX_PACKET_SIZE - wrapperSize;
 
 	UnsignedInt numChunks = bufferSize / commandSizePerPacket;
@@ -152,16 +152,6 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	bigPacketData = nullptr;
 
 	return commandList;
-}
-
-UnsignedInt NetPacket::GetBufferSizeNeededForCommand(NetCommandMsg *msg) {
-	// This is where the fun begins...
-
-	if (msg == nullptr) {
-		return 0; // There was nothing to add.
-	}
-	// Use the virtual function for all command message types
-	return msg->getSizeForNetPacket();
 }
 
 /**

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -105,6 +105,8 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	UnsignedInt currentChunk = 0;
 	UnsignedInt bigPacketCurrentOffset = 0;
 
+	DEBUG_ASSERTCRASH(bufferSize > 0 && numChunks > 0, ("buffer size for command must be bigger than 0"));
+
 	while (true) {
 		UnsignedInt dataSizeThisChunk = commandSizePerPacket;
 		if ((bufferSize - bigPacketCurrentOffset) < dataSizeThisChunk) {

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -105,7 +105,7 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	UnsignedInt currentChunk = 0;
 	UnsignedInt bigPacketCurrentOffset = 0;
 
-	while (currentChunk < numChunks) {
+	while (true) {
 		UnsignedInt dataSizeThisChunk = commandSizePerPacket;
 		if ((bufferSize - bigPacketCurrentOffset) < dataSizeThisChunk) {
 			dataSizeThisChunk = bufferSize - bigPacketCurrentOffset;
@@ -135,6 +135,12 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 
 		commandList->addMessage(chunkRef);
 		++currentChunk;
+
+		if (currentChunk >= numChunks)
+			break;
+
+		wrapperMsg->detach();
+		wrapperMsg = newInstance(NetWrapperCommandMsg);
 	}
 
 	wrapperMsg->detach();

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -93,10 +93,10 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	NetWrapperCommandMsg *wrapperMsg = newInstance(NetWrapperCommandMsg);
 	// get the amount of space needed for the wrapper message, not including the wrapped command data.
 	UnsignedInt wrapperSize = static_cast<NetCommandMsg*>(wrapperMsg)->getSizeForNetPacket();
-	UnsignedInt commandSizePerPacket = MAX_PACKET_SIZE - wrapperSize;
+	UnsignedInt maxDataSizePerPacket = MAX_PACKET_SIZE - wrapperSize;
 
-	UnsignedInt numChunks = bufferSize / commandSizePerPacket;
-	if ((bufferSize % commandSizePerPacket) > 0) {
+	UnsignedInt numChunks = bufferSize / maxDataSizePerPacket;
+	if ((bufferSize % maxDataSizePerPacket) > 0) {
 		++numChunks;
 	}
 
@@ -108,7 +108,7 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	DEBUG_ASSERTCRASH(bufferSize > 0 && numChunks > 0, ("buffer size for command must be bigger than 0"));
 
 	while (true) {
-		UnsignedInt dataSizeThisChunk = commandSizePerPacket;
+		UnsignedInt dataSizeThisChunk = maxDataSizePerPacket;
 		if ((bufferSize - bigPacketCurrentOffset) < dataSizeThisChunk) {
 			dataSizeThisChunk = bufferSize - bigPacketCurrentOffset;
 		}

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -92,7 +92,7 @@ NetCommandList *NetPacket::ConstructBigCommandList(NetCommandRef *ref)
 	// create the wrapper command message we'll be using.
 	NetWrapperCommandMsg *wrapperMsg = newInstance(NetWrapperCommandMsg);
 	// get the amount of space needed for the wrapper message, not including the wrapped command data.
-	UnsignedInt wrapperSize = static_cast<NetCommandMsg*>(wrapperMsg)->getSizeForNetPacket();
+	UnsignedInt wrapperSize = wrapperMsg->getSizeForNetPacket();
 	UnsignedInt maxDataSizePerPacket = MAX_PACKET_SIZE - wrapperSize;
 
 	UnsignedInt numChunks = bufferSize / maxDataSizePerPacket;


### PR DESCRIPTION
This PR makes two changes to remove all dynamic allocations for `NetPacket`:
1. Refactors `NetPacket::ConstructBigCommandList` so that `NetPacket` doesn't have to be memory pooled.
2. Removes memory pool for `NetPacket`, so that it can be stack allocated.