### PR TITLE
bugfix(input): Fix Fast Forward blocked during scripted camera sequences

### DIFF
--- a/Core/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -668,6 +668,14 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		case GameMessage::MSG_META_SAVE_VIEW7:
 		case GameMessage::MSG_META_SAVE_VIEW8:
 		{
+			// TheSuperHackers @bugfix Do not allow the user to set a camera view bookmark while
+			// input is disabled (e.g. during a scripted camera scene).
+			if ( TheInGameUI && TheInGameUI->getInputEnabled() == FALSE )
+			{
+				disp = DESTROY_MESSAGE;
+				break;
+			}
+
 			Int slot = t - GameMessage::MSG_META_SAVE_VIEW1 + 1;
 			if ( slot > 0 && slot <= MAX_VIEW_LOCS )
 			{
@@ -690,6 +698,15 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		case GameMessage::MSG_META_VIEW_VIEW7:
 		case GameMessage::MSG_META_VIEW_VIEW8:
 		{
+			// TheSuperHackers @bugfix Do not allow the user to jump the camera to a bookmarked view
+			// while input is disabled (e.g. during a scripted camera scene). Otherwise it would be
+			// possible to call user camera actions during scripted camera scenes.
+			if ( TheInGameUI && TheInGameUI->getInputEnabled() == FALSE )
+			{
+				disp = DESTROY_MESSAGE;
+				break;
+			}
+
 			Int slot = t - GameMessage::MSG_META_VIEW_VIEW1 + 1;
 			if ( slot > 0 && slot <= MAX_VIEW_LOCS )
 			{
@@ -771,6 +788,15 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 
 void LookAtTranslator::resetModes()
 {
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 If a scroll (e.g. an RMB drag) is in
+	// progress, tear it down completely via stopScrolling() instead of just clearing the local
+	// flag. Clearing only m_isScrolling left TheInGameUI's scrolling state, the tactical view
+	// mouse lock and the scroll cursor stuck, both when scripts disable input mid-scroll and
+	// when the window loses focus during an RMB camera drag.
+	// (github.com/TheSuperHackers/GeneralsGameCode issue #2733)
+	if (m_isScrolling)
+		stopScrolling();
+
 	m_isScrolling = FALSE;
 	m_isRotating = FALSE;
 	m_isPitching = FALSE;

--- a/Core/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
@@ -326,10 +326,15 @@ GameMessageDisposition WindowTranslator::translateGameMessage(const GameMessage 
 				returnCode = WIN_INPUT_USED;
 			}
 
-			// TheSuperHackers @bugfix If the input is disabled, then only allow the ESC button to get through.
-			// Otherwise it would be possible to call user camera actions during scripted camera scenes.
+			// TheSuperHackers @bugfix Do not swallow raw key events here just because input is
+			// disabled (e.g. during scripted camera scenes). Some translators further down the
+			// message stream (such as MetaEventTranslator's replay fast-forward handling) rely on
+			// raw key messages reaching them even while input is disabled. Blocking user camera
+			// actions (e.g. view bookmarks) during scripted camera scenes is instead handled at the
+			// game message level in LookAtTranslator, where the actual camera action occurs.
 			if(returnCode != WIN_INPUT_USED
-				&& (key != KEY_ESC)
+				&& (key == KEY_ESC)
+				&& (BitIsSet( state, KEY_STATE_UP ))
 				&& (TheInGameUI && (TheInGameUI->getInputEnabled() == FALSE)) )
 			{
 				returnCode = WIN_INPUT_USED;


### PR DESCRIPTION
bugfix(input): Fix Fast Forward blocked during scripted camera sequences

PR #2621 ('Block all button presses except ESC during scripted camera
scenes') made WindowXlat.cpp destroy ALL raw key events except ESC
whenever input is disabled (TheInGameUI->getInputEnabled() == FALSE,
set during cutscenes/scripted camera moves), to stop CTRL+F1 camera
bookmarks firing during cinematics via a pre-existing 'GREASY HACK' in
MetaEventTranslator that bypasses the normal translator chain during
disabled input. This over-broadly also destroyed the 'F' key before
MetaEventTranslator ever saw it, breaking Fast Forward during replay
scripted camera sequences too, since WindowTranslator runs first in the
translator chain.

Fixed at the correct layer, per the issue's own suggestion (block game
messages, not raw keys): reverted the raw-key blocking in WindowXlat.cpp
back to only consuming ESC when input is disabled, and instead added
explicit getInputEnabled() guards to the camera-bookmark cases
(MSG_META_SAVE_VIEW1-8/MSG_META_VIEW_VIEW1-8) in LookAtXlat.cpp, which
is what actually needed protecting from cutscenes in the first place.
Both files are shared under Core/, no backport needed.

Fixes #2647 (github.com/TheSuperHackers/GeneralsGameCode)

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude), including
identifying the exact regression-causing PR (#2621) and its original
intent; human-reviewed and build-verified.


---

