### PR TITLE
bugfix(rendering): Fix render-to-texture screen filters disabled under MSAA

### DIFF
--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
@@ -129,6 +129,7 @@ protected:
 	static IDirect3DTexture8 *m_renderTexture;		///<texture into which rendering will be redirected.
 	static IDirect3DSurface8 *m_newRenderSurface;	///<new render target inside m_renderTexture
 	static IDirect3DSurface8 *m_oldDepthSurface;	///<previous depth buffer surface
+	static IDirect3DSurface8 *m_newDepthSurface;	///<non-multisampled depth buffer used while rendering to m_renderTexture (only needed when MSAA is active)
 
 
 };

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
@@ -113,6 +113,7 @@ IDirect3DSurface8 *W3DShaderManager::m_oldRenderSurface=nullptr;	///<previous re
 IDirect3DTexture8 *W3DShaderManager::m_renderTexture=nullptr;		///<texture into which rendering will be redirected.
 IDirect3DSurface8 *W3DShaderManager::m_newRenderSurface=nullptr;	///<new render target inside m_renderTexture
 IDirect3DSurface8 *W3DShaderManager::m_oldDepthSurface=nullptr;	///<previous depth buffer surface
+IDirect3DSurface8 *W3DShaderManager::m_newDepthSurface=nullptr;	///<non-multisampled depth buffer used while rendering to m_renderTexture
 /*===========================================================================================*/
 /*=========      Screen Shaders	=============================================================*/
 /*===========================================================================================*/
@@ -2569,6 +2570,7 @@ W3DShaderManager::W3DShaderManager()
 	m_renderTexture = nullptr;
 	m_newRenderSurface = nullptr;
 	m_oldDepthSurface = nullptr;
+	m_newDepthSurface = nullptr;
 	m_renderingToTexture = false;
 	Int i;
 	for (i=0; i<W3DShaderManager::ST_MAX; i++)
@@ -2607,18 +2609,8 @@ void W3DShaderManager::init()
 			return;
 
 		m_oldRenderSurface->GetDesc(&desc);
-		
-		// TheSuperHackers @bugfix Redirecting rendering to a non-multisampled texture
-		// while using a multisampled depth buffer is an API violation in DX8.
-		if (desc.MultiSampleType == D3DMULTISAMPLE_NONE)
-		{
-			hr=DX8Wrapper::_Get_D3D_Device8()->CreateTexture(desc.Width,desc.Height,1,D3DUSAGE_RENDERTARGET,desc.Format,D3DPOOL_DEFAULT,&m_renderTexture);
-		}
-		else
-		{
-			// Force failure path to avoid MSAA mismatch
-			hr = E_FAIL;
-		}
+
+		hr=DX8Wrapper::_Get_D3D_Device8()->CreateTexture(desc.Width,desc.Height,1,D3DUSAGE_RENDERTARGET,desc.Format,D3DPOOL_DEFAULT,&m_renderTexture);
 
 		if (hr != S_OK)
 		{
@@ -2632,10 +2624,25 @@ void W3DShaderManager::init()
 				m_newRenderSurface = nullptr;
 			}	else {
 				hr = DX8Wrapper::_Get_D3D_Device8()->GetDepthStencilSurface(&m_oldDepthSurface);
+
+				// TheSuperHackers @bugfix Redirecting rendering to a non-multisampled texture while using a
+				// multisampled depth buffer is an API violation in DX8, which previously disabled all
+				// render-to-texture screen filters (motion blur zoom, black & white, crossfade) when MSAA is
+				// enabled. Create a matching non-multisampled depth buffer to use while rendering to the texture.
+				if (hr == S_OK && desc.MultiSampleType != D3DMULTISAMPLE_NONE)
+				{
+					D3DSURFACE_DESC depthDesc;
+					m_oldDepthSurface->GetDesc(&depthDesc);
+					hr = DX8Wrapper::_Get_D3D_Device8()->CreateDepthStencilSurface(desc.Width,desc.Height,depthDesc.Format,D3DMULTISAMPLE_NONE,&m_newDepthSurface);
+					if (hr != S_OK)
+						m_newDepthSurface = nullptr;
+				}
+
 				if (hr != S_OK)
 				{
 					SAFE_RELEASE(m_newRenderSurface);
 					SAFE_RELEASE(m_renderTexture);
+					SAFE_RELEASE(m_oldDepthSurface);
 					m_oldDepthSurface = nullptr;
 				}
 			}
@@ -2677,6 +2684,7 @@ void W3DShaderManager::shutdown()
 	SAFE_RELEASE(m_renderTexture);
 	SAFE_RELEASE(m_oldRenderSurface);
 	SAFE_RELEASE(m_oldDepthSurface);
+	SAFE_RELEASE(m_newDepthSurface);
 	m_currentShader = ST_INVALID;
 	m_currentFilter = FT_NULL_FILTER;
 	//release any assets associated with a shader (vertex/pixel shaders, textures, etc.)
@@ -2834,7 +2842,12 @@ void W3DShaderManager::startRenderToTexture()
 	DEBUG_ASSERTCRASH(!m_renderingToTexture, ("Already rendering to texture - cannot nest calls."));
 
 	if (m_renderingToTexture || m_newRenderSurface==nullptr || m_oldDepthSurface==nullptr) return;
-	HRESULT hr = DX8Wrapper::_Get_D3D_Device8()->SetRenderTarget(m_newRenderSurface,m_oldDepthSurface);
+
+	// TheSuperHackers @bugfix Use the dedicated non-multisampled depth buffer when the back buffer
+	// is multisampled, because pairing a non-multisampled render target with a multisampled depth
+	// buffer is invalid in DX8.
+	IDirect3DSurface8 *depthSurface = m_newDepthSurface ? m_newDepthSurface : m_oldDepthSurface;
+	HRESULT hr = DX8Wrapper::_Get_D3D_Device8()->SetRenderTarget(m_newRenderSurface,depthSurface);
 
 	// TheSuperHackers @bugfix If SetRenderTarget fails (e.g. due to MSAA forced by driver
 	// profile causing a depth buffer mismatch that D3DSURFACE_DESC doesn't report), permanently
@@ -2846,6 +2859,7 @@ void W3DShaderManager::startRenderToTexture()
 		SAFE_RELEASE(m_renderTexture);
 		SAFE_RELEASE(m_oldRenderSurface);
 		SAFE_RELEASE(m_oldDepthSurface);
+		SAFE_RELEASE(m_newDepthSurface);
 		return;
 	}
 


### PR DESCRIPTION
bugfix(rendering): Fix render-to-texture screen filters disabled under MSAA

Fixes GitHub issue #2656 (Minor), "Blur zoom no longer works".

Bisected in the issue thread to commit 8619fa8ee (PR #2482, "Implement
game option to set MSAA level"). Before that PR, MSAA was hardcoded
off, so W3DShaderManager::init()'s deliberate failure path -- refusing
to create the render-to-texture target whenever the back buffer is
multisampled, because pairing a non-multisampled render target with a
multisampled depth buffer is a DX8 API violation -- never triggered.
Once MSAA became configurable (AntiAliasing option, retail default 2),
that guard silently disabled every render-to-texture screen filter for
most players: the motion-blur zoom effect, the black & white filter,
and the crossfade filter.

Fix: instead of refusing to create the render target under MSAA,
create a dedicated non-multisampled depth-stencil surface to pair with
it -- the legal DX8 approach. W3DShaderManager::init() now always
creates the render texture; when the back buffer is multisampled, it
additionally creates a matching non-MSAA depth surface (falling back
to the old disabled behavior if that creation fails).
startRenderToTexture() uses the new depth surface when present. The
new surface is released alongside the existing ones in shutdown() and
on the runtime SetRenderTarget-failure fallback path.

Trade-off: frames rendered through an active screen filter render into
the non-MSAA texture, so they are unantialiased during that filter --
matching retail behavior, and unavoidable without an MSAA resolve
step, which DX8's CopyRects cannot perform.

Shared Core/ code, so this single change covers both Generals and
GeneralsMD.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, using a regression bisect already established in the
issue thread as the starting point.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

