### PR TITLE
chore: Replace CPP_11(= delete) with FUNCTION_DELETE macro to help clang format

### DIFF
--- a/Core/GameEngine/Include/Common/INI.h
+++ b/Core/GameEngine/Include/Common/INI.h
@@ -160,8 +160,8 @@ typedef void (*BuildMultiIniFieldProc)(MultiIniFieldParse& p);
 //-------------------------------------------------------------------------------------------------
 class INI
 {
-	INI(const INI&) CPP_11(= delete);
-	INI& operator=(const INI&) CPP_11(= delete);
+	INI(const INI&) FUNCTION_DELETE;
+	INI& operator=(const INI&) FUNCTION_DELETE;
 
 public:
 	INI();

--- a/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
+++ b/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
@@ -39,8 +39,8 @@ class NetCommandRef;
 //-----------------------------------------------------------------------------
 class NetCommandDataChunk
 {
-	NetCommandDataChunk(const NetCommandDataChunk&) CPP_11(= delete);
-	void operator=(const NetCommandDataChunk&) CPP_11(= delete);
+	NetCommandDataChunk(const NetCommandDataChunk&) FUNCTION_DELETE;
+	void operator=(const NetCommandDataChunk&) FUNCTION_DELETE;
 
 public:
 	NetCommandDataChunk(Byte *data, UnsignedInt size)

--- a/Core/Libraries/Source/WWVegas/WWMath/v3_rnd.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/v3_rnd.h
@@ -125,7 +125,7 @@ class Vector3SolidBoxRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidBoxRandomizer & operator = (const Vector3SolidBoxRandomizer&) CPP_11(= delete);
+		Vector3SolidBoxRandomizer & operator = (const Vector3SolidBoxRandomizer&) FUNCTION_DELETE;
 
 		Vector3	Extents;
 };
@@ -156,7 +156,7 @@ class Vector3SolidSphereRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidSphereRandomizer & operator = (const Vector3SolidSphereRandomizer&) CPP_11(= delete);
+		Vector3SolidSphereRandomizer & operator = (const Vector3SolidSphereRandomizer&) FUNCTION_DELETE;
 
 		float	Radius;
 };
@@ -187,7 +187,7 @@ class Vector3HollowSphereRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3HollowSphereRandomizer & operator = (const Vector3HollowSphereRandomizer&) CPP_11(= delete);
+		Vector3HollowSphereRandomizer & operator = (const Vector3HollowSphereRandomizer&) FUNCTION_DELETE;
 
 		float	Radius;
 };
@@ -219,7 +219,7 @@ class Vector3SolidCylinderRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidCylinderRandomizer & operator = (const Vector3SolidCylinderRandomizer&) CPP_11(= delete);
+		Vector3SolidCylinderRandomizer & operator = (const Vector3SolidCylinderRandomizer&) FUNCTION_DELETE;
 
 		float	Extent;
 		float	Radius;

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -43,8 +43,8 @@
 
 class ProfileFastCS
 {
-  ProfileFastCS(const ProfileFastCS&) CPP_11(= delete);
-  ProfileFastCS& operator=(const ProfileFastCS&) CPP_11(= delete);
+  ProfileFastCS(const ProfileFastCS&) FUNCTION_DELETE;
+  ProfileFastCS& operator=(const ProfileFastCS&) FUNCTION_DELETE;
 
 	static HANDLE testEvent;
 
@@ -112,8 +112,8 @@ public:
 
 	class Lock
 	{
-    Lock(const Lock&) CPP_11(= delete);
-	Lock& operator=(const Lock&) CPP_11(= delete);
+    Lock(const Lock&) FUNCTION_DELETE;
+	Lock& operator=(const Lock&) FUNCTION_DELETE;
 
 		ProfileFastCS& CriticalSection;
 

--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -27,8 +27,10 @@
 
 #if __cplusplus >= 201103L
 #define CPP_11(code) code
+#define FUNCTION_DELETE = delete
 #else
 #define CPP_11(code)
+#define FUNCTION_DELETE
 #define static_assert(expr, msg)
 #define constexpr
 #define noexcept

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -777,7 +777,7 @@ private:
 };
 
 // deleteInstance is not meant to be used with Object in order to require the use of TheGameLogic->destroyObject()
-void deleteInstance(Object* object) CPP_11(= delete);
+void deleteInstance(Object* object) FUNCTION_DELETE;
 
 // describe an object as an AsciiString: e.g. "Object 102 (KillerBuggy) [GLARocketBuggy, owned by player 2 (GLAIntroPlayer)]"
 AsciiString DebugDescribeObject(const Object *obj);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -129,7 +129,7 @@ class GapFillerClass
 	ShaderClass* ShaderArray[MeshMatDescClass::MAX_PASSES];
 	MeshModelClass* mmc;
 
-	GapFillerClass& operator = (const GapFillerClass&) CPP_11(= delete);
+	GapFillerClass& operator = (const GapFillerClass&) FUNCTION_DELETE;
 public:
 	GapFillerClass(MeshModelClass* mmc);
 	GapFillerClass(const GapFillerClass& that);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -821,7 +821,7 @@ private:
 };
 
 // deleteInstance is not meant to be used with Object in order to require the use of TheGameLogic->destroyObject()
-void deleteInstance(Object* object) CPP_11(= delete);
+void deleteInstance(Object* object) FUNCTION_DELETE;
 
 // describe an object as an AsciiString: e.g. "Object 102 (KillerBuggy) [GLARocketBuggy, owned by player 2 (GLAIntroPlayer)]"
 AsciiString DebugDescribeObject(const Object *obj);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -129,7 +129,7 @@ class GapFillerClass
 	ShaderClass* ShaderArray[MeshMatDescClass::MAX_PASSES];
 	MeshModelClass* mmc;
 
-	GapFillerClass& operator = (const GapFillerClass&) CPP_11(= delete);
+	GapFillerClass& operator = (const GapFillerClass&) FUNCTION_DELETE;
 public:
 	GapFillerClass(MeshModelClass* mmc);
 	GapFillerClass(const GapFillerClass& that);


### PR DESCRIPTION
In preparation for the clang format PR. This introduces FUNCTION_DELETE macro to fix clang-format.