### PR TITLE
bugfix(saveload): Restore the configured game speed when loading a save game

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -31,6 +31,7 @@
 #include "PreRTS.h"
 #include "Common/file.h"
 #include "Common/FileSystem.h"
+#include "Common/FramePacer.h"
 #include "Common/GameEngine.h"
 #include "Common/GameState.h"
 #include "Common/GameStateMap.h"
@@ -39,6 +40,7 @@
 #include "Common/PlayerList.h"
 #include "Common/RandomValue.h"
 #include "Common/Radar.h"
+#include "Common/SkirmishPreferences.h"
 #include "Common/Team.h"
 #include "Common/WellKnownKeys.h"
 #include "Common/XferLoad.h"
@@ -673,6 +675,26 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 
 	// clear out the game engine
 	TheGameEngine->reset();
+
+	// TheSuperHackers @bugfix Caball009/ZsoltFeher 19/07/2026 Use the Game Speed from the skirmish
+	// settings instead of the default frame rate after the game engine reset, matching the frame
+	// rate selection of a newly started skirmish game (see reallyDoStart and GameLogic::onNewGame).
+	// Without this, loaded save games always play at the GameData.ini default frame rate.
+	// Mission saves are excluded because they start a new game through MSG_NEW_GAME without a
+	// frame rate argument, like regular campaign missions.
+	if( gameInfo.saveGameInfo.saveFileType != SAVE_FILE_TYPE_MISSION )
+	{
+		Int maxFPS = SkirmishPreferences().getInt( "FPS", TheGlobalData->m_framesPerSecondLimit );
+
+		// slider positions above the highest labeled value (60) mean "no limit"
+		if( maxFPS > 60 )
+			maxFPS = 1000;
+		if( maxFPS < 15 )
+			maxFPS = 15;
+
+		TheFramePacer->setFramesPerSecondLimit( maxFPS );
+		TheWritableGlobalData->m_useFpsLimit = true;
+	}
 
 	// lock creation of new ghost objects
 	TheGhostObjectManager->saveLockGhostObjects( TRUE );

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -31,6 +31,7 @@
 #include "PreRTS.h"
 #include "Common/file.h"
 #include "Common/FileSystem.h"
+#include "Common/FramePacer.h"
 #include "Common/GameEngine.h"
 #include "Common/GameState.h"
 #include "Common/GameStateMap.h"
@@ -39,6 +40,7 @@
 #include "Common/PlayerList.h"
 #include "Common/RandomValue.h"
 #include "Common/Radar.h"
+#include "Common/SkirmishPreferences.h"
 #include "Common/Team.h"
 #include "Common/WellKnownKeys.h"
 #include "Common/XferLoad.h"
@@ -673,6 +675,26 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 
 	// clear out the game engine
 	TheGameEngine->reset();
+
+	// TheSuperHackers @bugfix Caball009/ZsoltFeher 19/07/2026 Use the Game Speed from the skirmish
+	// settings instead of the default frame rate after the game engine reset, matching the frame
+	// rate selection of a newly started skirmish game (see reallyDoStart and GameLogic::onNewGame).
+	// Without this, loaded save games always play at the GameData.ini default frame rate.
+	// Mission saves are excluded because they start a new game through MSG_NEW_GAME without a
+	// frame rate argument, like regular campaign missions.
+	if( gameInfo.saveGameInfo.saveFileType != SAVE_FILE_TYPE_MISSION )
+	{
+		Int maxFPS = SkirmishPreferences().getInt( "FPS", TheGlobalData->m_framesPerSecondLimit );
+
+		// slider positions above the highest labeled value (60) mean "no limit"
+		if( maxFPS > 60 )
+			maxFPS = 1000;
+		if( maxFPS < 15 )
+			maxFPS = 15;
+
+		TheFramePacer->setFramesPerSecondLimit( maxFPS );
+		TheWritableGlobalData->m_useFpsLimit = true;
+	}
 
 	// lock creation of new ghost objects
 	TheGhostObjectManager->saveLockGhostObjects( TRUE );


### PR DESCRIPTION
bugfix(saveload): Restore the configured game speed when loading a save game

Fixes GitHub issue #1285 (Minor).

GameState::loadGame() calls TheGameEngine->reset(), which resets every
subsystem including the ScriptEngine; ScriptEngine::reset() explicitly
sets the frame pacer's FPS limit back to TheGlobalData->m_framesPerSecondLimit
(the GameData.ini default, 30). Nothing on the load path ever
re-applied the user's actual Game Speed setting afterward, so every
loaded save played at the default framerate regardless of what the
skirmish menu (or the original session) had configured -- unlike
starting a fresh skirmish game, where reallyDoStart() reads the Game
Speed slider and GameLogic::onNewGame() applies it via
TheFramePacer->setFramesPerSecondLimit().

The issue's original reporter had already opened a fix (PR #1416)
using this exact same approach; it was closed only because it predated
this project's render/logic frame-rate decoupling refactor (the
FramePacer this fix now uses instead).

Fix: after TheGameEngine->reset() in GameState::loadGame(), for
non-mission saves, read the Game Speed from SkirmishPreferences
("FPS" key, same key reallyDoStart() writes and the skirmish menu
reads to initialize its slider) and apply it via
TheFramePacer->setFramesPerSecondLimit(), with the identical
slider-to-FPS conversion reallyDoStart() already uses (values above
the highest labeled slider position mean uncapped/1000, floor of 15).
Mission saves are excluded, since campaign missions restart through
MSG_NEW_GAME without an FPS argument and aren't affected by this gap.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, discovering and modernizing a previously-closed
community fix attempt (PR #1416) to this codebase's current FramePacer
API.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

