### PR TITLE
bugfix(gui): Fix black fade out at the end of the map load screen

### DIFF
--- a/Core/GameEngine/Include/Common/FramePacer.h
+++ b/Core/GameEngine/Include/Common/FramePacer.h
@@ -39,6 +39,7 @@ public:
 	~FramePacer();
 
 	void update(); ///< Signal that the app/render update is done and wait for the fps limit if applicable.
+	void reset(); ///< Move the frame timing anchor to now and predict the next update time from the target frame rate. Call after a long blocking operation so its duration does not leak into the next frame delta.
 
 	void setFramesPerSecondLimit( Int fps ); ///< Set the update fps limit.
 	Int  getFramesPerSecondLimit() const; ///< Get the update fps limit.

--- a/Core/GameEngine/Include/Common/FrameRateLimit.h
+++ b/Core/GameEngine/Include/Common/FrameRateLimit.h
@@ -27,6 +27,7 @@ public:
 	FrameRateLimit();
 
 	Real wait(UnsignedInt maxFps);
+	void reset(); ///< Move the timing anchor to now, discarding any time elapsed since the last call to wait.
 
 private:
 	Int64 m_freq;

--- a/Core/GameEngine/Source/Common/FramePacer.cpp
+++ b/Core/GameEngine/Source/Common/FramePacer.cpp
@@ -58,6 +58,12 @@ void FramePacer::update()
 	m_updateTime = m_frameRateLimit.wait(maxFps);
 }
 
+void FramePacer::reset()
+{
+	m_frameRateLimit.reset();
+	m_updateTime = 1.0f / (Real)getActualFramesPerSecondLimit();
+}
+
 void FramePacer::setFramesPerSecondLimit( Int fps )
 {
 	DEBUG_LOG(("FramePacer::setFramesPerSecondLimit() - setting max fps to %d (TheGlobalData->m_useFpsLimit == %d)", fps, TheGlobalData->m_useFpsLimit));

--- a/Core/GameEngine/Source/Common/FrameRateLimit.cpp
+++ b/Core/GameEngine/Source/Common/FrameRateLimit.cpp
@@ -58,6 +58,13 @@ Real FrameRateLimit::wait(UnsignedInt maxFps)
 	return (Real)elapsedSeconds;
 }
 
+void FrameRateLimit::reset()
+{
+	LARGE_INTEGER tick;
+	QueryPerformanceCounter(&tick);
+	m_start = tick.QuadPart;
+}
+
 
 const UnsignedInt RenderFpsPreset::s_fpsValues[] = {
 	30, 50, 56, 60, 65, 70, 72, 75, 80, 85, 90, 100, 110, 120, 144, 240, 480, UncappedFpsValue };

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1950,6 +1950,7 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 	// if we're in a load game, don't fade yet
 	if(loadingSaveGame == FALSE && TheTransitionHandler != nullptr && m_loadScreen)
 	{
+		TheFramePacer->reset();
 		TheTransitionHandler->setGroup("FadeWholeScreen");
 		while(!TheTransitionHandler->isFinished())
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2239,6 +2239,7 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 	// if we're in a load game, don't fade yet
 	if(loadingSaveGame == FALSE && TheTransitionHandler != nullptr && m_loadScreen)
 	{
+		TheFramePacer->reset();
 		TheTransitionHandler->setGroup("FadeWholeScreen");
 		while(!TheTransitionHandler->isFinished())
 		{


### PR DESCRIPTION
Follow up for #2848 and #2056.

The whole-screen fade loop in `GameLogic::tryStartNewGame` runs right after the map load, which is a long blocking operation that never ticks the frame pacer. So the first `TheFramePacer->update()` in the loop (added in #2848) measures the whole load gap as one frame, and the frame-rate-decoupled transition step from #2056 (`getBaseOverUpdateFpsRatio()`) reads that stale delta — floored to 5 fps, it scales the step by 6x and jumps the fade several frames on its first update instead of ramping from black.

Now resets the frame pacer right before the fade loop, so its first sample measures a real loop frame instead of the blocking load, and the fade ramps smoothly from the first frame.

Todo:
- [x] Test fade at new game start
- [x] Replicate to Generals
