### PR TITLE
bugfix(shroud): Fix bugged map shroud after Search and Destroy vision bonus is applied at saveload

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/Player.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Player.h
@@ -406,7 +406,7 @@ public:
 	/**
 		the given object has just become (or just ceased to be) a member of one of our teams (or subteams)
 	*/
-	void becomingTeamMember(Object *obj, Bool yes);
+	void becomingTeamMember(Object *obj, Bool yes, Bool objectXferLoad = false);
 
 	/**
 		this is called when the player becomes the local player (yes==true)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -639,7 +639,7 @@ public:
 
 protected:
 
-	void setOrRestoreTeam( Team* team, Bool restoring );
+	void setOrRestoreTeam( Team* team, Bool restoring, Bool objectXferLoad = false );
 
 	void onDisabledEdge(Bool becomingDisabled);
 	// All of our cheating for radars and power go here.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -639,7 +639,7 @@ public:
 
 protected:
 
-	void setOrRestoreTeam( Team* team, Bool restoring, Bool objectXferLoad = false );
+	void setOrRestoreTeam( Team* team, Bool restoring );
 
 	void onDisabledEdge(Bool becomingDisabled);
 	// All of our cheating for radars and power go here.

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1026,6 +1026,17 @@ void Player::becomingTeamMember(Object *obj, Bool yes)
 		obj->friend_adjustPowerForPlayer(yes);
 	}
 
+	if (obj->isKindOf(KINDOF_DOZER)
+			&& obj->getAIUpdateInterface()
+			&& obj->getAIUpdateInterface()->isIdle())
+	{
+		// Need to remove it from the pick a peasant button
+		if (yes)
+			TheInGameUI->addIdleWorker(obj);
+		else
+			TheInGameUI->removeIdleWorker(obj, getPlayerIndex());
+	}
+
 	// when we capture a building, we need to see if there's an AutoDepositUpdate hooked to it,
 	// if so, award the cash bonus
 	if(this != ThePlayerList->getNeutralPlayer() && yes)
@@ -1049,18 +1060,6 @@ void Player::becomingTeamMember(Object *obj, Bool yes)
 			//We are leaving a team with active battle plans so remove them now.
 			removeBattlePlanBonusesForObject( obj );
 		}
-	}
-
-
-	if (obj->isKindOf(KINDOF_DOZER)
-			&& obj->getAIUpdateInterface()
-			&& obj->getAIUpdateInterface()->isIdle())
-	{
-		// Need to remove it from the pick a peasant button
-		if (yes)
-			TheInGameUI->addIdleWorker(obj);
-		else
-			TheInGameUI->removeIdleWorker(obj, getPlayerIndex());
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1015,7 +1015,7 @@ void Player::initFromDict(const Dict* d)
 }
 
 //=============================================================================
-void Player::becomingTeamMember(Object *obj, Bool yes)
+void Player::becomingTeamMember(Object *obj, Bool yes, Bool objectXferLoad)
 {
 	if (!obj)
 		return;
@@ -1036,6 +1036,11 @@ void Player::becomingTeamMember(Object *obj, Bool yes)
 		else
 			TheInGameUI->removeIdleWorker(obj, getPlayerIndex());
 	}
+
+	// TheSuperHackers @bugfix Caball009 19/07/2026 Return early to avoid overwriting
+	// object data, e.g. the vision range, that may have been loaded during the xfer process.
+	if (objectXferLoad)
+		return;
 
 	// when we capture a building, we need to see if there's an AutoDepositUpdate hooked to it,
 	// if so, award the cash bonus

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -901,7 +901,7 @@ void Object::setTemporaryTeam( Team *team )
 
 //=============================================================================
 //=============================================================================
-void Object::setOrRestoreTeam( Team* team, Bool restoring )
+void Object::setOrRestoreTeam( Team* team, Bool restoring, Bool objectXferLoad )
 {
 	// don't do anything if the team hasn't changed
 	if( m_team == team )
@@ -915,7 +915,7 @@ void Object::setOrRestoreTeam( Team* team, Bool restoring )
 		if (m_team->isInList_TeamMemberList(this))
 		{
 			m_team->removeFrom_TeamMemberList(this);
-			m_team->getControllingPlayer()->becomingTeamMember(this, false);
+			m_team->getControllingPlayer()->becomingTeamMember(this, false, objectXferLoad);
 		}
 	}
 
@@ -928,7 +928,7 @@ void Object::setOrRestoreTeam( Team* team, Bool restoring )
 		if (!m_team->isInList_TeamMemberList(this))
 		{
 			m_team->prependTo_TeamMemberList(this);
-			m_team->getControllingPlayer()->becomingTeamMember(this, true);
+			m_team->getControllingPlayer()->becomingTeamMember(this, true, objectXferLoad);
 		}
 
 		// now, adjust the attitude of the unit to its new team.
@@ -4264,7 +4264,7 @@ void Object::xfer( Xfer *xfer )
 			throw SC_INVALID_DATA;
 		}
 		const Bool restoring = true;
-		setOrRestoreTeam( team, restoring );
+		setOrRestoreTeam( team, restoring, true );
 	}
 
 	// special model condition until

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -901,7 +901,7 @@ void Object::setTemporaryTeam( Team *team )
 
 //=============================================================================
 //=============================================================================
-void Object::setOrRestoreTeam( Team* team, Bool restoring, Bool objectXferLoad )
+void Object::setOrRestoreTeam( Team* team, Bool restoring )
 {
 	// don't do anything if the team hasn't changed
 	if( m_team == team )
@@ -914,6 +914,7 @@ void Object::setOrRestoreTeam( Team* team, Bool restoring, Bool objectXferLoad )
 	{
 		if (m_team->isInList_TeamMemberList(this))
 		{
+			const Bool objectXferLoad = restoring;
 			m_team->removeFrom_TeamMemberList(this);
 			m_team->getControllingPlayer()->becomingTeamMember(this, false, objectXferLoad);
 		}
@@ -927,6 +928,7 @@ void Object::setOrRestoreTeam( Team* team, Bool restoring, Bool objectXferLoad )
 	{
 		if (!m_team->isInList_TeamMemberList(this))
 		{
+			const Bool objectXferLoad = restoring;
 			m_team->prependTo_TeamMemberList(this);
 			m_team->getControllingPlayer()->becomingTeamMember(this, true, objectXferLoad);
 		}
@@ -4264,7 +4266,7 @@ void Object::xfer( Xfer *xfer )
 			throw SC_INVALID_DATA;
 		}
 		const Bool restoring = true;
-		setOrRestoreTeam( team, restoring, true );
+		setOrRestoreTeam( team, restoring );
 	}
 
 	// special model condition until

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -4737,10 +4737,8 @@ void PartitionManager::xfer( Xfer *xfer )
 
 		if(xfer->getXferMode() == XFER_LOAD)
 		{
-			// have to remove this assert, because during load there is a setTeam call for each guy on a sub-team, and that results
-			// in a queued unlook, so we actually have stuff in here at the start.  I am fairly certain that setTeam should wait
-			// until loadPostProcess, but I ain't gonna change it now.
-//			DEBUG_ASSERTCRASH(m_pendingUndoShroudReveals.empty(), ("At load, we appear to not be in a reset state.") );
+			DEBUG_ASSERTCRASH(m_pendingUndoShroudReveals.empty(),
+				("There should be no pending undo shround reveals during loading; check if battle plan bonuses were applied."));
 
 			// I have to split this up though, since on Load I need to make new instances.
 			for( Int infoIndex = 0; infoIndex < queueSize; infoIndex++ )


### PR DESCRIPTION
* Fixes https://github.com/TheSuperHackers/GeneralsGameCode/issues/2882
* Follow-up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2508

Prior to #2508 the object xfer loading process was as follows:
1. Call `Object::setOrRestoreTeam` -> `Player::becomingTeamMember` and apply battle plan bonuses if needed. If USA Search and Destroy was enabled it would increase the vision range for objects.
2. Xfer load the stored vision range data, overwriting the data set in step 1 (if any).

After #2508 that process was inverted which leads issues with the map shroud (see issue description). `Object::setShroudClearingRange` would be called (as part of S&D increased vision) when it shouldn't. Eventually `Object::unlook` would be called, which would previously return early originally because `m_partitionLastLook` wasn't xferred yet.

This PR adds an early return to `Player::becomingTeamMember` so that none of the battle plan bonuses are applied on object xfer load. My understanding is that all the object changes that are applied by the battle plans are already in the xferred data.

See commits for cleaner diffs.

## TODO:
- [ ] Replicate in Generals.