### PR TITLE
bugfix(terrain): Fix black terrain during extreme-angle scripted camera cutscenes

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1754,8 +1754,24 @@ void HeightMapRenderObjClass::updateCenter(CameraClass *camera, const Vector3 *c
 		}
 		calcVis(frustum, m_map, minX-WIDE_STEP/2, minY-WIDE_STEP/2, maxX+WIDE_STEP/2, maxY+WIDE_STEP/2, limit);
 
-		newOrgX = (visMaxX+visMinX)/2 - m_x/2;
-		newOrgY = (visMaxY+visMinY)/2 - m_y/2;
+		// TheSuperHackers @fix Guard against the frustum-based visibility scan finding no terrain tiles.
+		// This degenerates when the camera is very far from the terrain or at an extreme scripted cutscene
+		// angle (e.g. the USA Mission 3 MOAB-drop and mission intro reveal cutscenes): the coarse frustum
+		// sampling in calcVis can miss the visible terrain strip, leaving visMin/visMax at their initial
+		// inverted values. The old code then computed newOrg from (0 + mapExtent)/2, snapping the small
+		// rendered terrain window to the map center - away from where the camera is actually looking - so the
+		// on-screen terrain was left undrawn and appeared black while units/structures still rendered.
+		// In that case, fall back to centering the draw window on the camera look-at position instead.
+		if (visMaxX < visMinX || visMaxY < visMinY)
+		{
+			newOrgX = WWMath::Round(cameraPivot->X/MAP_XY_FACTOR) - m_x/2 + m_map->getBorderSizeInline();
+			newOrgY = WWMath::Round(cameraPivot->Y/MAP_XY_FACTOR) - m_y/2 + m_map->getBorderSizeInline();
+		}
+		else
+		{
+			newOrgX = (visMaxX+visMinX)/2 - m_x/2;
+			newOrgY = (visMaxY+visMinY)/2 - m_y/2;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
bugfix(terrain): Fix black terrain during extreme-angle scripted camera cutscenes

HeightMapRenderObjClass::updateCenter() only renders a small moving
window of the terrain, centered by a coarse frustum scan (calcVis) at
high camera pitch. When the scan finds zero visible tiles - a high-
altitude scripted zoom (e.g. a MOAB drop cutscene) or an extreme intro
reveal angle where the frustum can no longer intersect the terrain, a
case the surrounding code's own comment already acknowledges - the
min/max bounds stay inverted from their initial sentinel values, and
the centering formula collapses to the map's geometric center instead
of the camera's actual look-at point. The rendered window ends up
nowhere near what's on screen, so the terrain there is simply not
drawn: black terrain, while units/structures (independent scene
objects, not tied to this window) keep rendering normally.

Fixed by falling back to centering the window on the camera's pivot
point (the same formula the low-pitch branch already uses) whenever
the frustum scan finds no tiles. Only activates in that exact
degenerate zero-tile case; normal frames are byte-for-byte unchanged.

Fixes #2852, #2751 (github.com/TheSuperHackers/GeneralsGameCode)

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude) by tracing the
terrain draw-window centering code; human-reviewed and build-verified.
Visual confirmation of the exact cutscenes pending user playtest.


---

