### PR TITLE
refactor(WWMath): Qualify implementation header includes

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWMath/aabtreecull.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/aabtreecull.cpp
@@ -36,8 +36,8 @@
 
 
 #include "aabtreecull.h"
-#include "chunkio.h"
-#include "iostruct.h"
+#include "WWLib/chunkio.h"
+#include "WWLib/iostruct.h"
 #include "sphere.h"
 #include "colmath.h"
 #include "colmathinlines.h"

--- a/Core/Libraries/Source/WWVegas/WWMath/cardinalspline.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/cardinalspline.cpp
@@ -36,10 +36,10 @@
 
 
 #include "cardinalspline.h"
-#include "wwdebug.h"
-#include "persistfactory.h"
+#include "WWDebug/wwdebug.h"
+#include "WWSaveLoad/persistfactory.h"
 #include "wwmathids.h"
-#include "wwhack.h"
+#include "WWDebug/wwhack.h"
 
 /*
 ** Force-Link this module because the linker can't detect that we actually need it...

--- a/Core/Libraries/Source/WWVegas/WWMath/catmullromspline.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/catmullromspline.cpp
@@ -44,9 +44,9 @@
 
 
 #include "catmullromspline.h"
-#include "persistfactory.h"
+#include "WWSaveLoad/persistfactory.h"
 #include "wwmathids.h"
-#include "wwhack.h"
+#include "WWDebug/wwhack.h"
 
 /*
 ** Force-Link this module because the linker can't detect that we actually need it...

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathaabox.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathaabox.cpp
@@ -51,7 +51,7 @@
 #include "sphere.h"
 #include "aabox.h"
 #include "obbox.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 
 
 /***********************************************************************************************

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathaabtri.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathaabtri.cpp
@@ -50,7 +50,7 @@
 #include "colmath.h"
 #include "aabox.h"
 #include "tri.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 
 
 /*

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathfrustum.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathfrustum.cpp
@@ -45,7 +45,7 @@
 #include "aabox.h"
 #include "obbox.h"
 #include "frustum.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 
 
 // TODO: Most of these overlap functions actually do not catch all cases of when

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathline.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathline.cpp
@@ -43,7 +43,7 @@
 #include "sphere.h"
 #include "aabox.h"
 #include "obbox.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 
 
 /*

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathobbobb.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathobbobb.cpp
@@ -56,7 +56,7 @@
 #include "colmath.h"
 #include "obbox.h"
 #include "aabox.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 
 
 /*

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathobbox.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathobbox.cpp
@@ -46,7 +46,7 @@
 #include "sphere.h"
 #include "aabox.h"
 #include "obbox.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 
 
 

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathobbtri.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathobbtri.cpp
@@ -54,7 +54,7 @@
 #include "colmath.h"
 #include "obbox.h"
 #include "tri.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 
 
 /*

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathplane.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathplane.cpp
@@ -47,7 +47,7 @@
 #include "sphere.h"
 #include "aabox.h"
 #include "obbox.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 
 
 

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathsphere.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathsphere.cpp
@@ -51,7 +51,7 @@
 #include "sphere.h"
 #include "aabox.h"
 #include "obbox.h"
-#include "wwdebug.h"
+#include "WWDebug/wwdebug.h"
 
 
 // Sphere Intersection functions.  Does the sphere intersect the passed in object

--- a/Core/Libraries/Source/WWVegas/WWMath/cullsys.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/cullsys.cpp
@@ -35,8 +35,8 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "cullsys.h"
-#include "wwdebug.h"
-#include "wwprofile.h"
+#include "WWDebug/wwdebug.h"
+#include "WWDebug/wwprofile.h"
 
 
 /*************************************************************************

--- a/Core/Libraries/Source/WWVegas/WWMath/curve.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/curve.cpp
@@ -38,10 +38,10 @@
 
 
 #include "curve.h"
-#include "wwdebug.h"
-#include "persistfactory.h"
+#include "WWDebug/wwdebug.h"
+#include "WWSaveLoad/persistfactory.h"
 #include "wwmathids.h"
-#include "wwhack.h"
+#include "WWDebug/wwhack.h"
 
 /*
 ** Force-Link this module because the linker can't detect that we actually need it...

--- a/Core/Libraries/Source/WWVegas/WWMath/gridcull.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/gridcull.cpp
@@ -55,8 +55,8 @@
 
 
 #include "gridcull.h"
-#include "chunkio.h"
-#include "iostruct.h"
+#include "WWLib/chunkio.h"
+#include "WWLib/iostruct.h"
 #include "colmath.h"
 #include "colmathinlines.h"
 

--- a/Core/Libraries/Source/WWVegas/WWMath/hermitespline.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/hermitespline.cpp
@@ -37,8 +37,8 @@
 
 #include "hermitespline.h"
 #include "wwmathids.h"
-#include "persistfactory.h"
-#include "wwhack.h"
+#include "WWSaveLoad/persistfactory.h"
+#include "WWDebug/wwhack.h"
 
 
 /*

--- a/Core/Libraries/Source/WWVegas/WWMath/lookuptable.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/lookuptable.cpp
@@ -38,10 +38,10 @@
 
 #include "lookuptable.h"
 #include "curve.h"
-#include "WWFILE.h"
-#include "ffactory.h"
-#include "chunkio.h"
-#include "persistfactory.h"
+#include "WWLib/WWFILE.h"
+#include "WWLib/ffactory.h"
+#include "WWLib/chunkio.h"
+#include "WWSaveLoad/persistfactory.h"
 #include "vector2.h"
 
 

--- a/Core/Libraries/Source/WWVegas/WWMath/tcbspline.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/tcbspline.cpp
@@ -36,10 +36,10 @@
 
 
 #include "tcbspline.h"
-#include "wwdebug.h"
-#include "persistfactory.h"
+#include "WWDebug/wwdebug.h"
+#include "WWSaveLoad/persistfactory.h"
 #include "wwmathids.h"
-#include "wwhack.h"
+#include "WWDebug/wwhack.h"
 
 
 /*

--- a/Core/Libraries/Source/WWVegas/WWMath/vehiclecurve.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/vehiclecurve.cpp
@@ -37,9 +37,9 @@
 #include "vehiclecurve.h"
 #include "vector3.h"
 #include "matrix3d.h"
-#include "persistfactory.h"
+#include "WWSaveLoad/persistfactory.h"
 #include "wwmathids.h"
-#include "wwmemlog.h"
+#include "WWDebug/wwmemlog.h"
 
 
 //////////////////////////////////////////////////////////////////////

--- a/Core/Libraries/Source/WWVegas/WWMath/vp.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/vp.cpp
@@ -41,8 +41,8 @@
 #include "vector4.h"
 #include "matrix3d.h"
 #include "matrix4.h"
-#include "wwdebug.h"
-#include "cpudetect.h"
+#include "WWDebug/wwdebug.h"
+#include "WWLib/cpudetect.h"
 #include <memory.h>
 
 #define SHUFFLE(x, y, z, w)	(((x)&3)<< 6|((y)&3)<<4|((z)&3)<< 2|((w)&3))

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.cpp
@@ -36,11 +36,11 @@
 
 
 #include "wwmath.h"
-#include "wwhack.h"
+#include "WWDebug/wwhack.h"
 #include "lookuptable.h"
 #include <stdlib.h>
-#include "wwdebug.h"
-#include "wwprofile.h"
+#include "WWDebug/wwdebug.h"
+#include "WWDebug/wwprofile.h"
 
 // TODO: convert to use loouptablemanager...
 float _FastAcosTable[ARC_TABLE_SIZE];


### PR DESCRIPTION
* Relates to #2825

PR should be Squashed and Merged

This is the fifth in a series of PRs I am working on that migrate all of the header paths into the correct header paths.

Qualifies cross-component header includes in WWMath implementation files. 