### PR TITLE
bugfix(pathfind): Recover from dangling open/closed list pointers instead of crashing

### DIFF
--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1725,8 +1725,34 @@ void PathfindCell::forwardInsertionSortRetailCompatible(PathfindCellList& list)
 	PathfindCell* currentCell = list.m_head;
 	PathfindCell* previousCell = nullptr;
 	UnsignedInt cellCount = 0;
-	while (currentCell && cellCount < PATHFIND_CELLS_PER_FRAME && currentCell->m_info->m_totalCost <= m_info->m_totalCost)
+	while (currentCell)
 	{
+		// TheSuperHackers @bugfix 18/07/2026 The retail compatible pathfinding can leave dangling open list pointers
+		// that link a cell without PathfindCellInfo onto the open list. A retail client crashes here on a null pointer access.
+		// To recover, insert this cell at the current position, drop the unreachable corrupted remainder of the list
+		// and schedule a forced cleanup that releases the orphaned cells when the current pathfind finishes.
+		// Relates to issues #2637 and #2799.
+		if (currentCell->m_info == nullptr)
+		{
+			s_forceCleanCells = true;
+			if (previousCell)
+			{
+				previousCell->m_info->m_nextOpen = this->m_info;
+				m_info->m_prevOpen = previousCell->m_info;
+			}
+			else
+			{
+				// the corrupted cell is the list head, so the whole list is dropped
+				list.m_head = this;
+				m_info->m_prevOpen = nullptr;
+			}
+			m_info->m_nextOpen = nullptr;
+			return;
+		}
+
+		if (cellCount >= PATHFIND_CELLS_PER_FRAME || currentCell->m_info->m_totalCost > m_info->m_totalCost)
+			break;
+
 		cellCount++;
 		previousCell = currentCell;
 		currentCell = currentCell->getNextOpen();
@@ -1972,6 +1998,18 @@ void PathfindCell::putOnClosedList( PathfindCellList &list )
 	{
 		m_info->m_closed = FALSE;
 		m_info->m_closed = TRUE;
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+		// TheSuperHackers @bugfix 18/07/2026 The retail compatible pathfinding can leave dangling closed list pointers
+		// that link a cell without PathfindCellInfo at the closed list head. A retail client crashes here on a null pointer access.
+		// To recover, drop the corrupted list and schedule a forced cleanup that releases the orphaned cells
+		// when the current pathfind finishes. Relates to issues #2637 and #2799.
+		if (!s_useFixedPathfinding && list.m_head && list.m_head->m_info == nullptr)
+		{
+			s_forceCleanCells = true;
+			list.m_head = nullptr;
+		}
+#endif
 
 		m_info->m_prevOpen = nullptr;
 		m_info->m_nextOpen = list.m_head ? list.m_head->m_info : nullptr;
@@ -5006,6 +5044,9 @@ void Pathfinder::cleanOpenAndClosedLists() {
 	// TheSuperHackers @info this is here as the map cells are contained within the pathfinder and cannot be cleaned externally.
 	// If the crash mode within PathfindCell::releaseOpenList is hit, it will set s_forceCleanCells to allow the system to cleanly recover.
 	if (s_forceCleanCells) {
+		// TheSuperHackers @bugfix 18/07/2026 Also switch to the fixed pathfinding here, because s_forceCleanCells can now
+		// be set by crash mode detections deep inside an ongoing pathfind, which cannot safely switch mid search.
+		s_useFixedPathfinding = true;
 		forceCleanCells();
 		// TheSuperHackers @info cells on the closed list are forcefully cleaned up by this point
 		s_forceCleanCells = false;
@@ -5021,6 +5062,8 @@ void Pathfinder::cleanOpenAndClosedLists() {
 	// TheSuperHackers @info this is here and performs the same function as the above block, but for when the crash occurs within the closed list.
 	// If the crash mode within PathfindCell::releaseClosedList is hit, it will set s_forceCleanCells to allow the system to cleanly recover.
 	if (s_forceCleanCells) {
+		// TheSuperHackers @bugfix 18/07/2026 Also switch to the fixed pathfinding here, see the comment above.
+		s_useFixedPathfinding = true;
 		forceCleanCells();
 		s_forceCleanCells = false;
 	}
@@ -8892,6 +8935,20 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 		Real dx;
 		Real dy;
 		Real distSqr;
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+		// TheSuperHackers @bugfix 18/07/2026 This is here to catch a retail pathfinding crash point and to recover from it.
+		// A cell has gotten onto the open list without pathfinding info due to a dangling m_open pointer on the previous listed cell,
+		// so we need to force a cleanup before popping it crashes in PathfindCell::removeFromOpenList.
+		// Relates to issues #2637 and #2799.
+		if (!s_useFixedPathfinding && !m_openList.getHead()->hasInfo()) {
+			s_useFixedPathfinding = true;
+			forceCleanCells();
+			m_isTunneling = false;
+			return nullptr;
+		}
+#endif
+
 		// take head cell off of open list - it has lowest estimated total path cost
 		parentCell = m_openList.getHead();
 		parentCell->removeFromOpenList(m_openList);


### PR DESCRIPTION
bugfix(pathfind): Recover from dangling open/closed list pointers instead of crashing

Fixes GitHub issues #2799 and #2637 (both Major) -- one shared root
cause, two crash sites.

RETAIL_COMPATIBLE_PATHFINDING deliberately preserves retail's
pathfinding bugs for replay/network compatibility. Retail's
startPathfind marks the start cell's m_open=TRUE without linking it
into the open/closed list; when such a cell is later "removed" from a
list it was never actually on, removeFromOpenList/removeFromClosedList
splice dangling m_nextOpen/m_prevOpen pointers into otherwise-live
lists. Those pointers can reference freed PathfindCellInfo objects
whose owning cell's m_info has since gone null, and the next list
traversal dereferences it:
- #2799: forwardInsertionSortRetailCompatible(), walking the open list
  (currentCell->m_info->m_totalCost with currentCell->m_info == null).
- #2637: putOnClosedList(), at the closed list head
  (list.m_head->m_info->m_prevOpen with list.m_head->m_info == null).

This reproduces identically in replays (deterministic corruption from
the same retail bug), which is why #2637's reporter observed the
existing failover mechanism not yet triggering at these specific
sites -- the codebase already has a detection+recovery mechanism for
this exact corruption class (s_forceCleanCells / s_useFixedPathfinding
/ forceCleanCells()) at other crash-prone sites, just not these two.

Fix, all in shared Core/ (covers both Generals and Zero Hour):
1. forwardInsertionSortRetailCompatible(): detect a null m_info while
   walking the open list; if found, splice the new cell in at the
   current position, drop the unreachable (corrupted) remainder, and
   set s_forceCleanCells. The loop's original termination condition
   is preserved (restructured into an equivalent break check) for the
   normal, uncorrupted case.
2. putOnClosedList(): if the closed list head has no info, drop the
   corrupted list and set s_forceCleanCells before linking the new
   head.
3. cleanOpenAndClosedLists(): both existing s_forceCleanCells
   consumption points now also set s_useFixedPathfinding = true --
   needed because the two new detections above can now fire mid-search
   deep inside a pathfind, which cannot safely switch pathfinding mode
   immediately (that would corrupt the list via an unmaintained
   m_tail); the mode switch is deferred to this existing safe cleanup
   point instead. No-op for already-existing failover flows.
4. findClosestPath()'s A* loop: added a guard at the top of the loop,
   mirroring an existing guard elsewhere in the same function -- if
   the open list head has no info, fail over via forceCleanCells() and
   return no-path, before the adjacent removeFromOpenList() call would
   otherwise crash on it.

All four changes reuse the codebase's own existing recovery pattern
for this bug class rather than introducing a new mechanism. Every
search exit path already calls cleanOpenAndClosedLists(), and
forceCleanCells() resets both lists and all infos before
releaseClosedList runs; releaseInfo/getParentCell/prependCells were
verified null-tolerant on the paths that execute between detection
and cleanup.

Given this touches core pathfinding/simulation logic with
replay-determinism implications (RETAIL_COMPATIBLE_PATHFINDING exists
specifically for that), this is worth extra scrutiny/testing beyond
the clean build achieved here.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate these two specific
GitHub issues, using community-supplied crash dumps and replay files
referenced in both issue threads as the starting point.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

