### PR TITLE
bugfix(mapcache): Recover from a corrupted user MapCache.ini instead of crashing

### DIFF
--- a/Core/GameEngine/Include/GameClient/MapUtil.h
+++ b/Core/GameEngine/Include/GameClient/MapUtil.h
@@ -118,7 +118,7 @@ public:
 private:
 	void prepareUnseenMaps(const AsciiString &mapDir);
 	Bool clearUnseenMaps(const AsciiString &mapDir);
-	void loadMapsFromMapCacheINI(const AsciiString &mapDir);
+	void loadMapsFromMapCacheINI(const AsciiString &mapDir, Bool isUserMapCache);
 	Bool loadMapsFromDisk(const AsciiString &mapDir, Bool isOfficial, Bool filterByAllowedMaps = FALSE); // returns true if we needed to (re)parse a map
 	Bool addMap(const AsciiString &mapDir, const AsciiString &fname, const AsciiString &lowerFname, FileInfo &fileInfo, Bool isOfficial); ///< returns true if it had to (re)parse the map
 	void writeCacheINI(const AsciiString &mapDir);

--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -437,7 +437,7 @@ void MapCache::updateCache()
 	// Load user map cache first.
 	if (m_doLoadUserMapCacheINI)
 	{
-		loadMapsFromMapCacheINI(userMapDir);
+		loadMapsFromMapCacheINI(userMapDir, TRUE);
 		m_doLoadUserMapCacheINI = FALSE;
 	}
 
@@ -452,7 +452,7 @@ void MapCache::updateCache()
 	// This overwrites matching user maps to prevent munkees getting rowdy :)
 	if (m_doLoadStandardMapCacheINI)
 	{
-		loadMapsFromMapCacheINI(mapDir);
+		loadMapsFromMapCacheINI(mapDir, FALSE);
 		m_doLoadStandardMapCacheINI = FALSE;
 	}
 }
@@ -496,7 +496,7 @@ Bool MapCache::clearUnseenMaps( const AsciiString &mapDir )
 	return erasedSomething;
 }
 
-void MapCache::loadMapsFromMapCacheINI( const AsciiString &mapDir )
+void MapCache::loadMapsFromMapCacheINI( const AsciiString &mapDir, Bool isUserMapCache )
 {
 	INI ini;
 	AsciiString fname;
@@ -504,7 +504,24 @@ void MapCache::loadMapsFromMapCacheINI( const AsciiString &mapDir )
 
 	if (TheFileSystem->doesFileExist(fname.str()))
 	{
-		ini.load( fname, INI_LOAD_OVERWRITE, nullptr );
+		try
+		{
+			ini.load( fname, INI_LOAD_OVERWRITE, nullptr );
+		}
+		catch (...)
+		{
+			// TheSuperHackers @bugfix The user map cache is a disposable, auto-generated local file.
+			// If it is corrupted, delete it and let the cache rebuild from the maps on disk,
+			// instead of terminating with a release crash on startup. The standard map cache is
+			// regular game data and cannot be regenerated here, so its errors remain fatal.
+			if (!isUserMapCache || remove(fname.str()) != 0)
+			{
+				// propagate the exception.
+				throw;
+			}
+
+			DEBUG_LOG(("MapCache::loadMapsFromMapCacheINI - deleted corrupted map cache file '%s', the map cache will be rebuilt from the maps on disk", fname.str()));
+		}
 	}
 }
 


### PR DESCRIPTION
bugfix(mapcache): Recover from a corrupted user MapCache.ini instead of crashing

Fixes GitHub issue #2366 (Critical).

MapCache::updateCache() -> loadMapsFromMapCacheINI() called INI::load()
unguarded. A malformed entry (e.g. a stray -nan in a numeric field)
throws INIException, which propagates out of GameEngine::init()
uncaught until GameEngine.cpp's top-level handler turns it into a
RELEASE_CRASH -- blocking the game from ever reaching the main menu
until the user manually finds and deletes the file. Related to #1180
(a similarly-shaped uncaught exception on an improper Map.ini).

MapCache.ini comes in two flavors read through the same function: the
user-data-directory cache (an auto-generated, fully disposable local
file rebuilt by scanning installed maps) and the standard game-data
cache (regular shipped data, not something this code can regenerate).
Only the former is safe to recover from automatically.

Fix: loadMapsFromMapCacheINI() takes a new isUserMapCache parameter
and wraps ini.load() in try/catch. On failure for the user cache, the
corrupted file is deleted and the exception is swallowed; on failure
for the standard cache, or if deleting the corrupted file itself
fails, the exception is rethrown and the crash behaves exactly as
before. No retry loop is needed: updateCache() unconditionally calls
loadMapsFromDisk() right after loadMapsFromMapCacheINI() regardless of
outcome, which re-scans the maps directory and writes a fresh cache
via writeCacheINI() -- i.e. deleting the corrupted file naturally
falls into the same 'no cache present, build fresh' path already used
on first run.

MapCache is shared Core/ code, so this single fix covers both
Generals and GeneralsMD.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

