### PR TITLE
bugfix(ui): Fix inverted unit conversion making MessageDelayMS a no-op

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1847,7 +1847,10 @@ void InGameUI::update()
 	// frame
 	//
 	UnsignedInt currLogicFrame = TheGameLogic->getFrame();
-	const int messageTimeout = m_messageDelayMS / LOGICFRAMES_PER_SECOND / 1000;
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 This was dividing by LOGICFRAMES_PER_SECOND
+	// instead of multiplying, so messageTimeout integer-divided to 0 for any MessageDelayMS under
+	// 30000, making the MessageDelayMS INI setting a no-op. Converts milliseconds to logic frames.
+	const int messageTimeout = m_messageDelayMS * LOGICFRAMES_PER_SECOND / 1000;
 	UnsignedByte r, g, b, a;
 	Int amount;
 	for( i = MAX_UI_MESSAGES - 1; i >= 0; i-- )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1881,7 +1881,10 @@ void InGameUI::update()
 	// frame
 	//
 	UnsignedInt currLogicFrame = TheGameLogic->getFrame();
-	const int messageTimeout = m_messageDelayMS / LOGICFRAMES_PER_SECOND / 1000;
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 This was dividing by LOGICFRAMES_PER_SECOND
+	// instead of multiplying, so messageTimeout integer-divided to 0 for any MessageDelayMS under
+	// 30000, making the MessageDelayMS INI setting a no-op. Converts milliseconds to logic frames.
+	const int messageTimeout = m_messageDelayMS * LOGICFRAMES_PER_SECOND / 1000;
 	UnsignedByte r, g, b, a;
 	Int amount;
 	for( i = MAX_UI_MESSAGES - 1; i >= 0; i-- )


### PR DESCRIPTION
bugfix(ui): Fix inverted unit conversion making MessageDelayMS a no-op in Zero Hour

messageTimeout was computed as m_messageDelayMS / LOGICFRAMES_PER_SECOND / 1000
instead of m_messageDelayMS * LOGICFRAMES_PER_SECOND / 1000, so any
MessageDelayMS value under 30000ms integer-divided to 0. UI messages only
appeared to persist for a few seconds because of a second, separate
truncation in the fade-alpha calculation masking the first bug - the
MessageDelayMS INI setting itself never had any effect.

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude) via a targeted
codebase review; human-reviewed and build-verified.


---

bugfix(ui): Fix inverted unit conversion making MessageDelayMS a no-op in Generals

Generals replica of the same fix applied to Zero Hour, per contribution
guidelines. Identical bug, identical fix, same line in both trees.

--- AI disclosure ---
Backport applied with the help of an LLM (Claude); human-reviewed and
build-verified.


---

