### PR TITLE
bugfix(gameplay): Fix China ZH campaign Mission 4 never ending

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -363,6 +363,16 @@ void ActiveBody::attemptDamage( DamageInfo *damageInfo )
 
 				TheGameLogic->deselectObject(obj, PLAYERMASK_ALL, TRUE);
 
+				// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Notify the team that it permanently lost
+				// this member before converting it to the neutral team, so that map scripts counting unit
+				// losses via the team's OnUnitDestroyed script still fire when a vehicle is neutralized
+				// rather than destroyed. Otherwise missions that require an exact number of team member
+				// deaths can never complete. Left unconditional (not gated behind RETAIL_COMPATIBLE_CRC)
+				// since this only affects single-player campaign mission scripting, with no multiplayer/
+				// replay determinism concern.
+				if( obj->getTeam() )
+					obj->getTeam()->notifyTeamOfObjectDeath();
+
 				// Convert it to the neutral team so it renders gray giving visual representation that it is unmanned.
 				obj->setTeam( ThePlayerList->getNeutralPlayer()->getDefaultTeam() );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/NeutonBlastBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/NeutonBlastBehavior.cpp
@@ -33,6 +33,7 @@
 
 #include "Common/Player.h"
 #include "Common/PlayerList.h"
+#include "Common/Team.h"
 #include "GameLogic/Module/ContainModule.h"
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/Object.h"
@@ -149,6 +150,17 @@ void NeutronBlastBehavior::neutronBlastToObject( Object *obj )
 			Drawable* draw = obj->getDrawable();
 			if (draw)
 				draw->setTerrainDecal(TERRAIN_DECAL_NONE);
+
+			// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Notify the team that it permanently lost
+			// this member before converting it to the neutral team, so that map scripts counting unit
+			// losses via the team's OnUnitDestroyed script still fire when a vehicle is neutralized
+			// rather than destroyed. Otherwise missions that require an exact number of team member
+			// deaths can never complete, e.g. the ZH China mission 4 wave counters when vehicles are
+			// hit by Neutron Shells (GitHub issue #1441). Left unconditional (not gated behind
+			// RETAIL_COMPATIBLE_CRC) since this only affects single-player campaign mission scripting,
+			// with no multiplayer/replay determinism concern.
+			if( obj->getTeam() )
+				obj->getTeam()->notifyTeamOfObjectDeath();
 
 			// Convert it to the neutral team so it renders gray giving visual representation that it is unmanned.
 			obj->setTeam( ThePlayerList->getNeutralPlayer()->getDefaultTeam() );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -429,6 +429,17 @@ void ActiveBody::attemptDamage( DamageInfo *damageInfo )
           if ( obj->getAI() )
             obj->getAI()->aiIdle( CMD_FROM_AI );
 
+					// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Notify the team that it permanently lost
+					// this member before converting it to the neutral team, so that map scripts counting unit
+					// losses via the team's OnUnitDestroyed script still fire when a vehicle is neutralized
+					// rather than destroyed. Otherwise missions that require an exact number of team member
+					// deaths can never complete, e.g. the ZH China mission 4 wave counters when vehicles are
+					// hit by Neutron Shells (GitHub issue #1441). Left unconditional (not gated behind
+					// RETAIL_COMPATIBLE_CRC) since this only affects single-player campaign mission scripting,
+					// with no multiplayer/replay determinism concern.
+					if( obj->getTeam() )
+						obj->getTeam()->notifyTeamOfObjectDeath();
+
 					// Convert it to the neutral team so it renders gray giving visual representation that it is unmanned.
 					obj->setTeam( ThePlayerList->getNeutralPlayer()->getDefaultTeam() );
 				}


### PR DESCRIPTION
bugfix(gameplay): Fix China ZH campaign Mission 4 never ending

Fixes GitHub issue #1441.

Traced using the mission's own script data (extracted from the binary
.map file): the mission's win condition requires an EXACT unit-death
count from the final wave-6 teams (thresholds of 8/15/18 on Easy/
Medium/Hard, matching those teams' exact unit totals) via each team's
OnUnitDestroyed map script incrementing a counter
(INCREMENT_COUNTER('Wave 6 Counter')), which eventually starts the
mission's win timer and finale sequence.

Root cause: DAMAGE_KILLPILOT damage (dealt by, among other things, the
China Nuke Cannon's Neutron Shells and cluster mines -- both of which
this specific mission grants the player) and the Neutron Missile's
blast neutralize a vehicle by disabling it (DISABLED_UNMANNED) and
silently reassigning it to the neutral team, WITHOUT the vehicle ever
"dying" from its original team's perspective. No OnUnitDestroyed
notification fires for that vehicle, then or ever afterward (the gray
husk belongs to the neutral team from then on). Since the mission's
win condition requires the wave-6 teams' full original unit count to
register as destroyed via exactly that notification, neutralizing
even a single vehicle from the final waves with Neutron Shells makes
the counter permanently short of its threshold: the mission looks
cleared from the player's perspective but can never actually end.
This is retail-faithful engine behavior (reproduces on real EA 1.04),
not a regression introduced by this project.

Fix: at all three sites in this engine that unman a vehicle via
DAMAGE_KILLPILOT-class effects (ActiveBody::attemptDamage in both
trees, and NeutronBlastBehavior::neutronBlastToObject in GeneralsMD),
notify the vehicle's current team of its permanent loss
(Team::notifyTeamOfObjectDeath()) immediately before reassigning it
to the neutral team. notifyTeamOfObjectDeath() already early-returns
for teams with no OnUnitDestroyed script configured, so this is a
no-op for the vast majority of teams/maps; re-notification cannot
happen since the unit is neutral afterward, and any mission relying
on a minimum (not exact) kill count can only benefit from more
accurate counting.

Deliberately left unconditional (not gated behind
RETAIL_COMPATIBLE_CRC, unlike this session's other simulation-behavior
fixes): this only affects single-player campaign mission scripting
bookkeeping, with no multiplayer/replay-compatibility concern -- per
explicit confirmation from the human maintainer, who wanted this
specific fix active rather than dormant, since a campaign mission
that cannot be completed is a more severe practical problem for
single-player use than the (here, inapplicable) retail-CRC
compatibility concern that motivates the gating convention elsewhere
in this session's work.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue. A first investigation pass extracted and read the
mission's actual binary map script data (not normally accessible from
this source repo) to trace the exact win-condition mechanism before
being cut off by an unrelated API session limit; a second pass
resumed from that extracted data to find and fix the root cause.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #1441
