### PR TITLE
chore: Remove empty braces in macros to help clang format

### DIFF
--- a/Core/GameEngine/Include/Common/CRCDebug.h
+++ b/Core/GameEngine/Include/Common/CRCDebug.h
@@ -103,23 +103,23 @@
 
 #else // DEBUG_CRC
 
-	#define DUMPVEL {}
-	#define DUMPACCEL {}
-	#define DUMPVECTOR3(x) {}
-	#define DUMPVECTOR3NAMED(x, y) {}
-	#define DUMPCOORD3D(x) {}
-	#define DUMPCOORD3DNAMED(x, y) {}
-	#define DUMPMATRIX3D(x) {}
-	#define DUMPMATRIX3DNAMED(x, y) {}
+	#define DUMPVEL
+	#define DUMPACCEL
+	#define DUMPVECTOR3(x)
+	#define DUMPVECTOR3NAMED(x, y)
+	#define DUMPCOORD3D(x)
+	#define DUMPCOORD3DNAMED(x, y)
+	#define DUMPMATRIX3D(x)
+	#define DUMPMATRIX3DNAMED(x, y)
 
-	#define DUMPREAL(x) {}
-	#define DUMPREALNAMED(x, y) {}
+	#define DUMPREAL(x)
+	#define DUMPREALNAMED(x, y)
 
-	#define CRCDEBUG_LOG(x) {}
-	#define CRCDUMP_LOG(x) {}
-	#define CRCGEN_LOG(x) {}
+	#define CRCDEBUG_LOG(x)
+	#define CRCDUMP_LOG(x)
+	#define CRCGEN_LOG(x)
 
-	#define VERIFY_CRC {}
+	#define VERIFY_CRC
 
 #endif
 

--- a/Core/GameEngine/Include/GameNetwork/networkutil.h
+++ b/Core/GameEngine/Include/GameNetwork/networkutil.h
@@ -42,7 +42,7 @@ void dumpBufferToLog(const void *vBuf, Int len, const char *fname, Int line);
 };
 #define LOGBUFFER(buf, len) dumpBufferToLog(buf, len, __FILE__, __LINE__)
 #else
-#define LOGBUFFER(buf, len) {}
+#define LOGBUFFER(buf, len)
 #endif // DEBUG_LOGGING
 
 inline UnsignedInt AssembleIp(UnsignedByte a, UnsignedByte b, UnsignedByte c, UnsignedByte d)

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -59,7 +59,7 @@ void CheckServers(PEER peer);
 static LogClass s_pingLog("Ping.txt");
 #define PING_LOG(x) s_pingLog.log x
 #else // DEBUG_LOGGING
-#define PING_LOG(x) {}
+#define PING_LOG(x)
 #endif // DEBUG_LOGGING
 
 #ifdef DEBUG_LOGGING
@@ -69,7 +69,7 @@ static LogClass s_stateChangedLog("StateChanged.txt");
 
 #else // DEBUG_LOGGING
 
-#define STATECHANGED_LOG(x) {}
+#define STATECHANGED_LOG(x)
 
 #endif // DEBUG_LOGGING
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -181,11 +181,11 @@ LogClass BonePosLog("bonePositions.txt");
 
 #else // DEBUG_CRC
 
-#define BONEPOS_LOG(x) {}
-#define BONEPOS_DUMPMATRIX3D(x) {}
-#define BONEPOS_DUMPMATRIX3DNAMED(x, y) {}
-#define BONEPOS_DUMPREAL(x) {}
-#define BONEPOS_DUMPREALNAMED(x, y) {}
+#define BONEPOS_LOG(x)
+#define BONEPOS_DUMPMATRIX3D(x)
+#define BONEPOS_DUMPMATRIX3DNAMED(x, y)
+#define BONEPOS_DUMPREAL(x)
+#define BONEPOS_DUMPREALNAMED(x, y)
 
 #endif // DEBUG_CRC
 

--- a/Core/Libraries/Source/Compression/CompressionManager.cpp
+++ b/Core/Libraries/Source/Compression/CompressionManager.cpp
@@ -34,7 +34,7 @@
 
 
 // TheSuperHackers @todo Recover debug logging in this file?
-#define DEBUG_LOG(x) {}
+#define DEBUG_LOG(x)
 
 const char *CompressionManager::getCompressionNameByType( CompressionType compType )
 {

--- a/Core/Libraries/Source/Compression/LZHCompress/NoxCompress.cpp
+++ b/Core/Libraries/Source/Compression/LZHCompress/NoxCompress.cpp
@@ -30,7 +30,7 @@
 #define NoxRead fread
 #define DbgMalloc malloc
 #define DbgFree free
-#define DEBUG_LOG(x) {}
+#define DEBUG_LOG(x)
 
 Bool DecompressFile		(char *infile, char *outfile)
 {

--- a/Core/Libraries/Source/debug/internal.h
+++ b/Core/Libraries/Source/debug/internal.h
@@ -37,7 +37,7 @@
 #ifdef _DEBUG
 #  define __ASSERT(x) do { if (!(x)) DebugInternalAssert(__FILE__,__LINE__,#x); } while (0)
 #else
-#  define __ASSERT(x) do { } while(0)
+#  define __ASSERT(x)
 #endif
 
 /** \internal

--- a/Core/Tools/Autorun/GameText.cpp
+++ b/Core/Tools/Autorun/GameText.cpp
@@ -47,8 +47,8 @@
 #include <Lib/BaseType.h>
 #include "GameText.h"
 
-#define DEBUG_LOG(x) {}
-#define DEBUG_ASSERTCRASH(x, y) {}
+#define DEBUG_LOG(x)
+#define DEBUG_ASSERTCRASH(x, y)
 
 //#include <Common/Language.h>
 //#include <Common/Debug.h>

--- a/Core/Tools/CRCDiff/debug.h
+++ b/Core/Tools/CRCDiff/debug.h
@@ -31,6 +31,6 @@ void DebugLog( const char *fmt, ... );
 
 #else // DEBUG
 
-#define DEBUG_LOG(x) {}
+#define DEBUG_LOG(x)
 
 #endif // DEBUG

--- a/Core/Tools/Launcher/wdebug.h
+++ b/Core/Tools/Launcher/wdebug.h
@@ -122,10 +122,10 @@ will you be ready to leave grasshopper.
 // They are defined to {} for consistency when DEBUG is defined
 
 #define DBG(X)
-#define DBGSTREAM(X)  {}
-#define PVAR(v)       {}
-#define DBGMSG(X)     {}
-#define VERBOSE(X)    {}
+#define DBGSTREAM(X)
+#define PVAR(v)
+#define DBGMSG(X)
+#define VERBOSE(X)
 
 #else  // DEBUG _is_ defined
 

--- a/Core/Tools/PATCHGET/debug.h
+++ b/Core/Tools/PATCHGET/debug.h
@@ -32,7 +32,7 @@ void DebugLog( const char *fmt, ... );
 
 #else // DEBUG
 
-#define DEBUG_LOG(x) {}
+#define DEBUG_LOG(x)
 
 #endif // DEBUG
 

--- a/Core/Tools/mangler/wlib/wdebug.h
+++ b/Core/Tools/mangler/wlib/wdebug.h
@@ -172,10 +172,10 @@ extern CritSec DebugLibSemaphore;
 // They are defined to {} for consistency when DEBUG is defined
 
 #define DBG(X)
-#define DBGSTREAM(X)  {}
-#define PVAR(v)       {}
-#define DBGMSG(X)     {}
-#define VERBOSE(X)    {}
+#define DBGSTREAM(X)
+#define PVAR(v)
+#define DBGMSG(X)
+#define VERBOSE(X)
 
 #else  // DEBUG _is_ defined
 

--- a/Core/Tools/matchbot/debug.h
+++ b/Core/Tools/matchbot/debug.h
@@ -37,6 +37,6 @@ void DebugLog( const char *fmt, ... );
 
 #else // DEBUG
 
-#define DEBUG_LOG(x) {}
+#define DEBUG_LOG(x)
 
 #endif // DEBUG

--- a/Core/Tools/matchbot/wlib/wdebug.h
+++ b/Core/Tools/matchbot/wlib/wdebug.h
@@ -172,10 +172,10 @@ extern CritSec DebugLibSemaphore;
 // They are defined to {} for consistency when DEBUG is defined
 
 #define DBG(X)
-#define DBGSTREAM(X)  {}
-#define PVAR(v)       {}
-#define DBGMSG(X)     {}
-#define VERBOSE(X)    {}
+#define DBGSTREAM(X)
+#define PVAR(v)
+#define DBGMSG(X)
+#define VERBOSE(X)
 
 #else  // DEBUG _is_ defined
 

--- a/Core/Tools/textureCompress/textureCompress.cpp
+++ b/Core/Tools/textureCompress/textureCompress.cpp
@@ -94,7 +94,7 @@ static void debugLog(const char *fmt, ...)
 
 #else
 
-#define DEBUG_LOG(x) {}
+#define DEBUG_LOG(x)
 
 #endif // RTS_DEBUG
 

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -196,8 +196,8 @@ void dumpBattlePlanBonuses(const BattlePlanBonusesData *b, AsciiString name, con
 		kindofMaskAsAsciiString(b->m_invalidKindOf).str()));
 }
 #else
-#define DUMPBATTLEPLANBONUSES(x,y,z) {}
-#define CRCDUMPBATTLEPLANBONUSES(x,y,z) {}
+#define DUMPBATTLEPLANBONUSES(x,y,z)
+#define CRCDUMPBATTLEPLANBONUSES(x,y,z)
 #endif // DEBUG_CRC
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -78,7 +78,7 @@ void refreshPlayerList( Bool forceRefresh = FALSE );
 static LogClass s_perfLog("Perf.txt");
 #define PERF_LOG(x) s_perfLog.log x
 #else // DEBUG_LOGGING
-#define PERF_LOG(x) {}
+#define PERF_LOG(x)
 #endif // DEBUG_LOGGING
 
 // PRIVATE DATA ///////////////////////////////////////////////////////////////////////////////////

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -74,7 +74,7 @@ static LogClass s_perfLog("QMPerf.txt");
 static Bool s_inQM = FALSE;
 #define PERF_LOG(x) s_perfLog.log x
 #else // DEBUG_LOGGING
-#define PERF_LOG(x) {}
+#define PERF_LOG(x)
 #endif // DEBUG_LOGGING
 
 // PRIVATE DATA ///////////////////////////////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -196,8 +196,8 @@ void dumpBattlePlanBonuses(const BattlePlanBonusesData *b, AsciiString name, con
 		kindofMaskAsAsciiString(b->m_invalidKindOf).str()));
 }
 #else
-#define DUMPBATTLEPLANBONUSES(x,y,z) {}
-#define CRCDUMPBATTLEPLANBONUSES(x,y,z) {}
+#define DUMPBATTLEPLANBONUSES(x,y,z)
+#define CRCDUMPBATTLEPLANBONUSES(x,y,z)
 #endif // DEBUG_CRC
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -78,7 +78,7 @@ void refreshPlayerList( Bool forceRefresh = FALSE );
 static LogClass s_perfLog("Perf.txt");
 #define PERF_LOG(x) s_perfLog.log x
 #else // DEBUG_LOGGING
-#define PERF_LOG(x) {}
+#define PERF_LOG(x)
 #endif // DEBUG_LOGGING
 
 // PRIVATE DATA ///////////////////////////////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -75,7 +75,7 @@ static LogClass s_perfLog("QMPerf.txt");
 static Bool s_inQM = FALSE;
 #define PERF_LOG(x) s_perfLog.log x
 #else // DEBUG_LOGGING
-#define PERF_LOG(x) {}
+#define PERF_LOG(x)
 #endif // DEBUG_LOGGING
 
 // PRIVATE DATA ///////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In preparation for the clang format PR. This removes all empty braces from the source to avoid formatting issues.