### PR TITLE
fix(bitflags): Prevent linker errors from multiple defined BitFlags<N>::s_bitNameList

### DIFF
--- a/Core/GameEngine/Include/Common/DynamicAudioEventInfo.h
+++ b/Core/GameEngine/Include/Common/DynamicAudioEventInfo.h
@@ -98,7 +98,7 @@ class DynamicAudioEventInfo : public AudioEventInfo
     };
     // Warning: update xferNoName if you modify the enum list!
 
-    BitFlags< OVERRIDE_COUNT > m_overriddenFields;
+    BitFlags< OVERRIDE_COUNT, struct OverriddenQualifier > m_overriddenFields;
 
     // Retain the original name so we can look it up later
     AsciiString m_originalName;

--- a/Core/GameEngine/Include/Common/DynamicAudioEventInfo.h
+++ b/Core/GameEngine/Include/Common/DynamicAudioEventInfo.h
@@ -98,7 +98,7 @@ class DynamicAudioEventInfo : public AudioEventInfo
     };
     // Warning: update xferNoName if you modify the enum list!
 
-    BitFlags< OVERRIDE_COUNT, struct OverriddenQualifier > m_overriddenFields;
+    BitFlags< OVERRIDE_COUNT, struct OverriddenTag > m_overriddenFields;
 
     // Retain the original name so we can look it up later
     AsciiString m_originalName;

--- a/Core/GameEngine/Include/Common/ObjectStatusTypes.h
+++ b/Core/GameEngine/Include/Common/ObjectStatusTypes.h
@@ -95,7 +95,7 @@ enum ObjectStatusTypes CPP_11(: Int)
 
 };
 
-typedef BitFlags<OBJECT_STATUS_COUNT>	ObjectStatusMaskType;
+typedef BitFlags<OBJECT_STATUS_COUNT, struct ObjectStatusMaskTypeQualifier>	ObjectStatusMaskType;
 
 #define MAKE_OBJECT_STATUS_MASK(k) ObjectStatusMaskType(ObjectStatusMaskType::kInit, (k))
 #define MAKE_OBJECT_STATUS_MASK2(k,a) ObjectStatusMaskType(ObjectStatusMaskType::kInit, (k), (a))

--- a/Core/GameEngine/Include/Common/ObjectStatusTypes.h
+++ b/Core/GameEngine/Include/Common/ObjectStatusTypes.h
@@ -95,7 +95,7 @@ enum ObjectStatusTypes CPP_11(: Int)
 
 };
 
-typedef BitFlags<OBJECT_STATUS_COUNT, struct ObjectStatusMaskTypeQualifier>	ObjectStatusMaskType;
+typedef BitFlags<OBJECT_STATUS_COUNT, struct ObjectStatusMaskTypeTag>	ObjectStatusMaskType;
 
 #define MAKE_OBJECT_STATUS_MASK(k) ObjectStatusMaskType(ObjectStatusMaskType::kInit, (k))
 #define MAKE_OBJECT_STATUS_MASK2(k,a) ObjectStatusMaskType(ObjectStatusMaskType::kInit, (k), (a))

--- a/Core/GameEngine/Include/GameLogic/Damage.h
+++ b/Core/GameEngine/Include/GameLogic/Damage.h
@@ -96,7 +96,7 @@ enum DamageType CPP_11(: Int)
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-typedef BitFlags<DAMAGE_NUM_TYPES, struct DamageTypeFlagsQualifier> DamageTypeFlags;
+typedef BitFlags<DAMAGE_NUM_TYPES, struct DamageTypeFlagsTag> DamageTypeFlags;
 
 inline Bool getDamageTypeFlag(DamageTypeFlags flags, DamageType dt)
 {

--- a/Core/GameEngine/Include/GameLogic/Damage.h
+++ b/Core/GameEngine/Include/GameLogic/Damage.h
@@ -96,7 +96,7 @@ enum DamageType CPP_11(: Int)
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-typedef BitFlags<DAMAGE_NUM_TYPES> DamageTypeFlags;
+typedef BitFlags<DAMAGE_NUM_TYPES, struct DamageTypeFlagsQualifier> DamageTypeFlags;
 
 inline Bool getDamageTypeFlag(DamageTypeFlags flags, DamageType dt)
 {

--- a/Generals/Code/GameEngine/Include/Common/BitFlags.h
+++ b/Generals/Code/GameEngine/Include/Common/BitFlags.h
@@ -45,7 +45,7 @@ class AsciiString;
 	So we wrap to correct this, but leave the bitset "exposed" so that we can use all the non-ctor
 	functions on it directly (since it doesn't overload operator= to do the "wrong" thing, strangely enough)
 */
-template <size_t NUMBITS>
+template <size_t NUMBITS, typename TAG>
 class BitFlags
 {
 private:

--- a/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -36,8 +36,8 @@
 //-------------------------------------------------------------------------------------------------
 
 /*
-template <size_t NUMBITS>
-void BitFlags<NUMBITS>::buildDescription( AsciiString* str ) const
+template <size_t NUMBITS, typename TAG>
+void BitFlags<NUMBITS, TAG>::buildDescription( AsciiString* str ) const
 {
 	if ( str == nullptr )
 		return;//sanity
@@ -56,8 +56,8 @@ void BitFlags<NUMBITS>::buildDescription( AsciiString* str ) const
 */
 
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS>
-void BitFlags<NUMBITS>::parse(INI* ini, AsciiString* str)
+template <size_t NUMBITS, typename TAG>
+void BitFlags<NUMBITS, TAG>::parse(INI* ini, AsciiString* str)
 {
 //	m_bits.reset();
 	if (str)
@@ -129,16 +129,16 @@ void BitFlags<NUMBITS>::parse(INI* ini, AsciiString* str)
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS>
-/*static*/ void BitFlags<NUMBITS>::parseFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
+template <size_t NUMBITS, typename TAG>
+/*static*/ void BitFlags<NUMBITS, TAG>::parseFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
 {
 	((BitFlags*)store)->parse(ini, nullptr);
 }
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS>
-/*static*/ void BitFlags<NUMBITS>::parseSingleBitFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
+template <size_t NUMBITS, typename TAG>
+/*static*/ void BitFlags<NUMBITS, TAG>::parseSingleBitFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
 {
 	const char *token = ini->getNextToken();
 	Int bitIndex = INI::scanIndexList(token, s_bitNameList);	// this throws if the token is not found
@@ -152,8 +152,8 @@ template <size_t NUMBITS>
 	* Version Info:
 	* 1: Initial version */
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS>
-void BitFlags<NUMBITS>::xfer(Xfer* xfer)
+template <size_t NUMBITS, typename TAG>
+void BitFlags<NUMBITS, TAG>::xfer(Xfer* xfer)
 {
 	// this deserves a version number
 	XferVersion currentVersion = 1;

--- a/Generals/Code/GameEngine/Include/Common/DisabledTypes.h
+++ b/Generals/Code/GameEngine/Include/Common/DisabledTypes.h
@@ -61,7 +61,7 @@ enum DisabledType CPP_11(: Int)
 	DISABLED_ANY = 65535		///< Do not use this value for setting disabled types (read-only)
 };
 
-typedef BitFlags<DISABLED_COUNT>	DisabledMaskType;
+typedef BitFlags<DISABLED_COUNT, struct DisabledMaskTypeTag>	DisabledMaskType;
 
 #define MAKE_DISABLED_MASK(k) DisabledMaskType(DisabledMaskType::kInit, (k))
 #define MAKE_DISABLED_MASK2(k,a) DisabledMaskType(DisabledMaskType::kInit, (k), (a))

--- a/Generals/Code/GameEngine/Include/Common/KindOf.h
+++ b/Generals/Code/GameEngine/Include/Common/KindOf.h
@@ -176,7 +176,7 @@ enum KindOfType CPP_11(: Int)
 	KINDOF_FIRST = 0,
 };
 
-typedef BitFlags<KINDOF_COUNT>	KindOfMaskType;
+typedef BitFlags<KINDOF_COUNT, struct KindOfMaskTypeTag>	KindOfMaskType;
 
 #define MAKE_KINDOF_MASK(k) KindOfMaskType(KindOfMaskType::kInit, (k))
 

--- a/Generals/Code/GameEngine/Include/Common/ModelState.h
+++ b/Generals/Code/GameEngine/Include/Common/ModelState.h
@@ -215,7 +215,7 @@ enum ModelConditionFlagType CPP_11(: Int)
 
 //-------------------------------------------------------------------------------------------------
 
-typedef BitFlags<MODELCONDITION_COUNT> ModelConditionFlags;
+typedef BitFlags<MODELCONDITION_COUNT, struct ModelConditionFlagsTag> ModelConditionFlags;
 
 #define MAKE_MODELCONDITION_MASK(k) ModelConditionFlags(ModelConditionFlags::kInit, (k))
 #define MAKE_MODELCONDITION_MASK2(k,a) ModelConditionFlags(ModelConditionFlags::kInit, (k), (a))

--- a/Generals/Code/GameEngine/Include/Common/SpecialPowerMaskType.h
+++ b/Generals/Code/GameEngine/Include/Common/SpecialPowerMaskType.h
@@ -32,4 +32,4 @@
 #include "Common/BitFlagsIO.h"
 #include "Common/SpecialPowerType.h"
 
-typedef BitFlags<SPECIALPOWER_COUNT>	SpecialPowerMaskType;
+typedef BitFlags<SPECIALPOWER_COUNT, struct SpecialPowerMaskTypeTag>	SpecialPowerMaskType;

--- a/Generals/Code/GameEngine/Include/Common/Upgrade.h
+++ b/Generals/Code/GameEngine/Include/Common/Upgrade.h
@@ -56,7 +56,7 @@ enum UpgradeStatusType CPP_11(: Int)
 // A value of 512 was chosen to allow room for plenty of upgrades while also conserving memory.
 #define UPGRADE_MAX_COUNT 512
 
-typedef BitFlags<UPGRADE_MAX_COUNT>	UpgradeMaskType;
+typedef BitFlags<UPGRADE_MAX_COUNT, struct UpgradeMaskTypeTag>	UpgradeMaskType;
 
 #define MAKE_UPGRADE_MASK(k) UpgradeMaskType(UpgradeMaskType::kInit, (k))
 #define MAKE_UPGRADE_MASK2(k,a) UpgradeMaskType(UpgradeMaskType::kInit, (k), (a))

--- a/Generals/Code/GameEngine/Include/GameLogic/ArmorSet.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ArmorSet.h
@@ -52,7 +52,7 @@ enum ArmorSetType CPP_11(: Int)
 };
 
 //-------------------------------------------------------------------------------------------------
-typedef BitFlags<ARMORSET_COUNT> ArmorSetFlags;
+typedef BitFlags<ARMORSET_COUNT, struct ArmorSetFlagsTag> ArmorSetFlags;
 
 //-------------------------------------------------------------------------------------------------
 class ArmorTemplateSet

--- a/Generals/Code/GameEngine/Include/GameLogic/WeaponSetFlags.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/WeaponSetFlags.h
@@ -30,4 +30,4 @@
 
 #include "GameLogic/WeaponSetType.h"
 
-typedef BitFlags<WEAPONSET_COUNT> WeaponSetFlags;
+typedef BitFlags<WEAPONSET_COUNT, struct WeaponSetFlagsTag> WeaponSetFlags;

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
@@ -45,7 +45,7 @@ class AsciiString;
 	So we wrap to correct this, but leave the bitset "exposed" so that we can use all the non-ctor
 	functions on it directly (since it doesn't overload operator= to do the "wrong" thing, strangely enough)
 */
-template <size_t NUMBITS>
+template <size_t NUMBITS, typename QUALIFIER>
 class BitFlags
 {
 private:

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
@@ -45,7 +45,7 @@ class AsciiString;
 	So we wrap to correct this, but leave the bitset "exposed" so that we can use all the non-ctor
 	functions on it directly (since it doesn't overload operator= to do the "wrong" thing, strangely enough)
 */
-template <size_t NUMBITS, typename QUALIFIER>
+template <size_t NUMBITS, typename TAG>
 class BitFlags
 {
 private:

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -56,8 +56,8 @@ void BitFlags<NUMBITS>::buildDescription( AsciiString* str ) const
 */
 
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS>
-void BitFlags<NUMBITS>::parse(INI* ini, AsciiString* str)
+template <size_t NUMBITS, typename QUALIFIER>
+void BitFlags<NUMBITS, QUALIFIER>::parse(INI* ini, AsciiString* str)
 {
 //	m_bits.reset();
 	if (str)
@@ -129,16 +129,16 @@ void BitFlags<NUMBITS>::parse(INI* ini, AsciiString* str)
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS>
-/*static*/ void BitFlags<NUMBITS>::parseFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
+template <size_t NUMBITS, typename QUALIFIER>
+/*static*/ void BitFlags<NUMBITS, QUALIFIER>::parseFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
 {
 	((BitFlags*)store)->parse(ini, nullptr);
 }
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS>
-/*static*/ void BitFlags<NUMBITS>::parseSingleBitFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
+template <size_t NUMBITS, typename QUALIFIER>
+/*static*/ void BitFlags<NUMBITS, QUALIFIER>::parseSingleBitFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
 {
 	const char *token = ini->getNextToken();
 	Int bitIndex = INI::scanIndexList(token, s_bitNameList);	// this throws if the token is not found
@@ -152,8 +152,8 @@ template <size_t NUMBITS>
 	* Version Info:
 	* 1: Initial version */
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS>
-void BitFlags<NUMBITS>::xfer(Xfer* xfer)
+template <size_t NUMBITS, typename QUALIFIER>
+void BitFlags<NUMBITS, QUALIFIER>::xfer(Xfer* xfer)
 {
 	// this deserves a version number
 	XferVersion currentVersion = 1;

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -56,8 +56,8 @@ void BitFlags<NUMBITS>::buildDescription( AsciiString* str ) const
 */
 
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS, typename QUALIFIER>
-void BitFlags<NUMBITS, QUALIFIER>::parse(INI* ini, AsciiString* str)
+template <size_t NUMBITS, typename TAG>
+void BitFlags<NUMBITS, TAG>::parse(INI* ini, AsciiString* str)
 {
 //	m_bits.reset();
 	if (str)
@@ -129,16 +129,16 @@ void BitFlags<NUMBITS, QUALIFIER>::parse(INI* ini, AsciiString* str)
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS, typename QUALIFIER>
-/*static*/ void BitFlags<NUMBITS, QUALIFIER>::parseFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
+template <size_t NUMBITS, typename TAG>
+/*static*/ void BitFlags<NUMBITS, TAG>::parseFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
 {
 	((BitFlags*)store)->parse(ini, nullptr);
 }
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS, typename QUALIFIER>
-/*static*/ void BitFlags<NUMBITS, QUALIFIER>::parseSingleBitFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
+template <size_t NUMBITS, typename TAG>
+/*static*/ void BitFlags<NUMBITS, TAG>::parseSingleBitFromINI(INI* ini, void* /*instance*/, void *store, const void* /*userData*/)
 {
 	const char *token = ini->getNextToken();
 	Int bitIndex = INI::scanIndexList(token, s_bitNameList);	// this throws if the token is not found
@@ -152,8 +152,8 @@ template <size_t NUMBITS, typename QUALIFIER>
 	* Version Info:
 	* 1: Initial version */
 //-------------------------------------------------------------------------------------------------
-template <size_t NUMBITS, typename QUALIFIER>
-void BitFlags<NUMBITS, QUALIFIER>::xfer(Xfer* xfer)
+template <size_t NUMBITS, typename TAG>
+void BitFlags<NUMBITS, TAG>::xfer(Xfer* xfer)
 {
 	// this deserves a version number
 	XferVersion currentVersion = 1;

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -36,8 +36,8 @@
 //-------------------------------------------------------------------------------------------------
 
 /*
-template <size_t NUMBITS>
-void BitFlags<NUMBITS>::buildDescription( AsciiString* str ) const
+template <size_t NUMBITS, typename TAG>
+void BitFlags<NUMBITS, TAG>::buildDescription( AsciiString* str ) const
 {
 	if ( str == nullptr )
 		return;//sanity

--- a/GeneralsMD/Code/GameEngine/Include/Common/DisabledTypes.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/DisabledTypes.h
@@ -61,7 +61,7 @@ enum DisabledType CPP_11(: Int)
 	DISABLED_ANY = 65535		///< Do not use this value for setting disabled types (read-only)
 };
 
-typedef BitFlags<DISABLED_COUNT>	DisabledMaskType;
+typedef BitFlags<DISABLED_COUNT, struct DisabledMaskTypeQualifier>	DisabledMaskType;
 
 #define MAKE_DISABLED_MASK(k) DisabledMaskType(DisabledMaskType::kInit, (k))
 #define MAKE_DISABLED_MASK2(k,a) DisabledMaskType(DisabledMaskType::kInit, (k), (a))

--- a/GeneralsMD/Code/GameEngine/Include/Common/DisabledTypes.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/DisabledTypes.h
@@ -61,7 +61,7 @@ enum DisabledType CPP_11(: Int)
 	DISABLED_ANY = 65535		///< Do not use this value for setting disabled types (read-only)
 };
 
-typedef BitFlags<DISABLED_COUNT, struct DisabledMaskTypeQualifier>	DisabledMaskType;
+typedef BitFlags<DISABLED_COUNT, struct DisabledMaskTypeTag>	DisabledMaskType;
 
 #define MAKE_DISABLED_MASK(k) DisabledMaskType(DisabledMaskType::kInit, (k))
 #define MAKE_DISABLED_MASK2(k,a) DisabledMaskType(DisabledMaskType::kInit, (k), (a))

--- a/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
@@ -176,7 +176,7 @@ enum KindOfType CPP_11(: Int)
 	KINDOF_FIRST = 0,
 };
 
-typedef BitFlags<KINDOF_COUNT, struct KindOfMaskTypeQualifier>	KindOfMaskType;
+typedef BitFlags<KINDOF_COUNT, struct KindOfMaskTypeTag>	KindOfMaskType;
 
 #define MAKE_KINDOF_MASK(k) KindOfMaskType(KindOfMaskType::kInit, (k))
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/KindOf.h
@@ -176,7 +176,7 @@ enum KindOfType CPP_11(: Int)
 	KINDOF_FIRST = 0,
 };
 
-typedef BitFlags<KINDOF_COUNT>	KindOfMaskType;
+typedef BitFlags<KINDOF_COUNT, struct KindOfMaskTypeQualifier>	KindOfMaskType;
 
 #define MAKE_KINDOF_MASK(k) KindOfMaskType(KindOfMaskType::kInit, (k))
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/ModelState.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ModelState.h
@@ -243,7 +243,7 @@ enum ModelConditionFlagType CPP_11(: Int)
 
 //-------------------------------------------------------------------------------------------------
 
-typedef BitFlags<MODELCONDITION_COUNT> ModelConditionFlags;
+typedef BitFlags<MODELCONDITION_COUNT, struct ModelConditionFlagsQualifier> ModelConditionFlags;
 
 #define MAKE_MODELCONDITION_MASK(k) ModelConditionFlags(ModelConditionFlags::kInit, (k))
 #define MAKE_MODELCONDITION_MASK2(k,a) ModelConditionFlags(ModelConditionFlags::kInit, (k), (a))

--- a/GeneralsMD/Code/GameEngine/Include/Common/ModelState.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ModelState.h
@@ -243,7 +243,7 @@ enum ModelConditionFlagType CPP_11(: Int)
 
 //-------------------------------------------------------------------------------------------------
 
-typedef BitFlags<MODELCONDITION_COUNT, struct ModelConditionFlagsQualifier> ModelConditionFlags;
+typedef BitFlags<MODELCONDITION_COUNT, struct ModelConditionFlagsTag> ModelConditionFlags;
 
 #define MAKE_MODELCONDITION_MASK(k) ModelConditionFlags(ModelConditionFlags::kInit, (k))
 #define MAKE_MODELCONDITION_MASK2(k,a) ModelConditionFlags(ModelConditionFlags::kInit, (k), (a))

--- a/GeneralsMD/Code/GameEngine/Include/Common/SpecialPowerMaskType.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/SpecialPowerMaskType.h
@@ -32,4 +32,4 @@
 #include "Common/BitFlagsIO.h"
 #include "Common/SpecialPowerType.h"
 
-typedef BitFlags<SPECIALPOWER_COUNT, struct SpecialPowerMaskTypeQualifier>	SpecialPowerMaskType;
+typedef BitFlags<SPECIALPOWER_COUNT, struct SpecialPowerMaskTypeTag>	SpecialPowerMaskType;

--- a/GeneralsMD/Code/GameEngine/Include/Common/SpecialPowerMaskType.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/SpecialPowerMaskType.h
@@ -32,4 +32,4 @@
 #include "Common/BitFlagsIO.h"
 #include "Common/SpecialPowerType.h"
 
-typedef BitFlags<SPECIALPOWER_COUNT>	SpecialPowerMaskType;
+typedef BitFlags<SPECIALPOWER_COUNT, struct SpecialPowerMaskTypeQualifier>	SpecialPowerMaskType;

--- a/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
@@ -56,7 +56,7 @@ enum UpgradeStatusType CPP_11(: Int)
 // A value of 512 was chosen to allow room for plenty of upgrades while also conserving memory.
 #define UPGRADE_MAX_COUNT 512
 
-typedef BitFlags<UPGRADE_MAX_COUNT, struct UpgradeMaskTypeQualifier>	UpgradeMaskType;
+typedef BitFlags<UPGRADE_MAX_COUNT, struct UpgradeMaskTypeTag>	UpgradeMaskType;
 
 #define MAKE_UPGRADE_MASK(k) UpgradeMaskType(UpgradeMaskType::kInit, (k))
 #define MAKE_UPGRADE_MASK2(k,a) UpgradeMaskType(UpgradeMaskType::kInit, (k), (a))

--- a/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
@@ -56,7 +56,7 @@ enum UpgradeStatusType CPP_11(: Int)
 // A value of 512 was chosen to allow room for plenty of upgrades while also conserving memory.
 #define UPGRADE_MAX_COUNT 512
 
-typedef BitFlags<UPGRADE_MAX_COUNT>	UpgradeMaskType;
+typedef BitFlags<UPGRADE_MAX_COUNT, struct UpgradeMaskTypeQualifier>	UpgradeMaskType;
 
 #define MAKE_UPGRADE_MASK(k) UpgradeMaskType(UpgradeMaskType::kInit, (k))
 #define MAKE_UPGRADE_MASK2(k,a) UpgradeMaskType(UpgradeMaskType::kInit, (k), (a))

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ArmorSet.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ArmorSet.h
@@ -55,7 +55,7 @@ enum ArmorSetType CPP_11(: Int)
 };
 
 //-------------------------------------------------------------------------------------------------
-typedef BitFlags<ARMORSET_COUNT> ArmorSetFlags;
+typedef BitFlags<ARMORSET_COUNT, struct ArmorSetFlagsQualifier> ArmorSetFlags;
 
 //-------------------------------------------------------------------------------------------------
 class ArmorTemplateSet

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ArmorSet.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ArmorSet.h
@@ -55,7 +55,7 @@ enum ArmorSetType CPP_11(: Int)
 };
 
 //-------------------------------------------------------------------------------------------------
-typedef BitFlags<ARMORSET_COUNT, struct ArmorSetFlagsQualifier> ArmorSetFlags;
+typedef BitFlags<ARMORSET_COUNT, struct ArmorSetFlagsTag> ArmorSetFlags;
 
 //-------------------------------------------------------------------------------------------------
 class ArmorTemplateSet

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/WeaponSetFlags.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/WeaponSetFlags.h
@@ -30,4 +30,4 @@
 
 #include "GameLogic/WeaponSetType.h"
 
-typedef BitFlags<WEAPONSET_COUNT> WeaponSetFlags;
+typedef BitFlags<WEAPONSET_COUNT, struct WeaponSetFlagsQualifier> WeaponSetFlags;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/WeaponSetFlags.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/WeaponSetFlags.h
@@ -30,4 +30,4 @@
 
 #include "GameLogic/WeaponSetType.h"
 
-typedef BitFlags<WEAPONSET_COUNT, struct WeaponSetFlagsQualifier> WeaponSetFlags;
+typedef BitFlags<WEAPONSET_COUNT, struct WeaponSetFlagsTag> WeaponSetFlags;


### PR DESCRIPTION
This change prevents linker errors from multiple defined `BitFlags<N>::s_bitNameList` by introducing a templated tag type.