### PR TITLE
bugfix(gui): Decouple GUI window slide-in animation speed from framerate

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -178,10 +178,13 @@ public:
 	Bool isReversed();										///< Returns whether or not we're in our reversed state.
 	Bool isEmpty();
 private:
+	void step();															///< Runs a single base-rate step of all registered window animations
+
 	AnimateWindowList	m_winList;								///< A list of AnimationWindows that we don't care if their finished animating
 	AnimateWindowList m_winMustFinishList;			///< A list of AnimationWindows that we do care about
 	Bool m_needsUpdate;													///< If we're done animating all our monitored windows, then this will be false
 	Bool m_reverse;															///< Are we in a reverse state?
+	Real m_frameAccumulator;										///< Carries fractional base-rate frames between updates
 	ProcessAnimateWindowSlideFromRight *m_slideFromRight;			///< Holds the process in which the windows slide from the right
 	ProcessAnimateWindowSlideFromRightFast *m_slideFromRightFast;
 	ProcessAnimateWindowSlideFromTop *m_slideFromTop;					///< Holds the process in which the windows slide from the Top

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -57,6 +57,7 @@
 #include "GameClient/GameWindow.h"
 #include "GameClient/Display.h"
 #include "GameClient/ProcessAnimateWindow.h"
+#include "Common/FramePacer.h"
 //-----------------------------------------------------------------------------
 // DEFINES ////////////////////////////////////////////////////////////////////
 //-----------------------------------------------------------------------------
@@ -133,6 +134,7 @@ AnimateWindowManager::AnimateWindowManager()
 	m_winList.clear();
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_frameAccumulator = 0.0f;
 	m_winMustFinishList.clear();
 }
 AnimateWindowManager::~AnimateWindowManager()
@@ -159,6 +161,7 @@ void AnimateWindowManager::init()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_frameAccumulator = 0.0f;
 }
 
 void AnimateWindowManager::reset()
@@ -168,9 +171,23 @@ void AnimateWindowManager::reset()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_frameAccumulator = 0.0f;
 }
 
+// TheSuperHackers @tweak bobtista 27/06/2026 Decouple GUI window-move animations from the render frame rate
 void AnimateWindowManager::update()
+{
+	m_frameAccumulator += TheFramePacer->getBaseOverUpdateFpsRatio();
+	Int steps = (Int)m_frameAccumulator;
+	m_frameAccumulator -= (Real)steps;
+
+	while (steps-- > 0)
+	{
+		step();
+	}
+}
+
+void AnimateWindowManager::step()
 {
 
 	ProcessAnimateWindow *processAnim = nullptr;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -178,10 +178,13 @@ public:
 	Bool isReversed();										///< Returns whether or not we're in our reversed state.
 	Bool isEmpty();
 private:
+	void step();															///< Runs a single base-rate step of all registered window animations
+
 	AnimateWindowList	m_winList;								///< A list of AnimationWindows that we don't care if their finished animating
 	AnimateWindowList m_winMustFinishList;			///< A list of AnimationWindows that we do care about
 	Bool m_needsUpdate;													///< If we're done animating all our monitored windows, then this will be false
 	Bool m_reverse;															///< Are we in a reverse state?
+	Real m_frameAccumulator;										///< Carries fractional base-rate frames between updates
 	ProcessAnimateWindowSlideFromRight *m_slideFromRight;			///< Holds the process in which the windows slide from the right
 	ProcessAnimateWindowSlideFromRightFast *m_slideFromRightFast;
 	ProcessAnimateWindowSlideFromTop *m_slideFromTop;					///< Holds the process in which the windows slide from the Top

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -57,6 +57,7 @@
 #include "GameClient/GameWindow.h"
 #include "GameClient/Display.h"
 #include "GameClient/ProcessAnimateWindow.h"
+#include "Common/FramePacer.h"
 //-----------------------------------------------------------------------------
 // DEFINES ////////////////////////////////////////////////////////////////////
 //-----------------------------------------------------------------------------
@@ -133,6 +134,7 @@ AnimateWindowManager::AnimateWindowManager()
 	m_winList.clear();
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_frameAccumulator = 0.0f;
 	m_winMustFinishList.clear();
 }
 AnimateWindowManager::~AnimateWindowManager()
@@ -159,6 +161,7 @@ void AnimateWindowManager::init()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_frameAccumulator = 0.0f;
 }
 
 void AnimateWindowManager::reset()
@@ -168,9 +171,23 @@ void AnimateWindowManager::reset()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
+	m_frameAccumulator = 0.0f;
 }
 
+// TheSuperHackers @tweak bobtista 27/06/2026 Decouple GUI window-move animations from the render frame rate
 void AnimateWindowManager::update()
+{
+	m_frameAccumulator += TheFramePacer->getBaseOverUpdateFpsRatio();
+	Int steps = (Int)m_frameAccumulator;
+	m_frameAccumulator -= (Real)steps;
+
+	while (steps-- > 0)
+	{
+		step();
+	}
+}
+
+void AnimateWindowManager::step()
 {
 
 	ProcessAnimateWindow *processAnim = nullptr;


### PR DESCRIPTION
bugfix(gui): Decouple GUI window slide-in animation speed from framerate

Fixes GitHub issue #2832 (Major). Issue #2834 (promotion star blink)
turned out to already be fixed upstream by PR #2835 (merged
2026-07-09, already present in this local tree) -- no change needed
for that one.

AnimateWindowManager::update() advanced window slide-in/out animation
position by a fixed per-call step (and applied ease-out exponentially
per call) once per render frame, so the whole animation completed
proportionally faster at higher render frame rates than the 30 FPS
rate it was tuned at.

Fix adapts the same self-pacing pattern already used elsewhere in
this codebase (issue #2056): update() now accumulates
TheFramePacer->getBaseOverUpdateFpsRatio() into a new m_frameAccumulator
and runs whole base-rate (30 Hz) step()s (the old update() body,
renamed), carrying the fractional remainder to the next call. This
keeps the per-step math (including the exponential slowdown and
integer position deltas) bit-identical to the 30 FPS baseline, so the
intended animation duration is preserved at any render frame rate.
Shell::update() correspondingly now calls the manager's update() every
frame instead of throttling it to 30 Hz itself, since the manager
paces itself.

Adapted from upstream PR #2833 (same issue, open/unmerged at the time
of this commit, maintainer review feedback already incorporated),
applied directly to this local clone.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue,
including finding and adapting the matching open upstream PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

