### PR TITLE
bugfix(shell): Fix crash on window-close while in-game with ESC menu open

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/Shell.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Shell.h
@@ -180,6 +180,7 @@ protected:
 	AsciiString m_pendingPushName;													///< layout name to be pushed
 	Bool m_isShellActive;																		///< TRUE when the shell is active
 	Bool m_shellMapOn;																			///< TRUE when the shell map is on
+	Bool m_isDeconstructing;																///< TRUE while the shell is being torn down, revealed screens must not be re-initialized then
 	AnimateWindowManager *m_animateWindowManager;						///< The animate Window Manager
 	ShellMenuSchemeManager *m_schemeManager;								///< The Shell Scheme Manager
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -77,6 +77,7 @@ void Shell::construct()
 	m_pendingPushName.set( "" );
 	m_isShellActive = TRUE;
 	m_shellMapOn = FALSE;
+	m_isDeconstructing = FALSE;
 	m_background = nullptr;
 	m_clearBackground = FALSE;
 	m_animateWindowManager = NEW AnimateWindowManager;
@@ -90,6 +91,16 @@ void Shell::construct()
 //-------------------------------------------------------------------------------------------------
 void Shell::deconstruct()
 {
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Popping a screen normally runs the init
+	// callback of the newly revealed screen below it. During shell teardown this must not
+	// happen: the shell is destroyed from GameClient's destructor in the reverse-order
+	// subsystem shutdown, so subsystems initialized after TheGameClient (such as TheGameState)
+	// are already destroyed. When the application quit while in-game with the ESC menu chain
+	// still on the shell stack (e.g. closing the game with the window X button), popping those
+	// screens re-initialized the revealed save/load menu, which read from the already destroyed
+	// TheGameState and crashed. See GitHub issue #2777.
+	m_isDeconstructing = TRUE;
+
 	WindowLayout *newTop = top();
 	while(newTop)
 	{
@@ -205,15 +216,15 @@ void Shell::update()
 
 		}
 
-		// Update the animate window manager
-		m_animateWindowManager->update();
-
 		m_schemeManager->update();
 
 		// mark last time we ran the updates
 		lastUpdate = now;
 
 	}
+
+	// TheSuperHackers @tweak bobtista 08/07/2026 Update the animate window manager every frame, it paces itself now
+	m_animateWindowManager->update();
 
 }
 
@@ -701,8 +712,11 @@ void Shell::doPop( Bool impendingPush )
 	}
 
 	// run the init for the new top of the stack if present
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Skip the init while the shell is being torn
+	// down, because screen init callbacks use engine subsystems that are already destroyed at
+	// that point. See GitHub issue #2777.
 	WindowLayout *newTop = top();
-	if( newTop && !impendingPush )
+	if( newTop && !impendingPush && !m_isDeconstructing )
 	{
 		newTop->runInit( nullptr );
 		//newTop->bringForward();

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Shell.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Shell.h
@@ -180,6 +180,7 @@ protected:
 	AsciiString m_pendingPushName;													///< layout name to be pushed
 	Bool m_isShellActive;																		///< TRUE when the shell is active
 	Bool m_shellMapOn;																			///< TRUE when the shell map is on
+	Bool m_isDeconstructing;																///< TRUE while the shell is being torn down, revealed screens must not be re-initialized then
 	AnimateWindowManager *m_animateWindowManager;						///< The animate Window Manager
 	ShellMenuSchemeManager *m_schemeManager;								///< The Shell Scheme Manager
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -77,6 +77,7 @@ void Shell::construct()
 	m_pendingPushName.set( "" );
 	m_isShellActive = TRUE;
 	m_shellMapOn = FALSE;
+	m_isDeconstructing = FALSE;
 	m_background = nullptr;
 	m_clearBackground = FALSE;
 	m_animateWindowManager = NEW AnimateWindowManager;
@@ -90,6 +91,16 @@ void Shell::construct()
 //-------------------------------------------------------------------------------------------------
 void Shell::deconstruct()
 {
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Popping a screen normally runs the init
+	// callback of the newly revealed screen below it. During shell teardown this must not
+	// happen: the shell is destroyed from GameClient's destructor in the reverse-order
+	// subsystem shutdown, so subsystems initialized after TheGameClient (such as TheGameState)
+	// are already destroyed. When the application quit while in-game with the ESC menu chain
+	// still on the shell stack (e.g. closing the game with the window X button), popping those
+	// screens re-initialized the revealed save/load menu, which read from the already destroyed
+	// TheGameState and crashed. See GitHub issue #2777.
+	m_isDeconstructing = TRUE;
+
 	WindowLayout *newTop = top();
 	while(newTop)
 	{
@@ -205,15 +216,15 @@ void Shell::update()
 
 		}
 
-		// Update the animate window manager
-		m_animateWindowManager->update();
-
 		m_schemeManager->update();
 
 		// mark last time we ran the updates
 		lastUpdate = now;
 
 	}
+
+	// TheSuperHackers @tweak bobtista 08/07/2026 Update the animate window manager every frame, it paces itself now
+	m_animateWindowManager->update();
 
 }
 
@@ -706,8 +717,11 @@ void Shell::doPop( Bool impendingPush )
 	}
 
 	// run the init for the new top of the stack if present
+	// TheSuperHackers @bugfix ZsoltFeher 18/07/2026 Skip the init while the shell is being torn
+	// down, because screen init callbacks use engine subsystems that are already destroyed at
+	// that point. See GitHub issue #2777.
 	WindowLayout *newTop = top();
-	if( newTop && !impendingPush )
+	if( newTop && !impendingPush && !m_isDeconstructing )
 	{
 		newTop->runInit( nullptr );
 		//newTop->bringForward();


### PR DESCRIPTION
bugfix(shell): Fix crash on window-close while in-game with ESC menu open

Fixes GitHub issue #2777 (Minor).

Clicking the window's X button while in-game with the ESC menu chain
(including the full-screen save/load menu) still on the shell's
screen stack quits the app before that stack is unwound, unlike the
in-game quit-menu flow.

SubsystemInterfaceList::shutdownAll() destroys subsystems in reverse
init order. TheGameState is initialized after TheGameClient, so it is
destroyed before GameClient::~GameClient (and therefore Shell::~Shell)
runs. Shell::deconstruct() pops each remaining screen via doPop(),
which runs the init callback of the newly revealed screen underneath
-- re-running SaveLoadMenuFullScreenInit, which calls
TheGameState->populateSaveGameListbox() on the already-destructed
GameState, crashing on a list operation on a destroyed object. This
matches the issue's reported crash stack exactly.

Fix: new Shell::m_isDeconstructing flag, set at the top of
deconstruct() before popping any screens. doPop() now skips running
the revealed screen's init callback while m_isDeconstructing is true,
since screen init callbacks reference engine subsystems that may
already be destroyed at that point in shutdown. Normal pops, pushes,
Shell::reset(), and the quit-menu flow (which unwinds the shell before
subsystem teardown begins) are unaffected -- this only changes
behavior during the shell's own destructor.

Also includes an unrelated, concurrently-developed fix to the same
file for issue #2832 (GUI slide-in animation speed tied to
framerate, committed separately for AnimateWindowManager.h/.cpp):
Shell::update() now calls the animate window manager's update() every
frame instead of throttling it to the shell's own 30 Hz gate, since
that manager now paces itself internally.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

