### PR TITLE
bugfix(saveload): Fix Cargo Plane being killed after loading a save mid-delivery

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
@@ -143,9 +143,9 @@ public:
 	virtual StateReturnType update() override;
 	virtual StateReturnType onEnter() override;
 protected:
-	// snapshot interface	STUBBED - no member vars to save. jba.
+	// snapshot interface
 	virtual void crc( Xfer *xfer ) override {};
-	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void xfer( Xfer *xfer ) override;
 	virtual void loadPostProcess() override {};
 
   Coord3D facingDirectionUponDelivery;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -1121,6 +1121,38 @@ StateReturnType RecoverFromOffMapState::update() // Success if we should try aga
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
+// ------------------------------------------------------------------------------------------------
+/** Xfer method
+	* Version Info:
+	* 1: Initial version
+	* 2: TheSuperHackers @bugfix Save facingDirectionUponDelivery. It was never saved, so after
+	*    loading it was zero, making the deviation test in update() kill the plane as soon as it
+	*    turned while heading off the map.
+	*/
+// ------------------------------------------------------------------------------------------------
+void HeadOffMapState::xfer( Xfer *xfer )
+{
+	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
+	XferVersion version = currentVersion;
+	xfer->xferVersion( &version, currentVersion );
+
+	if( version >= 2 )
+	{
+		xfer->xferCoord3D( &facingDirectionUponDelivery );
+	}
+	else if( xfer->getXferMode() == XFER_LOAD )
+	{
+		// TheSuperHackers @bugfix Older saves did not store this vector. Approximate it with the
+		// current facing direction so the plane is not killed for deviating from a zero vector.
+		getMachineOwner()->getUnitDirectionVector3D( facingDirectionUponDelivery );
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 StateReturnType HeadOffMapState::onEnter() // Give move order out of town
 {


### PR DESCRIPTION
bugfix(saveload): Fix Cargo Plane being killed after loading a save mid-delivery

Fixes GitHub issue #2503 (Minor).

HeadOffMapState (the state a delivery plane is in while flying off
the map after dropping cargo) has a Zero-Hour-only anti-spin check:
if the plane turns and its current facing deviates too far (dot <
0.3) from facingDirectionUponDelivery, the plane is killed.

facingDirectionUponDelivery was set only in onEnter() and never
actually saved -- HeadOffMapState::xfer() was a stub (comment said
no member vars to save) left over from before this member was added.
After loading a save, the vector restored as zero, so the deviation
check compared against a zero vector: dot product 0 < 0.3 on the
very first turning frame, killing the plane with no attacker. Retail
behavior, not a regression introduced by this project.

Fix: HeadOffMapState::xfer() now saves/loads facingDirectionUponDelivery
at version 2, gated behind RETAIL_COMPATIBLE_XFER_SAVE like other
saveload fixes this session (defaults to version 1, matching retail).
For version 1 loads (retail saves, and this build's default), a
load-time fallback approximates the vector from the plane's current
facing direction, so the deviation test compares against a sane
reference instead of zero. Object::xfer() restores the transform
(and thus the plane's orientation) before per-module xfer runs, so
the fallback reads valid data.

Zero-Hour-only fix: the base Generals tree's HeadOffMapState has no
such member or kill check.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, building on a root-cause trace already posted in the
issue thread by a community member.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

