### PR TITLE
bugfix(saveload): Serialize base state machine in TurretStateMachine and DozerActionStateMachine

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
@@ -146,14 +146,28 @@ void TurretStateMachine::crc( Xfer *xfer )
 }
 
 // ------------------------------------------------------------------------------------------------
-/** Xfer Method */
+/** Xfer Method
+	* Version Info:
+	* 1: Initial version
+	* 2: TheSuperHackers @bugfix bobtista 19/07/2026 Serialize the base StateMachine state.
+	*    Without this the turret reverts to its default state on load.
+	*/
 // ------------------------------------------------------------------------------------------------
 void TurretStateMachine::xfer( Xfer *xfer )
 {
-	XferVersion cv = 1;
-	XferVersion v = cv;
-	xfer->xferVersion( &v, cv );
+	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
+	XferVersion version = currentVersion;
+	xfer->xferVersion( &version, currentVersion );
 
+	if (version >= 2)
+	{
+		StateMachine::xfer(xfer);
+	}
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -161,6 +175,7 @@ void TurretStateMachine::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void TurretStateMachine::loadPostProcess()
 {
+	StateMachine::loadPostProcess();
 }
 
 //----------------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -827,16 +827,30 @@ void DozerActionStateMachine::crc( Xfer *xfer )
 }
 
 // ------------------------------------------------------------------------------------------------
-/** Xfer Method */
+/** Xfer Method
+  * Version Info:
+  * 1: Initial version
+  * 2: TheSuperHackers @bugfix bobtista 19/07/2026 Serialize the base StateMachine state.
+  *    Without this the dozer reverts to its default state on load.
+  */
 // ------------------------------------------------------------------------------------------------
 void DozerActionStateMachine::xfer( Xfer *xfer )
 {
   // version
+#if RETAIL_COMPATIBLE_XFER_SAVE
   XferVersion currentVersion = 1;
+#else
+  XferVersion currentVersion = 2;
+#endif
   XferVersion version = currentVersion;
   xfer->xferVersion( &version, currentVersion );
 
 	xfer->xferUser(&m_task, sizeof(m_task));
+
+	if (version >= 2)
+	{
+		StateMachine::xfer(xfer);
+	}
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -844,6 +858,7 @@ void DozerActionStateMachine::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void DozerActionStateMachine::loadPostProcess()
 {
+	StateMachine::loadPostProcess();
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
@@ -146,17 +146,25 @@ void TurretStateMachine::crc( Xfer *xfer )
 }
 
 // ------------------------------------------------------------------------------------------------
-/** Xfer Method */
+/** Xfer Method
+	* Version Info:
+	* 1: Initial version
+	* 2: TheSuperHackers @bugfix bobtista 19/07/2026 Serialize the base StateMachine state.
+	*    Without this the turret reverts to its default state on load.
+	*/
 // ------------------------------------------------------------------------------------------------
 void TurretStateMachine::xfer( Xfer *xfer )
 {
-	// TheSuperHackers @bugfix bobtista 19/07/2026 Bump to version 2 to serialize the base
-	// StateMachine state. Without this the turret reverts to its default state on load.
-	XferVersion cv = 2;
-	XferVersion v = cv;
-	xfer->xferVersion( &v, cv );
+	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
+	XferVersion version = currentVersion;
+	xfer->xferVersion( &version, currentVersion );
 
-	if (v >= 2)
+	if (version >= 2)
 	{
 		StateMachine::xfer(xfer);
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
@@ -150,10 +150,16 @@ void TurretStateMachine::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void TurretStateMachine::xfer( Xfer *xfer )
 {
-	XferVersion cv = 1;
+	// TheSuperHackers @bugfix bobtista 19/07/2026 Bump to version 2 to serialize the base
+	// StateMachine state. Without this the turret reverts to its default state on load.
+	XferVersion cv = 2;
 	XferVersion v = cv;
 	xfer->xferVersion( &v, cv );
 
+	if (v >= 2)
+	{
+		StateMachine::xfer(xfer);
+	}
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -161,6 +167,7 @@ void TurretStateMachine::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void TurretStateMachine::loadPostProcess()
 {
+	StateMachine::loadPostProcess();
 }
 
 //----------------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -837,11 +837,18 @@ void DozerActionStateMachine::crc( Xfer *xfer )
 void DozerActionStateMachine::xfer( Xfer *xfer )
 {
   // version
-  XferVersion currentVersion = 1;
+  // TheSuperHackers @bugfix bobtista 19/07/2026 Bump to version 2 to serialize the base
+  // StateMachine state. Without this the dozer reverts to its default state on load.
+  XferVersion currentVersion = 2;
   XferVersion version = currentVersion;
   xfer->xferVersion( &version, currentVersion );
 
 	xfer->xferUser(&m_task, sizeof(m_task));
+
+	if (version >= 2)
+	{
+		StateMachine::xfer(xfer);
+	}
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -849,6 +856,7 @@ void DozerActionStateMachine::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void DozerActionStateMachine::loadPostProcess()
 {
+	StateMachine::loadPostProcess();
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -832,14 +832,21 @@ void DozerActionStateMachine::crc( Xfer *xfer )
 }
 
 // ------------------------------------------------------------------------------------------------
-/** Xfer Method */
+/** Xfer Method
+  * Version Info:
+  * 1: Initial version
+  * 2: TheSuperHackers @bugfix bobtista 19/07/2026 Serialize the base StateMachine state.
+  *    Without this the dozer reverts to its default state on load.
+  */
 // ------------------------------------------------------------------------------------------------
 void DozerActionStateMachine::xfer( Xfer *xfer )
 {
   // version
-  // TheSuperHackers @bugfix bobtista 19/07/2026 Bump to version 2 to serialize the base
-  // StateMachine state. Without this the dozer reverts to its default state on load.
+#if RETAIL_COMPATIBLE_XFER_SAVE
+  XferVersion currentVersion = 1;
+#else
   XferVersion currentVersion = 2;
+#endif
   XferVersion version = currentVersion;
   xfer->xferVersion( &version, currentVersion );
 


### PR DESCRIPTION
Fixes:
- Turret state machines revert to their default state after loading a save game
- Dozer action state machines revert to their default state after loading a save game

`TurretStateMachine::xfer` and `DozerActionStateMachine::xfer` override the base but never call `StateMachine::xfer`, so the active state ID, sleep timer, goal, and lock flag are never serialized. On load the machine snaps back to its default state.

Now both chain to `StateMachine::xfer`/`loadPostProcess`, matching every other state-machine subclass. Bumped to version 2 and gated the base call so existing version-1 saves still load. Audited all 18 StateMachine subclasses — these two were the only ones missing it.

Todo:
- [x] Replicate to Generals
