### PR TITLE
bugfix(ui): Fix command button flash draining too fast at raised render FPS

### DIFF
--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -963,6 +963,10 @@ protected:
 
 	//cameo flash
 	Bool m_flash;                                       ///< tells update whether or not to check for flash
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Tracks the last logic frame the command
+	// button flash was updated on, so the flash only advances once per logic frame instead of
+	// once per render frame (which drained the flash counter too fast at raised render FPS).
+	UnsignedInt m_lastCommandFlashFrame;
 
 	Bool m_sideSelectAnimateDown;
 	ICoord2D m_animateDownWin1Size;

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -958,6 +958,7 @@ ControlBar::ControlBar()
 	m_generalsScreenAnimate = nullptr;
 	m_animateWindowManagerForGenShortcuts = nullptr;
 	m_flash = FALSE;
+	m_lastCommandFlashFrame = 0xFFFFFFFF;
 	m_toggleButtonUpIn = nullptr;
 	m_toggleButtonUpOn = nullptr;
 	m_toggleButtonUpPushed = nullptr;
@@ -1486,6 +1487,15 @@ void ControlBar::update()
 	// check flashing
 	if( m_flash )
 	{
+		// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 getFrame() % 10 == 0 was a level check,
+		// not an edge check, so it stayed true for every render frame spanning the same logic
+		// frame - draining the flash counter far too fast once render FPS was raised above the
+		// logic tick rate. Only advance once per distinct logic frame.
+		const UnsignedInt currentFlashFrame = TheGameClient->getFrame();
+		const Bool isNewFlashFrame = (currentFlashFrame != m_lastCommandFlashFrame) && (currentFlashFrame % 10 == 0);
+		if (isNewFlashFrame)
+			m_lastCommandFlashFrame = currentFlashFrame;
+
 		// go through all the command buttons to see which one needs to flash
 		for( Int i = 0; i < MAX_COMMANDS_PER_SET; ++i )
 		{
@@ -1495,7 +1505,7 @@ void ControlBar::update()
 				const CommandButton *commandButton = (const CommandButton *)GadgetButtonGetData(button);
 				if( commandButton != nullptr )
 				{
-					if( commandButton->getFlashCount() > 0 && TheGameClient->getFrame() % 10 == 0 )
+					if( commandButton->getFlashCount() > 0 && isNewFlashFrame )
 					{
 						if( commandButton->getFlashCount() % 2 == 0 )
 						{


### PR DESCRIPTION
bugfix(ui): Fix command button flash draining too fast at raised render FPS

commandButton->getFlashCount() > 0 && TheGameClient->getFrame() % 10 == 0
was a level check, not an edge check: it stayed true for every render
frame spanning the same logic frame, so raising render FPS above the
logic tick rate drained the flash counter and toggled WIN_STATUS_FLASHING
far too fast. A nearby, structurally similar general-star flash effect
was already fixed with a FramePacer time accumulator - this one was
missed. Fixed here by tracking the last logic frame the flash advanced
on and only acting once per distinct logic frame, preserving the
original design's frame-based cadence instead of switching to
wall-clock time.

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude), using the
project's own existing fix for a sibling flash effect as a reference
pattern; human-reviewed and build-verified.


---

