### PR TITLE
tweak(camera): Widen screen edge scroll trigger zone from 3px to 15px

### DIFF
--- a/Core/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -77,7 +77,10 @@ static Bool scrollDir[4] = { false, false, false, false };
 constexpr const Real SCROLL_MULTIPLIER = 2.0f;
 constexpr const Real SCROLL_AMT = 100.0f * SCROLL_MULTIPLIER;
 
-static const Int edgeScrollSize = 3;
+// TheSuperHackers @tweak ZsoltFeher 18/07/2026 Widened from 3px to make edge-scroll easier
+// to trigger reliably, especially in fullscreen where hitting the exact physical screen edge
+// can be imprecise.
+static const Int edgeScrollSize = 15;
 
 static Mouse::MouseCursor prevCursor = Mouse::ARROW;
 


### PR DESCRIPTION
tweak(camera): Widen screen edge scroll trigger zone from 3px to 15px

Makes edge-scroll easier to trigger reliably by giving a more forgiving
margin at the physical screen edge.

--- AI disclosure ---
Written with the help of an LLM (Claude); human-reviewed and verified in
a live build.


---

