### PR TITLE
bugfix(mouse): Restore cursor capture in Mouse::reset instead of leaving it blocked

### DIFF
--- a/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -670,7 +670,13 @@ void Mouse::reset()
   if ( m_cursorTextDisplayString )
   	m_cursorTextDisplayString->reset();
 
-	blockCapture(CursorCaptureBlockReason_NoInit);
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Mouse::reset() previously blocked cursor
+	// capture via CursorCaptureBlockReason_NoInit and never unblocked it again, permanently
+	// breaking screen-edge scrolling (which requires isCursorCaptured()) for the rest of the
+	// session whenever reset() ran mid-game (e.g. on window focus loss/regain), not just at
+	// shutdown. initCapture() re-reads current preferences and correctly restores capture
+	// availability.
+	initCapture();
 
 }
 


### PR DESCRIPTION
bugfix(mouse): Restore cursor capture in Mouse::reset instead of leaving it blocked

Mouse::reset() blocked cursor capture via CursorCaptureBlockReason_NoInit
and never unblocked it again. This is harmless when reset() runs at final
shutdown, but reset() also runs mid-session (e.g. on window focus loss and
regain in fullscreen), which permanently breaks isCursorCaptured() for the
rest of that session once it fires - silently breaking screen-edge
scrolling (canScrollAtScreenEdge() requires isCursorCaptured()) while
leaving RMB-drag scrolling unaffected, since that path does not check
capture state.

initCapture() re-reads current OptionPreferences and correctly restores
capture availability, so calling it here instead of a bare block is safe
and idempotent regardless of which caller triggered reset().

--- AI disclosure ---
This fix was root-caused and written with the help of an LLM (Claude),
working interactively against a live, running build: static code reading
alone could not distinguish a one-time startup call from a call that also
fires mid-session, so the LLM added temporary on-screen instrumentation
(a capture-state and call-count HUD overlay, since removed) to observe
the actual runtime behavior before proposing this fix. The change itself
is a 4-line, human-reviewed and verified diff; the temporary
instrumentation is not part of this commit.


---

