### PR TITLE
bugfix(rendering): Fix scorch texture mip quality not updating with runtime texture reduction

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -318,6 +318,14 @@ void BaseHeightMapRenderObjClass::setTextureLOD(Int lod)
 		m_treeBuffer->setTextureLOD(lod);
 	if (m_map)
 		m_map->setTextureLOD(lod);
+#ifdef DO_SCORCH
+	// TheSuperHackers @bugfix The scorch texture is created directly and is not registered
+	// with the asset manager, so WW3D::_Invalidate_Textures() never refreshes it when the
+	// texture reduction changes at runtime. Invalidate it here so it reloads its mip chain
+	// with the currently active texture reduction.
+	if (m_scorchTexture)
+		m_scorchTexture->Invalidate();
+#endif
 }
 
 //=============================================================================


### PR DESCRIPTION
bugfix(rendering): Fix scorch texture mip quality not updating with runtime texture reduction

Fixes GitHub issue #2812 (Minor).

The scorch (battle damage decal) texture is created directly rather
than through the asset manager, so WW3D::_Invalidate_Textures() --
which normally refreshes registered textures when the texture
reduction setting changes at runtime -- never reaches it. Changing
Texture Resolution mid-game left the scorch texture's mip level
stuck at whatever it was when first created.

Fix: BaseHeightMapRenderObjClass::setTextureLOD() (already the
runtime hook other terrain textures use for this) now also invalidates
m_scorchTexture directly, so it reloads its mip chain at the currently
active texture reduction like everything else.

Shared Core/ code, so this single change covers both Generals and
GeneralsMD.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #2812
