### PR TITLE
bugfix(saveload): Fix silent crash loading old saves under RETAIL_COMPATIBLE_XFER_SAVE=0

### DIFF
--- a/Core/GameEngine/Source/GameLogic/System/Damage.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/Damage.cpp
@@ -153,7 +153,11 @@ void DamageInfoInput::xfer( Xfer *xfer )
 	xfer->xferReal( &m_amount );
 
 	// kill no matter what (old versions default to FALSE).
-	if( currentVersion >= 2 )
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Test against the version read from the save file,
+	// not the current version, otherwise a Generals build with RETAIL_COMPATIBLE_XFER_SAVE disabled
+	// reads data that is not present in a version 1 save file, corrupting the remainder of the load.
+	// Zero Hour is unaffected because it always saved version 3.
+	if( version >= 2 )
 	{
 		xfer->xferBool( &m_kill );
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2496,7 +2496,10 @@ void DozerAIUpdate::xfer( Xfer *xfer )
 	xfer->xferSnapshot(m_dozerMachine);
 	xfer->xferUser(&m_currentTask, sizeof(m_currentTask));
 
-	if (currentVersion >= 2)
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Test against the version read from the save file,
+	// not the current version, otherwise a build with RETAIL_COMPATIBLE_XFER_SAVE disabled reads data
+	// that is not present in a version 1 save file, corrupting the remainder of the load.
+	if (version >= 2)
 	{
 		xfer->xferUser(&m_previousTask, sizeof(m_previousTask));
 		xfer->xferUser(&m_previousTaskInfo, sizeof(m_previousTaskInfo));

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -1463,7 +1463,10 @@ void WorkerAIUpdate::xfer( Xfer *xfer )
 	xfer->xferSnapshot(m_dozerMachine);
 	xfer->xferUser(&m_currentTask, sizeof(m_currentTask));
 
-	if (currentVersion >= 2)
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Test against the version read from the save file,
+	// not the current version, otherwise a build with RETAIL_COMPATIBLE_XFER_SAVE disabled reads data
+	// that is not present in a version 1 save file, corrupting the remainder of the load.
+	if (version >= 2)
 	{
 		xfer->xferUser(&m_previousTask, sizeof(m_previousTask));
 		xfer->xferUser(&m_previousTaskInfo, sizeof(m_previousTaskInfo));

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2283,7 +2283,30 @@ void GameLogic::processDestroyList()
 		{
 			// have to re-get idx each time since each call to erase might change others.
 			Int idx = sleepyUpdatesForThisObject[numSUO]->friend_getIndexInLogic();
-			DEBUG_ASSERTCRASH(m_sleepyUpdates[idx] == sleepyUpdatesForThisObject[numSUO], ("Hmm, expected update mismatch here"));
+
+			// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Look up the module's real position when its cached
+			// index is invalid, instead of indexing the vector out of bounds. When a save game load fails after
+			// objects were already created, UpdateModule::xfer has reset the indices to -1 but
+			// GameLogic::loadPostProcess never ran to rebuild them, so the modules still sit in m_sleepyUpdates
+			// with stale indices. The out of bounds access then crashed the game in the load failure cleanup
+			// before it could show the load error message to the user.
+			const Int sleepyCount = m_sleepyUpdates.size();
+			if (idx < 0 || idx >= sleepyCount || m_sleepyUpdates[idx] != sleepyUpdatesForThisObject[numSUO])
+			{
+				idx = -1;
+				for (Int search = 0; search < sleepyCount; ++search)
+				{
+					if (m_sleepyUpdates[search] == sleepyUpdatesForThisObject[numSUO])
+					{
+						idx = search;
+						break;
+					}
+				}
+				DEBUG_ASSERTCRASH(idx != -1, ("Hmm, expected to find the sleepy update module here"));
+				if (idx == -1)
+					continue;
+			}
+
 			eraseSleepyUpdate(idx);
 			DEBUG_ASSERTCRASH(sleepyUpdatesForThisObject[numSUO]->friend_getIndexInLogic() == -1, ("Hmm, expected index to be -1 here"));
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2508,7 +2508,10 @@ void DozerAIUpdate::xfer( Xfer *xfer )
 	xfer->xferSnapshot(m_dozerMachine);
 	xfer->xferUser(&m_currentTask, sizeof(m_currentTask));
 
-	if (currentVersion >= 2)
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Test against the version read from the save file,
+	// not the current version, otherwise a build with RETAIL_COMPATIBLE_XFER_SAVE disabled reads data
+	// that is not present in a version 1 save file, corrupting the remainder of the load.
+	if (version >= 2)
 	{
 		xfer->xferUser(&m_previousTask, sizeof(m_previousTask));
 		xfer->xferUser(&m_previousTaskInfo, sizeof(m_previousTaskInfo));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -1473,7 +1473,10 @@ void WorkerAIUpdate::xfer( Xfer *xfer )
 	xfer->xferSnapshot(m_dozerMachine);
 	xfer->xferUser(&m_currentTask, sizeof(m_currentTask));
 
-	if (currentVersion >= 2)
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Test against the version read from the save file,
+	// not the current version, otherwise a build with RETAIL_COMPATIBLE_XFER_SAVE disabled reads data
+	// that is not present in a version 1 save file, corrupting the remainder of the load.
+	if (version >= 2)
 	{
 		xfer->xferUser(&m_previousTask, sizeof(m_previousTask));
 		xfer->xferUser(&m_previousTaskInfo, sizeof(m_previousTaskInfo));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2604,7 +2604,30 @@ void GameLogic::processDestroyList()
 		{
 			// have to re-get idx each time since each call to erase might change others.
 			Int idx = sleepyUpdatesForThisObject[numSUO]->friend_getIndexInLogic();
-			DEBUG_ASSERTCRASH(m_sleepyUpdates[idx] == sleepyUpdatesForThisObject[numSUO], ("Hmm, expected update mismatch here"));
+
+			// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Look up the module's real position when its cached
+			// index is invalid, instead of indexing the vector out of bounds. When a save game load fails after
+			// objects were already created, UpdateModule::xfer has reset the indices to -1 but
+			// GameLogic::loadPostProcess never ran to rebuild them, so the modules still sit in m_sleepyUpdates
+			// with stale indices. The out of bounds access then crashed the game in the load failure cleanup
+			// before it could show the load error message to the user.
+			const Int sleepyCount = m_sleepyUpdates.size();
+			if (idx < 0 || idx >= sleepyCount || m_sleepyUpdates[idx] != sleepyUpdatesForThisObject[numSUO])
+			{
+				idx = -1;
+				for (Int search = 0; search < sleepyCount; ++search)
+				{
+					if (m_sleepyUpdates[search] == sleepyUpdatesForThisObject[numSUO])
+					{
+						idx = search;
+						break;
+					}
+				}
+				DEBUG_ASSERTCRASH(idx != -1, ("Hmm, expected to find the sleepy update module here"));
+				if (idx == -1)
+					continue;
+			}
+
 			eraseSleepyUpdate(idx);
 			DEBUG_ASSERTCRASH(sleepyUpdatesForThisObject[numSUO]->friend_getIndexInLogic() == -1, ("Hmm, expected index to be -1 here"));
 		}


### PR DESCRIPTION
bugfix(saveload): Fix silent crash loading old saves under RETAIL_COMPATIBLE_XFER_SAVE=0

Fixes GitHub issue #2464 (Critical).

Two-layer bug:

1. DozerAIUpdate::xfer and WorkerAIUpdate::xfer (both trees) and the
   shared Core/ DamageInfoInput::xfer gated their newer payload on
   'currentVersion >= 2' (the code's own current version constant)
   instead of 'version' (the version actually read from the save
   file). Under the default build currentVersion is 1 so the gate
   never fires. With RETAIL_COMPATIBLE_XFER_SAVE=0, currentVersion
   becomes 2/3, so loading an older version-1 save reads bytes that
   were never written, desyncing the rest of the xfer stream. A
   subsequent sanity check aborts the load with SC_INVALID_DATA.
   Zero Hour's DozerAIUpdate/WorkerAIUpdate are unaffected in
   practice since retail ZH always wrote version 3, but the Damage.cpp
   instance affects Generals under this flag.

2. That abort is caught by GameState::loadGame, whose error path
   calls clearGameData -> GameLogic::reset -> destroyAllObjectsImmediate
   -> processDestroyList. Objects created before the abort had their
   update modules registered in m_sleepyUpdates with valid indices,
   but UpdateModule::xfer intentionally resets each module's cached
   index to -1 on load (to be restored by GameLogic::loadPostProcess,
   which never got to run because the load threw first).
   processDestroyList read that stale -1 back and passed it straight
   to eraseSleepyUpdate(-1), which indexed m_sleepyUpdates with it
   unchecked -- -1 wraps to a huge unsigned index, crashing the
   process before the intended "GUI:ErrorLoadingGame" message box
   could ever show. This is what made the failure silent.

Fixes both trees where applicable:
- DozerAIUpdate.cpp / WorkerAIUpdate.cpp (Generals and GeneralsMD):
  'currentVersion >= 2' -> 'version >= 2'. No-op whenever a save's
  version matches the code's current version, so ordinary loads are
  unaffected.
- Damage.cpp (shared Core/): same fix, one copy covers both trees.
- GameLogic.cpp (Generals and GeneralsMD), processDestroyList(): when
  a module's cached index is invalid or stale, fall back to scanning
  m_sleepyUpdates for its real position instead of indexing out of
  bounds, skipping (with a debug assert) only if genuinely not found.
  This keeps erasing the module (required, since the object and its
  modules are deleted immediately after) while surviving the
  documented mid-load -1 state, so a failed load now reaches the
  intended error dialog instead of crashing.

All other RETAIL_COMPATIBLE_XFER_SAVE-gated xfer call sites in both
trees were audited and already correctly gate on 'version', not
'currentVersion'.

Live-testing this specific reproduction requires a build compiled
with RETAIL_COMPATIBLE_XFER_SAVE=0 (not this project's normal build
config); the processDestroyList hardening alone can also be exercised
on a standard build via a deliberately corrupt/truncated .sav file.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, using a community-supplied crash callstack as a
starting point.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

