### PR TITLE
bugfix(rendering): Fix tinted objects turning permanently black after overlapping flashes

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -4822,6 +4822,15 @@ void TintEnvelope::update()
 			if (attackRate.Length() > delta.Length() || delta.Length() <= FADE_RATE_EPSILON)
 			{
 				// We are at the peak
+				// TheSuperHackers @bugfix Snap the current color to the peak color on arrival. With the
+				// tint time step decoupled from the render update, the attack overshoot check can trigger
+				// before the current color has actually reached the peak, leaving it off the peak color.
+				// The decay direction is derived from the peak color, so decaying a non-parallel color
+				// can push individual color components negative, briefly tinting the object black or in
+				// a dark wrong color when flashes overlap (e.g. selecting a building while it is being
+				// captured).
+				m_currentColor.Set( m_peakColor );
+				m_affect = TRUE;
 				if ( m_sustainCounter )
 				{
 					m_envState = ENVELOPE_STATE_SUSTAIN;

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -4793,7 +4793,13 @@ void TintEnvelope::update()
 		{
 			const Vector3 decayRate = m_decayRate * timeScale;
 
-			if (decayRate.Length() > m_currentColor.Length() || m_currentColor.Length() <= FADE_RATE_EPSILON)
+			// TheSuperHackers @bugfix Also rest when the decay step no longer opposes the current
+			// color. The decay direction is derived from the peak color, so when a new flash was
+			// played before the previous one finished, the current color is not parallel to the
+			// peak color and the length check alone can miss the rest window. The color then
+			// marches past zero into large negative values, turning the object permanently black.
+			if (decayRate.Length() > m_currentColor.Length() || m_currentColor.Length() <= FADE_RATE_EPSILON
+				|| Vector3::Dot_Product(decayRate, m_currentColor) >= 0.0f)
 			{
 				// We are at rest
 				m_envState = ENVELOPE_STATE_REST;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -5512,7 +5512,13 @@ void TintEnvelope::update()
 		{
 			const Vector3 decayRate = m_decayRate * timeScale;
 
-			if (decayRate.Length() > m_currentColor.Length() || m_currentColor.Length() <= FADE_RATE_EPSILON) 
+			// TheSuperHackers @bugfix Also rest when the decay step no longer opposes the current
+			// color. The decay direction is derived from the peak color, so when a new flash was
+			// played before the previous one finished, the current color is not parallel to the
+			// peak color and the length check alone can miss the rest window. The color then
+			// marches past zero into large negative values, turning the object permanently black.
+			if (decayRate.Length() > m_currentColor.Length() || m_currentColor.Length() <= FADE_RATE_EPSILON
+				|| Vector3::Dot_Product(decayRate, m_currentColor) >= 0.0f)
 			{
 				// We are at rest
 				m_envState = ENVELOPE_STATE_REST;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -5541,6 +5541,15 @@ void TintEnvelope::update()
 			if (attackRate.Length() > delta.Length() || delta.Length() <= FADE_RATE_EPSILON)
 			{
 				// We are at the peak
+				// TheSuperHackers @bugfix Snap the current color to the peak color on arrival. With the
+				// tint time step decoupled from the render update, the attack overshoot check can trigger
+				// before the current color has actually reached the peak, leaving it off the peak color.
+				// The decay direction is derived from the peak color, so decaying a non-parallel color
+				// can push individual color components negative, briefly tinting the object black or in
+				// a dark wrong color when flashes overlap (e.g. selecting a building while it is being
+				// captured).
+				m_currentColor.Set( m_peakColor );
+				m_affect = TRUE;
 				if ( m_sustainCounter )
 				{
 					m_envState = ENVELOPE_STATE_SUSTAIN;


### PR DESCRIPTION
bugfix(rendering): Fix tinted objects turning permanently black after overlapping flashes

Likely fixes GitHub issue #2112 ("Object tinting logic breaks if
multiple tints are applied on an object"), found while investigating
a related rendering issue cluster this session.

TintEnvelope::update()'s decay phase only checked whether the decay
step's magnitude exceeded the current color's magnitude (or the color
had already faded below a small epsilon) to decide when to stop
decaying and rest at zero. The decay direction is derived from the
peak color of whichever flash last set it. If a new tint flash starts
before the previous one's decay finished, the current color is no
longer parallel to the (new) decay direction, and the magnitude-only
check can miss the point where decay should stop: the color continues
to be decremented past zero into large negative RGB values, which
render as solid black -- and stay that way, since decay never
recognizes it should have stopped.

Fix: also treat the envelope as at rest once the decay step no longer
opposes the current color (their dot product is >= 0), in addition to
the existing magnitude checks. This catches the overshoot case
regardless of the current color's magnitude.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: found and fixed by an AI agent (Claude, via Claude
Code) while investigating a separate rendering-issue cluster this
session.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

bugfix(rendering): Fix objects briefly flashing black/wrong color on overlapping tint flashes

Fixes GitHub issue #2801 ("Oil turns black while capturing"), and
complements the earlier #2112/dot-product fix (commit 80c01c8cf) for
the same TintEnvelope class of bug.

Bisected in the issue thread to PR #1651 ("Decouple tint update step
from render update"). Before that PR, TintEnvelope::update() ran at a
fixed step, so the ATTACK phase's overshoot check always landed
m_currentColor exactly on m_peakColor before transitioning to DECAY;
decaying a color parallel to the peak can never push an individual
RGB component negative. After decoupling the tint step from a fixed
render rate, the overshoot check (attackRate.Length() > delta.Length())
can now fire before the color has actually reached the peak, without
snapping it there -- so when a second flash starts before the first
finishes (e.g. clicking a building while its capture-in-progress
flash is already playing), DECAY acts on a current color that is not
parallel to the peak, and per-component overshoot briefly renders the
object black or a dark wrong color.

The earlier 80c01c8cf fix (dot-product rest check in the DECAY branch)
already stopped the *permanent* runaway version of this bug, but the
*transient* one-or-two-frame black flash described in #2801 could
still occur even with that fix, since the dot product can still be
negative for a few frames before the rest condition trips.

Fix: when the ATTACK phase reaches its peak, explicitly snap
m_currentColor to m_peakColor before transitioning to SUSTAIN/DECAY,
restoring the invariant decay always relied on. At the original fixed
time step this is a no-op (the color already lands exactly on the
peak), so retail behavior is unchanged; it only matters once the time
step varies. Also sets m_affect = TRUE in this branch, matching the
sibling branch of the same case (the object is still actively tinted
at this point, not at rest).

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, using a regression bisect already established in the
issue thread as the starting point.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

