### PR TITLE
bugfix(math): Fix strict-aliasing UB in WWMath::Float_To_Int_Chop/Floor

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -40,6 +40,7 @@
 #include <math.h>
 #include <float.h>
 #include <assert.h>
+#include <string.h>
 
 /*
 ** Some global constants.
@@ -104,8 +105,8 @@ static WWINLINE float Fabs(float val)
 	return *(float*)&value;
 }
 
-static WWINLINE int Float_To_Int_Chop(const float& f);
-static WWINLINE int Float_To_Int_Floor(const float& f);
+static WWINLINE int Float_To_Int_Chop(float f);
+static WWINLINE int Float_To_Int_Floor(float f);
 
 #if defined(_MSC_VER) && defined(_M_IX86)
 static WWINLINE float Cos(float val);
@@ -580,9 +581,10 @@ WWINLINE float WWMath::Sqrt(float val)
 }
 #endif
 
-WWINLINE int WWMath::Float_To_Int_Chop(const float& f)
+WWINLINE int WWMath::Float_To_Int_Chop(float f)
 {
-    int a	= *reinterpret_cast<const int*>(&f);				// take bit pattern of float into a register
+    int a;
+    memcpy(&a, &f, sizeof(a));										// take bit pattern of float into a register (memcpy avoids strict-aliasing UB and compiles to a single move)
     int sign	= (a>>31);												// sign = 0xFFFFFFFF if original value is negative, 0 if positive
     int mantissa	= (a&((1<<23)-1))|(1<<23);						// extract mantissa and add the hidden bit
     int exponent	= ((a&0x7fffffff)>>23)-127;					// extract the exponent
@@ -590,9 +592,10 @@ WWINLINE int WWMath::Float_To_Int_Chop(const float& f)
     return ((r ^ (sign)) - sign ) &~ (exponent>>31);			// add original sign. If exponent was negative, make return value 0.
 }
 
-WWINLINE int WWMath::Float_To_Int_Floor (const float& f)
+WWINLINE int WWMath::Float_To_Int_Floor (float f)
 {
-	int a			= *reinterpret_cast<const int*>(&f);			// take bit pattern of float into a register
+	int a;
+	memcpy(&a, &f, sizeof(a));											// take bit pattern of float into a register (memcpy avoids strict-aliasing UB and compiles to a single move)
 	int sign		= (a>>31);												// sign = 0xFFFFFFFF if original value is negative, 0 if positive
 	a&=0x7fffffff;															// we don't need the sign any more
 


### PR DESCRIPTION
bugfix(math): Fix strict-aliasing UB in WWMath::Float_To_Int_Chop/Floor

Fixes GitHub issue #2142 (Major).

Both functions took a float by const reference and read its bit
pattern via 'int a = *reinterpret_cast<const int*>(&f);' -- accessing
a float object through an int lvalue, a strict-aliasing violation.
Not theoretical: a linked godbolt reproduction in the issue shows GCC
actually miscompiling this, since the by-reference parameter lets its
alias analysis assume the int load cannot observe the caller's float.

Fix: parameters changed from 'const float&' to 'float' (by value),
and the bit-pattern read changed to 'memcpy(&a, &f, sizeof(a))',
which is well-defined and compiles to a single register move as an
intrinsic on MSVC/GCC/Clang -- no behavior or performance change, and
compatible with VC6 (ruling out std::bit_cast, a C++20 feature). The
truncation algorithm itself (bit-level chop/floor via mantissa and
exponent extraction) is unchanged.

No RETAIL_COMPATIBLE_CRC guard needed: memcpy reads the identical bit
pattern the reinterpret_cast read under MSVC (the retail-behavior
compiler), and every caller is client-side (fast trig tables, terrain
vertex lighting, animation channels), not CRC-checked simulation
logic.

Shared Core/ code, so this single fix covers both Generals and
GeneralsMD.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

