### PR TITLE
bugfix(heightmap): Fix ray casting in BaseHeightMapRenderObjClass::Cast_Ray (2)

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -659,10 +659,6 @@ void BaseHeightMapRenderObjClass::reset()
 	}
 }
 
-/**@todo: Ray intersection needs to be optimized with some sort of grid-tracing
-(ala line drawing).  We should also try making the search in a front->back order
-relative to the ray so we can early exit as soon as we have a hit.
-*
 //=============================================================================
 // BaseHeightMapRenderObjClass::Cast_Ray
 //=============================================================================
@@ -674,18 +670,27 @@ map plane so this is very quick (small bounding box).  But it can become slow
 for arbitrary rays such as those used in AI visibility checks(2 units on
 opposite corners of the map would check every polygon in the map).
 */
+/** @todo: Ray intersection needs to be optimized with some sort of grid-tracing
+(ala line drawing).  We should also try making the search in a front->back order
+relative to the ray so we can early exit as soon as we have a hit.
+*/
+// TheSuperHackers @fix This function now creates its initial hit box
+// with dimensions that fit into the ray cast and no longer falls back to an
+// infinitely large search region if the initial box cannot be collided with.
 //=============================================================================
 bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 {
+	if (!m_map)
+		return false;	//need valid pointer to heightmap samples
+
 	TriClass tri;
 	Bool hit = false;
 	Int X,Y;
 	Vector3 normal,P0,P1,P2,P3;
-	Bool hasP0 = false;
-	Bool hasP1 = false;
-
-	if (!m_map)
-		return false;	//need valid pointer to heightmap samples
+	P0.Set(FLT_MAX, FLT_MAX, FLT_MAX); // Set initial bogus value
+	P1.Set(FLT_MAX, FLT_MAX, FLT_MAX); // Set initial bogus value
+	Int P0HitCount = 0;
+	Int P1HitCount = 0;
 
 	//Clip ray to extents of height map
 	AABoxClass hbox;
@@ -697,16 +702,24 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 	Int endCellY = 0;
 	const Int borderSize = m_map->getBorderSizeInline();
 	const Int overhang = 2*VERTEX_BUFFER_TILE_LENGTH + borderSize; // Allow picking past the edge for scrolling & objects.
- 	Vector3 minPt(MAP_XY_FACTOR*(-overhang), MAP_XY_FACTOR*(-overhang), -MAP_XY_FACTOR);
-	Vector3 maxPt(MAP_XY_FACTOR*(m_map->getXExtent()+overhang),
-		MAP_XY_FACTOR*(m_map->getYExtent()+overhang), MAP_HEIGHT_SCALE*m_map->getMaxHeightValue()+MAP_XY_FACTOR);
+
+	Real rayMinHeight = std::min(raytest.Ray.Get_P0().Z, raytest.Ray.Get_P1().Z);
+	Real rayMaxHeight = std::max(raytest.Ray.Get_P0().Z, raytest.Ray.Get_P1().Z);
+	Real mapMinHeight = MAP_HEIGHT_SCALE * m_map->getMinHeightValue(); // Begin with min map height.
+	Real mapMaxHeight = MAP_HEIGHT_SCALE * m_map->getMaxHeightValue(); // Begin with max map height.
+	mapMinHeight = std::max(mapMinHeight, rayMinHeight + 1.0f); // But not lower than the ray end plus a margin.
+	mapMaxHeight = std::min(mapMaxHeight, rayMaxHeight - 1.0f); // But not higher than the ray start minus a margin.
+
+	// The first hit box is very rough and is only meant to narrow the search.
+	Vector3 minPt(MAP_XY_FACTOR*(-overhang), MAP_XY_FACTOR*(-overhang), mapMinHeight);
+	Vector3 maxPt(MAP_XY_FACTOR*(m_map->getXExtent()+overhang), MAP_XY_FACTOR*(m_map->getYExtent()+overhang), mapMaxHeight);
 	MinMaxAABoxClass mmbox(minPt, maxPt);
 	hbox.Init(mmbox);
 
 	lineseg=raytest.Ray;
 
-	Int p;
-	for (p=0; p<3; p++) {
+	Int terrainIntersectionIteration = 0;
+	for (; ; ++terrainIntersectionIteration) {
 		//find intersection point of ray and terrain bounding box
 		result.Reset();
 		result.ComputeContactPoint=true;
@@ -719,8 +732,8 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 			if (!result.StartBad)	//check if start point inside terrain
 			{
 				newP0 = P0 != result.ContactPoint;
-				hasP0 = true;
 				P0 = result.ContactPoint;	//make intersection point the new start of the ray.
+				++P0HitCount;
 			}
 
 			//reverse direction of original ray and clip again to extent of heightmap
@@ -732,13 +745,18 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 				if (!result.StartBad)	//check if end point inside terrain
 				{
 					newP1 = P1 != result.ContactPoint;
-					hasP1 = true;
 					P1 = result.ContactPoint;	//make intersection point the new end point of ray
+					++P1HitCount;
 				}
 			}
 		}
 
-		if (!newP0 || !newP1)
+		// Has not even hit the first hit box?
+		if (P0HitCount == 0 || P1HitCount == 0)
+			return false;
+
+		// Has no new hit points?
+		if (!newP0 && !newP1)
 			break;
 
 		// Take the 2D bounding box of ray and check heights
@@ -758,6 +776,10 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 			endCellY = REAL_TO_INT_CEIL(P1.Y/MAP_XY_FACTOR);
 		}
 
+		// Stop narrowing after the third iteration
+		if (terrainIntersectionIteration == 2)
+			break;
+
 		Int i, j, minHt, maxHt;
 
 		minHt = m_map->getMaxHeightValue();
@@ -776,7 +798,8 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 		hbox.Init(mmbox);
 	}
 
-	if (!hasP0 || !hasP1)
+	// Needs at least 2 hit counts for a proper terrain collision.
+	if (P0HitCount < 2 || P1HitCount < 2)
 		return false;
 
 	raytest.Result->ComputeContactPoint=true;	//tell CollisionMath that we need point.
@@ -791,7 +814,6 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 	Int offset;
 	for (offset = 1; offset < 5; offset *= 3) {
 		for (Y=startCellY-offset; Y<=endCellY+offset; Y++) {
-
 			for (X=startCellX-offset; X<=endCellX+offset; X++) {
 				//test the 2 triangles in this cell
 				//	3-----2

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -674,8 +674,8 @@ opposite corners of the map would check every polygon in the map).
 (ala line drawing).  We should also try making the search in a front->back order
 relative to the ray so we can early exit as soon as we have a hit.
 */
-// TheSuperHackers @fix This function now creates its initial hit box
-// with dimensions that fit into the ray cast and no longer falls back to an
+// TheSuperHackers @fix The ray cast can now correctly collide with the initial
+// hit box even if the ray starts inside of it and no longer falls back to an
 // infinitely large search region if the initial box cannot be collided with.
 //=============================================================================
 bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -675,8 +675,8 @@ opposite corners of the map would check every polygon in the map).
 relative to the ray so we can early exit as soon as we have a hit.
 */
 // TheSuperHackers @fix The ray cast can now correctly collide with the initial
-// hit box even if the ray starts inside of it and no longer falls back to an
-// infinitely large search region if the initial box cannot be collided with.
+// hit boxes even if the ray starts inside of it and no longer falls back to an
+// infinitely large search region if the initial boxes cannot be collided with.
 //=============================================================================
 bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 {
@@ -703,7 +703,7 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 	const Int borderSize = m_map->getBorderSizeInline();
 	const Int overhang = 2*VERTEX_BUFFER_TILE_LENGTH + borderSize; // Allow picking past the edge for scrolling & objects.
 
-	// The first hit box is very rough and is only meant to narrow the search.
+	// The initial hit boxes are very rough and are only meant to narrow the search before the triangle intersection.
 	const Real mapMinHeight = MAP_HEIGHT_SCALE * m_map->getMinHeightValue();
 	const Real mapMaxHeight = MAP_HEIGHT_SCALE * m_map->getMaxHeightValue();
 	const Vector3 minPt(MAP_XY_FACTOR*(-overhang), MAP_XY_FACTOR*(-overhang), mapMinHeight);
@@ -723,13 +723,9 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 
 		if (CollisionMath::Collide(lineseg,hbox,&result))
 		{
-			// Go ahead if point is not starting inside terrain or it is the first rough box collision.
-			if (!result.StartBad || terrainIntersectionIteration == 0)
-			{
-				newP0 = P0 != result.ContactPoint;
-				P0 = result.ContactPoint;	//make intersection point the new start of the ray.
-				++P0HitCount;
-			}
+			newP0 = P0 != result.ContactPoint;
+			P0 = result.ContactPoint;	//make intersection point the new start of the ray.
+			++P0HitCount;
 
 			//reverse direction of original ray and clip again to extent of heightmap
 			result.Fraction=1.0f;	//reset the result
@@ -737,13 +733,9 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 			lineseg2.Set(lineseg.Get_P1(),lineseg.Get_P0());	//reverse line segment
 			if (CollisionMath::Collide(lineseg2,hbox,&result))
 			{
-				// Go ahead if point is not starting inside terrain or it is the first rough box collision.
-				if (!result.StartBad || terrainIntersectionIteration == 0)
-				{
-					newP1 = P1 != result.ContactPoint;
-					P1 = result.ContactPoint;	//make intersection point the new end point of ray
-					++P1HitCount;
-				}
+				newP1 = P1 != result.ContactPoint;
+				P1 = result.ContactPoint;	//make intersection point the new end point of ray
+				++P1HitCount;
 			}
 		}
 
@@ -793,10 +785,6 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 		MinMaxAABoxClass mmbox(minPt, maxPt);
 		hbox.Init(mmbox);
 	}
-
-	// Needs at least 2 hit counts for a proper terrain collision.
-	if (P0HitCount < 2 || P1HitCount < 2)
-		return false;
 
 	raytest.Result->ComputeContactPoint=true;	//tell CollisionMath that we need point.
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -703,19 +703,12 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 	const Int borderSize = m_map->getBorderSizeInline();
 	const Int overhang = 2*VERTEX_BUFFER_TILE_LENGTH + borderSize; // Allow picking past the edge for scrolling & objects.
 
-	const Real rayMinHeight = std::min(raytest.Ray.Get_P0().Z, raytest.Ray.Get_P1().Z);
-	const Real rayMaxHeight = std::max(raytest.Ray.Get_P0().Z, raytest.Ray.Get_P1().Z);
-	const Real rayHeightDelta = rayMaxHeight - rayMinHeight;
-	const Real rayHeightMargin = std::min(1.0f, rayHeightDelta * 0.49f);
-	Real mapMinHeight = MAP_HEIGHT_SCALE * m_map->getMinHeightValue(); // Begin with min map height.
-	Real mapMaxHeight = MAP_HEIGHT_SCALE * m_map->getMaxHeightValue(); // Begin with max map height.
-	mapMinHeight = std::max(mapMinHeight, rayMinHeight + rayHeightMargin); // But not lower than the ray end plus a margin.
-	mapMaxHeight = std::min(mapMaxHeight, rayMaxHeight - rayHeightMargin); // But not higher than the ray start minus a margin.
-
 	// The first hit box is very rough and is only meant to narrow the search.
-	Vector3 minPt(MAP_XY_FACTOR*(-overhang), MAP_XY_FACTOR*(-overhang), mapMinHeight);
-	Vector3 maxPt(MAP_XY_FACTOR*(m_map->getXExtent()+overhang), MAP_XY_FACTOR*(m_map->getYExtent()+overhang), mapMaxHeight);
-	MinMaxAABoxClass mmbox(minPt, maxPt);
+	const Real mapMinHeight = MAP_HEIGHT_SCALE * m_map->getMinHeightValue();
+	const Real mapMaxHeight = MAP_HEIGHT_SCALE * m_map->getMaxHeightValue();
+	const Vector3 minPt(MAP_XY_FACTOR*(-overhang), MAP_XY_FACTOR*(-overhang), mapMinHeight);
+	const Vector3 maxPt(MAP_XY_FACTOR*(m_map->getXExtent()+overhang), MAP_XY_FACTOR*(m_map->getYExtent()+overhang), mapMaxHeight);
+	const MinMaxAABoxClass mmbox(minPt, maxPt);
 	hbox.Init(mmbox);
 
 	lineseg=raytest.Ray;
@@ -730,8 +723,8 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 
 		if (CollisionMath::Collide(lineseg,hbox,&result))
 		{
-			//ray intersects terrain or starts inside the terrain.
-			if (!result.StartBad)	//check if start point inside terrain
+			// Go ahead if point is not starting inside terrain or it is the first rough box collision.
+			if (!result.StartBad || terrainIntersectionIteration == 0)
 			{
 				newP0 = P0 != result.ContactPoint;
 				P0 = result.ContactPoint;	//make intersection point the new start of the ray.
@@ -744,7 +737,8 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 			lineseg2.Set(lineseg.Get_P1(),lineseg.Get_P0());	//reverse line segment
 			if (CollisionMath::Collide(lineseg2,hbox,&result))
 			{
-				if (!result.StartBad)	//check if end point inside terrain
+				// Go ahead if point is not starting inside terrain or it is the first rough box collision.
+				if (!result.StartBad || terrainIntersectionIteration == 0)
 				{
 					newP1 = P1 != result.ContactPoint;
 					P1 = result.ContactPoint;	//make intersection point the new end point of ray

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -703,12 +703,14 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 	const Int borderSize = m_map->getBorderSizeInline();
 	const Int overhang = 2*VERTEX_BUFFER_TILE_LENGTH + borderSize; // Allow picking past the edge for scrolling & objects.
 
-	Real rayMinHeight = std::min(raytest.Ray.Get_P0().Z, raytest.Ray.Get_P1().Z);
-	Real rayMaxHeight = std::max(raytest.Ray.Get_P0().Z, raytest.Ray.Get_P1().Z);
+	const Real rayMinHeight = std::min(raytest.Ray.Get_P0().Z, raytest.Ray.Get_P1().Z);
+	const Real rayMaxHeight = std::max(raytest.Ray.Get_P0().Z, raytest.Ray.Get_P1().Z);
+	const Real rayHeightDelta = rayMaxHeight - rayMinHeight;
+	const Real rayHeightMargin = std::min(1.0f, rayHeightDelta * 0.49f);
 	Real mapMinHeight = MAP_HEIGHT_SCALE * m_map->getMinHeightValue(); // Begin with min map height.
 	Real mapMaxHeight = MAP_HEIGHT_SCALE * m_map->getMaxHeightValue(); // Begin with max map height.
-	mapMinHeight = std::max(mapMinHeight, rayMinHeight + 1.0f); // But not lower than the ray end plus a margin.
-	mapMaxHeight = std::min(mapMaxHeight, rayMaxHeight - 1.0f); // But not higher than the ray start minus a margin.
+	mapMinHeight = std::max(mapMinHeight, rayMinHeight + rayHeightMargin); // But not lower than the ray end plus a margin.
+	mapMaxHeight = std::min(mapMaxHeight, rayMaxHeight - rayHeightMargin); // But not higher than the ray start minus a margin.
 
 	// The first hit box is very rough and is only meant to narrow the search.
 	Vector3 minPt(MAP_XY_FACTOR*(-overhang), MAP_XY_FACTOR*(-overhang), mapMinHeight);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -821,7 +821,10 @@ void W3DView::updateCameraClipPlanes(const Matrix3D &transform)
 		}
 	}
 
-	m_3DCamera->Set_Clip_Planes(NearZ, farZ);
+	if (farZ >= 0.0f)
+	{
+		m_3DCamera->Set_Clip_Planes(NearZ, farZ);
+	}
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -797,7 +797,7 @@ void W3DView::updateCameraClipPlanes(const Matrix3D &transform)
 		const Real projectedRadiusToEdge = fabs(dx * camDir.X) + fabs(dy * camDir.Y);
 
 		// Final far plane
-		farZ = projectedDistanceToCenter + projectedRadiusToEdge;
+		farZ = std::max(projectedDistanceToCenter + projectedRadiusToEdge, 0.0f);
 	}
 	else
 	{
@@ -821,10 +821,7 @@ void W3DView::updateCameraClipPlanes(const Matrix3D &transform)
 		}
 	}
 
-	if (farZ >= 0.0f)
-	{
-		m_3DCamera->Set_Clip_Planes(NearZ, farZ);
-	}
+	m_3DCamera->Set_Clip_Planes(NearZ, farZ);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -2196,8 +2196,8 @@ TerrainTextureClass *WorldHeightMap::getFlatTexture(Int xCell, Int yCell, Int ce
 Region2D WorldHeightMap::getDrawRegion2D()
 {
 	// Get region in heightmap space
-	const Int loX = getDrawOrgX() - getBorderSize();
-	const Int loY = getDrawOrgY() - getBorderSize();
+	const Int loX = getDrawOrgX() - getBorderSizeInline();
+	const Int loY = getDrawOrgY() - getBorderSizeInline();
 	const Int hiX = loX + getDrawWidth();
 	const Int hiY = loY + getDrawHeight();
 

--- a/Core/Libraries/Source/WWVegas/WWMath/castres.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/castres.h
@@ -56,7 +56,7 @@ struct CastResultStruct
 	CastResultStruct()	{ Reset(); }
 	void		Reset()		{ StartBad = false; Fraction = 1.0f; Normal.Set(0,0,0); SurfaceType = 0; ComputeContactPoint = false; ContactPoint.Set(0,0,0); }
 
-	bool		StartBad;		// was the initial configuration interpenetrating something?
+	bool		StartBad;		// was the initial configuration interpenetrating something? true if ray starts inside the collided geometry
 	float		Fraction;		// fraction of the move up until collision
 	Vector3	Normal;			// surface normal at the collision point
 	uint32	SurfaceType;	// surface type of polygon at collision point (see W3D_SURFACE_TYPES in w3d_file.h)

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathline.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathline.cpp
@@ -293,6 +293,10 @@ bool CollisionMath::Collide(const LineSegClass & line,const AABoxClass & box,Cas
 	// if ray starts inside the box, note that fact and bail.
 	if (test.Inside) {
 		res->StartBad = true;
+		// TheSuperHackers @tweak The contact point will be where the line has started.
+		if (res->ComputeContactPoint) {
+			res->ContactPoint = line.Get_P0();
+		}
 		return true;
 	}
 
@@ -328,6 +332,10 @@ bool CollisionMath::Collide(const LineSegClass & line,const OBBoxClass & box,Cas
 	// if ray starts inside the box, don't collide
 	if (test.Inside) {
 		result->StartBad = true;
+		// TheSuperHackers @tweak The contact point will be where the line has started.
+		if (result->ComputeContactPoint) {
+			result->ContactPoint = line.Get_P0();
+		}
 		return true;
 	}
 


### PR DESCRIPTION
* Follow up for #2836

This change is follow up for #2836 and applies more fixing in the Cast_Ray function.

Before this change the ray cast was failing if the camera was positioned below the max terrain height. The logical consequence was that no unit could be ordered to move anywhere on close zoom.

With the fixed logic the initial terrain hit box is assembled in a way that the ray cast has a chance to hit it before moving forward with the narrowing search.