### PR TITLE
bugfix(gameengine): Decouple simulation speed from render frame rate by default

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/GameMain.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameMain.cpp
@@ -42,6 +42,12 @@ Int GameMain()
 	// initialize the game engine using factory function
 	TheFramePacer = new FramePacer();
 	TheFramePacer->enableFramesPerSecondLimit(TRUE);
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Decouple simulation speed from render frame
+	// rate by default. Without this, raising the render FPS limit also speeds up game logic
+	// (unit/aircraft movement), since FramePacer::getActualLogicTimeScaleFps() falls back to an
+	// uncapped value aligned to render FPS whenever logic time scale is disabled. Network games
+	// are unaffected, they use TheNetwork->getFrameRate() instead.
+	TheFramePacer->enableLogicTimeScale(TRUE);
 	TheGameEngine = CreateGameEngine();
 	TheGameEngine->init();
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameMain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameMain.cpp
@@ -42,6 +42,12 @@ Int GameMain()
 	// initialize the game engine using factory function
 	TheFramePacer = new FramePacer();
 	TheFramePacer->enableFramesPerSecondLimit(TRUE);
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Decouple simulation speed from render frame
+	// rate by default. Without this, raising the render FPS limit also speeds up game logic
+	// (unit/aircraft movement), since FramePacer::getActualLogicTimeScaleFps() falls back to an
+	// uncapped value aligned to render FPS whenever logic time scale is disabled. Network games
+	// are unaffected, they use TheNetwork->getFrameRate() instead.
+	TheFramePacer->enableLogicTimeScale(TRUE);
 	TheGameEngine = CreateGameEngine();
 	TheGameEngine->init();
 


### PR DESCRIPTION
bugfix(gameengine): Decouple simulation speed from render frame rate by default in Zero Hour

FramePacer::getActualLogicTimeScaleFps() falls back to an uncapped value
aligned to render FPS whenever logic time scale is disabled, which is the
constructor default. Nothing previously enabled it at startup, so raising
the render FPS cap also sped up game logic (unit/aircraft movement).
Network games are unaffected, they use TheNetwork->getFrameRate() instead.
FramePacer already defaults its fixed logic tick rate to
LOGICFRAMES_PER_SECOND (30); this just turns the existing decoupling
mechanism on.

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude) by tracing
FramePacer/GameEngine call sites; a 1-line functional change plus a
comment, human-reviewed and verified against a live build.


---

bugfix(gameengine): Decouple simulation speed from render frame rate by default in Generals

Generals replica of the same fix applied to Zero Hour, per contribution
guidelines. Identical change, GameMain.cpp has the same structure in
both trees.

--- AI disclosure ---
Backport applied with the help of an LLM (Claude), mirroring the Zero
Hour change; human-reviewed.


---

