### PR TITLE
bugfix(rendering): Smooth frame time used to scale camera/UI motion to reduce stutter

### DIFF
--- a/Core/GameEngine/Include/Common/FramePacer.h
+++ b/Core/GameEngine/Include/Common/FramePacer.h
@@ -49,6 +49,8 @@ public:
 
 	Real getUpdateTime() const; ///< Get the last update delta time in seconds.
 	Real getUpdateFps() const; ///< Get the last update fps.
+	Real getSmoothedUpdateTime() const; ///< Get the exponentially smoothed update delta time in seconds. Preferred for scaling visible motion to avoid jitter.
+	Real getSmoothedUpdateFps() const; ///< Get the exponentially smoothed update fps.
 	Real getBaseOverUpdateFpsRatio(Real minUpdateFps = 5.0f); ///< Get the last engine base over update fps ratio. Used to scale user inputs to a frame rate independent speed.
 
 	void setTimeFrozen(Bool frozen); ///< Set time frozen. Allows scripted camera movement.
@@ -74,6 +76,7 @@ protected:
 	Int m_logicTimeScaleFPS; ///< Maximum frames per second for logic time scale
 
 	Real m_updateTime; ///< Last update delta time in seconds
+	Real m_smoothedUpdateTime; ///< Exponentially smoothed update delta time in seconds
 
 	Bool m_enableFpsLimit;
 	Bool m_enableLogicTimeScale;

--- a/Core/GameEngine/Source/Common/FramePacer.cpp
+++ b/Core/GameEngine/Source/Common/FramePacer.cpp
@@ -38,6 +38,7 @@ FramePacer::FramePacer()
 	m_maxFPS = BaseFps;
 	m_logicTimeScaleFPS = LOGICFRAMES_PER_SECOND;
 	m_updateTime = 1.0f / (Real)BaseFps; // initialized to something to avoid division by zero on first use
+	m_smoothedUpdateTime = m_updateTime;
 	m_enableFpsLimit = FALSE;
 	m_enableLogicTimeScale = FALSE;
 	m_isTimeFrozen = FALSE;
@@ -56,6 +57,17 @@ void FramePacer::update()
 	// with higher resolution counters to cap the frame rate more accurately to the desired limit.
 	const UnsignedInt maxFps = getActualFramesPerSecondLimit();// allowFpsLimit ? getFramesPerSecondLimit() : RenderFpsPreset::UncappedFpsValue;
 	m_updateTime = m_frameRateLimit.wait(maxFps);
+
+	// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Maintain an exponentially smoothed frame time
+	// alongside the raw frame time. Scaling visible motion (camera scroll, scripted camera moves,
+	// client fades) by the raw time of the previous frame turns every frame time spike into a
+	// single oversized movement step on the following frame, which is visible as stuttering and
+	// far jumps during heavy scenes even when the average frame rate is high. See GitHub #1942.
+	// The smoothing uses a ~100 ms time constant, so it converges quickly after real frame rate
+	// changes but suppresses per-frame jitter.
+	const Real smoothTimeConstant = 0.1f;
+	const Real alpha = std::min(1.0f, m_updateTime / smoothTimeConstant);
+	m_smoothedUpdateTime += (m_updateTime - m_smoothedUpdateTime) * alpha;
 }
 
 void FramePacer::setFramesPerSecondLimit( Int fps )
@@ -118,11 +130,23 @@ Real FramePacer::getUpdateFps()  const
 	return 1.0f / m_updateTime;
 }
 
+Real FramePacer::getSmoothedUpdateTime() const
+{
+	return m_smoothedUpdateTime;
+}
+
+Real FramePacer::getSmoothedUpdateFps() const
+{
+	return 1.0f / m_smoothedUpdateTime;
+}
+
 Real FramePacer::getBaseOverUpdateFpsRatio(Real minUpdateFps)
 {
 	// Update fps is floored to default 5 fps, 200 ms.
 	// Useful to prevent insane ratios on frame spikes/stalls.
-	return (Real)BaseFps / std::max(getUpdateFps(), minUpdateFps);
+	// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Use the smoothed update fps so that single
+	// frame time spikes do not translate into oversized movement steps on the next frame. See GitHub #1942.
+	return (Real)BaseFps / std::max(getSmoothedUpdateFps(), minUpdateFps);
 }
 
 void FramePacer::setTimeFrozen(Bool frozen)
@@ -200,7 +224,12 @@ Real FramePacer::getActualLogicTimeScaleOverFpsRatio(LogicTimeQueryFlags flags) 
 {
 	// TheSuperHackers @info Clamps ratio to min 1, because the logic
 	// frame rate is currently capped by the render frame rate.
-	return min(1.0f, (Real)getActualLogicTimeScaleFps(flags) / getUpdateFps());
+	// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Use the smoothed update fps so that render side
+	// steps (scripted camera movement, client fades) advance evenly across frames instead of
+	// jumping after frame time spikes. See GitHub #1942. The raw update time remains in use for
+	// the logic time accumulator in GameEngine, which needs the exact frame time to keep the
+	// long-run logic rate correct.
+	return min(1.0f, (Real)getActualLogicTimeScaleFps(flags) / getSmoothedUpdateFps());
 }
 
 Real FramePacer::getLogicTimeStepSeconds(LogicTimeQueryFlags flags) const


### PR DESCRIPTION
bugfix(rendering): Smooth frame time used to scale camera/UI motion to reduce stutter

Fixes GitHub issue #1942 (Major), "Stuttering Camera and Unit Movement".

Reported and reproduced at render FPS consistently above 100 during
heavily scripted scenes (e.g. the first wave on AOD Cobalt Rush),
smooth in retail. A maintainer diagnosed the mechanism directly on the
issue thread: camera/UI motion is scaled per frame by the RAW,
instantaneous duration of the PREVIOUS frame
(FramePacer::getBaseOverUpdateFpsRatio() / getActualLogicTimeScaleOverFpsRatio(),
consumed by edge/RMB camera scroll, camera zoom/pivot, scripted camera
waypoint movement, rotate/zoom/pitch, the camera shaker, and UI
transitions). During a heavy scripted wave, individual frame times
spike even while the average FPS stays high; because each frame's
movement step is sized by the previous frame's duration, a spike frame
causes the NEXT (fast) frame to take one oversized step, followed by
a run of tiny steps -- visible as stutter and "far jumps". Retail
moved the camera a constant amount per frame regardless of frame time,
so the same spikes only briefly slowed motion there.

Fix: FramePacer now also maintains an exponentially smoothed frame
time (m_smoothedUpdateTime, ~100ms time constant -- converges within
a few tenths of a second after a genuine FPS change, but suppresses
single-frame jitter). getBaseOverUpdateFpsRatio() and
getActualLogicTimeScaleOverFpsRatio() now divide by the smoothed FPS
instead of the raw last-frame FPS. The raw getUpdateTime() is
deliberately left driving the logic-tick accumulator in
GameEngine::canUpdateRegularGameLogic(), which needs the exact frame
time to keep the long-run logic simulation rate correct; only the
render-side motion-scaling consumers were changed.

Shared Core/ code, so this single change covers both Generals and
GeneralsMD.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue,
implementing the exact remedy ("use avg frame rate instead of each
frame") already proposed by a maintainer on the issue thread.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

