### PR TITLE
bugfix(input): Release all held keyboard keys on focus loss, not just Alt

### DIFF
--- a/Core/GameEngine/Include/GameClient/Keyboard.h
+++ b/Core/GameEngine/Include/GameClient/Keyboard.h
@@ -124,7 +124,7 @@ public:
 	WideChar getPrintableKey( KeyDefType key, Int state );
 	enum { MAX_KEY_STATES = 3};
 private:
-	void refreshAltKeys() const;									///< refresh the state of the alt keys, necessary after alt tab
+	void releaseHeldKeys() const;									///< synthesize key-up events for all held keys, necessary after focus loss
 protected:
 
 	/** get the key data for a single key, KEY_NONE should be returned when

--- a/Core/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Core/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -752,7 +752,14 @@ void Keyboard::resetKeys()
 
 	// TheSuperHackers @fix Caball009 13/12/2025 Fix bug where game remains in waypoint mode
 	// because the key up state for the alt key is not detected after alt tab.
-	refreshAltKeys();
+	// TheSuperHackers @fix 18/07/2026 Generalized from the ALT keys to every held key.
+	// When focus is lost (alt tab, or clicking outside the window while cursor lock is
+	// disabled), Windows delivers no key-up for keys that were held at that moment, so any
+	// translator latch driven by a raw key-up stays stuck forever. Synthesizing a key-up for
+	// every currently held key clears them all through the normal input path: arrow-key camera
+	// scroll (LookAtXlat scrollDir, issues #2732/#2733) and the CTRL force-attack mode
+	// (MetaEvent -> END_FORCEATTACK, issue #2734), in addition to the ALT waypoint mode.
+	releaseHeldKeys();
 
 	memset( m_keys, 0, sizeof( m_keys ) );
 	memset( m_keyStatus, 0, sizeof( m_keyStatus ) );
@@ -765,21 +772,20 @@ void Keyboard::resetKeys()
 }
 
 //-------------------------------------------------------------------------------------------------
-// Refresh the state of the alt keys, necessary after alt tab
+// Synthesize a raw key-up event for every currently held key, necessary after focus loss
+// (alt tab / clicking outside the window) because Windows sends no key-up for keys that were
+// held at that moment, which would otherwise leave translator hold-state latches stuck.
 //-------------------------------------------------------------------------------------------------
-void Keyboard::refreshAltKeys() const
+void Keyboard::releaseHeldKeys() const
 {
-	if (BitIsSet(m_keyStatus[KEY_LALT].state, KEY_STATE_DOWN))
+	for (Int key = KEY_NONE + 1; key < KEY_COUNT; ++key)
 	{
-		GameMessage* msg = TheMessageStream->appendMessage(GameMessage::MSG_RAW_KEY_UP);
-		msg->appendIntegerArgument(KEY_LALT);
-		msg->appendIntegerArgument(KEY_STATE_UP);
-	}
-	if (BitIsSet(m_keyStatus[KEY_RALT].state, KEY_STATE_DOWN))
-	{
-		GameMessage* msg = TheMessageStream->appendMessage(GameMessage::MSG_RAW_KEY_UP);
-		msg->appendIntegerArgument(KEY_RALT);
-		msg->appendIntegerArgument(KEY_STATE_UP);
+		if (BitIsSet(m_keyStatus[key].state, KEY_STATE_DOWN))
+		{
+			GameMessage* msg = TheMessageStream->appendMessage(GameMessage::MSG_RAW_KEY_UP);
+			msg->appendIntegerArgument(key);
+			msg->appendIntegerArgument(KEY_STATE_UP);
+		}
 	}
 }
 


### PR DESCRIPTION
bugfix(input): Release all held keyboard keys on focus loss, not just Alt

Keyboard::resetKeys() (called from WM_KILLFOCUS) memset the low-level
key-state arrays but only ever synthesized MSG_RAW_KEY_UP for the ALT
keys (refreshAltKeys(), added for a prior stuck-waypoint-mode bug).
Held-key latches driven by the raw input message stream rather than
live keyboard state - LookAtXlat.cpp's scrollDir[] array (arrow-key
camera scroll) and force-attack mode (toggled by Ctrl down/up via
MetaEventTranslator) - never received their key-up, so they stayed
stuck active if focus was lost while a key was held (e.g. alt-tabbing
mid-scroll). Generalized the existing, already-proven mechanism from
Alt-only to every key still marked KEY_STATE_DOWN when resetKeys() runs.
Emitting up-events for keys already reset to released is monotonically
safe. Shared under Core/, covers both trees.

Fixes #2732, and the arrow-key/Ctrl symptoms in #2733 and #2734
(github.com/TheSuperHackers/GeneralsGameCode)

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude) by generalizing
an existing, already-shipped fix for the same bug class; human-reviewed
and build-verified.


---

