### PR TITLE
feat(headless): stub gogoMessageBox in GameWindowManagerDummy

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/GameWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameWindowManager.h
@@ -389,6 +389,16 @@ public:
 
 	virtual GameWindow *allocateNewWindow() override { return newInstance(GameWindowDummy); }
 
+	// TheSuperHackers @fix bobtista 19/07/2026 Return no message box window in headless mode
+	virtual GameWindow *gogoMessageBox(Int x, Int y, Int width, Int height, UnsignedShort buttonFlags,
+		UnicodeString titleString, UnicodeString bodyString,
+		GameWinMsgBoxFunc yesCallback, GameWinMsgBoxFunc noCallback,
+		GameWinMsgBoxFunc okCallback, GameWinMsgBoxFunc cancelCallback) override { return nullptr; }
+	virtual GameWindow *gogoMessageBox(Int x, Int y, Int width, Int height, UnsignedShort buttonFlags,
+		UnicodeString titleString, UnicodeString bodyString,
+		GameWinMsgBoxFunc yesCallback, GameWinMsgBoxFunc noCallback,
+		GameWinMsgBoxFunc okCallback, GameWinMsgBoxFunc cancelCallback, Bool useLogo) override { return nullptr; }
+
 	virtual GameWinDrawFunc getPushButtonImageDrawFunc() override { return nullptr; }
 	virtual GameWinDrawFunc getPushButtonDrawFunc() override { return nullptr; }
 	virtual GameWinDrawFunc getCheckBoxImageDrawFunc() override { return nullptr; }

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameWindowManager.h
@@ -389,6 +389,16 @@ public:
 
 	virtual GameWindow *allocateNewWindow() override { return newInstance(GameWindowDummy); }
 
+	// TheSuperHackers @fix bobtista 19/07/2026 Return no message box window in headless mode
+	virtual GameWindow *gogoMessageBox(Int x, Int y, Int width, Int height, UnsignedShort buttonFlags,
+		UnicodeString titleString, UnicodeString bodyString,
+		GameWinMsgBoxFunc yesCallback, GameWinMsgBoxFunc noCallback,
+		GameWinMsgBoxFunc okCallback, GameWinMsgBoxFunc cancelCallback) override { return nullptr; }
+	virtual GameWindow *gogoMessageBox(Int x, Int y, Int width, Int height, UnsignedShort buttonFlags,
+		UnicodeString titleString, UnicodeString bodyString,
+		GameWinMsgBoxFunc yesCallback, GameWinMsgBoxFunc noCallback,
+		GameWinMsgBoxFunc okCallback, GameWinMsgBoxFunc cancelCallback, Bool useLogo) override { return nullptr; }
+
 	virtual GameWinDrawFunc getPushButtonImageDrawFunc() override { return nullptr; }
 	virtual GameWinDrawFunc getPushButtonDrawFunc() override { return nullptr; }
 	virtual GameWinDrawFunc getCheckBoxImageDrawFunc() override { return nullptr; }


### PR DESCRIPTION
- Relates to #2139

GameWindowManagerDummy inherits the base gogoMessageBox implementations, so paths that raise a message box in headless mode, eg GameState::saveGame reporting a save error via MessageBoxOk still try to build a message box layout without a display.

Fix:
GameWindowManagerDummy returns no window for both gogoMessageBox overloads, consistent with its other no-op window functions. The message box call sites reachable in headless mode ignore the returned window - the callers that keep the pointer are all interactive menu code.

Todo:
- [ ] Verify the save error path in headless mode returns cleanly instead of crashing
- [x] Replicate to Generals