### PR TITLE
bugfix(ai): Fix invalid group rectangle in AIGroup::groupMoveToPosition

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -1625,7 +1625,14 @@ void AIGroup::groupMoveToPosition( const Coord3D *pos, Bool addWaypoint, Command
 		isFormation = false;
 		if (!addWaypoint) {
 			Int dx = (max.x-min.x)/PATHFIND_CELL_SIZE_F;
+#if RETAIL_COMPATIBLE_AIGROUP
 			Int dy = (max.x-min.x)/PATHFIND_CELL_SIZE_F;
+#else
+			// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Compute the group rectangle height from the
+			// y extents instead of reusing the x extents, so the cell count reflects the actual group
+			// area rather than its width squared. (GitHub issue #2462)
+			Int dy = (max.y-min.y)/PATHFIND_CELL_SIZE_F;
+#endif
 			Int cells = (dx*dy);
 			if (cells<2000) {
 				groupTightenToPosition(pos, false, cmdSource);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -1663,7 +1663,14 @@ void AIGroup::groupMoveToPosition( const Coord3D *p_posIn, Bool addWaypoint, Com
 		isFormation = false;
 		if (!addWaypoint) {
 			Int dx = (max.x-min.x)/PATHFIND_CELL_SIZE_F;
+#if RETAIL_COMPATIBLE_AIGROUP
 			Int dy = (max.x-min.x)/PATHFIND_CELL_SIZE_F;
+#else
+			// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Compute the group rectangle height from the
+			// y extents instead of reusing the x extents, so the cell count reflects the actual group
+			// area rather than its width squared. (GitHub issue #2462)
+			Int dy = (max.y-min.y)/PATHFIND_CELL_SIZE_F;
+#endif
 			Int cells = (dx*dy);
 			if (cells<2000) {
 				groupTightenToPosition(pos, false, cmdSource);


### PR DESCRIPTION
bugfix(ai): Fix invalid group rectangle in AIGroup::groupMoveToPosition

Fixes GitHub issue #2462 (Minor).

The group-tighten cell-count estimate computed both dx and dy from
the same x extents (max.x-min.x) -- a copy-paste bug -- instead of
using the y extents (max.y-min.y) for dy, so the rectangle's area was
effectively its width squared rather than width times height. This
made the "is this group small enough to tighten" cell-count check
consider an incorrect (and for non-square groups, wrong-shaped)
rectangle size.

Fix gated behind !RETAIL_COMPATIBLE_AIGROUP, matching this session's
established pattern of guarding changes to CRC-checked simulation/AI
behavior behind the project's own retail-compatibility flags: dormant
in the default build, active if that flag is ever lifted for AIGroup
logic.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue;
the Generals-tree mirror (an identical copy-paste bug in its own copy
of the same function) was found and fixed separately after the
agent's session was cut off before completing it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #2462
