### PR TITLE
bugfix(saveload): Fix map shroud corruption from Strategy Center bonus reapplication on load

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3744,8 +3744,20 @@ void Object::xfer( Xfer *xfer )
 			DEBUG_CRASH(( "Object::xfer - Unable to load team" ));
 			throw SC_INVALID_DATA;
 		}
+		// TheSuperHackers @bugfix Caball009 19/07/2026 Temporarily clear m_modulesReady so that
+		// Player::becomingTeamMember does not re-apply battle plan bonuses (Strategy Center) while
+		// restoring the team. The bonus effects are already contained in the saved object state
+		// (vision range, shroud clearing range, weapon bonus condition, body damage scalar), so
+		// re-applying them here would double the sight range scalar and trigger a shroud look at
+		// the wrong time, corrupting the sighting data that must stay in sync with the saved
+		// partition cell shroud state. This left the map shroud bugged after loading a game with
+		// an active Search And Destroy battle plan.
+		m_modulesReady = false;
+
 		const Bool restoring = true;
 		setOrRestoreTeam( team, restoring );
+
+		m_modulesReady = true;
 	}
 
 	// special model condition until

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4263,8 +4263,21 @@ void Object::xfer( Xfer *xfer )
 			DEBUG_CRASH(( "Object::xfer - Unable to load team" ));
 			throw SC_INVALID_DATA;
 		}
+
+		// TheSuperHackers @bugfix Caball009 19/07/2026 Temporarily clear m_modulesReady so that
+		// Player::becomingTeamMember does not re-apply battle plan bonuses (Strategy Center) while
+		// restoring the team. The bonus effects are already contained in the saved object state
+		// (vision range, shroud clearing range, weapon bonus condition, body damage scalar), so
+		// re-applying them here would double the sight range scalar and trigger a shroud look at
+		// the wrong time, corrupting the sighting data that must stay in sync with the saved
+		// partition cell shroud state. This left the map shroud bugged after loading a game with
+		// an active Search And Destroy battle plan.
+		m_modulesReady = false;
+
 		const Bool restoring = true;
 		setOrRestoreTeam( team, restoring );
+
+		m_modulesReady = true;
 	}
 
 	// special model condition until


### PR DESCRIPTION
bugfix(saveload): Fix map shroud corruption from Strategy Center bonus reapplication on load

Fixes GitHub issue #2882 (Major).

PR #2508 moved the load-time setOrRestoreTeam(team, restoring=true)
call in Object::xfer from before the sighting/vision xfers to after
them (needed so power adjustment sees correct disabled flags at that
point). Side effect: setOrRestoreTeam -> Player::becomingTeamMember,
which -- if the player has active battle plans and the object's
modules are marked ready -- calls applyBattlePlanBonusesForObject().
For an active Search And Destroy plan, that recomputes and reapplies
setVisionRange()/setShroudClearingRange() with the sight-range bonus
scalar.

At the new call position, m_visionRange/m_shroudClearingRange (saved
WITH the bonus already included) and the sighting records
(m_partitionLastLook/m_partitionLastShroud) have already been loaded
from the save. Reapplying the bonus here double-applies the sight
scalar, and because the range changed, it also triggers a shroud
look/unlook mid-load, clobbering the just-restored sighting records
before the save's own partition cell shroud data has finished
loading -- corrupting shroud refcounts, observed as the map shroud
resetting incorrectly around the affected unit's position after the
next time it moves or dies. Retail order applied the same bogus
bonus, but before those xfers ran, so it was harmlessly overwritten
by the subsequently-loaded saved data -- which is why this is a
regression specific to the post-#2508 xfer ordering, not a retail
bug.

Fix (workaround endorsed by the issue's investigator): temporarily
clear m_modulesReady around the restoring setOrRestoreTeam() call, so
becomingTeamMember's existing areModulesReady() gate suppresses the
premature bonus reapplication -- all bonus-derived state is already
correctly present in the saved object data. m_modulesReady is xfer'd
from the save later in the same function, so its real value is
restored regardless of what it's temporarily set to here.
areModulesReady() has no other consumers in either tree, so PR
#2508's original power-adjustment fix is untouched.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, applying the exact workaround already proposed and
endorsed in the issue thread by community investigator Caball009.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

