### PR TITLE
bugfix(input): Cancel stuck mouse-drag latches on focus loss

### DIFF
--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -58,6 +58,9 @@
 #include "GameClient/GameClient.h"
 #include "GameLogic/GameLogic.h"  ///< @todo for demo, remove
 #include "GameClient/Mouse.h"
+#include "GameClient/LookAtXlat.h"
+#include "GameClient/SelectionXlat.h"
+#include "GameClient/View.h"
 #include "GameClient/IMEManager.h"
 #include "Win32Device/GameClient/Win32Mouse.h"
 #include "Win32Device/Common/Win32GameEngine.h"
@@ -452,6 +455,45 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 						TheMouse->onCursorMovedOutside();
 					}
 				}
+
+				// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Windows delivers no mouse
+				// button-up events for buttons that were held when focus is lost (alt tab, or
+				// clicking outside the window while cursor lock is disabled), so mouse-drag
+				// gesture latches stayed stuck until the next matching button-up inside the
+				// window. Explicitly cancel each latch here with its existing cancellation
+				// path, rather than synthesizing fake button-up events, because a fake
+				// button-up would falsely confirm a real action (complete an area selection,
+				// or confirm a building placement) instead of harmlessly canceling it.
+				// (github.com/TheSuperHackers/GeneralsGameCode issues #2733, #2734, #2735)
+
+				// Cancel an in-progress RMB drag-scroll or MMB rotate/pitch of the camera.
+				if (TheLookAtTranslator)
+					TheLookAtTranslator->resetModes();
+
+				// Cancel an in-progress left-drag area selection. This mirrors the teardown
+				// GameWindow already performs when a drag-select ends on the control bar.
+				if (TheSelectionTranslator)
+				{
+					TheSelectionTranslator->setLeftMouseButton(FALSE);
+					TheSelectionTranslator->setDragSelecting(FALSE);
+
+					if (TheTacticalView)
+						TheTacticalView->setMouseLock( FALSE );
+
+					if (TheInGameUI)
+					{
+						TheInGameUI->setSelecting( FALSE );
+						TheInGameUI->endAreaSelectHint(nullptr);
+					}
+				}
+
+				// Unhook a building placement angle-drag anchor (left button held to rotate a
+				// building before placing it). This keeps the pending placement itself alive
+				// and mirrors the existing "unhook the anchor so they can try again" path in
+				// PlaceEventTranslator, so the next click starts a fresh anchor instead of
+				// being misinterpreted.
+				if (TheInGameUI)
+					TheInGameUI->setPlacementStart( nullptr );
 
 				break;
 			}

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -59,6 +59,9 @@
 #include "GameClient/GameClient.h"
 #include "GameLogic/GameLogic.h"  ///< @todo for demo, remove
 #include "GameClient/Mouse.h"
+#include "GameClient/LookAtXlat.h"
+#include "GameClient/SelectionXlat.h"
+#include "GameClient/View.h"
 #include "GameClient/IMEManager.h"
 #include "Win32Device/GameClient/Win32Mouse.h"
 #include "Win32Device/Common/Win32GameEngine.h"
@@ -454,6 +457,45 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 						TheMouse->onCursorMovedOutside();
 					}
 				}
+
+				// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Windows delivers no mouse
+				// button-up events for buttons that were held when focus is lost (alt tab, or
+				// clicking outside the window while cursor lock is disabled), so mouse-drag
+				// gesture latches stayed stuck until the next matching button-up inside the
+				// window. Explicitly cancel each latch here with its existing cancellation
+				// path, rather than synthesizing fake button-up events, because a fake
+				// button-up would falsely confirm a real action (complete an area selection,
+				// or confirm a building placement) instead of harmlessly canceling it.
+				// (github.com/TheSuperHackers/GeneralsGameCode issues #2733, #2734, #2735)
+
+				// Cancel an in-progress RMB drag-scroll or MMB rotate/pitch of the camera.
+				if (TheLookAtTranslator)
+					TheLookAtTranslator->resetModes();
+
+				// Cancel an in-progress left-drag area selection. This mirrors the teardown
+				// GameWindow already performs when a drag-select ends on the control bar.
+				if (TheSelectionTranslator)
+				{
+					TheSelectionTranslator->setLeftMouseButton(FALSE);
+					TheSelectionTranslator->setDragSelecting(FALSE);
+
+					if (TheTacticalView)
+						TheTacticalView->setMouseLock( FALSE );
+
+					if (TheInGameUI)
+					{
+						TheInGameUI->setSelecting( FALSE );
+						TheInGameUI->endAreaSelectHint(nullptr);
+					}
+				}
+
+				// Unhook a building placement angle-drag anchor (left button held to rotate a
+				// building before placing it). This keeps the pending placement itself alive
+				// and mirrors the existing "unhook the anchor so they can try again" path in
+				// PlaceEventTranslator, so the next click starts a fresh anchor instead of
+				// being misinterpreted.
+				if (TheInGameUI)
+					TheInGameUI->setPlacementStart( nullptr );
 
 				break;
 			}


### PR DESCRIPTION
bugfix(input): Cancel stuck mouse-drag latches on focus loss

Companion fix to the keyboard held-key fix above, for the mouse half of
the same bug family. Three latches could stay stuck if focus was lost
mid-gesture, since their corresponding mouse-up event never arrives
when the OS doesn't deliver it to an unfocused window:

- RMB camera drag (LookAtTranslator::m_isScrolling/SCROLL_RMB) -
  resetModes() is a pre-existing method documented as 'used when
  disabling input, so when we reenable it we aren't stuck in a mode',
  but only cleared flags, silently skipping the actual stopScrolling()
  teardown - itself a latent bug in resetModes()'s one existing caller
  (ScriptActions::doDisableInput). Fixed resetModes() to call
  stopScrolling() when scrolling, which is already proven safe to call
  out-of-gesture elsewhere (MSG_META_OPTIONS).
- Left-drag select-box (SelectionTranslator::m_dragSelecting /
  m_leftMouseButtonIsDown) - mirrors the exact external cancel pattern
  GameWindow.cpp's control-bar teardown already uses: clears the drag/
  selecting/mouse-lock flags without appending any selection message,
  so nothing gets falsely selected.
- Building placement anchor (InGameUI::setPlacementStart(nullptr)) -
  the engine's own existing 'unhook the anchor and let them retry'
  path (used elsewhere in PlaceEventTranslator.cpp), deliberately not
  a full placement cancel, so placement mode survives refocus and the
  next click starts a correctly-interpreted fresh anchor.

Deliberately does NOT synthesize fake mouse-up events (unlike the
keyboard fix) - doing so on these three latches would falsely CONFIRM
a real gameplay action (completing a selection or building placement)
instead of cancelling it. All three use pre-existing, proven-safe
cancellation primitives already exercised elsewhere in the codebase for
different callers. WinMain.cpp is per-tree; identical WM_KILLFOCUS
edits applied to both Generals and GeneralsMD. The three translator
files are shared under Core/.

Fixes the remaining RMB-drag, selection, and placement symptoms in
#2733, #2734, #2735 (github.com/TheSuperHackers/GeneralsGameCode)

--- AI disclosure ---
Root-caused and written with the help of an LLM (Claude), identifying
each latch's exact pre-existing safe cancellation primitive by finding
where it's already used elsewhere in the codebase for a different
caller, rather than inventing new teardown logic; human-reviewed and
build-verified in both trees.


---

