### PR TITLE
tweak(camera): Increase mouse wheel zoom speed to match raised MaxCameraHeight

### DIFF
--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -79,7 +79,9 @@ public:
 
 	enum
 	{
-		ZoomHeightPerSecond = 10,
+		// TheSuperHackers @tweak ZsoltFeher 18/07/2026 Bumped 4x to keep mouse-wheel zoom
+		// speed proportional to a raised MaxCameraHeight (e.g. default 310 raised to 1200).
+		ZoomHeightPerSecond = 40,
 	};
 
 	/// Add an impulse force to shake the camera


### PR DESCRIPTION
tweak(camera): Increase mouse wheel zoom speed to match raised MaxCameraHeight

ZoomHeightPerSecond bumped 10 -> 40 (4x) so mouse-wheel zoom stays
proportional when the camera max zoom-out height is raised well beyond
the default 310 (e.g. to 1200 via GameData.ini). This is a hardcoded
constant; maintainers may prefer it scale with MaxCameraHeight via INI
rather than a fixed bump.

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude) by tracing the
mouse-wheel zoom message handler; human-reviewed and verified in a live
build.


---

