### PR TITLE
bugfix(gamelogic): Initialize closestDistance in OpenContain::getClosestRider

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -531,7 +531,8 @@ void OpenContain::iterateContained( ContainIterateFunc func, void *userData, Boo
 Object* OpenContain::getClosestRider( const Coord3D *pos )
 {
 	Object *closest = nullptr;
-	Real closestDistance;
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 closestDistance was uninitialized
+	Real closestDistance = FLT_MAX;
 
 	for(ContainedItemsList::const_iterator it = m_containList.begin(); it != m_containList.end(); ++it)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -625,9 +625,7 @@ void OpenContain::iterateContained( ContainIterateFunc func, void *userData, Boo
 Object* OpenContain::getClosestRider( const Coord3D *pos )
 {
 	Object *closest = nullptr;
-	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 closestDistance was uninitialized. Safe at
-	// runtime due to the !closest short-circuit, but initializing to FLT_MAX lets us drop that
-	// check entirely. (github.com/TheSuperHackers/GeneralsGameCode issue #2800)
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 closestDistance was uninitialized
 	Real closestDistance = FLT_MAX;
 
 	for(ContainedItemsList::const_iterator it = m_containList.begin(); it != m_containList.end(); ++it)
@@ -637,7 +635,7 @@ Object* OpenContain::getClosestRider( const Coord3D *pos )
     if (rider)
     {
       Real distance = ThePartitionManager->getDistanceSquared( rider, pos, FROM_CENTER_2D );
-	    if( closestDistance > distance )
+	    if( !closest || closestDistance > distance )
 	    {
 		    closest = rider;
 		    closestDistance = distance;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -625,7 +625,10 @@ void OpenContain::iterateContained( ContainIterateFunc func, void *userData, Boo
 Object* OpenContain::getClosestRider( const Coord3D *pos )
 {
 	Object *closest = nullptr;
-	Real closestDistance;
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 closestDistance was uninitialized. Safe at
+	// runtime due to the !closest short-circuit, but initializing to FLT_MAX lets us drop that
+	// check entirely. (github.com/TheSuperHackers/GeneralsGameCode issue #2800)
+	Real closestDistance = FLT_MAX;
 
 	for(ContainedItemsList::const_iterator it = m_containList.begin(); it != m_containList.end(); ++it)
 	{
@@ -634,7 +637,7 @@ Object* OpenContain::getClosestRider( const Coord3D *pos )
     if (rider)
     {
       Real distance = ThePartitionManager->getDistanceSquared( rider, pos, FROM_CENTER_2D );
-	    if( !closest || closestDistance > distance )
+	    if( closestDistance > distance )
 	    {
 		    closest = rider;
 		    closestDistance = distance;


### PR DESCRIPTION
bugfix(gamelogic): Initialize closestDistance in OpenContain::getClosestRider

Runtime behavior was already safe due to short-circuit evaluation, but
initializing to FLT_MAX removes the uninitialized-read warning and the
now-redundant !closest check.

Fixes #2800 (github.com/TheSuperHackers/GeneralsGameCode)

--- AI disclosure ---
Written with the help of an LLM (Claude), applying the exact fix a
maintainer already proposed in the issue thread; human-reviewed and
build-verified.


---

Fix uninitialized closestDistance in OpenContain::getClosestRider (#2800)

Real closestDistance was declared without an initializer. The existing
`!closest || closestDistance > distance` short-circuit made this safe in
practice (closestDistance is never read before it's first written), but it
is undefined-behavior-adjacent and fragile to future refactors of that
condition.

Initialized closestDistance to FLT_MAX at declaration, matching the
established "find closest X" idiom already used elsewhere in this codebase
(e.g. AIPathfind.cpp, GameLogic.cpp).

TheSuperHackers @bugfix ZsoltFeher 07/20/2026 closestDistance was
uninitialized in OpenContain::getClosestRider.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #2800
