### PR TITLE
bugfix(rendering): Fix deadlock during scripted camera intro/outro when the game is halted

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1802,7 +1802,13 @@ AGAIN:
   	//
 	//PredictiveLODOptimizerClass::Optimize_LODs( 5000 );
 
-	Bool freezeTime = TheFramePacer->isTimeFrozen() || TheFramePacer->isGameHalted();
+	// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Keep the halted state separate from the frozen
+	// time. When the game is halted (e.g. the network is stalling), the scripted camera does not
+	// advance, so the render loop below would never see the camera movement finish and would spin
+	// forever, never returning to the engine loop that services the network. Render a single frame
+	// and return instead. Fixes a multiplayer freeze during scripted camera intros/outros (#1995).
+	const Bool gameHalted = TheFramePacer->isGameHalted();
+	Bool freezeTime = TheFramePacer->isTimeFrozen() || gameHalted;
 
 	/// @todo: I'm assuming the first view is our main 3D view.
 	W3DView *primaryW3DView=(W3DView *)getFirstView();
@@ -2005,7 +2011,7 @@ AGAIN:
 			freezeTime = false; // We're frozen for debug or for pause, and need to continue out of the loop.
 		}
 
-	} while (freezeTime && !TheTacticalView->isCameraMovementFinished());
+	} while (freezeTime && !gameHalted && !TheTacticalView->isCameraMovementFinished());
 
 #ifdef EXTENDED_STATS
 	if (DX8Wrapper::stats.m_disableOverhead) {

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1882,7 +1882,13 @@ AGAIN:
   	//
 	//PredictiveLODOptimizerClass::Optimize_LODs( 5000 );
 
-	Bool freezeTime = TheFramePacer->isTimeFrozen() || TheFramePacer->isGameHalted();
+	// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Keep the halted state separate from the frozen
+	// time. When the game is halted (e.g. the network is stalling), the scripted camera does not
+	// advance, so the render loop below would never see the camera movement finish and would spin
+	// forever, never returning to the engine loop that services the network. Render a single frame
+	// and return instead. Fixes a multiplayer freeze during scripted camera intros/outros (#1995).
+	const Bool gameHalted = TheFramePacer->isGameHalted();
+	Bool freezeTime = TheFramePacer->isTimeFrozen() || gameHalted;
 
 	/// @todo: I'm assuming the first view is our main 3D view.
 	W3DView *primaryW3DView=(W3DView *)getFirstView();
@@ -2094,7 +2100,7 @@ AGAIN:
 			freezeTime = false; // We're frozen for debug or for pause, and need to continue out of the loop.
 		}
 
-	} while (freezeTime && !TheTacticalView->isCameraMovementFinished());
+	} while (freezeTime && !gameHalted && !TheTacticalView->isCameraMovementFinished());
 
 #ifdef EXTENDED_STATS
 	if (DX8Wrapper::stats.m_disableOverhead) {


### PR DESCRIPTION
bugfix(rendering): Fix deadlock during scripted camera intro/outro when the game is halted

Fixes GitHub issue #1995 (Major).

W3DDisplay::draw()'s render loop treated "time frozen" and "game
halted" (e.g. a stalling network connection) as the same condition,
looping until either debug/pause freeze cleared or the scripted
camera's movement finished. But the scripted camera does not advance
while the game is halted (isGameHalted() gates the camera's frame
progression, correctly, since the camera must not run ahead during a
stall) -- so during a halt, "camera movement finished" can never
become true, and the loop spins forever. Since GameEngine::update()
(which services the network) never runs while spinning inside
draw(), the stall can never resolve: a real deadlock, reported as a
freeze during scripted camera intros/outros and confirmed in the
issue thread by a maintainer via an independent read of the same code
path.

Fix: track isGameHalted() separately from isTimeFrozen(), keeping it
folded into freezeTime for the existing fast-time shortcut behavior,
but excluding it from the loop's continue condition. While halted,
the loop now renders exactly one frame and returns to the engine
loop (allowing the network to be serviced and the stall to clear)
instead of spinning until a camera state that cannot occur. Frozen
time (debug freeze, pause, single-player cinematics) is unaffected --
those still render to completion as before, since the camera step is
nonzero and completion is still reachable in that case.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue,
confirming and formalizing a root-cause diagnosis already discussed
in the issue thread.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

