### PR TITLE
bugfix(gui): Fix uninitialized memory in W3DGadgetHorizontalSliderImageDrawA

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DHorizontalSlider.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DHorizontalSlider.cpp
@@ -351,8 +351,10 @@ void W3DGadgetHorizontalSliderImageDrawA( GameWindow *window,
 
 		leftImageRight = leftImageLeft					= GadgetSliderGetDisabledImageLeft( window );
 		rightImageRight = rightImageLeft				= GadgetSliderGetDisabledImageRight( window );
-//		centerImageRight = centerImageLeft				= GadgetSliderGetDisabledImageCenter( window );
-//		smallCenterImageRight = smallCenterImageLeft	= GadgetSliderGetDisabledImageSmallCenter( window );
+		// TheSuperHackers @fix Restores the disabled center image assignments, which were commented
+		// out in the original code and left these pointers uninitialized on the disabled code path.
+		centerImageRight = centerImageLeft				= GadgetSliderGetDisabledImageCenter( window );
+		smallCenterImageRight = smallCenterImageLeft	= GadgetSliderGetDisabledImageSmallCenter( window );
 
 	}
 	else //if( BitIsSet( instData->getState(), WIN_STATE_HILITED ) )


### PR DESCRIPTION
bugfix(gui): Fix uninitialized memory in W3DGadgetHorizontalSliderImageDrawA

Fixes GitHub issue #961 (Minor).

The disabled-state branch only assigned leftImage*/rightImage*; the
center and small-center image assignments were commented out in the
original EA code. All eight image pointers are read a few lines later
in a null sanity check before being passed to winDrawImage, so on the
disabled path centerImageLeft/Right and smallCenterImageLeft/Right
held uninitialized stack memory -- if non-null by chance, garbage
Image* pointers would reach winDrawImage (undefined behavior/crash);
if null, the slider would silently draw incompletely.

The direct analog, W3DGadgetVerticalSliderImageDraw, does assign its
disabled center/small-center images in its own disabled branch,
confirming this is the intended pattern the horizontal slider's
commented-out code was meant to follow. Restored the two assignments
using the existing GadgetSliderGetDisabledImageCenter/SmallCenter
accessors.

Shared Core/ file, compiled into both Generals and GeneralsMD.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

