### PR TITLE
feat(camera): Add player-facing camera pitch via middle-mouse-drag vertical movement

### DIFF
--- a/Core/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -290,6 +290,12 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			m_middleButtonDownTimeMsec = now;
 
 			m_isRotating = true;
+			// TheSuperHackers @feature ZsoltFeher 18/07/2026 Camera pitch was previously a
+			// debug-only tool (bound to KEY_COMMA in CommandMapDebug.ini, RTS_DEBUG-only).
+			// Exposed to players here by piggybacking on the existing middle-mouse-drag
+			// rotate gesture: horizontal drag still rotates (m_isRotating, unchanged),
+			// vertical drag now also pitches (m_isPitching, previously unreachable).
+			m_isPitching = true;
 			m_anchor = msg->getArgument( 0 )->pixel;
 			m_anchorAngle = TheTacticalView->getAngle();
 			m_originalAnchor = msg->getArgument( 0 )->pixel;
@@ -307,6 +313,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			const UnsignedInt PIXEL_OFFSET = 5;
 
 			m_isRotating = false;
+			m_isPitching = false;
 			Int dx = m_currentPos.x-m_originalAnchor.x;
 			if (dx<0) dx = -dx;
 			Int dy = m_currentPos.y-m_originalAnchor.y;

--- a/Core/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -369,6 +369,19 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 				}
 			}
 
+			// rotate the view up/down
+			// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Must run before the rotate block:
+			// the rotate block overwrites m_anchor with the current mouse position, which would
+			// zero out this block's vertical delta (m_currentPos.y - m_anchor.y) and prevent
+			// pitch from ever engaging while dragging with the middle mouse button.
+			if (m_isPitching)
+			{
+				constexpr const Real Scale = 0.01f;
+				const Real angle = Scale * (m_currentPos.y - m_anchor.y);
+				TheTacticalView->userSetPitch( TheTacticalView->getPitch() - angle );
+				m_anchor = msg->getArgument( 0 )->pixel;
+			}
+
 			// rotate the view
 			if (m_isRotating)
 			{
@@ -385,15 +398,6 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 				}
 
 				TheTacticalView->userSetAngle(targetAngle);
-				m_anchor = msg->getArgument( 0 )->pixel;
-			}
-
-			// rotate the view up/down
-			if (m_isPitching)
-			{
-				constexpr const Real Scale = 0.01f;
-				const Real angle = Scale * (m_currentPos.y - m_anchor.y);
-				TheTacticalView->userSetPitch( TheTacticalView->getPitch() - angle );
 				m_anchor = msg->getArgument( 0 )->pixel;
 			}
 


### PR DESCRIPTION
feat(camera): Add player-facing camera pitch via middle-mouse-drag vertical movement

Camera pitch adjustment existed as working code (View::userSetPitch via
m_isPitching) but was only reachable through a debug-only tool
(MSG_META_DEMO_BEGIN/END_ADJUST_PITCH, RTS_DEBUG-only, bound to KEY_COMMA
in the also RTS_DEBUG-only CommandMapDebug.ini) - never available to
players in a release build. Exposes it by piggybacking on the existing
middle-mouse-button-drag rotate gesture: horizontal drag still rotates
the camera (unchanged), vertical drag now also pitches it, since both
axes are independent and were already computed from the same drag
gesture's mouse position.

--- AI disclosure ---
Implemented with the help of an LLM (Claude) based on the user's own
design (bind pitch to the existing middle-mouse-drag gesture's vertical
axis rather than a new keybinding); human-reviewed and build-verified.


---

bugfix(camera): Fix pitch not engaging during middle-mouse-drag

The rotate block ran before the pitch block in the mouse-move handler
and unconditionally overwrote m_anchor to the current mouse position.
The pitch block computed its vertical delta as (m_currentPos.y -
m_anchor.y), but m_anchor.y had just been set equal to m_currentPos.y
by the rotate block moments earlier, so the delta was always 0 and
userSetPitch never actually moved the camera. Reordering the pitch
block before the rotate block fixes this: pitch now reads the previous
frame's m_anchor.y (its incremental reference) before rotate overwrites
it. Rotate only ever writes m_anchor (its own math uses the separate
m_originalAnchor), so the reorder is behavior-neutral for rotation.

--- AI disclosure ---
Root-caused and fixed with the help of an LLM (Claude); human-reviewed
and build-verified.


---

