### PR TITLE
feat(headless): add DisplayStringManagerDummy for headless mode

### DIFF
--- a/Core/GameEngine/Include/GameClient/DisplayString.h
+++ b/Core/GameEngine/Include/GameClient/DisplayString.h
@@ -125,4 +125,30 @@ inline void DisplayString::setClipRegion( IRegion2D *region ) {}
 inline void DisplayString::notifyTextChanged() {}
 inline DisplayString *DisplayString::next() { return m_next; }
 
+// TheSuperHackers @feature bobtista 19/07/2026
+// DisplayString that does nothing. Used for Headless Mode.
+class DisplayStringDummy : public DisplayString
+{
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( DisplayStringDummy, "DisplayStringDummy" )
+public:
+	virtual void setWordWrap( Int wordWrap ) override {}
+	virtual void setWordWrapCentered( Bool isCentered ) override {}
+	virtual void draw( Int x, Int y, Color color, Color dropColor ) override {}
+	virtual void draw( Int x, Int y, Color color, Color dropColor, Int xDrop, Int yDrop ) override {}
+	virtual void getSize( Int *width, Int *height ) override
+	{
+		if( width != nullptr )
+		{
+			*width = 0;
+		}
+		if( height != nullptr )
+		{
+			*height = 0;
+		}
+	}
+	virtual Int getWidth( Int charPos = -1 ) override { return 0; }
+	virtual void setUseHotkey( Bool useHotkey, Color hotKeyColor ) override {}
+};
+EMPTY_DTOR(DisplayStringDummy)
+
 // EXTERNALS //////////////////////////////////////////////////////////////////

--- a/Core/GameEngine/Include/GameClient/DisplayStringManager.h
+++ b/Core/GameEngine/Include/GameClient/DisplayStringManager.h
@@ -61,5 +61,53 @@ protected:
 	DisplayString *m_currentCheckpoint; ///< current checkpoint of strings to be freed
 };
 
+// TheSuperHackers @feature bobtista 19/07/2026
+// DisplayStringManager that creates DisplayStrings that do nothing. Used for Headless Mode.
+class DisplayStringManagerDummy : public DisplayStringManager
+{
+public:
+
+	DisplayStringManagerDummy() : m_dummyDisplayString(nullptr) {}
+
+	virtual ~DisplayStringManagerDummy() override
+	{
+		freeDisplayString( m_dummyDisplayString );
+		m_dummyDisplayString = nullptr;
+	}
+
+	virtual void init() override
+	{
+		m_dummyDisplayString = newDisplayString();
+	}
+
+	virtual DisplayString *newDisplayString() override
+	{
+		DisplayString *newString = newInstance(DisplayStringDummy);
+		link( newString );
+		return newString;
+	}
+
+	virtual void freeDisplayString( DisplayString *string ) override
+	{
+		if( string == nullptr )
+		{
+			return;
+		}
+		unLink( string );
+		if( m_currentCheckpoint == string )
+		{
+			m_currentCheckpoint = nullptr;
+		}
+		deleteInstance( string );
+	}
+
+	virtual DisplayString *getGroupNumeralString( Int numeral ) override { return m_dummyDisplayString; }
+	virtual DisplayString *getFormationLetterString() override { return m_dummyDisplayString; }
+
+protected:
+
+	DisplayString *m_dummyDisplayString; ///< shared no-op string for group numerals and formation letter
+};
+
 // EXTERNALS //////////////////////////////////////////////////////////////////////////////////////
 extern DisplayStringManager *TheDisplayStringManager;  ///< singleton extern

--- a/Core/GameEngine/Source/Common/System/GameMemoryInitPools_Generals.inl
+++ b/Core/GameEngine/Source/Common/System/GameMemoryInitPools_Generals.inl
@@ -295,6 +295,7 @@ static PoolSizeRec PoolSizes[] =
 
 	{ "DozerActionStateMachine", 256, 32 },
 	{ "DozerPrimaryStateMachine", 256, 32 },
+	{ "DisplayStringDummy", 1024, 128 },
 	{ "W3DDisplayString", 1024, 128 },
 	{ "W3DDefaultDraw", 1024, 128 },
 	{ "W3DDebrisDraw", 1024, 128 },

--- a/Core/GameEngine/Source/Common/System/GameMemoryInitPools_GeneralsMD.inl
+++ b/Core/GameEngine/Source/Common/System/GameMemoryInitPools_GeneralsMD.inl
@@ -291,6 +291,7 @@ static PoolSizeRec PoolSizes[] =
 
 	{ "DozerActionStateMachine", 256, 32 },
 	{ "DozerPrimaryStateMachine", 256, 32 },
+	{ "DisplayStringDummy", 1400, 128 },
 	{ "W3DDisplayString", 1400, 128 },
 	{ "W3DDefaultDraw", 1024, 128 },
 	{ "W3DDebrisDraw", 128, 128 },

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -252,7 +252,7 @@ void GameClient::init()
 	}
 
 	// create the display string factory
-	TheDisplayStringManager = createDisplayStringManager();
+	TheDisplayStringManager = TheGlobalData->m_headless ? NEW DisplayStringManagerDummy : createDisplayStringManager();
 	if( TheDisplayStringManager )	{
 		TheDisplayStringManager->init();
 		TheDisplayStringManager->setName("TheDisplayStringManager");

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -260,7 +260,7 @@ void GameClient::init()
 	}
 
 	// create the display string factory
-	TheDisplayStringManager = createDisplayStringManager();
+	TheDisplayStringManager = TheGlobalData->m_headless ? NEW DisplayStringManagerDummy : createDisplayStringManager();
 	if( TheDisplayStringManager )	{
 		TheDisplayStringManager->init();
 		TheDisplayStringManager->setName("TheDisplayStringManager");


### PR DESCRIPTION
- Relates to #2139

In headless mode the game still creates the W3D display string manager, so InGameUI::addMessageText allocates W3DDisplayStrings whose setFont dereferences font data that is never loaded without a display. This crashes when saving a game during a headless replay, because GameState::saveGame prints the GUI:GameSaveComplete message through TheInGameUI.

Fix:
GameClient::init creates a DisplayStringManagerDummy in headless mode, which allocates DisplayStrings that store their text but do nothing on draw and measurement, so message call sites need no headless checks. A single shared dummy string backs the group numeral and formation letter lookups.

Todo:
- [ ] Verify saving during a headless replay completes without crashing
- [ ] Verify a normal-mode replay is unaffected
- [x] Replicate to Generals