### PR TITLE
feat(gameengine): Add -startMission command-line flag to jump to any campaign mission

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -351,6 +351,11 @@ public:
 	Bool m_buildMapCache;
 	AsciiString m_initialFile;				///< If this is specified, load a specific map from the command-line
 	AsciiString m_pendingFile;				///< If this is specified, use this map at the next game start
+	// TheSuperHackers @feature ZsoltFeher 18/07/2026 Debug entry point to start any campaign mission
+	// directly, going through CampaignManager (unlike -file) so shellmap, intro, and mission
+	// progression state all remain correct.
+	AsciiString m_debugStartCampaign;	///< If this and m_debugStartMission are specified, jump to this campaign
+	AsciiString m_debugStartMission;		///< If this and m_debugStartCampaign are specified, jump to this mission
 
 	std::vector<AsciiString> m_simulateReplays; ///< If not empty, simulate this list of replays and exit.
 	Int m_simulateReplayJobs; ///< Maximum number of processes to use for simulation, or SIMULATE_REPLAYS_SEQUENTIAL for sequential simulation

--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -689,6 +689,19 @@ Int parseFile(char *args[], int num)
 	return 2;
 }
 
+// TheSuperHackers @feature ZsoltFeher 18/07/2026 Jumps directly to a specific campaign mission
+// via CampaignManager, unlike -file this keeps shellmap/intro/progression state correct so the
+// mission's own cutscenes and "next mission" transition behave exactly as in normal play.
+Int parseStartMission(char *args[], int num)
+{
+	if (num > 2)
+	{
+		TheWritableGlobalData->m_debugStartCampaign = args[1];
+		TheWritableGlobalData->m_debugStartMission = args[2];
+	}
+	return 3;
+}
+
 
 Int parsePreloadEverything( char *args[], int num )
 {
@@ -1254,6 +1267,7 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-munkee", parseMunkee },
 	{ "-displayDebug", parseDisplayDebug },
 	{ "-file", parseFile },
+	{ "-startMission", parseStartMission }, // TheSuperHackers @feature Jump to any campaign mission via CampaignManager.
 
 //	{ "-preload", parsePreload },
 

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -83,6 +83,7 @@
 #include "GameLogic/ScriptEngine.h"
 #include "GameLogic/SidesList.h"
 
+#include "GameClient/CampaignManager.h"
 #include "GameClient/ClientInstance.h"
 #include "GameClient/FXList.h"
 #include "GameClient/GameClient.h"
@@ -560,6 +561,24 @@ void GameEngine::init()
 				GameMessage *msg = TheMessageStream->appendMessage( GameMessage::MSG_NEW_GAME );
 				msg->appendIntegerArgument(GAME_SINGLE_PLAYER);
 				msg->appendIntegerArgument(DIFFICULTY_NORMAL);
+				msg->appendIntegerArgument(0);
+				InitRandom(0);
+			}
+		}
+
+		// TheSuperHackers @feature ZsoltFeher 18/07/2026 Jump directly to any campaign mission via
+		// CampaignManager, so shellmap, intro, and mission progression state all remain correct
+		// (unlike -file, which bypasses CampaignManager entirely).
+		if (TheGlobalData->m_debugStartMission.isEmpty() == FALSE && TheCampaignManager)
+		{
+			TheCampaignManager->setCampaignAndMission(TheGlobalData->m_debugStartCampaign, TheGlobalData->m_debugStartMission);
+			if (TheCampaignManager->getCurrentMission())
+			{
+				TheWritableGlobalData->m_pendingFile = TheCampaignManager->getCurrentMap();
+
+				GameMessage *msg = TheMessageStream->appendMessage( GameMessage::MSG_NEW_GAME );
+				msg->appendIntegerArgument(GAME_SINGLE_PLAYER);
+				msg->appendIntegerArgument(TheCampaignManager->getGameDifficulty());
 				msg->appendIntegerArgument(0);
 				InitRandom(0);
 			}

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -403,6 +403,30 @@ void GameEngine::init()
 		// special-case: parse command-line parameters after loading global data
 		CommandLine::parseCommandLineForEngineInit();
 
+		// TheSuperHackers @feature ZsoltFeher 18/07/2026 Skip the EA/SuperHackers boot trailer
+		// when jumping straight to a mission via -startMission, since it would otherwise still
+		// be playing when the mission's map load (queued further below) tries to start. This is
+		// unrelated to the mission's own scripted intro cutscene (IntroMovie=...), which is a
+		// separate, later mechanism unaffected by this flag. TheGameClient (and thus the Intro
+		// object, which reads m_playIntro in its constructor) is not created until later, so this
+		// must be set here rather than alongside the rest of the -startMission handling below.
+		// The Sizzle promotional movie must be skipped as well: once the mission's load screen
+		// activates, m_loadScreenRender suppresses fullscreen movie rendering in W3DDisplay::draw,
+		// so the Sizzle would play invisibly (audio only) while TheDisplay->isMoviePlaying() blocks
+		// the deferred map load in GameLogic::update for the movie's entire duration.
+		// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Also disable the animated shell map
+		// background, mirroring -file (see the -file block further below). Shell::showShell()'s
+		// own Menus/MainMenu.wnd push (see GameClient.cpp) only fires while m_shellMapOn is FALSE;
+		// leaving it TRUE means nothing ever seeds the shell screen stack, so later exiting a
+		// -startMission game back to the main menu pops the only screen on the stack and leaves
+		// a permanently blank, menu-less shell for the rest of the session.
+		if (TheGlobalData->m_debugStartMission.isEmpty() == FALSE)
+		{
+			TheWritableGlobalData->m_playIntro = FALSE;
+			TheWritableGlobalData->m_playSizzle = FALSE;
+			TheWritableGlobalData->m_shellMapOn = FALSE;
+		}
+
 		TheArchiveFileSystem->loadMods();
 
 		// doesn't require resets so just create a single instance here.
@@ -581,6 +605,15 @@ void GameEngine::init()
 				msg->appendIntegerArgument(TheCampaignManager->getGameDifficulty());
 				msg->appendIntegerArgument(0);
 				InitRandom(0);
+			}
+			else
+			{
+				// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 If the campaign/mission name
+				// could not be resolved (e.g. a typo), clear these so the Shell.cpp guards that
+				// key off m_debugStartMission fall back to the normal main menu instead of
+				// leaving the player on a blank screen with no menu and no mission.
+				TheWritableGlobalData->m_debugStartCampaign.clear();
+				TheWritableGlobalData->m_debugStartMission.clear();
 			}
 		}
 

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -987,6 +987,8 @@ GlobalData::GlobalData()
 	m_buildMapCache = FALSE;
 	m_initialFile.clear();
 	m_pendingFile.clear();
+	m_debugStartCampaign.clear();
+	m_debugStartMission.clear();
 
 	m_simulateReplays.clear();
 	m_simulateReplayJobs = SIMULATE_REPLAYS_SEQUENTIAL;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -466,7 +466,9 @@ void Shell::showShell( Bool runInit )
 {
 	DEBUG_LOG(("Shell:showShell() - %s (%s)", TheGlobalData->m_initialFile.str(), (top())?top()->getFilename().str():"no top screen"));
 
-	if(!TheGlobalData->m_initialFile.isEmpty() || !TheGlobalData->m_simulateReplays.empty())
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 -startMission must skip the main menu push
+	// just like -file does, or the requested mission is followed by an interactive main menu.
+	if(!TheGlobalData->m_initialFile.isEmpty() || !TheGlobalData->m_debugStartMission.isEmpty() || !TheGlobalData->m_simulateReplays.empty())
 	{
 		return;
 	}
@@ -523,7 +525,8 @@ void Shell::showShell( Bool runInit )
 void Shell::showShellMap(Bool useShellMap )
 {
 	// we don't want any of this to show if we're loading straight into a file
-	if (TheGlobalData->m_initialFile.isNotEmpty() || !TheGameLogic || !TheGlobalData->m_simulateReplays.empty())
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Same applies to -startMission.
+	if (TheGlobalData->m_initialFile.isNotEmpty() || TheGlobalData->m_debugStartMission.isNotEmpty() || !TheGameLogic || !TheGlobalData->m_simulateReplays.empty())
 		return;
 	if(useShellMap && TheGlobalData->m_shellMapOn)
 	{

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -515,6 +515,35 @@ void GameClient::update()
 
 			TheShell->showShellMap(TRUE);
 			TheShell->showShell();
+
+			// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 With -startMission the two shell calls
+			// above are suppressed (see Shell::showShell), so MainMenuInit never runs and never
+			// clears m_breakTheMovie, which Intro::doPostIntro just set. Left set, it disables the
+			// entire render block in W3DDisplay::draw forever, freezing the screen on the last
+			// presented frame while audio keeps playing. Clear it here, and consume the
+			// -startMission fields so the shell behaves normally again afterwards
+			// (e.g. score screen and menus once the mission ends).
+			if (TheGlobalData->m_debugStartMission.isNotEmpty())
+			{
+				TheWritableGlobalData->m_breakTheMovie = FALSE;
+				TheWritableGlobalData->m_debugStartCampaign.clear();
+				TheWritableGlobalData->m_debugStartMission.clear();
+
+				// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Because the two shell calls above
+				// were suppressed, Menus/MainMenu.wnd was never pushed onto the (still empty) shell
+				// screen stack the way it would be on a normal boot. That leaves the shell with
+				// nothing to fall back on: later, when the player exits the mission back to the
+				// main menu, GameLogic::clearGameData() pushes Menus/ScoreScreen.wnd on top and its
+				// "OK" button just pops the top of the stack -- popping the ONLY screen leaves a
+				// permanently blank, menu-less shell for the rest of the session. Re-invoke
+				// showShell() now that the guard fields above are cleared and m_shellMapOn was
+				// forced FALSE at boot (see GameEngine::init), so it pushes Menus/MainMenu.wnd
+				// here. It gets hidden again a few lines later this same frame by
+				// GameLogic::prepareNewGame()'s TheShell->hideShell() call (run during
+				// TheMessageStream->propagateMessages(), which happens after GameClient::update()
+				// returns), so it is never actually drawn.
+				TheShell->showShell();
+			}
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
@@ -272,6 +272,12 @@ void CampaignManager::setCampaignAndMission( AsciiString campaign, AsciiString m
 	CampaignListIt it;
 	it = m_campaignList.begin();
 	campaign.toLower();
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Mission names are stored lowercased by
+	// Campaign::newMission(), but this lookup compared against the caller's original casing
+	// (case-sensitive AsciiString::compare in Campaign::getMission()), so any caller passing
+	// mission names as they appear in Campaign.ini (e.g. "Mission05") would silently fail to
+	// find the mission.
+	mission.toLower();
 	while	( it != m_campaignList.end())
 	{
 		Campaign *camp = *it;

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -352,6 +352,11 @@ public:
 	Bool m_buildMapCache;
 	AsciiString m_initialFile;				///< If this is specified, load a specific map from the command-line
 	AsciiString m_pendingFile;				///< If this is specified, use this map at the next game start
+	// TheSuperHackers @feature ZsoltFeher 18/07/2026 Debug entry point to start any campaign mission
+	// directly, going through CampaignManager (unlike -file) so shellmap, intro, and mission
+	// progression state all remain correct.
+	AsciiString m_debugStartCampaign;	///< If this and m_debugStartMission are specified, jump to this campaign
+	AsciiString m_debugStartMission;		///< If this and m_debugStartCampaign are specified, jump to this mission
 
 	std::vector<AsciiString> m_simulateReplays; ///< If not empty, simulate this list of replays and exit.
 	Int m_simulateReplayJobs; ///< Maximum number of processes to use for simulation, or SIMULATE_REPLAYS_SEQUENTIAL for sequential simulation

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -671,14 +671,7 @@ Int parsePreload( char *args[], int num )
 #endif
 
 
-#if defined(RTS_DEBUG)
-Int parseDisplayDebug(char *args[], int)
-{
-	TheWritableGlobalData->m_displayDebug = TRUE;
-
-	return 1;
-}
-
+// TheSuperHackers @tweak Now available in Release builds so a map can be launched from the command line.
 Int parseFile(char *args[], int num)
 {
 	if (num > 1)
@@ -687,6 +680,27 @@ Int parseFile(char *args[], int num)
 		ConvertShortMapPathToLongMapPath(TheWritableGlobalData->m_initialFile);
 	}
 	return 2;
+}
+
+// TheSuperHackers @feature ZsoltFeher 18/07/2026 Jumps directly to a specific campaign mission
+// via CampaignManager, unlike -file this keeps shellmap/intro/progression state correct so the
+// mission's own cutscenes and "next mission" transition behave exactly as in normal play.
+Int parseStartMission(char *args[], int num)
+{
+	if (num > 2)
+	{
+		TheWritableGlobalData->m_debugStartCampaign = args[1];
+		TheWritableGlobalData->m_debugStartMission = args[2];
+	}
+	return 3;
+}
+
+#if defined(RTS_DEBUG)
+Int parseDisplayDebug(char *args[], int)
+{
+	TheWritableGlobalData->m_displayDebug = TRUE;
+
+	return 1;
 }
 
 
@@ -1148,6 +1162,8 @@ static CommandLineParam paramsForEngineInit[] =
 {
 	{ "-nologo", parseNoLogo }, // TheSuperHackers @tweak Is now available in Release builds.
 	{ "-noshellmap", parseNoShellMap },
+	{ "-file", parseFile }, // TheSuperHackers @tweak Is now available in Release builds.
+	{ "-startMission", parseStartMission }, // TheSuperHackers @feature Jump to any campaign mission via CampaignManager.
 	{ "-noShellAnim", parseNoWindowAnimation }, // TheSuperHackers @tweak Is now available in Release builds.
 	{ "-xres", parseXRes },
 	{ "-yres", parseYRes },
@@ -1253,7 +1269,6 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-jabber", parseJabber },
 	{ "-munkee", parseMunkee },
 	{ "-displayDebug", parseDisplayDebug },
-	{ "-file", parseFile },
 
 //	{ "-preload", parsePreload },
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -473,6 +473,30 @@ void GameEngine::init()
 		// special-case: parse command-line parameters after loading global data
 		CommandLine::parseCommandLineForEngineInit();
 
+		// TheSuperHackers @feature ZsoltFeher 18/07/2026 Skip the EA/SuperHackers boot trailer
+		// when jumping straight to a mission via -startMission, since it would otherwise still
+		// be playing when the mission's map load (queued further below) tries to start. This is
+		// unrelated to the mission's own scripted intro cutscene (IntroMovie=...), which is a
+		// separate, later mechanism unaffected by this flag. TheGameClient (and thus the Intro
+		// object, which reads m_playIntro in its constructor) is not created until later, so this
+		// must be set here rather than alongside the rest of the -startMission handling below.
+		// The Sizzle promotional movie must be skipped as well: once the mission's load screen
+		// activates, m_loadScreenRender suppresses fullscreen movie rendering in W3DDisplay::draw,
+		// so the Sizzle would play invisibly (audio only) while TheDisplay->isMoviePlaying() blocks
+		// the deferred map load in GameLogic::update for the movie's entire duration.
+		// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Also disable the animated shell map
+		// background, mirroring -file (see the -file block further below). Shell::showShell()'s
+		// own Menus/MainMenu.wnd push (see GameClient.cpp) only fires while m_shellMapOn is FALSE;
+		// leaving it TRUE means nothing ever seeds the shell screen stack, so later exiting a
+		// -startMission game back to the main menu pops the only screen on the stack and leaves
+		// a permanently blank, menu-less shell for the rest of the session.
+		if (TheGlobalData->m_debugStartMission.isEmpty() == FALSE)
+		{
+			TheWritableGlobalData->m_playIntro = FALSE;
+			TheWritableGlobalData->m_playSizzle = FALSE;
+			TheWritableGlobalData->m_shellMapOn = FALSE;
+		}
+
 		TheArchiveFileSystem->loadMods();
 
 		// doesn't require resets so just create a single instance here.
@@ -748,6 +772,15 @@ void GameEngine::init()
 				msg->appendIntegerArgument(TheCampaignManager->getGameDifficulty());
 				msg->appendIntegerArgument(0);
 				InitRandom(0);
+			}
+			else
+			{
+				// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 If the campaign/mission name
+				// could not be resolved (e.g. a typo), clear these so the Shell.cpp guards that
+				// key off m_debugStartMission fall back to the normal main menu instead of
+				// leaving the player on a blank screen with no menu and no mission.
+				TheWritableGlobalData->m_debugStartCampaign.clear();
+				TheWritableGlobalData->m_debugStartMission.clear();
 			}
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -85,6 +85,7 @@
 #include "GameLogic/ScriptEngine.h"
 #include "GameLogic/SidesList.h"
 
+#include "GameClient/CampaignManager.h"
 #include "GameClient/ClientInstance.h"
 #include "GameClient/FXList.h"
 #include "GameClient/GameClient.h"
@@ -727,6 +728,24 @@ void GameEngine::init()
 				GameMessage *msg = TheMessageStream->appendMessage( GameMessage::MSG_NEW_GAME );
 				msg->appendIntegerArgument(GAME_SINGLE_PLAYER);
 				msg->appendIntegerArgument(DIFFICULTY_NORMAL);
+				msg->appendIntegerArgument(0);
+				InitRandom(0);
+			}
+		}
+
+		// TheSuperHackers @feature ZsoltFeher 18/07/2026 Jump directly to any campaign mission via
+		// CampaignManager, so shellmap, intro, and mission progression state all remain correct
+		// (unlike -file, which bypasses CampaignManager entirely).
+		if (TheGlobalData->m_debugStartMission.isEmpty() == FALSE && TheCampaignManager)
+		{
+			TheCampaignManager->setCampaignAndMission(TheGlobalData->m_debugStartCampaign, TheGlobalData->m_debugStartMission);
+			if (TheCampaignManager->getCurrentMission())
+			{
+				TheWritableGlobalData->m_pendingFile = TheCampaignManager->getCurrentMap();
+
+				GameMessage *msg = TheMessageStream->appendMessage( GameMessage::MSG_NEW_GAME );
+				msg->appendIntegerArgument(GAME_SINGLE_PLAYER);
+				msg->appendIntegerArgument(TheCampaignManager->getGameDifficulty());
 				msg->appendIntegerArgument(0);
 				InitRandom(0);
 			}

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -994,6 +994,8 @@ GlobalData::GlobalData()
 	m_buildMapCache = FALSE;
 	m_initialFile.clear();
 	m_pendingFile.clear();
+	m_debugStartCampaign.clear();
+	m_debugStartMission.clear();
 
 	m_simulateReplays.clear();
 	m_simulateReplayJobs = SIMULATE_REPLAYS_SEQUENTIAL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -466,7 +466,9 @@ void Shell::showShell( Bool runInit )
 {
 	DEBUG_LOG(("Shell:showShell() - %s (%s)", TheGlobalData->m_initialFile.str(), (top())?top()->getFilename().str():"no top screen"));
 
-	if(!TheGlobalData->m_initialFile.isEmpty() || !TheGlobalData->m_simulateReplays.empty())
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 -startMission must skip the main menu push
+	// just like -file does, or the requested mission is followed by an interactive main menu.
+	if(!TheGlobalData->m_initialFile.isEmpty() || !TheGlobalData->m_debugStartMission.isEmpty() || !TheGlobalData->m_simulateReplays.empty())
 	{
 		return;
 	}
@@ -528,7 +530,8 @@ void Shell::showShell( Bool runInit )
 void Shell::showShellMap(Bool useShellMap )
 {
 	// we don't want any of this to show if we're loading straight into a file
-	if (TheGlobalData->m_initialFile.isNotEmpty() || !TheGameLogic || !TheGlobalData->m_simulateReplays.empty())
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Same applies to -startMission.
+	if (TheGlobalData->m_initialFile.isNotEmpty() || TheGlobalData->m_debugStartMission.isNotEmpty() || !TheGameLogic || !TheGlobalData->m_simulateReplays.empty())
 		return;
 	if(useShellMap && TheGlobalData->m_shellMapOn)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -536,6 +536,35 @@ void GameClient::update()
 
 			TheShell->showShellMap(TRUE);
 			TheShell->showShell();
+
+			// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 With -startMission the two shell calls
+			// above are suppressed (see Shell::showShell), so MainMenuInit never runs and never
+			// clears m_breakTheMovie, which Intro::doPostIntro just set. Left set, it disables the
+			// entire render block in W3DDisplay::draw forever, freezing the screen on the last
+			// presented frame while audio keeps playing. Clear it here, and consume the
+			// -startMission fields so the shell behaves normally again afterwards
+			// (e.g. score screen and menus once the mission ends).
+			if (TheGlobalData->m_debugStartMission.isNotEmpty())
+			{
+				TheWritableGlobalData->m_breakTheMovie = FALSE;
+				TheWritableGlobalData->m_debugStartCampaign.clear();
+				TheWritableGlobalData->m_debugStartMission.clear();
+
+				// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Because the two shell calls above
+				// were suppressed, Menus/MainMenu.wnd was never pushed onto the (still empty) shell
+				// screen stack the way it would be on a normal boot. That leaves the shell with
+				// nothing to fall back on: later, when the player exits the mission back to the
+				// main menu, GameLogic::clearGameData() pushes Menus/ScoreScreen.wnd on top and its
+				// "OK" button just pops the top of the stack -- popping the ONLY screen leaves a
+				// permanently blank, menu-less shell for the rest of the session. Re-invoke
+				// showShell() now that the guard fields above are cleared and m_shellMapOn was
+				// forced FALSE at boot (see GameEngine::init), so it pushes Menus/MainMenu.wnd
+				// here. It gets hidden again a few lines later this same frame by
+				// GameLogic::prepareNewGame()'s TheShell->hideShell() call (run during
+				// TheMessageStream->propagateMessages(), which happens after GameClient::update()
+				// returns), so it is never actually drawn.
+				TheShell->showShell();
+			}
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
@@ -280,6 +280,12 @@ void CampaignManager::setCampaignAndMission( AsciiString campaign, AsciiString m
 	CampaignListIt it;
 	it = m_campaignList.begin();
 	campaign.toLower();
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Mission names are stored lowercased by
+	// Campaign::newMission(), but this lookup compared against the caller's original casing
+	// (case-sensitive AsciiString::compare in Campaign::getMission()), so any caller passing
+	// mission names as they appear in Campaign.ini (e.g. "Mission05") would silently fail to
+	// find the mission.
+	mission.toLower();
 	while	( it != m_campaignList.end())
 	{
 		Campaign *camp = *it;


### PR DESCRIPTION
feat(gameengine): Add -startMission command-line flag to jump to any campaign mission

Adds a new -startMission <campaign> <mission> flag that goes through
TheCampaignManager->setCampaignAndMission() before dispatching
MSG_NEW_GAME, mirroring the exact flow already used by
startNextCampaignGame() (ScoreScreen.cpp) when continuing after a
mission.

Unlike the existing -file flag, which sets m_pendingFile directly and
disables the shellmap/intro entirely, this keeps CampaignManager state
correct: the mission's own intro cutscene plays normally, the shellmap
background keeps animating, and mission-complete/next-mission
transitions and save-game descriptions (which read
getCurrentMissionNumber()/getCurrentMap()) all behave as in normal
campaign progression.

Implemented in both Generals and GeneralsMD trees (CampaignManager and
GlobalData are per-tree, not shared via Core/).

AI-assisted change: implemented with Claude Code (Anthropic).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

bugfix(gameengine): Fix -startMission menu skip, boot race, and exit-to-menu freeze

Four issues surfaced while making -startMission actually usable
end-to-end, all fixed in both Generals and GeneralsMD trees:

1. Shell::showShell()/showShellMap() only checked m_initialFile (the
   -file flag) to decide whether to skip pushing Menus/MainMenu.wnd
   after the boot trailer, so -startMission was silently followed by
   an interactive main menu instead of the requested mission. Added
   the equivalent m_debugStartMission checks.

2. CampaignManager::setCampaignAndMission() lowercased the campaign
   name before comparing but never lowercased the mission name, while
   Campaign::getMission() does a case-sensitive compare against names
   Campaign::newMission() stores lowercased. Mission names as they
   appear in Campaign.ini (e.g. Mission05) never matched, silently
   failing the lookup. This is a real, pre-existing engine bug beyond
   -startMission's own use of this API (also used by save-game load).

3. Leaving m_playIntro/m_playSizzle untouched meant the EA/SuperHackers
   splash and Sizzle promotional movie both still played after
   -startMission had already queued the mission's MSG_NEW_GAME. Once
   the mission's load screen activated, m_loadScreenRender suppressed
   fullscreen movie rendering, so the Sizzle kept playing invisibly
   (audio only) while TheDisplay->isMoviePlaying() blocked the
   deferred map load in GameLogic::update for its entire duration.
   When Intro::doPostIntro() then set m_breakTheMovie (normally
   cleared by MainMenuInit, which never got a chance to run because
   fix #1 suppresses the main menu for -startMission), rendering
   stayed permanently disabled in W3DDisplay::draw: screen frozen on
   the last frame, audio still looping, process unresponsive. Fixed
   by skipping both movies for -startMission and clearing
   m_breakTheMovie once the (now near-instant) boot Intro finishes.

4. Because Shell::showShell()/showShellMap() were suppressed at boot
   (fix #1) and m_shellMapOn was left TRUE, nothing ever pushed
   Menus/MainMenu.wnd onto the shell's screen stack the way normal
   boot does. Exiting a -startMission game back to the main menu made
   GameLogic::clearGameData() push Menus/ScoreScreen.wnd on top, and
   its OK button popped the only screen on the stack, leaving a
   permanently blank, menu-less shell for the rest of the session.
   Fixed by forcing m_shellMapOn = FALSE for -startMission (mirroring
   -file) and re-invoking showShell() once boot's Intro finishes and
   the guard fields are cleared, seeding MainMenu.wnd hidden at the
   base of the stack exactly as normal boot would. It is hidden again
   the same frame by prepareNewGame()'s hideShell() once the mission's
   MSG_NEW_GAME is dispatched, so it never visibly flashes.

Verified end-to-end by the human user: -startMission USA Mission05
now skips straight to the mission's own intro FMV and gameplay with
no boot trailer or menu in between, and Exit to Main Menu correctly
returns to the interactive main menu afterward.

AI-assisted change: root causes for issues #3 and #4 were found and
fixed by an AI agent (Claude, via Claude Code) after manual live
testing surfaced each symptom in turn; issues #1 and #2 were
implemented directly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

