### PR TITLE
bugfix(contain): Restore retail compatibility after changes to Object::m_containedByID

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -424,9 +424,13 @@ public:
 	void onContainedBy( Object *containedBy );
 	void onRemovedFrom( Object *removedFrom );
 	Int getTransportSlotCount() const;
-	void friend_setContainedBy( Object *containedBy ) { m_containedBy = containedBy; }
+	void friend_setContainedBy( Object *containedBy );
 	const Object* getEnclosingContainedBy() const; ///< Find the first enclosing container in the containment chain.
 	const Object* getOuterObject() const; ///< Get the top-level object
+
+#if RTS_ZEROHOUR && RETAIL_COMPATIBLE_CRC
+	void friend_setContainedByID(ObjectID id) { m_containedByID = id; }
+#endif
 
 	// Special Powers -------------------------------------------------------------------------------
 	SpecialPowerModuleInterface *getSpecialPowerModule( const SpecialPowerTemplate *specialPowerTemplate ) const;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -674,6 +674,15 @@ Int Object::getTransportSlotCount() const
 	return count;
 }
 
+void Object::friend_setContainedBy(Object* containedBy)
+{
+	m_containedBy = containedBy;
+
+#if !RETAIL_COMPATIBLE_CRC
+	m_containedByFrame = containedBy ? TheGameLogic->getFrame() : 0;
+#endif
+}
+
 const Object* Object::getEnclosingContainedBy() const
 {
 	for (const Object* child = this, *container = getContainedBy(); container; child = container, container = container->getContainedBy())
@@ -3771,8 +3780,9 @@ void Object::xfer( Xfer *xfer )
 		// No, the contain module is just going to friend_ reach in and set this for us.
 		// Containers more complicated than Open (like Tunnel) can't do that.  Our variable,
 		// our responsibility.
-#if !RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_CRC
 		// TheSuperHackers @tweak Contained by ID is already set with retail compatibility; don't overwrite it.
+#else
 		if( xfer->getXferMode() == XFER_SAVE )
 		{
 			if( m_containedBy != nullptr )

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -453,7 +453,7 @@ public:
 	const Object* getEnclosingContainedBy() const; ///< Find the first enclosing container in the containment chain.
 	const Object* getOuterObject() const; ///< Get the top-level object
 
-#if RETAIL_COMPATIBLE_CRC
+#if RTS_ZEROHOUR && RETAIL_COMPATIBLE_CRC
 	void friend_setContainedByID(ObjectID id) { m_containedByID = id; }
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -453,6 +453,10 @@ public:
 	const Object* getEnclosingContainedBy() const; ///< Find the first enclosing container in the containment chain.
 	const Object* getOuterObject() const; ///< Get the top-level object
 
+#if RETAIL_COMPATIBLE_CRC
+	void friend_setContainedByID(ObjectID id) { m_containedByID = id; }
+#endif
+
 	// Special Powers -------------------------------------------------------------------------------
 	SpecialPowerModuleInterface *getSpecialPowerModule( const SpecialPowerTemplate *specialPowerTemplate ) const;
 	void doSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, UnsignedInt commandOptions, Bool forced = false );	///< execute power

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -449,7 +449,7 @@ public:
 	void onContainedBy( Object *containedBy );
 	void onRemovedFrom( Object *removedFrom );
 	Int getTransportSlotCount() const;
-	void friend_setContainedBy( Object *containedBy ) { m_containedBy = containedBy; }
+	void friend_setContainedBy( Object *containedBy );
 	const Object* getEnclosingContainedBy() const; ///< Find the first enclosing container in the containment chain.
 	const Object* getOuterObject() const; ///< Get the top-level object
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
@@ -320,10 +320,16 @@ void HelixContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 	{
     Object *portable = getPortableStructure();
     if ( portable )
+    {
+#if RETAIL_COMPATIBLE_CRC
+      portable->friend_setContainedByID(INVALID_ID);
+#else
+      portable->friend_setContainedBy(nullptr);
+#endif
 
       m_portableStructureID = INVALID_ID;
       //portable->kill();
-
+    }
   }
   else
   {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
@@ -250,10 +250,10 @@ void HelixContain::addToContainList( Object *obj )
     if ( portable )
       TheGameLogic->destroyObject( portable );
 
-    m_portableStructureID = obj->getID();
-    obj->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
+    portable = obj;
 
-
+    m_portableStructureID = portable->getID();
+    portable->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
   }
   else
 		TransportContain::addToContainList( obj );
@@ -268,10 +268,10 @@ void HelixContain::addToContain( Object *obj )
     if ( portable )
       TheGameLogic->destroyObject( portable );
 
-    m_portableStructureID = obj->getID();
-    obj->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
+    portable = obj;
 
-
+    m_portableStructureID = portable->getID();
+    portable->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
   }
   else
 		TransportContain::addToContain( obj );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
@@ -254,6 +254,24 @@ void HelixContain::addToContainList( Object *obj )
 
     m_portableStructureID = portable->getID();
     portable->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
+
+#if RETAIL_COMPATIBLE_CRC
+    Object* containedBy = getObject();
+
+    // TheSuperHackers @info Set INVALID_ID if the container object was destroyed
+    // to indicate that the pointer will become a dangling pointer in the next frame.
+    if (containedBy && !containedBy->isDestroyed())
+    {
+      portable->friend_setContainedByID(containedBy->getID());
+    }
+    else
+    {
+      portable->friend_setContainedByID(INVALID_ID);
+    }
+#else
+    DEBUG_ASSERTCRASH(getObject() == nullptr || !getObject()->isDestroyed(),
+      ("HelixContain::addToContainList - Adding to a destroyed container"));
+#endif
   }
   else
 		TransportContain::addToContainList( obj );
@@ -272,6 +290,24 @@ void HelixContain::addToContain( Object *obj )
 
     m_portableStructureID = portable->getID();
     portable->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
+
+#if RETAIL_COMPATIBLE_CRC
+    Object* containedBy = getObject();
+
+    // TheSuperHackers @info Set INVALID_ID if the container object was destroyed
+    // to indicate that the pointer will become a dangling pointer in the next frame.
+    if (containedBy && !containedBy->isDestroyed())
+    {
+      portable->friend_setContainedByID(containedBy->getID());
+    }
+    else
+    {
+      portable->friend_setContainedByID(INVALID_ID);
+    }
+#else
+    DEBUG_ASSERTCRASH(getObject() == nullptr || !getObject()->isDestroyed(),
+      ("HelixContain::addToContain - Adding to a destroyed container"));
+#endif
   }
   else
 		TransportContain::addToContain( obj );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -749,6 +749,15 @@ Int Object::getTransportSlotCount() const
 	return count;
 }
 
+void Object::friend_setContainedBy(Object* containedBy)
+{
+	m_containedBy = containedBy;
+
+#if !RETAIL_COMPATIBLE_CRC
+	m_containedByFrame = containedBy ? TheGameLogic->getFrame() : 0;
+#endif
+}
+
 const Object* Object::getEnclosingContainedBy() const
 {
 	for (const Object* child = this, *container = getContainedBy(); container; child = container, container = container->getContainedBy())

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4299,8 +4299,9 @@ void Object::xfer( Xfer *xfer )
 		// No, the contain module is just going to friend_ reach in and set this for us.
 		// Containers more complicated than Open (like Tunnel) can't do that.  Our variable,
 		// our responsibility.
-#if !RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_CRC
 		// TheSuperHackers @tweak Contained by ID is already set with retail compatibility; don't overwrite it.
+#else
 		if( xfer->getXferMode() == XFER_SAVE )
 		{
 			if( m_containedBy != nullptr )


### PR DESCRIPTION
* Follow-up PR for: https://github.com/TheSuperHackers/GeneralsGameCode/pull/2747

PR #2747 forgot to set the `containedByID` variable for objects that make use of the helix container code. This causes a mismatch for the following 5 replays: [replays.zip](https://github.com/user-attachments/files/29940871/replays.zip)

This PR adds the same code that was added to `Object::onContainedBy` to `HelixContain::addToContain` and `HelixContain::addToContainList` to fix the issue.

**Resetting the contain variables, as is done in the [third commit](https://github.com/TheSuperHackers/GeneralsGameCode/pull/2868/changes/25f1ec37e87baf994efc20f63a27b0380fe6522c), is not needed to restore retail compatibility. I added that code because I think it's correct to reset the contain variables when the object is removed from its container.**

## TODO:
- [x] Replicate in Generals.
- [x] Test against replays again.