### PR TITLE
feat(camera): Add DefaultCameraHeight INI field, decoupled from MaxCameraHeight

### DIFF
--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -301,6 +301,13 @@ private:
 	Real getDesiredZoom(Real x, Real y) const;
 	Real getMaxHeight(Real x, Real y) const;
 	Real getMaxZoom(Real x, Real y) const;
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Reference zoom for SCRIPTED camera moves
+	// (mission intro cutscenes, doSetupCamera/cameraModFinalZoom, resetCamera), which express
+	// their zoom as a fraction of this value. getMaxZoom() is anchored to the full, raised
+	// MaxCameraHeight (e.g. 1200), which made scripted "zoom = 1.0" cutscenes zoom out 4x more
+	// than their retail-tuned design. This anchors scripted zoom to DefaultCameraHeight instead
+	// (clamped to never exceed the actual max), independent of the manual zoom-out ceiling.
+	Real getScriptZoomReference(Real x, Real y) const;
 	void updateCameraTransform(); ///< update the transform matrix of m_3DCamera, based on m_pos & m_angle
 	void updateCameraClipPlanes(const Matrix3D &transform);
 	void setCameraTransform(const Matrix3D &transform);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -2275,9 +2275,19 @@ void W3DView::setZoom(Real z)
 //-------------------------------------------------------------------------------------------------
 void W3DView::setZoomToDefault()
 {
-	// default zoom has to be max, otherwise players will just zoom to max always
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Default zoom previously always equaled max
+	// zoom (m_maxHeightAboveGround), which silently broke once MaxCameraHeight was raised well
+	// beyond its original design range - anything relying on "default zoom" (e.g. mission intro
+	// cutscenes) would zoom out to the new, much higher, max. DefaultCameraHeight is a separate,
+	// independently tunable value (clamped to never exceed the actual max) so raising the
+	// zoom-out ceiling no longer drags the default view out with it.
+	const Real savedMaxHeightAboveGround = m_maxHeightAboveGround;
+	m_maxHeightAboveGround = min(TheGlobalData->m_defaultCameraHeight, m_maxHeightAboveGround);
+
 	m_heightAboveGround = m_maxHeightAboveGround;
 	m_zoom = getMaxZoom(m_pos.x, m_pos.y);
+
+	m_maxHeightAboveGround = savedMaxHeightAboveGround;
 
 	stopDoingScriptedCamera();
 	m_CameraArrivedAtWaypointOnPathFlag = false;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -723,6 +723,19 @@ Real W3DView::getMaxZoom(Real x, Real y) const
 }
 
 //-------------------------------------------------------------------------------------------------
+Real W3DView::getScriptZoomReference(Real x, Real y) const
+{
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 See declaration comment in W3DView.h.
+	const Real referenceHeightAboveGround = min(TheGlobalData->m_defaultCameraHeight, m_maxHeightAboveGround);
+	const Real referenceHeight =
+#if PRESERVE_RETAIL_SCRIPTED_CAMERA
+		!m_isUserControlled ? (getHeightAroundPos(x, y) + referenceHeightAboveGround) :
+#endif
+		(m_pos.z + referenceHeightAboveGround);
+	return referenceHeight / getCameraOffsetZ();
+}
+
+//-------------------------------------------------------------------------------------------------
 /** set the transform matrix of m_3DCamera, based on m_pos & m_angle */
 //-------------------------------------------------------------------------------------------------
 void W3DView::updateCameraTransform()
@@ -2873,16 +2886,20 @@ void W3DView::pitchCamera( Real finalPitch, Int milliseconds, Real easeIn, Real 
 //-------------------------------------------------------------------------------------------------
 void W3DView::cameraModFinalZoom( Real finalZoom, Real easeIn, Real easeOut )
 {
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Was getMaxZoom(), anchored to the full,
+	// raised MaxCameraHeight - made scripted "zoom = 1.0" mission-intro cutscenes zoom out
+	// proportionally to the raised manual zoom-out ceiling instead of their retail-tuned
+	// design. getScriptZoomReference() anchors this to DefaultCameraHeight instead.
 	if (hasScriptedState(Scripted_Rotate))
 	{
 		Real time = (m_rcInfo.numFrames + m_rcInfo.numHoldFrames - m_rcInfo.curFrame)*TheW3DFrameLengthInMsec;
-		zoomCamera( finalZoom*getMaxZoom(m_pos.x, m_pos.y), time, time*easeIn, time*easeOut );
+		zoomCamera( finalZoom*getScriptZoomReference(m_pos.x, m_pos.y), time, time*easeIn, time*easeOut );
 	}
 	if (hasScriptedState(Scripted_MoveOnWaypointPath))
 	{
 		Coord3D pos = m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints];
 		Real time = m_mcwpInfo.totalTimeMilliseconds - m_mcwpInfo.elapsedTimeMilliseconds;
-		zoomCamera( finalZoom*getMaxZoom(pos.x, pos.y), time, time*easeIn, time*easeOut );
+		zoomCamera( finalZoom*getScriptZoomReference(pos.x, pos.y), time, time*easeIn, time*easeOut );
 	}
 }
 
@@ -3117,7 +3134,8 @@ void W3DView::resetCamera(const Coord3D *location, Int milliseconds, Real easeIn
 	// m_mcwpInfo.cameraAngle[2] = m_defaultAngle;
 	View::setAngle(m_mcwpInfo.cameraAngle[0]);
 
-	zoomCamera( getMaxZoom(location->x, location->y), milliseconds, easeIn, easeOut );
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Was getMaxZoom() - see cameraModFinalZoom().
+	zoomCamera( getScriptZoomReference(location->x, location->y), milliseconds, easeIn, easeOut );
 
 	pitchCamera( 1.0f, milliseconds, easeIn, easeOut );
 }

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -191,6 +191,11 @@ public:
 #endif
 	Real m_maxCameraHeight;
 	Real m_minCameraHeight;
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Separate, independently tunable "default
+	// view" height. W3DView::setZoomToDefault() previously equated default zoom with max zoom,
+	// which silently broke once MaxCameraHeight was raised well beyond its original design
+	// range (e.g. mission intro cutscenes zooming out to the new, much higher, max).
+	Real m_defaultCameraHeight;
 	Real m_terrainHeightAtEdgeOfMap;
 	Real m_unitDamagedThresh;
 	Real m_unitReallyDamagedThresh;

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -191,6 +191,7 @@ GlobalData* GlobalData::m_theOriginal = nullptr;
 #endif
 	{ "MaxCameraHeight",						INI::parseReal,				nullptr,			offsetof( GlobalData, m_maxCameraHeight ) },
 	{ "MinCameraHeight",						INI::parseReal,				nullptr,			offsetof( GlobalData, m_minCameraHeight ) },
+	{ "DefaultCameraHeight",				INI::parseReal,				nullptr,			offsetof( GlobalData, m_defaultCameraHeight ) },
 	{ "TerrainHeightAtEdgeOfMap",					INI::parseReal,				nullptr,			offsetof( GlobalData, m_terrainHeightAtEdgeOfMap ) },
 	{ "UnitDamagedThreshold",				INI::parseReal,				nullptr,			offsetof( GlobalData, m_unitDamagedThresh ) },
 	{ "UnitReallyDamagedThreshold",	INI::parseReal,				nullptr,			offsetof( GlobalData, m_unitReallyDamagedThresh ) },
@@ -850,6 +851,7 @@ GlobalData::GlobalData()
 #endif
 	m_minCameraHeight = 100.0f;
 	m_maxCameraHeight = 300.0f;
+	m_defaultCameraHeight = 300.0f;
 	m_terrainHeightAtEdgeOfMap = 0.0f;
 
 	m_unitDamagedThresh = 0.5f;

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -192,6 +192,11 @@ public:
 #endif
 	Real m_maxCameraHeight;
 	Real m_minCameraHeight;
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Separate, independently tunable "default
+	// view" height. W3DView::setZoomToDefault() previously equated default zoom with max zoom,
+	// which silently broke once MaxCameraHeight was raised well beyond its original design
+	// range (e.g. mission intro cutscenes zooming out to the new, much higher, max).
+	Real m_defaultCameraHeight;
 	Real m_terrainHeightAtEdgeOfMap;
 	Real m_unitDamagedThresh;
 	Real m_unitReallyDamagedThresh;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -191,6 +191,7 @@ GlobalData* GlobalData::m_theOriginal = nullptr;
 #endif
 	{ "MaxCameraHeight",						INI::parseReal,				nullptr,			offsetof( GlobalData, m_maxCameraHeight ) },
 	{ "MinCameraHeight",						INI::parseReal,				nullptr,			offsetof( GlobalData, m_minCameraHeight ) },
+	{ "DefaultCameraHeight",				INI::parseReal,				nullptr,			offsetof( GlobalData, m_defaultCameraHeight ) },
 	{ "TerrainHeightAtEdgeOfMap",					INI::parseReal,				nullptr,			offsetof( GlobalData, m_terrainHeightAtEdgeOfMap ) },
 	{ "UnitDamagedThreshold",				INI::parseReal,				nullptr,			offsetof( GlobalData, m_unitDamagedThresh ) },
 	{ "UnitReallyDamagedThreshold",	INI::parseReal,				nullptr,			offsetof( GlobalData, m_unitReallyDamagedThresh ) },
@@ -854,6 +855,7 @@ GlobalData::GlobalData()
 #endif
 	m_minCameraHeight = 100.0f;
 	m_maxCameraHeight = 300.0f;
+	m_defaultCameraHeight = 300.0f;
 	m_terrainHeightAtEdgeOfMap = 0.0f;
 
 	m_unitDamagedThresh = 0.5f;


### PR DESCRIPTION
feat(camera): Add DefaultCameraHeight INI field, decoupled from MaxCameraHeight in Zero Hour

W3DView::setZoomToDefault() hardcoded default zoom to equal max zoom
(m_maxHeightAboveGround). This is fine near the original design range,
but silently breaks anything relying on 'default zoom' (e.g. mission
intro cutscenes) once MaxCameraHeight is raised well beyond it - the
default view zooms out to the new, much higher, max. Adds a separate,
independently tunable DefaultCameraHeight field so raising the zoom-out
ceiling no longer drags the default view out with it. Defaults to 300
(matching the original MaxCameraHeight default) so behavior is unchanged
unless explicitly configured.

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude); human-reviewed
and build-verified.


---

feat(camera): Add DefaultCameraHeight INI field, decoupled from MaxCameraHeight in Generals

Generals replica of the same field applied to Zero Hour, per contribution
guidelines. Identical field, identical default, same location in both
trees.

--- AI disclosure ---
Backport applied with the help of an LLM (Claude); human-reviewed and
build-verified.


---

bugfix(camera): Use DefaultCameraHeight instead of max zoom in setZoomToDefault

Companion to the DefaultCameraHeight field added in GlobalData. Clamps
to never exceed the actual max (m_maxHeightAboveGround) so a
misconfigured DefaultCameraHeight can't put the camera outside its
normal bounds. Reuses the existing getMaxZoom() logic rather than
duplicating its terrain-height/camera-offset calculation, by
temporarily substituting m_maxHeightAboveGround for the duration of
the call.

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude); human-reviewed
and build-verified.


---

bugfix(camera): Anchor scripted cutscene zoom to DefaultCameraHeight, not max zoom

The DefaultCameraHeight fix in a prior commit only covered
setZoomToDefault() (the manual reset-to-default action), but mission
intro cutscenes go through a separate scripted-camera path:
cameraModFinalZoom() and resetCamera() express their zoom as a fraction
of getMaxZoom(), which is anchored to the full, raised MaxCameraHeight.
A script saying 'zoom = 1.0' therefore zoomed out proportionally to the
raised manual zoom-out ceiling instead of the mission's retail-tuned
design. Adds getScriptZoomReference(), anchored to DefaultCameraHeight
(clamped to never exceed the real max) instead, and uses it in both
cameraModFinalZoom() call sites and resetCamera(). Root-caused by
tracing the actual call chain from doSetupCamera()/doResetCamera() in
ScriptActions.cpp through to these functions, rather than assuming the
earlier setZoomToDefault() fix was sufficient.

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude); human-reviewed
and build-verified.


---

