### PR TITLE
bugfix(rendering): Fix 16-bit vertex count overflow in SortingRendererClass::Flush_Sorting_Pool

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -323,6 +323,10 @@ static unsigned overlapping_node_count;
 static unsigned overlapping_polygon_count;
 static unsigned overlapping_vertex_count;
 static const unsigned MAX_OVERLAPPING_NODES=4096;
+// TheSuperHackers @fix 18/07/2026 The sorting pool copies all node vertices into one combined
+// dynamic vertex buffer that is addressed with 16-bit indices, so the pool must never
+// accumulate more vertices than fit in an unsigned short.
+static const unsigned MAX_SORTING_VERTEX_COUNT=65535;
 static SortingNodeStruct* overlapping_nodes[MAX_OVERLAPPING_NODES];
 
 // ----------------------------------------------------------------------------
@@ -346,6 +350,19 @@ void SortingRendererClass::Insert_To_Sorted_List(SortingNodeStruct *state)
 
 void SortingRendererClass::Insert_To_Sorting_Pool(SortingNodeStruct* state)
 {
+	// TheSuperHackers @fix 18/07/2026
+	// Flush the pool early when adding this node would push the accumulated vertex count past
+	// the 16-bit limit of the combined dynamic vertex buffer. Exceeding it silently truncated
+	// the buffer allocation size (DynamicVBAccessClass takes an unsigned short) and wrapped the
+	// 16-bit triangle indices, corrupting memory and crashing. Nodes arrive here sorted
+	// back-to-front, so flushing in batches preserves the draw order of transparent geometry.
+	if (overlapping_node_count > 0 && overlapping_vertex_count + (unsigned)state->vertex_count > MAX_SORTING_VERTEX_COUNT) {
+		bool old_enable=DX8Wrapper::_Is_Triangle_Draw_Enabled();
+		DX8Wrapper::_Enable_Triangle_Draw(_EnableTriangleDraw);
+		Flush_Sorting_Pool();
+		DX8Wrapper::_Enable_Triangle_Draw(old_enable);
+	}
+
 	if (overlapping_node_count>=MAX_OVERLAPPING_NODES) {
 		Release_Refs(state);
 		delete state;
@@ -426,6 +443,10 @@ void SortingRendererClass::Flush_Sorting_Pool()
 	if (overlapping_vertex_count > vertexAllocCount)
 		vertexAllocCount = overlapping_vertex_count;
 	WWASSERT(DEFAULT_SORTING_VERTEX_COUNT == 1 || vertexAllocCount <= DEFAULT_SORTING_VERTEX_COUNT);
+	// TheSuperHackers @fix 18/07/2026 The combined vertex buffer uses 16-bit indices and the
+	// DynamicVBAccessClass constructor takes an unsigned short, so the pooled vertex count must
+	// fit in 16 bits. Insert_To_Sorting_Pool guarantees this by flushing the pool in batches.
+	WWASSERT(vertexAllocCount <= MAX_SORTING_VERTEX_COUNT);
 	DynamicVBAccessClass dyn_vb_access(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,vertexAllocCount/*overlapping_vertex_count*/);
 	{
 		DynamicVBAccessClass::WriteLockClass lock(&dyn_vb_access);


### PR DESCRIPTION
bugfix(rendering): Fix 16-bit vertex count overflow in SortingRendererClass::Flush_Sorting_Pool

Fixes GitHub issue #2007 (Major).

The sorting pool copies all accumulated transparent/sorted geometry
into one combined dynamic vertex buffer per flush. That buffer is
addressed with 16-bit triangle indices, and DynamicVBAccessClass's
constructor takes an unsigned short vertex count -- but nothing
capped overlapping_vertex_count against that limit. Once enough
sorted polygons accumulated in one frame (e.g. a large particle count
with overlapping transparent effects), the vertex count silently
truncated on the unsigned short constructor parameter, the lock
returned a too-small buffer, and the per-node vertex copy loop wrote
past its end -- heap/driver buffer overrun and crash.

A prior fix already in this local clone (upstream PR #2783) chunked
the separate index-buffer writes and fixed a related loop-bound bug,
but left this vertex-side overflow unaddressed, per the issue's own
follow-up comment.

Fix, all in the shared sorting pool implementation:
1. New MAX_SORTING_VERTEX_COUNT=65535 constant.
2. Insert_To_Sorting_Pool() now flushes the pool early -- via the same
   Flush_Sorting_Pool() path, with the same triangle-draw-enable
   toggling Flush() already uses -- when adding a node would push the
   accumulated vertex count past that limit, before the node is
   inserted into the (now empty) pool. Nodes arrive already sorted
   back-to-front, so batch-flushing preserves transparent draw order.
   A single node's own vertex_count is itself unsigned short, so it
   always fits in a freshly-flushed pool.
3. Defensive WWASSERT(vertexAllocCount <= MAX_SORTING_VERTEX_COUNT) at
   the allocation site in Flush_Sorting_Pool(), to catch any future
   violation of the invariant in debug builds.

sortingrenderer.cpp is shared Core/ code (compiled into both trees'
ww3d2 library), so this single fix covers both Generals and
GeneralsMD.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, including identifying that a prior upstream PR had only
partially addressed it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

