### PR TITLE
tweak(intro): Implement intro skipping with ESC button

### DIFF
--- a/Core/GameEngine/Include/GameClient/Intro.h
+++ b/Core/GameEngine/Include/GameClient/Intro.h
@@ -61,6 +61,7 @@ public:
 	void update();
 	void draw();
 
+	Bool skipCurrentIntroStage();
 	Bool isDone() const { return m_currentState == IntroState_Done; }
 
 private:

--- a/Core/GameEngine/Source/GameClient/Intro.cpp
+++ b/Core/GameEngine/Source/GameClient/Intro.cpp
@@ -98,9 +98,32 @@ void Intro::draw()
 	}
 }
 
+Bool Intro::skipCurrentIntroStage()
+{
+	// Aborts waits, stops movies and skips waiting states
+
+	Bool isSkipping = !isDone();
+
+	m_waitUntilMs = 0;
+
+	switch (m_currentState)
+	{
+	case IntroState_EALogoMovie:
+	case IntroState_SizzleMovie:
+		TheDisplay->stopMovie();
+		enterNextState();
+		break;
+
+	case IntroState_TheSuperHackers:
+		enterNextState();
+		break;
+	}
+
+	return isSkipping;
+}
+
 void Intro::doEALogoMovie()
 {
-	TheWritableGlobalData->m_allowExitOutOfMovies = FALSE;
 	if (TheGameLODManager && TheGameLODManager->didMemPass())
 		TheDisplay->playMovie("EALogoMovie");
 	else
@@ -221,7 +244,6 @@ void Intro::doTheSuperHackers()
 
 void Intro::doSizzleMovie()
 {
-	TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
 	if (TheGameLODManager && TheGameLODManager->didMemPass())
 		TheDisplay->playMovie("Sizzle");
 	else
@@ -231,7 +253,6 @@ void Intro::doSizzleMovie()
 void Intro::doPostIntro()
 {
 	TheWritableGlobalData->m_breakTheMovie = TRUE;
-	TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
 }
 
 void Intro::doAsyncWait(UnsignedInt milliseconds)

--- a/Core/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
@@ -50,6 +50,7 @@
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
 #include "Common/MessageStream.h"
+#include "GameClient/GameClient.h"
 #include "GameClient/GameWindowManager.h"
 #include "GameClient/WindowXlat.h"
 #include "GameClient/Shell.h"
@@ -318,12 +319,17 @@ GameMessageDisposition WindowTranslator::translateGameMessage(const GameMessage 
 			// If we're in a movie, we want to be able to escape out of it
 			if(returnCode != WIN_INPUT_USED
 				&& (key == KEY_ESC)
-				&& (BitIsSet( state, KEY_STATE_UP ))
-				&& TheDisplay->isMoviePlaying()
-				&& TheGlobalData->m_allowExitOutOfMovies == TRUE )
+				&& (BitIsSet( state, KEY_STATE_UP )) )
 			{
-				TheDisplay->stopMovie();
-				returnCode = WIN_INPUT_USED;
+				if (TheGameClient->skipCurrentIntroStage())
+				{
+					returnCode = WIN_INPUT_USED;
+				}
+				else if (TheDisplay->isMoviePlaying())
+				{
+					TheDisplay->stopMovie();
+					returnCode = WIN_INPUT_USED;
+				}
 			}
 
 			// TheSuperHackers @bugfix If the input is disabled, then only allow the ESC button to get through.

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -365,7 +365,6 @@ public:
 	Bool m_shellMapOn;								///< User can set the shell map not to load
 	Bool m_playIntro;									///< Flag to say if we're to play the intro or not
 	Bool m_playSizzle;								///< Flag to say whether we play the sizzle movie after the logo movie.
-	Bool m_allowExitOutOfMovies;			///< flag to allow exit out of movies only after the Intro has played
 
 	Bool m_loadScreenRender;						///< flag to disallow rendering of almost everything during a loadscreen
 

--- a/Generals/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameClient.h
@@ -150,6 +150,8 @@ public:
 	UnsignedInt getRenderedObjectCount() const { return m_renderedObjectCount; }
 	void incrementRenderedObjectCount() { m_renderedObjectCount++; }
 
+	Bool skipCurrentIntroStage();
+
 	static Bool isMovieAbortRequested();
 
 protected:

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1009,7 +1009,6 @@ GlobalData::GlobalData()
 	m_shellMapOn =TRUE;
 	m_playIntro = TRUE;
 	m_playSizzle = TRUE;
-	m_allowExitOutOfMovies = FALSE;
 	m_loadScreenRender = FALSE;
 
 	m_keyboardDefaultScrollFactor = m_keyboardScrollFactor = 0.5f;

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -711,6 +711,15 @@ void GameClient::step()
 	TheDisplay->step();
 }
 
+Bool GameClient::skipCurrentIntroStage()
+{
+	if (m_intro != nullptr)
+	{
+		return m_intro->skipCurrentIntroStage();
+	}
+	return false;
+}
+
 Bool GameClient::isMovieAbortRequested()
 {
 	if (TheGameEngine)
@@ -723,7 +732,7 @@ Bool GameClient::isMovieAbortRequested()
 	{
 		TheKeyboard->UPDATE();
 		KeyboardIO *io = TheKeyboard->findKey(KEY_ESC, KeyboardIO::STATUS_UNUSED);
-		if (io && BitIsSet(io->state, KEY_STATE_DOWN))
+		if (io && BitIsSet(io->state, KEY_STATE_UP))
 		{
 			io->setUsed();
 			return TRUE;

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -366,7 +366,6 @@ public:
 	Bool m_shellMapOn;								///< User can set the shell map not to load
 	Bool m_playIntro;									///< Flag to say if we're to play the intro or not
 	Bool m_playSizzle;								///< Flag to say whether we play the sizzle movie after the logo movie.
-	Bool m_allowExitOutOfMovies;			///< flag to allow exit out of movies only after the Intro has played
 
 	Bool m_loadScreenRender;						///< flag to disallow rendering of almost everything during a loadscreen
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -155,6 +155,8 @@ public:
 	void incrementRenderedObjectCount() { m_renderedObjectCount++; }
 	virtual void notifyTerrainObjectMoved(Object *obj) = 0;
 
+	Bool skipCurrentIntroStage();
+
 	static Bool isMovieAbortRequested();
 
 protected:

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1016,7 +1016,6 @@ GlobalData::GlobalData()
 	m_shellMapOn =TRUE;
 	m_playIntro = TRUE;
 	m_playSizzle = TRUE;
-	m_allowExitOutOfMovies = FALSE;
 	m_loadScreenRender = FALSE;
 
 	m_keyboardDefaultScrollFactor = m_keyboardScrollFactor = 0.5f;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -748,6 +748,15 @@ void GameClient::step()
 	TheDisplay->step();
 }
 
+Bool GameClient::skipCurrentIntroStage()
+{
+	if (m_intro != nullptr)
+	{
+		return m_intro->skipCurrentIntroStage();
+	}
+	return false;
+}
+
 Bool GameClient::isMovieAbortRequested()
 {
 	if (TheGameEngine)
@@ -760,7 +769,7 @@ Bool GameClient::isMovieAbortRequested()
 	{
 		TheKeyboard->UPDATE();
 		KeyboardIO *io = TheKeyboard->findKey(KEY_ESC, KeyboardIO::STATUS_UNUSED);
-		if (io && BitIsSet(io->state, KEY_STATE_DOWN))
+		if (io && BitIsSet(io->state, KEY_STATE_UP))
 		{
 			io->setUsed();
 			return TRUE;


### PR DESCRIPTION
* Follow up for #2267

This change implements intro skipping with ESC button. Press ESC 3 times to skip the whole intro.

## TODO

- [x] Replicate in Generals