### PR TITLE
bugfix(rendering): Fix crash on failed vertex buffer lock in TerrainTracksRenderObjClassSystem::flush

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainTracks.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainTracks.cpp
@@ -825,6 +825,17 @@ Try improving the fit to vertical surfaces like cliffs.
 	{
 		DX8VertexBufferClass::WriteLockClass lockVtxBuffer(m_vertexBuffer);
 		VertexFormatXYZDUV1 *verts = (VertexFormatXYZDUV1*)lockVtxBuffer.Get_Vertex_Array();
+
+		// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 The vertex buffer lock can fail
+		// (for example on a lost device), leaving no vertex array to write to. Skip drawing
+		// the track marks this frame instead of crashing on a null pointer dereference.
+		if (verts == nullptr)
+		{
+			DEBUG_LOG(("TerrainTracksRenderObjClassSystem::flush - vertex buffer lock failed, skipping track marks this frame"));
+			m_edgesToFlush=0;
+			return;
+		}
+
 		trackStartIndex=0;
 
 		mod=m_usedModules;

--- a/Core/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -64,7 +64,9 @@ protected:
 	void* Vertices;
 
 	// This class can't be used directly, so constructor as to be protected
-	VertexBufferLockClass(VertexBufferClass* vertex_buffer_) : VertexBuffer(vertex_buffer_) {}
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Initialize Vertices to null so a failed
+	// buffer lock leaves a reliably null pointer for callers to test, rather than stack garbage.
+	VertexBufferLockClass(VertexBufferClass* vertex_buffer_) : VertexBuffer(vertex_buffer_), Vertices(nullptr) {}
 public:
 	void* Get_Vertex_Array() { return Vertices; }
 };


### PR DESCRIPTION
bugfix(rendering): Fix crash on failed vertex buffer lock in TerrainTracksRenderObjClassSystem::flush

Fixes GitHub issue #2827 (Major).

flush() locked its vertex buffer via DX8VertexBufferClass::WriteLockClass
and dereferenced the returned vertex array with no failure check. Two
defects combined to make this crash: VertexBufferLockClass::Vertices
was never initialized in the constructor (only set inside
IDirect3DVertexBuffer8::Lock() on success), and DX8_ErrorCode swallows
the HRESULT on a failed lock in release builds -- so on a lost device
(e.g. an alt-tab/fullscreen transition), Vertices was left as
uninitialized stack garbage rather than a reliable null, and flush()
wrote through it unconditionally.

Fix:
1. dx8vertexbuffer.h: VertexBufferLockClass's constructor now
   initializes Vertices(nullptr), so a failed lock reliably yields
   null instead of garbage. This also makes an existing, similar null
   check in W3DTreeBuffer.cpp actually sound.
2. W3DTerrainTracks.cpp, flush(): after the lock, if the vertex array
   is null, log it, reset m_edgesToFlush, and return -- skipping track
   marks for that one frame instead of crashing. Tracks resume
   drawing normally next frame once the device/buffer recovers.

Both files are shared Core/, so this single fix covers both Generals
and GeneralsMD.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

