### PR TITLE
build(string): Decouple AsciiString / UnicodeString debug pointer from RTS_DEBUG

### DIFF
--- a/Core/GameEngine/Include/Common/AsciiString.h
+++ b/Core/GameEngine/Include/Common/AsciiString.h
@@ -84,7 +84,7 @@ private:
 	// add a ctor/dtor, 'cuz they won't ever be called.
 	struct AsciiStringData
 	{
-#if defined(RTS_DEBUG)
+#if defined(RTS_DEBUG) || defined(_DEBUG)
 		const char* m_debugptr;	// just makes it easier to read in the debugger
 #endif
 		unsigned short	m_refCount;						// reference count

--- a/Core/GameEngine/Include/Common/UnicodeString.h
+++ b/Core/GameEngine/Include/Common/UnicodeString.h
@@ -84,7 +84,7 @@ private:
 	// add a ctor/dtor, 'cuz they won't ever be called.
 	struct UnicodeStringData
 	{
-#if defined(RTS_DEBUG)
+#if defined(RTS_DEBUG) || defined(_DEBUG)
 		const WideChar* m_debugptr;	// just makes it easier to read in the debugger
 #endif
 		unsigned short	m_refCount;						// reference count

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -151,7 +151,7 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 	AsciiStringData* newData = (AsciiStringData*)TheDynamicMemoryAllocator->allocateBytesDoNotZero(actualBytes, "STR_AsciiString::ensureUniqueBufferOfSize");
 	newData->m_refCount = 1;
 	newData->m_numCharsAllocated = (actualBytes - sizeof(AsciiStringData))/sizeof(char);
-#if defined(RTS_DEBUG)
+#if defined(RTS_DEBUG) || defined(_DEBUG)
 	newData->m_debugptr = newData->peek();	// just makes it easier to read in the debugger
 #endif
 

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -102,7 +102,7 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 	UnicodeStringData* newData = (UnicodeStringData*)TheDynamicMemoryAllocator->allocateBytesDoNotZero(actualBytes, "STR_UnicodeString::ensureUniqueBufferOfSize");
 	newData->m_refCount = 1;
 	newData->m_numCharsAllocated = (actualBytes - sizeof(UnicodeStringData))/sizeof(WideChar);
-#if defined(RTS_DEBUG)
+#if defined(RTS_DEBUG) || defined(_DEBUG)
 	newData->m_debugptr = newData->peek();	// just makes it easier to read in the debugger
 #endif
 


### PR DESCRIPTION
This PR makes it possible to inspect strings `AsciiString` and `UnicodeString` in debug builds without `RTS_DEBUG` enabled. 

`RTS_DEBUG` makes game starts noticeably slower so I don't always use it. It's still nice to be able to see the contents of strings in the Visual Studio debugger without any additional effort, though.