### PR TITLE
bugfix(rendering): Fix ghost objects appearing vertically offset

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -362,6 +362,14 @@ void W3DGhostObject::snapShot(int playerIndex)
 			//as for build-ups that are currently disabled.
 			if (robj)
 			{
+				// TheSuperHackers @bugfix The render object's transform is only refreshed while its
+				// drawable is actually drawn, which is not the case while it is obscured by the shroud
+				// of the currently rendered player. Snapshots can now be taken for players other than
+				// the rendered local player, so the transform can be stale here, most notably carrying
+				// an outdated construction height offset that would leave the ghost object vertically
+				// offset. Refresh the transform from the drawable before taking the snapshot.
+				w3dDraw->reactToTransformChange(draw->getTransformMatrix(), draw->getPosition(), draw->getOrientation());
+
 				if (snap == nullptr)
 				{
 					snap = NEW W3DRenderObjectSnapshot(robj, &m_drawableInfo);	// poolify

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -366,6 +366,14 @@ void W3DGhostObject::snapShot(int playerIndex)
 			//as for build-ups that are currently disabled.
 			if (robj)
 			{
+				// TheSuperHackers @bugfix The render object's transform is only refreshed while its
+				// drawable is actually drawn, which is not the case while it is obscured by the shroud
+				// of the currently rendered player. Snapshots can now be taken for players other than
+				// the rendered local player, so the transform can be stale here, most notably carrying
+				// an outdated construction height offset that would leave the ghost object vertically
+				// offset. Refresh the transform from the drawable before taking the snapshot.
+				w3dDraw->reactToTransformChange(draw->getTransformMatrix(), draw->getPosition(), draw->getOrientation());
+
 				if (snap == nullptr)
 				{
 					snap = NEW W3DRenderObjectSnapshot(robj, &m_drawableInfo);	// poolify


### PR DESCRIPTION
bugfix(rendering): Fix ghost objects appearing vertically offset

Fixes GitHub issue #1730 (Minor).

A render object's transform is normally only refreshed while its
drawable is actively drawn. Ghost object snapshots (the shrouded/
last-seen representation of an object under fog of war) can now be
taken for players other than the currently rendered local player, so
by the time a snapshot is captured for one of those other players,
the drawable may not have been drawn recently and its render object's
transform can be stale -- most notably still carrying an outdated
construction height offset, leaving the ghost object rendered visibly
above or below its correct position.

Fix: W3DGhostObject::snapShot() now refreshes the render object's
transform from the drawable's current transform/position/orientation
immediately before capturing the snapshot, so the snapshot always
reflects the drawable's actual up-to-date placement.

Mirrored in both Generals and GeneralsMD trees (this file is
per-tree, not shared).

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #1730
