### PR TITLE
bugfix(ai): Fix multiple AISkirmishPlayer bugs (7 GitHub issues)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -339,6 +339,18 @@ void AIPlayer::queueSupplyTruck()
 				info->setCurrentGatherers(curGatherers);
 			}
 		} else {
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix 18/07/2026 Don't reattach loose harvesters to GLA rebuild holes.
+			// The build list entry can point at a rebuild hole (KINDOF_REBUILD_HOLE), which is not a
+			// valid dock, so ordering a harvester to dock there leaves it stuck. The servicing branch
+			// above already skips rebuild holes; this branch was missing the check.
+			{
+				Object *center = TheGameLogic->findObjectByID(info->getObjectID());
+				if (center && center->isKindOf(KINDOF_REBUILD_HOLE)) {
+					continue;
+				}
+			}
+#endif
 			/* See if we have any "loose" harvesters (cause my supply center got nuked.) */
 			Player::PlayerTeamList::const_iterator it;
 			for (it = m_player->getPlayerTeams()->begin(); it != m_player->getPlayerTeams()->end(); ++it) {
@@ -928,7 +940,14 @@ void AIPlayer::guardSupplyCenter( Team *team, Int minSupplies )
 //-------------------------------------------------------------------------------------------------
 Bool AIPlayer::isSupplySourceAttacked()
 {
+#if RETAIL_COMPATIBLE_CRC
 	const Int SCAN_RATE = 10; // don't scan more often than every 10 seconds.
+#else
+	// TheSuperHackers @bugfix 18/07/2026 SCAN_RATE is compared against frame counts but was specified
+	// in seconds, shrinking the intended 10 second attack memory window to 10 frames (0.33 seconds),
+	// making the AI forget attacks on its supply lines almost immediately.
+	const Int SCAN_RATE = 10 * LOGICFRAMES_PER_SECOND; // don't scan more often than every 10 seconds.
+#endif
 	UnsignedInt curFrame = TheGameLogic->getFrame();
 	if (curFrame==0) {
 		m_supplySourceAttackCheckFrame = curFrame+SCAN_RATE;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -137,6 +137,10 @@ void AISkirmishPlayer::processBaseBuilding()
 							if (priorID == spawnerID) {
 								DEBUG_LOG(("AI Found hole to rebuild %s", curPlan->getName().str()));
 								info->setObjectID(obj->getID());
+#if !RETAIL_COMPATIBLE_CRC
+								// TheSuperHackers @bugfix 18/07/2026 Stop scanning once the matching rebuild hole is found.
+								break;
+#endif
 							}
 						}
  					}
@@ -182,6 +186,12 @@ void AISkirmishPlayer::processBaseBuilding()
 					info->setObjectTimestamp(0); // ready to build.
 				}
 			}
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix 18/07/2026 Re-fetch the building, because the object ID may have been
+			// updated to a GLA rebuild hole above. The hole rebuilds the structure autonomously, so the
+			// entry must be treated as already built and skipped, instead of being considered missing.
+			bldg = TheGameLogic->findObjectByID( info->getObjectID() );
+#endif
 			if (bldg) {
 				continue; // already built.
 			}
@@ -215,7 +225,14 @@ void AISkirmishPlayer::processBaseBuilding()
 				}
 				continue;
 			}
+#if RETAIL_COMPATIBLE_CRC
 			if (TheBuildAssistant->canMakeUnit(dozer, bldgPlan)!=CANMAKE_OK) {
+#else
+			// TheSuperHackers @bugfix 18/07/2026 Check buildability of the entry currently being evaluated
+			// (curPlan) instead of the accumulated candidate (bldgPlan), which starts as null and
+			// blocked all automatic build entries from ever becoming candidates.
+			if (TheBuildAssistant->canMakeUnit(dozer, curPlan)!=CANMAKE_OK) {
+#endif
 				if (info->isBuildable()) {
 					AsciiString bldgName = info->getTemplateName();
 					bldgName.concat(" - Dozer unable to build - money or technology missing.");
@@ -510,12 +527,25 @@ void AISkirmishPlayer::acquireEnemy()
 					// Some ai is already targeting this guy.  Add a distance penalty.
 					curDistSqr += (500*500);
 				}
+#if RETAIL_COMPATIBLE_CRC
 				if (somePlayer->isSkirmishAIPlayer() && (somePlayer->getCurrentEnemy()==m_player)) {
 					// he is attacking me.  So I will (gently) prefer to attack him.
 					curDistSqr -= (25*25);
 					if (curDistSqr<0) curDistSqr = 0;
 				}
+#endif
 			}
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix 18/07/2026 Apply the retaliation bonus to the candidate that is
+			// attacking us. Previously the check tested the inner loop player instead of the candidate,
+			// so the bonus was applied to unrelated candidates, while the actual attacker, skipped by
+			// the k==i check, never received it.
+			if (curPlayer->isSkirmishAIPlayer() && (curPlayer->getCurrentEnemy()==m_player)) {
+				// he is attacking me.  So I will (gently) prefer to attack him.
+				curDistSqr -= (25*25);
+				if (curDistSqr<0) curDistSqr = 0;
+			}
+#endif
 
 			// Ai enemy - will take if we don't get a better offer.
 			if (curDistSqr<bestDistanceSqr) {
@@ -662,7 +692,22 @@ void AISkirmishPlayer::buildAIBaseDefenseStructure(const AsciiString &thingName,
 			}
 		}
 
+#if RETAIL_COMPATIBLE_CRC
 		if (angle > PI/3) break;
+#else
+		// TheSuperHackers @bugfix 18/07/2026 Limit both sides of the defense arc to 60 degrees.
+		// The previous check never triggered for the negative (right side) angles, allowing one
+		// placement outside the intended sector, and it left the placement counter stuck once the
+		// left side reached the limit, permanently stopping base defense construction.
+		if (fabs(angle) > PI/3) {
+			if (flank) {
+				m_curFlankBaseDefense++;
+			} else {
+				m_curFrontBaseDefense++;
+			}
+			break;
+		}
+#endif
 		Real s = sin(angle);
 		Real c = cos(angle);
 
@@ -866,9 +911,15 @@ void AISkirmishPlayer::doBaseBuilding()
 				m_readyToBuildStructure = true;
 				m_buildDelay = 0;
 			}
+#if RETAIL_COMPATIBLE_CRC
 			if (m_structureTimer > 3*LOGICFRAMES_PER_SECOND) {
 				m_structureTimer = 3*LOGICFRAMES_PER_SECOND;
 			}
+#else
+			// TheSuperHackers @bugfix 18/07/2026 Removed the hardcoded 3 second timer cap that overrode
+			// the structure build delay configured via AIData.ini
+			// (StructureSeconds and the StructuresWealthyRate/StructuresPoorRate modifiers).
+#endif
 		}
 		// This timer is to keep from banging on the logic each frame.  If something interesting
 		// happens, like a building is added or a unit finished, the timers are shortcut.
@@ -918,9 +969,15 @@ void AISkirmishPlayer::doTeamBuilding()
 				m_readyToBuildTeam = true;
 				m_teamDelay = 0;
 			}
+#if RETAIL_COMPATIBLE_CRC
 			if (m_teamTimer > 3*LOGICFRAMES_PER_SECOND) {
 				m_teamTimer = 3*LOGICFRAMES_PER_SECOND;
 			}
+#else
+			// TheSuperHackers @bugfix 18/07/2026 Removed the hardcoded 3 second timer cap that overrode
+			// the team build delay configured via AIData.ini
+			// (TeamSeconds and the TeamsWealthyRate/TeamsPoorRate modifiers).
+#endif
 		}
 
 		// This timer is to keep from banging on the logic each frame.  If something interesting
@@ -1175,13 +1232,18 @@ void AISkirmishPlayer::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info;
-	* 1: Initial version */
+	* 1: Initial version
+	* 2: TheSuperHackers @bugfix 18/07/2026 Save the current enemy and the next enemy check frame */
 // ------------------------------------------------------------------------------------------------
 void AISkirmishPlayer::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -1211,6 +1273,26 @@ void AISkirmishPlayer::xfer( Xfer *xfer )
 
 	// right flank right defense angle
 	xfer->xferReal( &m_curRightFlankRightDefenseAngle );
+
+	// TheSuperHackers @bugfix 18/07/2026 Restore the current enemy and the next enemy check frame.
+	// Previously these were not saved, causing the AI to forget its chosen enemy and re-acquire
+	// an enemy from scratch immediately after loading a save.
+	if (version >= 2)
+	{
+		// frame to check enemy
+		xfer->xferUnsignedInt( &m_frameToCheckEnemy );
+
+		// current enemy, stored as a player index
+		Int enemyIndex = m_currentEnemy ? m_currentEnemy->getPlayerIndex() : PLAYER_INDEX_INVALID;
+		xfer->xferInt( &enemyIndex );
+		if (xfer->getXferMode() == XFER_LOAD)
+		{
+			if (enemyIndex >= 0 && enemyIndex < ThePlayerList->getPlayerCount())
+				m_currentEnemy = ThePlayerList->getNthPlayer( enemyIndex );
+			else
+				m_currentEnemy = nullptr;
+		}
+	}
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -343,6 +343,18 @@ void AIPlayer::queueSupplyTruck()
 				info->setCurrentGatherers(curGatherers);
 			}
 		} else {
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix 18/07/2026 Don't reattach loose harvesters to GLA rebuild holes.
+			// The build list entry can point at a rebuild hole (KINDOF_REBUILD_HOLE), which is not a
+			// valid dock, so ordering a harvester to dock there leaves it stuck. The servicing branch
+			// above already skips rebuild holes; this branch was missing the check.
+			{
+				Object *center = TheGameLogic->findObjectByID(info->getObjectID());
+				if (center && center->isKindOf(KINDOF_REBUILD_HOLE)) {
+					continue;
+				}
+			}
+#endif
 			/* See if we have any "loose" harvesters (cause my supply center got nuked.) */
 			Player::PlayerTeamList::const_iterator it;
 			for (it = m_player->getPlayerTeams()->begin(); it != m_player->getPlayerTeams()->end(); ++it) {
@@ -935,7 +947,14 @@ void AIPlayer::guardSupplyCenter( Team *team, Int minSupplies )
 //-------------------------------------------------------------------------------------------------
 Bool AIPlayer::isSupplySourceAttacked()
 {
+#if RETAIL_COMPATIBLE_CRC
 	const Int SCAN_RATE = 10; // don't scan more often than every 10 seconds.
+#else
+	// TheSuperHackers @bugfix 18/07/2026 SCAN_RATE is compared against frame counts but was specified
+	// in seconds, shrinking the intended 10 second attack memory window to 10 frames (0.33 seconds),
+	// making the AI forget attacks on its supply lines almost immediately.
+	const Int SCAN_RATE = 10 * LOGICFRAMES_PER_SECOND; // don't scan more often than every 10 seconds.
+#endif
 	UnsignedInt curFrame = TheGameLogic->getFrame();
 	if (curFrame==0) {
 		m_supplySourceAttackCheckFrame = curFrame+SCAN_RATE;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -137,6 +137,10 @@ void AISkirmishPlayer::processBaseBuilding()
 							if (priorID == spawnerID) {
 								DEBUG_LOG(("AI Found hole to rebuild %s", curPlan->getName().str()));
 								info->setObjectID(obj->getID());
+#if !RETAIL_COMPATIBLE_CRC
+								// TheSuperHackers @bugfix 18/07/2026 Stop scanning once the matching rebuild hole is found.
+								break;
+#endif
 							}
 						}
  					}
@@ -189,6 +193,12 @@ void AISkirmishPlayer::processBaseBuilding()
 					info->setObjectTimestamp(0); // ready to build.
 				}
 			}
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix 18/07/2026 Re-fetch the building, because the object ID may have been
+			// updated to a GLA rebuild hole above. The hole rebuilds the structure autonomously, so the
+			// entry must be treated as already built and skipped, instead of being considered missing.
+			bldg = TheGameLogic->findObjectByID( info->getObjectID() );
+#endif
 			if (bldg) {
 				continue; // already built.
 			}
@@ -222,7 +232,14 @@ void AISkirmishPlayer::processBaseBuilding()
 				}
 				continue;
 			}
+#if RETAIL_COMPATIBLE_CRC
 			if (TheBuildAssistant->canMakeUnit(dozer, bldgPlan)!=CANMAKE_OK) {
+#else
+			// TheSuperHackers @bugfix 18/07/2026 Check buildability of the entry currently being evaluated
+			// (curPlan) instead of the accumulated candidate (bldgPlan), which starts as null and
+			// blocked all automatic build entries from ever becoming candidates.
+			if (TheBuildAssistant->canMakeUnit(dozer, curPlan)!=CANMAKE_OK) {
+#endif
 				if (info->isBuildable()) {
 					AsciiString bldgName = info->getTemplateName();
 					bldgName.concat(" - Dozer unable to build - money or technology missing.");
@@ -517,12 +534,25 @@ void AISkirmishPlayer::acquireEnemy()
 					// Some ai is already targeting this guy.  Add a distance penalty.
 					curDistSqr += (500*500);
 				}
+#if RETAIL_COMPATIBLE_CRC
 				if (somePlayer->isSkirmishAIPlayer() && (somePlayer->getCurrentEnemy()==m_player)) {
 					// he is attacking me.  So I will (gently) prefer to attack him.
 					curDistSqr -= (25*25);
 					if (curDistSqr<0) curDistSqr = 0;
 				}
+#endif
 			}
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix 18/07/2026 Apply the retaliation bonus to the candidate that is
+			// attacking us. Previously the check tested the inner loop player instead of the candidate,
+			// so the bonus was applied to unrelated candidates, while the actual attacker, skipped by
+			// the k==i check, never received it.
+			if (curPlayer->isSkirmishAIPlayer() && (curPlayer->getCurrentEnemy()==m_player)) {
+				// he is attacking me.  So I will (gently) prefer to attack him.
+				curDistSqr -= (25*25);
+				if (curDistSqr<0) curDistSqr = 0;
+			}
+#endif
 
 			// Ai enemy - will take if we don't get a better offer.
 			if (curDistSqr<bestDistanceSqr) {
@@ -671,7 +701,22 @@ void AISkirmishPlayer::buildAIBaseDefenseStructure(const AsciiString &thingName,
 			}
 		}
 
+#if RETAIL_COMPATIBLE_CRC
 		if (angle > PI/3) break;
+#else
+		// TheSuperHackers @bugfix 18/07/2026 Limit both sides of the defense arc to 60 degrees.
+		// The previous check never triggered for the negative (right side) angles, allowing one
+		// placement outside the intended sector, and it left the placement counter stuck once the
+		// left side reached the limit, permanently stopping base defense construction.
+		if (fabs(angle) > PI/3) {
+			if (flank) {
+				m_curFlankBaseDefense++;
+			} else {
+				m_curFrontBaseDefense++;
+			}
+			break;
+		}
+#endif
 		Real s = sin(angle);
 		Real c = cos(angle);
 
@@ -875,9 +920,15 @@ void AISkirmishPlayer::doBaseBuilding()
 				m_readyToBuildStructure = true;
 				m_buildDelay = 0;
 			}
+#if RETAIL_COMPATIBLE_CRC
 			if (m_structureTimer > 3*LOGICFRAMES_PER_SECOND) {
 				m_structureTimer = 3*LOGICFRAMES_PER_SECOND;
 			}
+#else
+			// TheSuperHackers @bugfix 18/07/2026 Removed the hardcoded 3 second timer cap that overrode
+			// the structure build delay configured via AIData.ini
+			// (StructureSeconds and the StructuresWealthyRate/StructuresPoorRate modifiers).
+#endif
 		}
 		// This timer is to keep from banging on the logic each frame.  If something interesting
 		// happens, like a building is added or a unit finished, the timers are shortcut.
@@ -927,9 +978,15 @@ void AISkirmishPlayer::doTeamBuilding()
 				m_readyToBuildTeam = true;
 				m_teamDelay = 0;
 			}
+#if RETAIL_COMPATIBLE_CRC
 			if (m_teamTimer > 3*LOGICFRAMES_PER_SECOND) {
 				m_teamTimer = 3*LOGICFRAMES_PER_SECOND;
 			}
+#else
+			// TheSuperHackers @bugfix 18/07/2026 Removed the hardcoded 3 second timer cap that overrode
+			// the team build delay configured via AIData.ini
+			// (TeamSeconds and the TeamsWealthyRate/TeamsPoorRate modifiers).
+#endif
 		}
 
 		// This timer is to keep from banging on the logic each frame.  If something interesting
@@ -1186,13 +1243,18 @@ void AISkirmishPlayer::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info;
-	* 1: Initial version */
+	* 1: Initial version
+	* 2: TheSuperHackers @bugfix 18/07/2026 Save the current enemy and the next enemy check frame */
 // ------------------------------------------------------------------------------------------------
 void AISkirmishPlayer::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -1222,6 +1284,26 @@ void AISkirmishPlayer::xfer( Xfer *xfer )
 
 	// right flank right defense angle
 	xfer->xferReal( &m_curRightFlankRightDefenseAngle );
+
+	// TheSuperHackers @bugfix 18/07/2026 Restore the current enemy and the next enemy check frame.
+	// Previously these were not saved, causing the AI to forget its chosen enemy and re-acquire
+	// an enemy from scratch immediately after loading a save.
+	if (version >= 2)
+	{
+		// frame to check enemy
+		xfer->xferUnsignedInt( &m_frameToCheckEnemy );
+
+		// current enemy, stored as a player index
+		Int enemyIndex = m_currentEnemy ? m_currentEnemy->getPlayerIndex() : PLAYER_INDEX_INVALID;
+		xfer->xferInt( &enemyIndex );
+		if (xfer->getXferMode() == XFER_LOAD)
+		{
+			if (enemyIndex >= 0 && enemyIndex < ThePlayerList->getPlayerCount())
+				m_currentEnemy = ThePlayerList->getNthPlayer( enemyIndex );
+			else
+				m_currentEnemy = nullptr;
+		}
+	}
 
 }
 


### PR DESCRIPTION
bugfix(ai): Fix multiple AISkirmishPlayer bugs (7 GitHub issues)

All fixes gated behind !RETAIL_COMPATIBLE_CRC (and, for the one
save/load fix, !RETAIL_COMPATIBLE_XFER_SAVE), matching this session's
established pattern: AI decisions affect CRC-checked simulation state,
so changing AI behavior must not alter retail-compatible replay/
multiplayer sync by default. All fixes below are dormant unless that
project-wide constraint is lifted.

#2386 (Minor) - AIPlayer.cpp, isSupplySourceAttacked(): SCAN_RATE was
declared as "10" intending 10 seconds but compared directly against
frame counts (LOGICFRAMES_PER_SECOND=30), shrinking the intended
10-second attack memory window to 10 frames (0.33s) -- the AI forgot
an attack on its supply lines almost immediately. Fixed by scaling
SCAN_RATE by LOGICFRAMES_PER_SECOND.

#2388 (Minor) - AIPlayer.cpp, queueSupplyTruck(): the "loose harvester"
reattachment branch was missing the KINDOF_REBUILD_HOLE check that the
sibling servicing branch already had, so orphaned harvesters could be
ordered to dock at a GLA rebuild hole (not a valid dock) and get stuck.

#2407 (Minor) - AISkirmishPlayer.cpp, processBaseBuilding(): two
distinct bugs. (1) The rebuild-hole scan didn't stop once a match was
found, continuing to overwrite info->setObjectID() with later holes.
(2) After a hole was assigned, the code re-checked buildability against
the still-null accumulated bldgPlan pointer instead of curPlan,
blocking every automatic build entry from ever becoming a candidate;
also, a hole rebuilds its structure autonomously, so its entry must be
treated as already built (re-fetch by the possibly-updated object ID)
rather than considered missing.

#2398 (Minor) - AISkirmishPlayer.cpp, buildAIBaseDefenseStructure():
the angle limit check only tested the positive (left) side, so
placements on the negative (right) side of the sector were never
rejected and could land outside the intended arc; the check also
never incremented the placement counter on the left-side limit,
permanently stalling further base defense construction once reached.
Fixed to test fabs(angle) and to still advance the counter when the
limit is hit.

#2409 (Minor) - AISkirmishPlayer.cpp, doBaseBuilding()/doTeamBuilding():
a hardcoded 3-second timer cap silently overrode the StructureSeconds/
TeamSeconds (and their WealthyRate/PoorRate modifiers) settings
configured via AIData.ini. Cap removed.

#2413 (Minor) - AISkirmishPlayer.cpp, acquireEnemy(): the retaliation
distance bonus was tested against the wrong loop variable (the inner
loop's player instead of the outer loop's candidate), applying the
bonus to unrelated candidates while the actual attacker -- excluded
from the inner loop by its own k==i check -- never received it. Fixed
to test the actual candidate.

#2420 (Minor) - AISkirmishPlayer.cpp, xfer(): m_currentEnemy and
m_frameToCheckEnemy were never saved, so after loading a save the AI
forgot its chosen enemy and reacquired one from scratch immediately.
Fixed via a new xfer version 2, saving m_frameToCheckEnemy directly
and m_currentEnemy as a player index (resolved back through
ThePlayerList on load).

Mirrored identically in both Generals and GeneralsMD trees.

AI-assisted change: root causes found and fixed by an AI agent
(Claude, via Claude Code) after being asked to investigate these
seven specific GitHub issues in the same AI subsystem as one focused
pass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

