### PR TITLE
bugfix(rendering): Fix memory corruption drawing Passable/impassable areas overlay

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -1285,7 +1285,19 @@ Bool BaseHeightMapRenderObjClass::showAsVisibleCliff(Int xIndex, Int yIndex) con
 
 	Int xSize = m_map->getXExtent();
 
-	return m_showAsVisibleCliff[xIndex + yIndex * xSize];
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Guard against reading past the end of
+	// m_showAsVisibleCliff. This vector is cleared on every map reset and is only (re)built by
+	// updateViewImpassableAreas(), so it can be empty (or sized for a previous map) when the
+	// impassable areas debug overlay is enabled in game. Indexing the empty std::vector<bool>
+	// dereferenced its null internal storage and crashed while drawing passable areas.
+	// See GitHub issue #254.
+	const size_t index = (size_t)xIndex + (size_t)yIndex * (size_t)xSize;
+	if (index >= m_showAsVisibleCliff.size())
+	{
+		return false;
+	}
+
+	return m_showAsVisibleCliff[index];
 }
 
 //=============================================================================

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -320,6 +320,16 @@ Int HeightMapRenderObjClass::updateVB(DX8VertexBufferClass	*pVB, VERTEX_FORMAT *
 		assert(x0 >= originX && y0 >= originY && x1>x0 && y1>y0 && x1<=originX+VERTEX_BUFFER_TILE_LENGTH && y1<=originY+VERTEX_BUFFER_TILE_LENGTH);
 #endif
 
+		// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Build the visible cliff lookup table before
+		// it is read below via showAsVisibleCliff(). In game, updateViewImpassableAreas() was only
+		// ever called from doPartialUpdate() (terrain deformation), so enabling the impassable
+		// areas debug overlay usually read an unallocated (empty) table and crashed, and only
+		// worked on the rare occasions the table happened to be built. See GitHub issue #254.
+		if (m_showImpassableAreas &&
+				m_showAsVisibleCliff.size() != (size_t)pMap->getXExtent() * (size_t)pMap->getYExtent()) {
+			updateViewImpassableAreas();
+		}
+
 		DX8VertexBufferClass::WriteLockClass lockVtxBuffer(pVB);
 		VERTEX_FORMAT *vbHardware = (VERTEX_FORMAT*)lockVtxBuffer.Get_Vertex_Array();
 		VERTEX_FORMAT *vBase = data;


### PR DESCRIPTION
bugfix(rendering): Fix memory corruption drawing Passable/impassable areas overlay

Fixes GitHub issue #254 (Critical).

BaseHeightMapRenderObjClass::showAsVisibleCliff() indexed
m_showAsVisibleCliff (a std::vector<bool>) with no bounds check. That
vector is cleared on every map reset and, in the running game, is
only ever (re)built as a side effect of terrain deformation
(doPartialUpdate() -> updateViewImpassableAreas()) -- never at map
load. Enabling the impassable/passable areas debug overlay therefore
usually indexed an empty vector, dereferencing its null internal bit
storage: unallocated memory access, matching the issue title exactly.
It "worked on rare occasions" precisely when a crater or scorch mark
had already triggered a partial terrain update that happened to
allocate the table first. WorldBuilder does not hit this because it
calls updateViewImpassableAreas() explicitly, which is why the
overlay looked correct there but not in-game (per the issue's
side-by-side screenshots).

Fix, both in shared Core/ (covers both Generals and GeneralsMD):
1. BaseHeightMap.cpp, showAsVisibleCliff(): bounds-check the computed
   index against the vector's actual size and return false if out of
   range, instead of indexing unconditionally.
2. HeightMap.cpp, updateVB(): when the impassable-areas overlay is
   enabled and the lookup table isn't sized for the current map,
   lazily call updateViewImpassableAreas() before it's read, so the
   overlay renders correctly instead of silently returning false
   forever after the bounds fix.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue via static code review (no live repro was available --
the issue itself has no known reliable reproduction steps).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

