### PR TITLE
bugfix(security): Include CommandSet.ini in the INI load CRC check

### DIFF
--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -57,6 +57,7 @@ class UpgradeTemplate;
 class ControlBarResizer;
 class GameWindowTransitionsHandler;
 class DisplayString;
+class Xfer;
 
 enum ProductionID CPP_11(: Int);
 
@@ -659,6 +660,11 @@ public:
 	virtual void reset() override;					///< from subsystem interface
 	virtual void update() override;				///< from subsystem interface
 
+	// TheSuperHackers @bugfix Include CommandSet.ini in the INI load CRC check (GitHub issue #80).
+	// GameEngine::init sets this Xfer while the INI CRC is accumulating, so that ControlBar::init
+	// includes the CommandSet INI data in the CRC. It is null outside of that window.
+	static void setIniLoadCRC( Xfer *xfer ) { s_iniLoadCRC = xfer; }
+
 	/// mark the UI as dirty so the context of everything is re-evaluated
 	void markUIDirty();
 
@@ -787,6 +793,8 @@ public:
 	void drawSpecialPowerShortcutMultiplierText();
 
 protected:
+	static Xfer *s_iniLoadCRC;	///< accumulates the INI CRC during engine initialization, see setIniLoadCRC
+
 	void updateRadarAttackGlow ();
 
 	void setDefaultControlBarConfig();

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -88,6 +88,8 @@
 // PUBLIC /////////////////////////////////////////////////////////////////////////////////////////
 ControlBar *TheControlBar = nullptr;
 
+Xfer *ControlBar::s_iniLoadCRC = nullptr;
+
 const Image* ControlBar::m_rankVeteranIcon	= nullptr;
 const Image* ControlBar::m_rankEliteIcon		= nullptr;
 const Image* ControlBar::m_rankHeroicIcon		= nullptr;
@@ -1069,7 +1071,9 @@ void ControlBar::init()
 	ini.loadFileDirectory( "Data\\INI\\CommandButton", INI_LOAD_OVERWRITE, nullptr );
 
 	// load the command sets
-	ini.loadFileDirectory( "Data\\INI\\CommandSet", INI_LOAD_OVERWRITE, nullptr );
+	// TheSuperHackers @bugfix Include CommandSet.ini in the INI load CRC check (GitHub issue #80).
+	// s_iniLoadCRC is set by GameEngine::init while the INI CRC is accumulating and is null otherwise.
+	ini.loadFileDirectory( "Data\\INI\\CommandSet", INI_LOAD_OVERWRITE, s_iniLoadCRC );
 
 	// post process step after loading the command buttons and command sets
 	postProcessCommands();

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -84,6 +84,7 @@
 #include "GameLogic/SidesList.h"
 
 #include "GameClient/ClientInstance.h"
+#include "GameClient/ControlBar.h"
 #include "GameClient/FXList.h"
 #include "GameClient/GameClient.h"
 #include "GameClient/Keyboard.h"
@@ -473,7 +474,18 @@ void GameEngine::init()
 #endif
 
 		initSubsystem(TheUpgradeCenter,"TheUpgradeCenter", MSGNEW("GameEngineSubsystem") UpgradeCenter, &xferCRC, "Data\\INI\\Default\\Upgrade", "Data\\INI\\Upgrade");
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Include CommandSet.ini in the INI load CRC check (GitHub issue #80).
+		// CommandSet.ini is loaded by ControlBar::init during TheGameClient initialization, which
+		// previously bypassed the CRC accumulation. Hand the CRC Xfer to ControlBar for this window.
+		// Note that including it changes the final m_iniCRC and therefore breaks online/LAN lobby
+		// compatibility with retail 1.08 and older builds, hence the RETAIL_COMPATIBLE_CRC guard.
+		ControlBar::setIniLoadCRC(&xferCRC);
+#endif
 		initSubsystem(TheGameClient,"TheGameClient", createGameClient(), nullptr);
+#if !RETAIL_COMPATIBLE_CRC
+		ControlBar::setIniLoadCRC(nullptr);
+#endif
 		initSubsystem(TheAI,"TheAI", MSGNEW("GameEngineSubsystem") AI(), &xferCRC,  "Data\\INI\\Default\\AIData", "Data\\INI\\AIData");
 		initSubsystem(TheGameLogic,"TheGameLogic", createGameLogic(), nullptr);
 		initSubsystem(TheTeamFactory,"TheTeamFactory", MSGNEW("GameEngineSubsystem") TeamFactory(), nullptr);

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -86,6 +86,7 @@
 #include "GameLogic/SidesList.h"
 
 #include "GameClient/ClientInstance.h"
+#include "GameClient/ControlBar.h"
 #include "GameClient/FXList.h"
 #include "GameClient/GameClient.h"
 #include "GameClient/Keyboard.h"
@@ -597,7 +598,18 @@ void GameEngine::init()
 #endif
 
 		initSubsystem(TheUpgradeCenter,"TheUpgradeCenter", MSGNEW("GameEngineSubsystem") UpgradeCenter, &xferCRC, "Data\\INI\\Default\\Upgrade", "Data\\INI\\Upgrade");
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Include CommandSet.ini in the INI load CRC check (GitHub issue #80).
+		// CommandSet.ini is loaded by ControlBar::init during TheGameClient initialization, which
+		// previously bypassed the CRC accumulation. Hand the CRC Xfer to ControlBar for this window.
+		// Note that including it changes the final m_iniCRC and therefore breaks online/LAN lobby
+		// compatibility with retail 1.04 and older builds, hence the RETAIL_COMPATIBLE_CRC guard.
+		ControlBar::setIniLoadCRC(&xferCRC);
+#endif
 		initSubsystem(TheGameClient,"TheGameClient", createGameClient(), nullptr);
+#if !RETAIL_COMPATIBLE_CRC
+		ControlBar::setIniLoadCRC(nullptr);
+#endif
 
 
 	#ifdef DUMP_PERF_STATS///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
bugfix(security): Include CommandSet.ini in the INI load CRC check

Fixes GitHub issue #80 (Critical).

CommandSet.ini defines what commands (build/train/ability buttons
etc.) each unit/structure has available. Unlike its neighbors, it was
never included in the running CRC accumulated over game-data INI
files at startup (TheGlobalData->m_iniCRC), so a client could modify
it -- e.g. to unlock free/instant abilities -- without other
players/the server detecting the tampering via CRC mismatch.

Root cause: CommandSet.ini is not loaded through the
initSubsystem(..., &xferCRC, path1, path2) pattern its siblings use.
It's loaded by ControlBar::init() (shared Core/, used by both games)
via a plain INI object with an explicit nullptr Xfer -- the INI parser
only accumulates CRC when a non-null Xfer is passed. ControlBar::init()
does run inside the CRC accumulation window (GameEngine::init() ->
initSubsystem(TheGameClient) -> GameClient::init() -> InGameUI::init()
-> TheControlBar->init()), the plumbing to reach it was simply never
threaded through. Re-loading the directory a second time with
&xferCRC from GameEngine.cpp is not viable, since
ControlBar::parseCommandSetDefinition throws on duplicate command set
definitions.

Fix: ControlBar gains a static Xfer* (s_iniLoadCRC, null by default)
and a setIniLoadCRC() setter; GameEngine::init() (both trees) sets it
to &xferCRC immediately before initSubsystem(TheGameClient, ...) and
clears it back to nullptr immediately after, so only this one
initialization pass accumulates CRC -- WorldBuilder and the in-game
recreateControlBar() path still see a null Xfer and are unaffected.

Guarded behind #if !RETAIL_COMPATIBLE_CRC: per this project's own
documented policy (GameDefines.h), RETAIL_COMPATIBLE_CRC (on by
default, no override in this build) keeps m_iniCRC bit-identical to
retail so patched clients can still join LAN/GameSpy lobbies and
exchange replays with retail/unpatched clients. Including CommandSet
unconditionally would change m_iniCRC for every patched client and
break that compatibility. The fix is therefore compiled but dormant
in the default build; it activates under a RETAIL_COMPATIBLE_CRC=0
build (or by removing the guard, a two-line change) once retail
compatibility for this value is no longer a project constraint.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, including identifying and respecting the project's
existing RETAIL_COMPATIBLE_CRC compatibility policy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

