### PR TITLE
bugfix(camera): Decouple scripted camera rotate/zoom/pitch from render frame rate

### DIFF
--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -77,6 +77,7 @@ typedef struct
 {
 	Int			numFrames;						///< Number of frames to rotate.
 	Int			curFrame;							///< Current frame.
+	Real		frameAccumulator;			///< TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Fractional logic frames elapsed since curFrame last advanced, so curFrame steps at the logic tick rate rather than once per render call.
 	Int			startTimeMultiplier;
 	Int			endTimeMultiplier;
 	Int			numHoldFrames;				///< Number of frames to hold the camera before finishing the movement
@@ -102,6 +103,7 @@ typedef struct
 {
 	Int			numFrames;						///< Number of frames to pitch.
 	Int			curFrame;							///< Current frame.
+	Real		frameAccumulator;			///< TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Fractional logic frames elapsed since curFrame last advanced, so curFrame steps at the logic tick rate rather than once per render call.
 	Real		angle;
 	Real		startPitch;
 	Real		endPitch;
@@ -116,6 +118,7 @@ typedef struct
 {
 	Int			numFrames;						///< Number of frames to zoom.
 	Int			curFrame;							///< Current frame.
+	Real		frameAccumulator;			///< TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Fractional logic frames elapsed since curFrame last advanced, so curFrame steps at the logic tick rate rather than once per render call.
 	Real		startZoom;
 	Real		endZoom;
 	Int			startTimeMultiplier;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -2736,6 +2736,7 @@ void W3DView::rotateCamera(Real rotations, Int milliseconds, Real easeIn, Real e
 		m_rcInfo.numFrames = 1;
 	}
 	m_rcInfo.curFrame = 0;
+	m_rcInfo.frameAccumulator = 0.0f;
 	addScriptedState(Scripted_Rotate);
 	m_rcInfo.angle.startAngle = m_angle;
 	m_rcInfo.angle.endAngle = m_angle + 2*PI*rotations;
@@ -2765,6 +2766,7 @@ void W3DView::rotateCameraTowardObject(ObjectID id, Int milliseconds, Int holdMi
 		m_rcInfo.numFrames = 1;
 	}
 	m_rcInfo.curFrame = 0;
+	m_rcInfo.frameAccumulator = 0.0f;
 	addScriptedState(Scripted_Rotate);
 	m_rcInfo.target.targetObjectID = id;
 	m_rcInfo.startTimeMultiplier = m_timeMultiplier;
@@ -2809,6 +2811,7 @@ void W3DView::rotateCameraTowardPosition(const Coord3D *pLoc, Int milliseconds, 
 	}
 
 	m_rcInfo.curFrame = 0;
+	m_rcInfo.frameAccumulator = 0.0f;
 	addScriptedState(Scripted_Rotate);
 	m_rcInfo.angle.startAngle = m_angle;
 	// TheSuperHackers @todo Investigate if the non Generals code is correct for Zero Hour.
@@ -2836,6 +2839,7 @@ void W3DView::zoomCamera( Real finalZoom, Int milliseconds, Real easeIn, Real ea
 		m_zcInfo.numFrames = 1;
 	}
 	m_zcInfo.curFrame = 0;
+	m_zcInfo.frameAccumulator = 0.0f;
 	addScriptedState(Scripted_Zoom);
 	m_zcInfo.startZoom = m_zoom;
 	m_zcInfo.endZoom = finalZoom;
@@ -2852,6 +2856,7 @@ void W3DView::pitchCamera( Real finalPitch, Int milliseconds, Real easeIn, Real 
 		m_pcInfo.numFrames = 1;
 	}
 	m_pcInfo.curFrame = 0;
+	m_pcInfo.frameAccumulator = 0.0f;
 	addScriptedState(Scripted_Pitch);
 	m_pcInfo.startPitch = m_FXPitch;
 	m_pcInfo.endPitch = finalPitch;
@@ -3283,6 +3288,16 @@ static Real makeQuadraticS(Real t)
 // ------------------------------------------------------------------------------------------------
 void W3DView::rotateCameraOneFrame()
 {
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 curFrame previously advanced by 1 every call,
+	// but this function is called once per render frame, so raising render FPS above the logic
+	// tick rate made scripted camera rotations complete N times too fast. Only advance curFrame
+	// once enough real logic time has accumulated, matching the decoupling already applied to
+	// moveAlongWaypointPath() below.
+	m_rcInfo.frameAccumulator += TheFramePacer->getLogicTimeStepMilliseconds(FramePacer::IgnoreFrozenTime) / TheW3DFrameLengthInMsec;
+	if (m_rcInfo.frameAccumulator < 1.0f)
+		return;
+	m_rcInfo.frameAccumulator -= 1.0f;
+
 	m_rcInfo.curFrame++;
 	if (TheGlobalData->m_disableCameraMovement) {
 		if (m_rcInfo.curFrame >= m_rcInfo.numFrames + m_rcInfo.numHoldFrames) {
@@ -3354,6 +3369,13 @@ void W3DView::rotateCameraOneFrame()
 // ------------------------------------------------------------------------------------------------
 void W3DView::zoomCameraOneFrame()
 {
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 See rotateCameraOneFrame() above - same
+	// render-rate-coupling bug, same fix.
+	m_zcInfo.frameAccumulator += TheFramePacer->getLogicTimeStepMilliseconds(FramePacer::IgnoreFrozenTime) / TheW3DFrameLengthInMsec;
+	if (m_zcInfo.frameAccumulator < 1.0f)
+		return;
+	m_zcInfo.frameAccumulator -= 1.0f;
+
 	m_zcInfo.curFrame++;
 	if (TheGlobalData->m_disableCameraMovement) {
 		if (m_zcInfo.curFrame >= m_zcInfo.numFrames) {
@@ -3380,6 +3402,13 @@ void W3DView::zoomCameraOneFrame()
 // ------------------------------------------------------------------------------------------------
 void W3DView::pitchCameraOneFrame()
 {
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 See rotateCameraOneFrame() above - same
+	// render-rate-coupling bug, same fix.
+	m_pcInfo.frameAccumulator += TheFramePacer->getLogicTimeStepMilliseconds(FramePacer::IgnoreFrozenTime) / TheW3DFrameLengthInMsec;
+	if (m_pcInfo.frameAccumulator < 1.0f)
+		return;
+	m_pcInfo.frameAccumulator -= 1.0f;
+
 	m_pcInfo.curFrame++;
 	if (TheGlobalData->m_disableCameraMovement) {
 		if (m_pcInfo.curFrame >= m_pcInfo.numFrames) {


### PR DESCRIPTION
bugfix(camera): Decouple scripted camera rotate/zoom/pitch from render frame rate

rotateCameraOneFrame()/zoomCameraOneFrame()/pitchCameraOneFrame() advanced
their internal curFrame counter by 1 every call, but these functions run
once per render frame, so raising render FPS above the logic tick rate
made scripted camera rotations, zooms and pitches (campaign cutscenes,
shellmap) complete proportionally too fast, and the remaining-time
reported back to the script engine was wrong too. The sibling
moveAlongWaypointPath() branch in the same calling function was already
decoupled via a FramePacer-based elapsed-time accumulator; the
rotate/zoom/pitch branches next to it were not. Fixed the same way: a
fractional per-info frameAccumulator now gates how often curFrame
actually advances, preserving all existing per-frame logic and control
flow unchanged, just correcting the rate at which it runs. No Xfer/
save-game usage of these fields was found.

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude), using the
project's own existing fix for the sibling moveAlongWaypointPath branch
as the reference pattern; human-reviewed and build-verified against both
the Zero Hour and Generals targets.


---

