### PR TITLE
bugfix(texture): Fix black terrain/props/vegetation at lowest texture resolution

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
@@ -201,7 +201,10 @@ void W3DGameClient::setTextureLOD( Int level )
 {
 	if (WW3D::Get_Texture_Reduction() != level)
 	{
-		WW3D::Set_Texture_Reduction(level, 6);
+		// TheSuperHackers @bugfix Since the WW3D2 texture code merge, the second argument is a
+		// minimum texture dimension in pixels (as in Zero Hour), no longer a minimum mip level
+		// count. Passing the legacy value 6 over-reduced small textures. Use 32 to match Zero Hour.
+		WW3D::Set_Texture_Reduction(level, 32);
 
 		//I commented this out because we're no longer using terrain LOD.  So I
 		//stole this function and keys to adjust the texture resolution instead. -MW

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
@@ -98,15 +98,6 @@ DDSFileClass::DDSFileClass(const char* name,unsigned reduction_factor)
 	MipLevels=SurfaceDesc.MipMapCount;
 	if (MipLevels==0) MipLevels=1;
 
-	//Adjust the reduction factor to keep textures above some minimum dimensions
-	if (MipLevels <= WW3D::Get_Texture_Min_Dimension())
-		ReductionFactor=0;
-	else
-	{	int mipToDrop=MipLevels-WW3D::Get_Texture_Min_Dimension();
-		if (ReductionFactor >= mipToDrop)
-			ReductionFactor=mipToDrop;
-	}
-
 	if (MipLevels>ReductionFactor) MipLevels-=ReductionFactor;
 	else {
 		MipLevels=1;
@@ -183,15 +174,6 @@ DDSFileClass::DDSFileClass(const char* name,unsigned reduction_factor)
 		if (MipLevels>2)
 			CubeFaceSize+=16;
 	}
-	// Verify we read through the whole file (not more, not less).
-#if 0
-	// This code is commented out because it complains for all our files, but it doesn't seem to actually
-	// be a problem. The new version of ddsfile from Vegas actually has removed this check entirely.
-	int expected_size=level_offset+SurfaceDesc.Size+4;
-	if (expected_size!=file->Size()) {
-		WWDEBUG_SAY(("Warning: file % size is not consistent with the data (file size should be %d but was %d)",Name,expected_size,file->Size()));
-	}
-#endif
 	file->Close();
 }
 
@@ -521,10 +503,6 @@ void DDSFileClass::Copy_Level_To_Surface
 					WWDEBUG_SAY(("Warning: DXT1 format should not contain alpha information - file %s",Name));
 				}
 			}
-		}
-		// TODO: Scaling not handled...
-		else {
-			//int a=0;
 		}
 	}
 }


### PR DESCRIPTION
bugfix(texture): Fix black terrain/props/vegetation at lowest texture resolution in Generals

Fixes GitHub issue #2787 (Critical).

Root cause: PR #1989 moved the Zero Hour texture loader
(textureloader.cpp, texture.cpp) into shared Core/, but left
ddsfile.cpp duplicated per-tree. The Generals copy still contained
logic written for the old, pre-merge loader's semantics.

W3DGameClient::setTextureLOD() calls WW3D::Set_Texture_Reduction(level,
minDim); Generals passed minDim=6, Zero Hour passes 32. Under the old
Generals engine this argument meant "minimum number of mip levels to
keep"; under the merged Zero Hour code (now shared in Core/) it means
"minimum texture dimension in pixels".

The shared Core loader (textureloader.cpp) computes a reduction factor
from the current texture resolution setting, creates the D3D texture
at the reduced size, and constructs DDSFileClass(path, reduction)
expecting the DDS reader to honor that exact reduction. The Generals
ddsfile.cpp constructor then re-clamped that reduction with a stale,
units-mismatched rule: mip level count (a small integer, typically
under 10) compared directly against what is now a pixel-dimension
floor (6, later 32) -- so almost every texture's mip count was <= the
floor and its ReductionFactor got silently forced to 0. That produced
a source/destination size mismatch in Copy_Level_To_Surface, whose
size-mismatch branch was an empty else{} (a pre-existing "scaling not
handled" TODO) that copies nothing, leaving a locked, uninitialized
D3D surface: opaque terrain/props render black, alpha-tested
vegetation renders as fully transparent (i.e. disappears).

Fix:
1. ddsfile.cpp: removed the stale reduction re-clamp (and unrelated
   dead/commented-out code alongside it), syncing this file to be
   identical to the already-correct GeneralsMD copy.
2. W3DGameClient.cpp: Set_Texture_Reduction's second argument changed
   from 6 to 32 to match the new pixel-dimension semantics, mirroring
   Zero Hour's equivalent call exactly.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, including git-blame/history analysis of PR #1989 to
identify the exact regression.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

