### PR TITLE
bugfix(gameclient): Unpause/unfreeze logic before starting next campaign mission

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -215,6 +215,21 @@ void startNextCampaignGame()
 			TheGameLogic->clearGameData();
 	}
 
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 The logic update must not be halted to
+	// process MSG_NEW_GAME, mirroring the identical fix already applied to GameLogic::exitGame().
+	// Without this, MSG_NEW_GAME can be silently dropped by processCommandList() if the game
+	// logic is paused or script-time-frozen when Continue/Play Again is clicked, since
+	// GameEngine::update() only runs GameLogic::update() while canUpdateGameLogic() is true, and
+	// GameLogic::update() itself early-returns on frozen time before reaching
+	// processCommandList(). (github.com/TheSuperHackers/GeneralsGameCode issue #2534)
+	if (TheGameLogic)
+		TheGameLogic->setGamePaused(FALSE);
+	if (TheScriptEngine)
+	{
+		TheScriptEngine->forceUnfreezeTime();
+		TheScriptEngine->doUnfreezeTime();
+	}
+
 	// send a message to the logic for a new game
 	GameMessage *msg = TheMessageStream->appendMessage( GameMessage::MSG_NEW_GAME );
 	msg->appendIntegerArgument(GAME_SINGLE_PLAYER);


### PR DESCRIPTION
bugfix(gameclient): Unpause/unfreeze logic before starting next campaign mission

MSG_NEW_GAME (appended by the Continue/Play Again button on the score
screen) is only processed by GameLogic::update() -> processCommandList(),
which is skipped entirely while the game logic is halted (paused) and
early-returns before reaching processCommandList() while script time is
frozen - silently dropping the message and leaving Continue/Play Again
appearing to do nothing. GameLogic::exitGame() already carries the
identical fix for the same bug class, with a comment explicitly noting
'the logic update must not be halted to process the game exit message' -
that fix was never applied to the Continue path. Mirrors it here.

Fixes #2534 (github.com/TheSuperHackers/GeneralsGameCode)

--- AI disclosure ---
Root-caused with the help of an LLM (Claude), which found the fix by
pattern-matching to an already-shipped fix for the identical bug class
in a sibling function rather than inventing a new mechanism; human-
reviewed and build-verified. Could not be visually confirmed end-to-end
(requires completing a mission) - worth confirming Continue actually
advances to the next mission in play.


---

