### PR TITLE
refactor(WWLib): Qualify library and download header includes

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWDownload/Download.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/Download.cpp
@@ -19,7 +19,7 @@
 // Download.cpp : Implementation of CDownload
 #include "DownloadDebug.h"
 #include "Download.h"
-#include "stringex.h"
+#include "WWLib/stringex.h"
 #include <mmsystem.h>
 #include <assert.h>
 #include <direct.h>

--- a/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
@@ -35,7 +35,7 @@
 #include <time.h>
 #include <direct.h>
 #include <errno.h>
-#include <WWCommon.h>
+#include <WWLib/WWCommon.h>
 //#include "wlib/wstring.h"
 
 #include "DownloadDebug.h"

--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -22,7 +22,7 @@
 
 #include "Registry.h"
 #include <string>
-#include "win.h"
+#include "WWLib/win.h"
 
 bool  getStringFromRegistry(HKEY root, std::string path, std::string key, std::string& val)
 {

--- a/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
@@ -58,8 +58,8 @@
 #include "MPU.h"
 //#include "commando\nat.h"
 #include "thread.h"
-#include "wwdebug.h"
-#include "wwmemlog.h"
+#include "WWDebug/wwdebug.h"
+#include "WWDebug/wwmemlog.h"
 
 #include	<conio.h>
 #include	<imagehlp.h>

--- a/Core/Libraries/Source/WWVegas/WWLib/bufffile.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/bufffile.cpp
@@ -36,7 +36,7 @@
 
 #include	"always.h"
 #include	"bufffile.h"
-#include	"wwdebug.h"
+#include	"WWDebug/wwdebug.h"
 
 int		BufferedFileClass::_DesiredBufferSize	=	1024*16;
 

--- a/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -18,7 +18,7 @@
 
 #include "cpudetect.h"
 #include "wwstring.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 #include "thread.h"
 #pragma warning (disable : 4201)	// Nonstandard extension - nameless struct
 #include "systimer.h"

--- a/Core/Libraries/Source/WWVegas/WWLib/hash.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/hash.cpp
@@ -36,7 +36,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "hash.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 #include "realcrc.h"
 
 /*

--- a/Core/Libraries/Source/WWVegas/WWLib/lzo.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/lzo.cpp
@@ -38,7 +38,7 @@
 
 #include "lzo.h"
 #include "mutex.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 #include <stdlib.h>
 
 /*

--- a/Core/Libraries/Source/WWVegas/WWLib/lzo1x_c.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/lzo1x_c.cpp
@@ -63,7 +63,7 @@
 #include	"always.h"
 #include	"lzo1x.h"
 #include	"lzo_conf.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 #include	<assert.h>
 
 #if !defined(LZO1X) && !defined(LZO1Y)

--- a/Core/Libraries/Source/WWVegas/WWLib/multilist.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/multilist.cpp
@@ -37,7 +37,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "multilist.h"
-#include "wwmemlog.h"
+#include "WWDebug/wwmemlog.h"
 
 /*
 ** Declare the pool for ListNodes

--- a/Core/Libraries/Source/WWVegas/WWLib/mutex.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/mutex.cpp
@@ -17,7 +17,7 @@
 */
 
 #include "mutex.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 #ifdef _WIN32
 #include <windows.h>
 #endif

--- a/Core/Libraries/Source/WWVegas/WWLib/tgatodxt.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/tgatodxt.cpp
@@ -41,7 +41,7 @@
 #include "nvdxtlib.h"
 #include "TARGA.h"
 #include "tgatodxt.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 #include <io.h>
 #include	<stdlib.h>
 

--- a/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
@@ -19,7 +19,7 @@
 
 #include "thread.h"
 #include "Except.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 #pragma warning ( push )
 #pragma warning ( disable : 4201 )
 #include "systimer.h"

--- a/Core/Libraries/Source/WWVegas/WWLib/wwstring.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/wwstring.cpp
@@ -35,7 +35,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "wwstring.h"
-#include "wwmemlog.h"
+#include "WWDebug/wwmemlog.h"
 #include "mutex.h"
 
 


### PR DESCRIPTION
* Relates to #2825

PR should be Squashed and Merged

This is the fourth in a series of PRs I am working on that migrate all of the header paths into the correct header paths.

Qualifies cross-component header includes in WWLib and WWDownload implementation files.