### PR TITLE
bugfix(weapon): Fix use-after-free when a weapon change fires during its own attack

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -824,6 +824,11 @@ public:
 		return newInstance(Weapon)(tmpl, wslot);	// my, that was easy
 	}
 
+	// TheSuperHackers @bugfix 18/07/2026 Queues a Weapon for deletion at the start of the next
+	// WeaponStore update, when no Weapon can be executing its fire on the call stack. Use this
+	// instead of an immediate deleteInstance whenever the Weapon may currently be firing.
+	void deleteWeaponLater(Weapon* weapon);
+
 	void createAndFireTempWeapon(const WeaponTemplate* w, const Object *source, const Coord3D* pos);
 	void createAndFireTempWeapon(const WeaponTemplate* w, const Object *source, Object *target);
 
@@ -839,6 +844,7 @@ protected:
 	WeaponTemplate *newOverride( WeaponTemplate *weaponTemplate );
 
 	void deleteAllDelayedDamage();
+	void deleteAllPendingWeapons();
 	void resetWeaponTemplates();
 	void setDelayedDamage(const WeaponTemplate *weapon, const Coord3D* pos, UnsignedInt whichFrame, ObjectID sourceID, ObjectID victimID, const WeaponBonus& bonus);
 
@@ -868,6 +874,10 @@ private:
 	WeaponTemplateMap m_weaponTemplateHashMap;
 
 	std::list<WeaponDelayedDamageInfo> m_weaponDDI;
+
+	// TheSuperHackers @bugfix 18/07/2026 Weapons queued by deleteWeaponLater, deleted at the
+	// start of the next WeaponStore update (see deleteAllPendingWeapons).
+	std::vector<Weapon*> m_weaponsPendingDelete;
 };
 
 // EXTERNALS //////////////////////////////////////////////////////////////////////////////////////

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1428,6 +1428,7 @@ WeaponStore::WeaponStore()
 //-------------------------------------------------------------------------------------------------
 WeaponStore::~WeaponStore()
 {
+	deleteAllPendingWeapons();
 	deleteAllDelayedDamage();
 
 	for (size_t i = 0; i < m_weaponTemplateVector.size(); i++)
@@ -1536,8 +1537,32 @@ WeaponTemplate *WeaponStore::newOverride(WeaponTemplate *weaponTemplate)
 }
 
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @bugfix 18/07/2026 Queues a Weapon for deletion at a point where it can no
+// longer be executing on the call stack. WeaponSet::updateWeaponSet can be reached from within
+// Weapon::privateFireWeapon (dealing damage can score a kill, which can raise the attacker's
+// veterancy level and change its weapon set flags), so deleting the replaced Weapon immediately
+// would free the very Weapon still executing its fire, causing a use-after-free. See GitHub #941.
+void WeaponStore::deleteWeaponLater(Weapon* weapon)
+{
+	if (weapon != nullptr)
+		m_weaponsPendingDelete.push_back(weapon);
+}
+
+//-------------------------------------------------------------------------------------------------
+void WeaponStore::deleteAllPendingWeapons()
+{
+	for (size_t i = 0; i < m_weaponsPendingDelete.size(); ++i)
+		deleteInstance(m_weaponsPendingDelete[i]);
+	m_weaponsPendingDelete.clear();
+}
+
+//-------------------------------------------------------------------------------------------------
 void WeaponStore::update()
 {
+	// TheSuperHackers @bugfix 18/07/2026 Delete weapons that were replaced during this frame.
+	// This runs in the end-of-frame cleanup of GameLogic::update, when no Weapon is firing.
+	deleteAllPendingWeapons();
+
 	for (std::list<WeaponDelayedDamageInfo>::iterator ddi = m_weaponDDI.begin(); ddi != m_weaponDDI.end(); )
 	{
 		UnsignedInt curFrame = TheGameLogic->getFrame();
@@ -1588,6 +1613,7 @@ void WeaponStore::reset()
 		}
 	}
 
+	deleteAllPendingWeapons();
 	deleteAllDelayedDamage();
 	resetWeaponTemplates();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -324,7 +324,13 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 		m_hasDamageWeapon = false;
 		for (Int i = WEAPONSLOT_COUNT - 1; i >= PRIMARY_WEAPON ; --i)
 		{
-			deleteInstance(m_weapons[i]);
+			// TheSuperHackers @bugfix 18/07/2026 Defer the deletion of the replaced Weapon.
+			// updateWeaponSet can be reached from within Weapon::privateFireWeapon of this very
+			// Weapon: dealing damage can score a kill, raise the attacker's veterancy level and
+			// thereby change its weapon set flags. Deleting the Weapon here would free it while
+			// it is still executing its fire on the call stack, causing a use-after-free.
+			// Instead, the WeaponStore deletes it in the end-of-frame cleanup. See GitHub #941.
+			TheWeaponStore->deleteWeaponLater(m_weapons[i]);
 			m_weapons[i] = nullptr;
 
 			if (set->getNth((WeaponSlotType)i))

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -849,6 +849,11 @@ public:
 		return newInstance(Weapon)(tmpl, wslot);	// my, that was easy
 	}
 
+	// TheSuperHackers @bugfix 18/07/2026 Queues a Weapon for deletion at the start of the next
+	// WeaponStore update, when no Weapon can be executing its fire on the call stack. Use this
+	// instead of an immediate deleteInstance whenever the Weapon may currently be firing.
+	void deleteWeaponLater(Weapon* weapon);
+
 	void createAndFireTempWeapon(const WeaponTemplate* w, const Object *source, const Coord3D* pos);
 	void createAndFireTempWeapon(const WeaponTemplate* w, const Object *source, Object *target);
 
@@ -864,6 +869,7 @@ protected:
 	WeaponTemplate *newOverride( WeaponTemplate *weaponTemplate );
 
 	void deleteAllDelayedDamage();
+	void deleteAllPendingWeapons();
 	void resetWeaponTemplates();
 	void setDelayedDamage(const WeaponTemplate *weapon, const Coord3D* pos, UnsignedInt whichFrame, ObjectID sourceID, ObjectID victimID, const WeaponBonus& bonus);
 
@@ -893,6 +899,10 @@ private:
 	WeaponTemplateMap m_weaponTemplateHashMap;
 
 	std::list<WeaponDelayedDamageInfo> m_weaponDDI;
+
+	// TheSuperHackers @bugfix 18/07/2026 Weapons queued by deleteWeaponLater, deleted at the
+	// start of the next WeaponStore update (see deleteAllPendingWeapons).
+	std::vector<Weapon*> m_weaponsPendingDelete;
 };
 
 // EXTERNALS //////////////////////////////////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1574,6 +1574,7 @@ WeaponStore::WeaponStore()
 //-------------------------------------------------------------------------------------------------
 WeaponStore::~WeaponStore()
 {
+	deleteAllPendingWeapons();
 	deleteAllDelayedDamage();
 
 	for (size_t i = 0; i < m_weaponTemplateVector.size(); i++)
@@ -1682,8 +1683,32 @@ WeaponTemplate *WeaponStore::newOverride(WeaponTemplate *weaponTemplate)
 }
 
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @bugfix 18/07/2026 Queues a Weapon for deletion at a point where it can no
+// longer be executing on the call stack. WeaponSet::updateWeaponSet can be reached from within
+// Weapon::privateFireWeapon (dealing damage can score a kill, which can raise the attacker's
+// veterancy level and change its weapon set flags), so deleting the replaced Weapon immediately
+// would free the very Weapon still executing its fire, causing a use-after-free. See GitHub #941.
+void WeaponStore::deleteWeaponLater(Weapon* weapon)
+{
+	if (weapon != nullptr)
+		m_weaponsPendingDelete.push_back(weapon);
+}
+
+//-------------------------------------------------------------------------------------------------
+void WeaponStore::deleteAllPendingWeapons()
+{
+	for (size_t i = 0; i < m_weaponsPendingDelete.size(); ++i)
+		deleteInstance(m_weaponsPendingDelete[i]);
+	m_weaponsPendingDelete.clear();
+}
+
+//-------------------------------------------------------------------------------------------------
 void WeaponStore::update()
 {
+	// TheSuperHackers @bugfix 18/07/2026 Delete weapons that were replaced during this frame.
+	// This runs in the end-of-frame cleanup of GameLogic::update, when no Weapon is firing.
+	deleteAllPendingWeapons();
+
 	for (std::list<WeaponDelayedDamageInfo>::iterator ddi = m_weaponDDI.begin(); ddi != m_weaponDDI.end(); )
 	{
 		UnsignedInt curFrame = TheGameLogic->getFrame();
@@ -1734,6 +1759,7 @@ void WeaponStore::reset()
 		}
 	}
 
+	deleteAllPendingWeapons();
 	deleteAllDelayedDamage();
 	resetWeaponTemplates();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -332,7 +332,13 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 		m_hasDamageWeapon = false;
 		for (Int i = WEAPONSLOT_COUNT - 1; i >= PRIMARY_WEAPON ; --i)
 		{
-			deleteInstance(m_weapons[i]);
+			// TheSuperHackers @bugfix 18/07/2026 Defer the deletion of the replaced Weapon.
+			// updateWeaponSet can be reached from within Weapon::privateFireWeapon of this very
+			// Weapon: dealing damage can score a kill, raise the attacker's veterancy level and
+			// thereby change its weapon set flags. Deleting the Weapon here would free it while
+			// it is still executing its fire on the call stack, causing a use-after-free.
+			// Instead, the WeaponStore deletes it in the end-of-frame cleanup. See GitHub #941.
+			TheWeaponStore->deleteWeaponLater(m_weapons[i]);
 			m_weapons[i] = nullptr;
 
 			if (set->getNth((WeaponSlotType)i))


### PR DESCRIPTION
bugfix(weapon): Fix use-after-free when a weapon change fires during its own attack

Fixes GitHub issue #941 (Major).

Despite the issue title ("WeaponTemplate use-after-free"), the freed
object is the Weapon instance itself, deleted while its own fire call
is still on the call stack. Confirmed from the issue's ASAN report and
tracing the actual call chain:

Weapon::privateFireWeapon -> WeaponTemplate::fireWeaponTemplate ->
dealDamageInternal -> a victim (an AngryMob member, in the reported
case) dies -> Object::scoreTheKill -> the attacker's
ExperienceTracker::addExperiencePoints -> a veterancy level-up ->
Object::onVeterancyLevelChanged -> setWeaponSetFlag -> updateWeaponSet
-> deleteInstance(m_weapons[i]) on the very Weapon whose
privateFireWeapon frame is still executing. Control returns to that
frame, which then writes into (and further code paths use) the freed
Weapon.

AngryMob simply makes this reliable to hit: a swarm of individually
killable, XP-yielding members means kills mid-burst (and the
resulting veterancy-triggered weapon set changes) are frequent, but
the underlying bug is general and not specific to AngryMob.

Fix: defer the deletion instead of changing when/whether weapon sets
get replaced. WeaponSet::updateWeaponSet() now hands a replaced
Weapon to a new WeaponStore::deleteWeaponLater() queue instead of
deleting it immediately; the queue is flushed at the start of
WeaponStore::update() (GameLogic's end-of-frame cleanup, when no
Weapon can be mid-fire), and also in WeaponStore::reset() and its
destructor so nothing leaks across a reset or shutdown. Weapon has no
destructor side effects that depend on exact timing, so deferring by
at most one frame is invisible to game state and needs no xfer
support (the queue is always empty across saved frames).

Mirrored identically in both Generals and GeneralsMD trees.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, using a community-supplied ASAN report as the starting
point for tracing the actual re-entrant call chain.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

