### PR TITLE
bugfix(common): Fix NameKeyGenerator::nameToLowercaseKey storing original case on cache miss

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -175,7 +175,11 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const AsciiString& name)
 	}
 
 	// nope, guess not. let's allocate it.
-	return createNameKey(hash, name);
+	// TheSuperHackers @bugfix Store the lowercased name, not the original-case name, so that
+	// a subsequent nameToKey() on the already-lowercased string finds this same bucket entry.
+	AsciiString lowercaseName = name;
+	lowercaseName.toLower();
+	return createNameKey(hash, lowercaseName);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -209,7 +213,11 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const char *name)
 	}
 
 	// nope, guess not. let's allocate it.
-	return createNameKey(hash, name);
+	// TheSuperHackers @bugfix Store the lowercased name, not the original-case name, so that
+	// a subsequent nameToKey() on the already-lowercased string finds this same bucket entry.
+	AsciiString lowercaseName(name);
+	lowercaseName.toLower();
+	return createNameKey(hash, lowercaseName);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -175,7 +175,11 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const AsciiString& name)
 	}
 
 	// nope, guess not. let's allocate it.
-	return createNameKey(hash, name);
+	// TheSuperHackers @bugfix Store the lowercased name, not the original-case name, so that
+	// a subsequent nameToKey() on the already-lowercased string finds this same bucket entry.
+	AsciiString lowercaseName = name;
+	lowercaseName.toLower();
+	return createNameKey(hash, lowercaseName);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -209,7 +213,11 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const char *name)
 	}
 
 	// nope, guess not. let's allocate it.
-	return createNameKey(hash, name);
+	// TheSuperHackers @bugfix Store the lowercased name, not the original-case name, so that
+	// a subsequent nameToKey() on the already-lowercased string finds this same bucket entry.
+	AsciiString lowercaseName(name);
+	lowercaseName.toLower();
+	return createNameKey(hash, lowercaseName);
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
bugfix(common): Fix NameKeyGenerator::nameToLowercaseKey storing original case on cache miss

The lookup path correctly hashes/compares case-insensitively, so
existing keys were found regardless of case. But on a cache miss it
called createNameKey() with the original, un-lowercased name - storing
e.g. 'Test1234567' instead of 'test1234567'. A later nameToKey() on the
lowercase string hashes to the same bucket but does a case-SENSITIVE
compare against the stored mixed-case entry, which fails, so it
allocates a different key instead of reusing the first one. Fixed by
lowercasing the name (via the existing AsciiString::toLower()) before
createNameKey() in both overloads. This file is duplicated per-tree
(no shared Core/ copy), fixed identically in both.

Fixes #2841 (github.com/TheSuperHackers/GeneralsGameCode)

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude); human-reviewed
and build-verified in both trees.


---

Fixes #2841
