### PR TITLE
bugfix(gpu): Export NvOptimusEnablement/AmdPowerXpressRequestHighPerformance

### DIFF
--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -71,6 +71,21 @@
 
 
 // GLOBALS ////////////////////////////////////////////////////////////////////
+
+// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 On hybrid-GPU systems (notebooks with an
+// integrated GPU plus a dedicated GPU), the game was rendered on the default GPU, which is
+// typically the weak integrated one, leaving the strong dedicated GPU unused and performance
+// poor. NVIDIA (Optimus) and AMD (PowerXpress/Enduro) drivers look for these exported symbols
+// by name in the launched executable and, when present, route the process to the
+// high-performance GPU. The values 0x00000001 (NVIDIA) and 1 (AMD) are the documented
+// "prefer high-performance GPU" values. This is the standard, widely-used technique adopted
+// by virtually every Windows game affected by hybrid-GPU switching, and works even though
+// DirectX 8 itself has no GPU-preference concept. See GitHub issue #880.
+extern "C" {
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+
 HINSTANCE ApplicationHInstance = nullptr;  ///< our application instance
 HWND ApplicationHWnd = nullptr;  ///< our application window handle
 Win32Mouse *TheWin32Mouse = nullptr;  ///< for the WndProc() only

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -73,6 +73,21 @@
 
 
 // GLOBALS ////////////////////////////////////////////////////////////////////
+
+// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 On hybrid-GPU systems (notebooks with an
+// integrated GPU plus a dedicated GPU), the game was rendered on the default GPU, which is
+// typically the weak integrated one, leaving the strong dedicated GPU unused and performance
+// poor. NVIDIA (Optimus) and AMD (PowerXpress/Enduro) drivers look for these exported symbols
+// by name in the launched executable and, when present, route the process to the
+// high-performance GPU. The values 0x00000001 (NVIDIA) and 1 (AMD) are the documented
+// "prefer high-performance GPU" values. This is the standard, widely-used technique adopted
+// by virtually every Windows game affected by hybrid-GPU switching, and works even though
+// DirectX 8 itself has no GPU-preference concept. See GitHub issue #880.
+extern "C" {
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+
 HINSTANCE ApplicationHInstance = nullptr;  ///< our application instance
 HWND ApplicationHWnd = nullptr;  ///< our application window handle
 Win32Mouse *TheWin32Mouse = nullptr;  ///< for the WndProc() only


### PR DESCRIPTION
bugfix(gpu): Export NvOptimusEnablement/AmdPowerXpressRequestHighPerformance

Fixes GitHub issue #880 (Critical).

On hybrid-GPU laptops (integrated GPU plus a dedicated/discrete GPU),
the game always rendered on the default (typically weak, integrated)
GPU, leaving the stronger dedicated GPU unused and performance poor.

NVIDIA (Optimus) and AMD (PowerXpress/Enduro) drivers scan a launched
executable's export table by name for these two symbols and, when
present with the documented values, route the process to the
high-performance GPU. This works even though DirectX 8 itself has no
cross-GPU-preference concept. This is the standard, widely-used
technique for this exact class of bug, not something specific to this
game.

Verified via dumpbin /exports that both built executables now export
exactly these two symbols with the correct names.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

