### PR TITLE
bugfix(audio): Restart in-progress sounds after loading a save game (6 GitHub issues)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -230,6 +230,18 @@ void HackInternetAIUpdate::loadPostProcess()
 {
  // extend base class
 	AIUpdateInterface::loadPostProcess();
+
+	// TheSuperHackers @bugfix 19/07/2026 Replay the unpack or pack sound when still unpacking or
+	// packing, because playing sounds are not saved and would otherwise stay silent after loading
+	// a save game. The sound is replayed from its beginning.
+	const StateID currentState = getStateMachine()->getCurrentStateID();
+	if( currentState == UNPACKING || currentState == PACKING )
+	{
+		Object *owner = getObject();
+		AudioEventRTS sound = *owner->getTemplate()->getPerUnitSound( currentState == UNPACKING ? "UnitUnpack" : "UnitPack" );
+		sound.setObjectID( owner->getID() );
+		TheAudio->addAudioEvent( &sound );
+	}
 }
 
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
@@ -337,4 +337,9 @@ void FlammableUpdate::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
+	// TheSuperHackers @bugfix 19/07/2026 Restart the burning sound when the object is still aflame,
+	// because playing sounds are not saved and would otherwise stay silent after loading a save game.
+	if( m_status == FS_AFLAME )
+		startBurningSound();
+
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/HelicopterSlowDeathUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/HelicopterSlowDeathUpdate.cpp
@@ -551,4 +551,18 @@ void HelicopterSlowDeathBehavior::loadPostProcess()
 	// extend base class
 	SlowDeathBehavior::loadPostProcess();
 
+	// TheSuperHackers @bugfix 19/07/2026 Restart the death sound loop when the helicopter is still
+	// crashing and has not yet hit the ground, because playing sounds are not saved and would
+	// otherwise stay silent after loading a save game.
+	if( isSlowDeathActivated() && m_hitGroundFrame == 0 )
+	{
+		m_deathSound = getHelicopterSlowDeathBehaviorModuleData()->m_deathSound;
+
+		if( m_deathSound.getEventName().isNotEmpty() )
+		{
+			m_deathSound.setObjectID( getObject()->getID() );
+			m_deathSound.setPlayingHandle( TheAudio->addAudioEvent( &m_deathSound ) );
+		}
+	}
+
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -320,4 +320,13 @@ void MissileLauncherBuildingUpdate::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
+	// TheSuperHackers @bugfix 19/07/2026 Restart the door open idle sound when the door is still open,
+	// because playing sounds are not saved and would otherwise stay silent after loading a save game.
+	if( m_doorState == DOOR_OPEN &&
+			m_openIdleAudio.getEventName().isNotEmpty() && !m_openIdleAudio.isCurrentlyPlaying() )
+	{
+		m_openIdleAudio.setObjectID( getObject()->getID() );
+		m_openIdleAudio.setPlayingHandle( TheAudio->addAudioEvent( &m_openIdleAudio ) );
+	}
+
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -1466,37 +1466,41 @@ void ParticleUplinkCannonUpdate::loadPostProcess()
 				DEBUG_CRASH(( "ParticleUplinkCannonUpdate::loadPostProcess - Unable to find drawable for m_orbitToTargetBeamID" ));
 			}
 		}
+	}
 
-		// TheSuperHackers @bugfix stephanmeesters 13/02/2026
-		// For retail game compatibility, this fixes an issue where particle cannon sounds are not audible after saveload.
-		if( (m_status == STATUS_CHARGING || m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY) &&
-			m_powerupSound.getEventName().isNotEmpty() )
+	// TheSuperHackers @bugfix stephanmeesters 13/02/2026
+	// This fixes an issue where particle cannon sounds are not audible after saveload.
+	// TheSuperHackers @bugfix 19/07/2026 Restart the sounds for all save versions, because the
+	// playing sounds are not saved in any version. Also no longer restart the firing and
+	// annihilation sounds while the cannon is already packing, because the firing sequence is
+	// about to end then and restarting these loud sounds from their beginning plays a strange
+	// sound right after loading.
+	if( (m_status == STATUS_CHARGING || m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY) &&
+		m_powerupSound.getEventName().isNotEmpty() )
+	{
+		m_powerupSound.setObjectID( getObject()->getID() );
+		m_powerupSound.setPlayingHandle( TheAudio->addAudioEvent( &m_powerupSound ) );
+	}
+
+	if( (m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY || m_status == STATUS_READY_TO_FIRE || m_status == STATUS_PREFIRE) &&
+		m_unpackToReadySound.getEventName().isNotEmpty() )
+	{
+		m_unpackToReadySound.setObjectID( getObject()->getID() );
+		m_unpackToReadySound.setPlayingHandle( TheAudio->addAudioEvent( &m_unpackToReadySound ) );
+	}
+
+	if( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE )
+	{
+		if( m_firingToIdleSound.getEventName().isNotEmpty() )
 		{
-			m_powerupSound.setObjectID( getObject()->getID() );
-			m_powerupSound.setPlayingHandle( TheAudio->addAudioEvent( &m_powerupSound ) );
+			m_firingToIdleSound.setObjectID( getObject()->getID() );
+			m_firingToIdleSound.setPlayingHandle( TheAudio->addAudioEvent( &m_firingToIdleSound ) );
 		}
 
-		if( (m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY || m_status == STATUS_READY_TO_FIRE || m_status == STATUS_PREFIRE) &&
-			m_unpackToReadySound.getEventName().isNotEmpty() )
+		if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID && m_annihilationSound.getEventName().isNotEmpty() )
 		{
-			m_unpackToReadySound.setObjectID( getObject()->getID() );
-			m_unpackToReadySound.setPlayingHandle( TheAudio->addAudioEvent( &m_unpackToReadySound ) );
-		}
-
-		if( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE ||
-			(m_status == STATUS_PACKING && (m_laserStatus == LASERSTATUS_DECAYING || m_laserStatus == LASERSTATUS_DEAD)) )
-		{
-			if( m_firingToIdleSound.getEventName().isNotEmpty() )
-			{
-				m_firingToIdleSound.setObjectID( getObject()->getID() );
-				m_firingToIdleSound.setPlayingHandle( TheAudio->addAudioEvent( &m_firingToIdleSound ) );
-			}
-
-			if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID && m_annihilationSound.getEventName().isNotEmpty() )
-			{
-				m_annihilationSound.setDrawableID( m_orbitToTargetBeamID );
-				m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
-			}
+			m_annihilationSound.setDrawableID( m_orbitToTargetBeamID );
+			m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1904,4 +1904,18 @@ void SpecialAbilityUpdate::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
+	// TheSuperHackers @bugfix 19/07/2026 Restart the preparation sound loop when the special ability
+	// is still preparing, because playing sounds are not saved and would otherwise stay silent after
+	// loading a save game.
+	if( m_active && !isPreparationComplete() )
+	{
+		const SpecialAbilityUpdateModuleData *data = getSpecialAbilityUpdateModuleData();
+		if( data->m_prepSoundLoop.getEventName().isNotEmpty() )
+		{
+			m_prepSoundLoop = data->m_prepSoundLoop;
+			m_prepSoundLoop.setObjectID( getObject()->getID() );
+			m_prepSoundLoop.setPlayingHandle( TheAudio->addAudioEvent( &m_prepSoundLoop ) );
+		}
+	}
+
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -236,6 +236,18 @@ void HackInternetAIUpdate::loadPostProcess()
 {
  // extend base class
 	AIUpdateInterface::loadPostProcess();
+
+	// TheSuperHackers @bugfix 19/07/2026 Replay the unpack or pack sound when still unpacking or
+	// packing, because playing sounds are not saved and would otherwise stay silent after loading
+	// a save game. The sound is replayed from its beginning.
+	const StateID currentState = getStateMachine()->getCurrentStateID();
+	if( currentState == UNPACKING || currentState == PACKING )
+	{
+		Object *owner = getObject();
+		AudioEventRTS sound = *owner->getTemplate()->getPerUnitSound( currentState == UNPACKING ? "UnitUnpack" : "UnitPack" );
+		sound.setObjectID( owner->getID() );
+		TheAudio->addAudioEvent( &sound );
+	}
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
@@ -337,4 +337,9 @@ void FlammableUpdate::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
+	// TheSuperHackers @bugfix 19/07/2026 Restart the burning sound when the object is still aflame,
+	// because playing sounds are not saved and would otherwise stay silent after loading a save game.
+	if( m_status == FS_AFLAME )
+		startBurningSound();
+
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/HelicopterSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/HelicopterSlowDeathUpdate.cpp
@@ -551,4 +551,18 @@ void HelicopterSlowDeathBehavior::loadPostProcess()
 	// extend base class
 	SlowDeathBehavior::loadPostProcess();
 
+	// TheSuperHackers @bugfix 19/07/2026 Restart the death sound loop when the helicopter is still
+	// crashing and has not yet hit the ground, because playing sounds are not saved and would
+	// otherwise stay silent after loading a save game.
+	if( isSlowDeathActivated() && m_hitGroundFrame == 0 )
+	{
+		m_deathSound = getHelicopterSlowDeathBehaviorModuleData()->m_deathSound;
+
+		if( m_deathSound.getEventName().isNotEmpty() )
+		{
+			m_deathSound.setObjectID( getObject()->getID() );
+			m_deathSound.setPlayingHandle( TheAudio->addAudioEvent( &m_deathSound ) );
+		}
+	}
+
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -336,4 +336,13 @@ void MissileLauncherBuildingUpdate::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
+	// TheSuperHackers @bugfix 19/07/2026 Restart the door open idle sound when the door is still open,
+	// because playing sounds are not saved and would otherwise stay silent after loading a save game.
+	if( m_doorState == DOOR_OPEN &&
+			m_openIdleAudio.getEventName().isNotEmpty() && !m_openIdleAudio.isCurrentlyPlaying() )
+	{
+		m_openIdleAudio.setObjectID( getObject()->getID() );
+		m_openIdleAudio.setPlayingHandle( TheAudio->addAudioEvent( &m_openIdleAudio ) );
+	}
+
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -1559,37 +1559,41 @@ void ParticleUplinkCannonUpdate::loadPostProcess()
 				DEBUG_CRASH(( "ParticleUplinkCannonUpdate::loadPostProcess - Unable to find drawable for m_orbitToTargetBeamID" ));
 			}
 		}
+	}
 
-		// TheSuperHackers @bugfix stephanmeesters 13/02/2026
-		// For retail game compatibility, this fixes an issue where particle cannon sounds are not audible after saveload.
-		if( (m_status == STATUS_CHARGING || m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY) &&
-			m_powerupSound.getEventName().isNotEmpty() )
+	// TheSuperHackers @bugfix stephanmeesters 13/02/2026
+	// This fixes an issue where particle cannon sounds are not audible after saveload.
+	// TheSuperHackers @bugfix 19/07/2026 Restart the sounds for all save versions, because the
+	// playing sounds are not saved in any version. Also no longer restart the firing and
+	// annihilation sounds while the cannon is already packing, because the firing sequence is
+	// about to end then and restarting these loud sounds from their beginning plays a strange
+	// sound right after loading.
+	if( (m_status == STATUS_CHARGING || m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY) &&
+		m_powerupSound.getEventName().isNotEmpty() )
+	{
+		m_powerupSound.setObjectID( getObject()->getID() );
+		m_powerupSound.setPlayingHandle( TheAudio->addAudioEvent( &m_powerupSound ) );
+	}
+
+	if( (m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY || m_status == STATUS_READY_TO_FIRE || m_status == STATUS_PREFIRE) &&
+		m_unpackToReadySound.getEventName().isNotEmpty() )
+	{
+		m_unpackToReadySound.setObjectID( getObject()->getID() );
+		m_unpackToReadySound.setPlayingHandle( TheAudio->addAudioEvent( &m_unpackToReadySound ) );
+	}
+
+	if( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE )
+	{
+		if( m_firingToIdleSound.getEventName().isNotEmpty() )
 		{
-			m_powerupSound.setObjectID( getObject()->getID() );
-			m_powerupSound.setPlayingHandle( TheAudio->addAudioEvent( &m_powerupSound ) );
+			m_firingToIdleSound.setObjectID( getObject()->getID() );
+			m_firingToIdleSound.setPlayingHandle( TheAudio->addAudioEvent( &m_firingToIdleSound ) );
 		}
 
-		if( (m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY || m_status == STATUS_READY_TO_FIRE || m_status == STATUS_PREFIRE) &&
-			m_unpackToReadySound.getEventName().isNotEmpty() )
+		if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID && m_annihilationSound.getEventName().isNotEmpty() )
 		{
-			m_unpackToReadySound.setObjectID( getObject()->getID() );
-			m_unpackToReadySound.setPlayingHandle( TheAudio->addAudioEvent( &m_unpackToReadySound ) );
-		}
-
-		if( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE ||
-			(m_status == STATUS_PACKING && (m_laserStatus == LASERSTATUS_DECAYING || m_laserStatus == LASERSTATUS_DEAD)) )
-		{
-			if( m_firingToIdleSound.getEventName().isNotEmpty() )
-			{
-				m_firingToIdleSound.setObjectID( getObject()->getID() );
-				m_firingToIdleSound.setPlayingHandle( TheAudio->addAudioEvent( &m_firingToIdleSound ) );
-			}
-
-			if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID && m_annihilationSound.getEventName().isNotEmpty() )
-			{
-				m_annihilationSound.setDrawableID( m_orbitToTargetBeamID );
-				m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
-			}
+			m_annihilationSound.setDrawableID( m_orbitToTargetBeamID );
+			m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -2081,4 +2081,18 @@ void SpecialAbilityUpdate::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
+	// TheSuperHackers @bugfix 19/07/2026 Restart the preparation sound loop when the special ability
+	// is still preparing, because playing sounds are not saved and would otherwise stay silent after
+	// loading a save game.
+	if( m_active && !isPreparationComplete() )
+	{
+		const SpecialAbilityUpdateModuleData *data = getSpecialAbilityUpdateModuleData();
+		if( data->m_prepSoundLoop.getEventName().isNotEmpty() )
+		{
+			m_prepSoundLoop = data->m_prepSoundLoop;
+			m_prepSoundLoop.setObjectID( getObject()->getID() );
+			m_prepSoundLoop.setPlayingHandle( TheAudio->addAudioEvent( &m_prepSoundLoop ) );
+		}
+	}
+
 }


### PR DESCRIPTION
bugfix(audio): Restart in-progress sounds after loading a save game (6 GitHub issues)

Fixes #2685, #2683, #2682, #2684, #2023, and #2419 (all Minor). #2686
(dam breaking) investigated but deliberately left unfixed -- see below.

Shared root cause across all of these: each affected module tracks a
currently-playing AudioEventRTS/sound handle that is only ever started
by a state-transition event (igniting, a door opening, a slow death
beginning, an ability's preparation starting, a state machine entering
a state, a laser/beam status changing). Save/load correctly restores
the resulting STATE (m_status, m_doorState, m_flags, m_prepFrames, the
active state machine state, etc.), but never the playing sound itself,
and a loaded object starts directly IN that state rather than
transitioning into it -- so the audio-triggering event never re-fires,
and sounds that should still be playing are silent.

The established fix pattern for this bug class (from previously-merged
PR #2302, already applied to ParticleUplinkCannonUpdate for issue
#2023) is to re-issue TheAudio->addAudioEvent() from the module's
loadPostProcess() based on the restored state. Applied to five more
affected modules and extended for two issues in the same file:

- #2685 (burning trees) - FlammableUpdate::loadPostProcess(): restart
  the burning sound when m_status == FS_AFLAME.
- #2683 (nuke silo door) - MissileLauncherBuildingUpdate::loadPostProcess():
  restart DoorOpenIdleAudio when m_doorState == DOOR_OPEN.
- #2682 (helicopter crash loop) - HelicopterSlowDeathBehavior::loadPostProcess():
  restart SoundDeathLoop when the slow death is active and the
  helicopter hasn't hit the ground yet (m_hitGroundFrame == 0); ground
  impact still removes it normally via the newly-restored handle.
- #2684 (Hacker/Black Lotus prep) - two separate mechanisms, both
  fixed: SpecialAbilityUpdate::loadPostProcess() restarts PrepSoundLoop
  for an in-progress ability (Black Lotus capture/hack, hacker disable
  building); HackInternetAIUpdate::loadPostProcess() replays the
  UnitUnpack/UnitPack one-shot laptop sound when the state machine is
  still mid-UNPACKING/PACKING.
- #2023 + #2419 (Particle Cannon) - ParticleUplinkCannonUpdate::loadPostProcess():
  the existing #2302 fix only ran under a legacy save-version guard, so
  it silently didn't apply to current-format saves; moved the restore
  logic out of that guard so it always runs. Separately, dropped the
  STATUS_PACKING clause that also restarted the loud firing/annihilation
  sounds from their beginning when a save was made while the cannon's
  firing sequence was already ending -- exactly the "strange sound"
  #2419 reported. Those two sounds now only restart during
  STATUS_FIRING/STATUS_POSTFIRE, matching #2023's actual repro.

#2686 (dam breaking) intentionally left unfixed: the break sounds are
one-shot effects fired through an FXList by TransitionDamageFX, which
serializes no transition timestamp -- there's no saved data indicating
when the break happened or how much of the sound would remain, so a
correct restore isn't possible without a save-format change (blocked
by RETAIL_COMPATIBLE_XFER_SAVE, on by default). The related persistent
DamDamageLoop ambient loops already restore correctly via existing
Drawable::loadPostProcess() machinery; no fix needed there. Replaying
the one-shot sound unconditionally on every load of an already-damaged
dam would just be wrong in a different way, so this was left alone
rather than adding a bad fix.

Mirrored identically in both Generals and GeneralsMD trees.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate these seven related
GitHub issues as one focused pass, including finding and extending a
previously-merged partial fix (PR #2302) rather than duplicating it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

