### PR TITLE
fix(displaystring): Guard null bold font pointer in W3DDisplayString::setFont()

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -306,9 +306,7 @@ void W3DDisplayString::setFont( GameFont *font )
 	// set the font in our renderer
 	m_textRenderer.Set_Font( static_cast<FontCharsClass *>(m_font->fontData) );
 
-	// TheSuperHackers @fix bobtista 19/07/2026 Guard against null bold font to prevent crash when font loading fails
-	GameFont *boldFont = TheFontLibrary->getFont( font->nameString, font->pointSize, TRUE );
-	if( boldFont != nullptr )
+	if( GameFont *boldFont = TheFontLibrary->getFont( font->nameString, font->pointSize, TRUE ) )
 	{
 		m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(boldFont->fontData) );
 	}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -306,7 +306,12 @@ void W3DDisplayString::setFont( GameFont *font )
 	// set the font in our renderer
 	m_textRenderer.Set_Font( static_cast<FontCharsClass *>(m_font->fontData) );
 
-	m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(TheFontLibrary->getFont(font->nameString,font->pointSize, TRUE)->fontData) );
+	// TheSuperHackers @fix bobtista 19/07/2026 Guard against null bold font to prevent crash when font loading fails
+	GameFont *boldFont = TheFontLibrary->getFont( font->nameString, font->pointSize, TRUE );
+	if( boldFont != nullptr )
+	{
+		m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(boldFont->fontData) );
+	}
 	// recompute extents for text with new font
 	computeExtents();
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -306,9 +306,7 @@ void W3DDisplayString::setFont( GameFont *font )
 	// set the font in our renderer
 	m_textRenderer.Set_Font( static_cast<FontCharsClass *>(m_font->fontData) );
 
-	// TheSuperHackers @fix bobtista 19/07/2026 Guard against null bold font to prevent crash when font loading fails
-	GameFont *boldFont = TheFontLibrary->getFont( font->nameString, font->pointSize, TRUE );
-	if( boldFont != nullptr )
+	if( GameFont *boldFont = TheFontLibrary->getFont( font->nameString, font->pointSize, TRUE ) )
 	{
 		m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(boldFont->fontData) );
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -306,7 +306,12 @@ void W3DDisplayString::setFont( GameFont *font )
 	// set the font in our renderer
 	m_textRenderer.Set_Font( static_cast<FontCharsClass *>(m_font->fontData) );
 
-	m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(TheFontLibrary->getFont(font->nameString,font->pointSize, TRUE)->fontData) );
+	// TheSuperHackers @fix bobtista 19/07/2026 Guard against null bold font to prevent crash when font loading fails
+	GameFont *boldFont = TheFontLibrary->getFont( font->nameString, font->pointSize, TRUE );
+	if( boldFont != nullptr )
+	{
+		m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(boldFont->fontData) );
+	}
 	// recompute extents for text with new font
 	computeExtents();
 


### PR DESCRIPTION
- Relates to #2139

W3DDisplayString::setFont dereferences the result of TheFontLibrary->getFont() for the bold hotkey font without a null check. getFont can return null when font loading fails in headless mode where no display resources exist, and the game crashes as soon as a display string receives a font.

Now setFont only sets the hotkey renderer font when the bold font lookup succeeds, matching the null tolerance at the top of the function.

Todo:
- [x] Verify a game save during a headless replay no longer crashes in setFont
- [x] Replicate to Generals