### PR TITLE
tweak(cmake): Use GameSpy SDK from TheSuperHackers repository

### DIFF
--- a/cmake/gamespy.cmake
+++ b/cmake/gamespy.cmake
@@ -3,7 +3,7 @@ set(GAMESPY_SERVER_NAME "server.cnc-online.net")
 
 FetchContent_Declare(
     gamespy
-    GIT_REPOSITORY https://github.com/TheAssemblyArmada/GamespySDK.git
+    GIT_REPOSITORY https://github.com/TheSuperHackers/GamespySDK.git
     GIT_TAG        07e3d15c500415abc281efb74322ab6d9c857eb8
 )
 


### PR DESCRIPTION
## Summary
- Point the GameSpy FetchContent dependency to TheSuperHackers/GamespySDK.
- Preserve the existing pinned SDK revision.

## Testing
- CMake FetchContent repository and pinned revision verification
- `cmake --preset vc6`
- `cmake --build --preset vc6 --target g_generals z_generals`

Closes: #2611