### PR TITLE
bugfix(controlbar): Fix possible divisions by zero in Control Bar code

### DIFF
--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -425,8 +425,7 @@ void ControlBar::populatePurchaseScience( Player* player )
 	win = TheWindowManager->winGetWindowFromId( m_contextParent[ CP_PURCHASE_SCIENCE ], TheNameKeyGenerator->nameToKey( "GeneralsExpPoints.wnd:ProgressBarExperience" ) );
 	if(win)
 	{
-		Int progress;
-		progress = ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) /(player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown());
+		const Int progress = ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) / (player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown());
 		GadgetProgressBarSetProgress(win, progress);
 	}
 
@@ -484,8 +483,7 @@ void ControlBar::updateContextPurchaseScience()
 	win = TheWindowManager->winGetWindowFromId( m_contextParent[ CP_PURCHASE_SCIENCE ], TheNameKeyGenerator->nameToKey( "GeneralsExpPoints.wnd:ProgressBarExperience" ) );
 	if(win)
 	{
-		Int progress;
-		progress = ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) /(player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown());
+		const Int progress = ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) / (player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown());
 		GadgetProgressBarSetProgress(win, progress);
 	}
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
@@ -477,14 +477,8 @@ void W3DCommandBarGenExpDraw( GameWindow *window, WinInstanceData *instData )
 	static const Image *endBar = TheMappedImageCollection->findImageByName("GenExpBarTop1");
 	static const Image *beginBar = TheMappedImageCollection->findImageByName("GenExpBarBottom1");
 	static const Image *centerBar = TheMappedImageCollection->findImageByName("GenExpBar1");
-	Int progress = 0;
-	Int skillPointsRequired = player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown();
 
-	// TheSuperHackers @bugfix Mauller 04/05/2025 Prevent possible division by zero
-	if ( skillPointsRequired > 0)
-	{
-		progress = ( ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) / skillPointsRequired );
-	}
+	Int progress = ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) / (player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown());
 
 	if(progress <= 0)
 		return;

--- a/GeneralsMD/Code/GameEngine/Include/Common/Player.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Player.h
@@ -682,6 +682,8 @@ private:
 	*/
 	Bool addScience(ScienceType science);
 
+	void setSafeLevels(Int levelUp, Int levelDown);
+
 public:
 	Int getSkillPoints() const						{ return m_skillPoints; }
 	Int getSciencePurchasePoints() const	{ return m_sciencePurchasePoints; }

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2702,8 +2702,7 @@ void Player::resetRank()
 	m_rankLevel = 1;
 	m_skillPoints = 0;
 	const RankInfo* nextRank = TheRankInfoStore->getRankInfo(m_rankLevel+1);
-	m_levelUp = nextRank ? nextRank->m_skillPointsNeeded : INT_MAX;
-	m_levelDown = 0;
+	setSafeLevels(nextRank ? nextRank->m_skillPointsNeeded : INT_MAX, 0);
 	m_sciences.clear();
 	m_sciencePurchasePoints = getPlayerTemplate() ? getPlayerTemplate()->getIntrinsicSciencePurchasePoints() : 0;
 	const RankInfo* curRank = TheRankInfoStore->getRankInfo(m_rankLevel);
@@ -2762,7 +2761,8 @@ Bool Player::setRankLevel(Int newLevel)
 	}
 
 	const RankInfo* nextRank = TheRankInfoStore->getRankInfo(newLevel + 1);
-	m_levelUp = nextRank ? nextRank->m_skillPointsNeeded : INT_MAX;
+	setSafeLevels(nextRank ? nextRank->m_skillPointsNeeded : INT_MAX, m_levelDown);
+
 	m_rankLevel = newLevel;
 
 	DEBUG_ASSERTCRASH(m_skillPoints >= m_levelDown && m_skillPoints < m_levelUp, ("hmm, wrong"));
@@ -2786,6 +2786,22 @@ Bool Player::setRankLevel(Int newLevel)
 	}
 
 	return true;
+}
+
+//=============================================================================
+void Player::setSafeLevels(Int levelUp, Int levelDown)
+{
+	if (levelUp == levelDown)
+	{
+		// TheSuperHackers @bugfix Prevent possible division by zero in the control bar code.
+		m_levelUp = INT_MAX;
+		m_levelDown = 0;
+	}
+	else
+	{
+		m_levelUp = levelUp;
+		m_levelDown = levelDown;
+	}
 }
 
 //=============================================================================
@@ -4588,6 +4604,5 @@ void Player::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void Player::loadPostProcess()
 {
-
+	setSafeLevels(m_levelUp, m_levelDown);
 }
-


### PR DESCRIPTION
* Related issue: https://github.com/TheSuperHackers/GeneralsGameCode/issues/797
* Follow-up for PR: https://github.com/TheSuperHackers/GeneralsGameCode/pull/810

Using the modified rank file in #797, there are two more places the game would crash because of a division by zero; in `ControlBar::populatePurchaseScience` and `ControlBar::updateContextPurchaseScience`.

Issue reproduction steps:
1. Add the modified rank ini data to a custom map.
2. Start a match and click on the special powers menu.
3. Game crashes due to a division by zero.

Callstacks:
```
generalszh.exe!ControlBar::populatePurchaseScience(Player * player) Line 430
generalszh.exe!ControlBar::showPurchaseScience() Line 2977
generalszh.exe!ControlBar::togglePurchaseScience() Line 3016
generalszh.exe!ControlBarSystem(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 418
generalszh.exe!GameWindowManager::winSendSystemMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 705
generalszh.exe!GadgetPushButtonInput(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 218
generalszh.exe!GameWindowManager::winSendInputMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 724
generalszh.exe!GameWindowManager::winProcessMouseEvent(GameWindowMessage msg, ICoord2D * mousePos, void * data) Line 919
generalszh.exe!WindowTranslator::translateGameMessage(const GameMessage * msg) Line 242
generalszh.exe!MessageStream::propagateMessages() Line 1090
generalszh.exe!GameEngine::update() Line 910
generalszh.exe!Win32GameEngine::update() Line 91
generalszh.exe!GameEngine::execute() Line 983
generalszh.exe!GameMain() Line 55
generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 929
```

```
generalszh.exe!ControlBar::updateContextPurchaseScience() Line 495
generalszh.exe!ControlBar::update() Line 1530
generalszh.exe!InGameUI::update() Line 2093
generalszh.exe!W3DInGameUI::update() Line 370
generalszh.exe!SubsystemInterface::UPDATE() Line 131
generalszh.exe!GameClient::update() Line 781
generalszh.exe!W3DGameClient::update() Line 94
generalszh.exe!SubsystemInterface::UPDATE() Line 131
generalszh.exe!GameEngine::update() Line 910
generalszh.exe!Win32GameEngine::update() Line 91
generalszh.exe!GameEngine::execute() Line 983
generalszh.exe!GameMain() Line 55
generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 929
```

## TODO:
- [ ] Replicate in Generals.