### PR TITLE
bugfix(input): Fix CTRL/ALT getting stuck latched while a text entry has focus

### DIFF
--- a/Core/GameEngine/Source/GameClient/GUI/Gadget/GadgetTextEntry.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/Gadget/GadgetTextEntry.cpp
@@ -151,6 +151,18 @@ WindowMsgHandledType GadgetTextEntryInput( GameWindow *window, UnsignedInt msg,
 
 			switch( mData1 )
 			{
+				// --------------------------------------------------------------------
+				// TheSuperHackers @bugfix Ignore the CTRL and ALT modifier keys themselves.
+				// Their key-down passes through above (it carries the CONTROL/ALT state bit),
+				// but their key-up does not, and was consumed here. The consumed raw key-up
+				// then never reached MetaEventTranslator, leaving hold-state latches stuck,
+				// e.g. CTRL force attack mode while the beacon text entry has focus (#986).
+				case KEY_LCTRL:
+				case KEY_RCTRL:
+				case KEY_LALT:
+				case KEY_RALT:
+					return MSG_IGNORED;
+
 				/*
 				// --------------------------------------------------------------------
 				case KEY_KPENTER:


### PR DESCRIPTION
bugfix(input): Fix CTRL/ALT getting stuck latched while a text entry has focus

Fixes GitHub issue #986 (Major).

Selecting a beacon gives keyboard focus to the beacon caption text
entry (ControlBar::populateBeacon -> winSetFocus). With a text entry
focused, GadgetTextEntryInput's GWM_CHAR handler processes raw key
events before they reach MetaEventTranslator.

CTRL/ALT key-DOWN passed through the handler unconsumed, because
Keyboard::updateKeys ORs the current modifier bits into the same
frame's key events, so the down event itself carries KEY_STATE_DOWN
plus CONTROL/ALT, and an earlier check in the handler already
returns MSG_IGNORED for that combination. But the matching key-UP
carries neither KEY_STATE_DOWN nor the modifier bit (it's already
cleared by the time the up event is processed), so it fell through
the handler's switch statement to a default `return MSG_HANDLED`,
which caused the raw key-up to be destroyed before it ever reached
MetaEventTranslator.

MetaEventTranslator maps CTRL/ALT to MK_NONE and relies on the raw
key-up specifically to fire the paired END meta-event and clear the
hold latch (MSG_META_BEGIN_FORCEATTACK on down, MSG_META_END_FORCEATTACK
on up, and the equivalent for ALT/waypoint mode). With the key-up
eaten, the BEGIN latch (already fired on key-down before focus moved
to the beacon window, or fired while focused since down still passes
through) never gets its matching END: force-attack mode stays
latched, so left-clicks force-attack instead of selecting, until CTRL
is pressed and released again outside the text entry. This also
explains "not every time": if the down and up land in the same
keyboard poll batch, the down is symmetrically eaten too (m_modifiers
is still zero when it's read), so no latch is left stuck.

This is a distinct mechanism from the earlier alt-tab stuck-modifier
fixes (#2733/#2734/#2735, #116) fixed elsewhere this session: those
were about Windows never delivering a key-up at all during a focus
loss; this is about a raw key-up arriving normally but being consumed
inside the window system before it reaches the translator chain.

Fix: GadgetTextEntryInput's GWM_CHAR switch now explicitly returns
MSG_IGNORED for KEY_LCTRL/KEY_RCTRL/KEY_LALT/KEY_RALT, so both the
down and up events for these keys always bubble past a focused text
entry to MetaEventTranslator, keeping BEGIN/END meta-events paired.
Shift was left alone since its down/up were already consumed
symmetrically (no latch to get stuck). Text entry typing behavior is
unaffected, since it never used these raw modifier key events itself.

Shared Core/ file, so this single change covers both Generals and
GeneralsMD.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

