### PR TITLE
bugfix(audio): Fix movie/video audio ignoring volume settings

### DIFF
--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -96,6 +96,27 @@
 //         Private Functions
 //----------------------------------------------------------------------------
 
+// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Compute the Bink audio volume from the
+// speech (voice) volume setting. Bink expects 0..32768, where 32768 is full volume.
+// The 0.8 scale matches the original game's intended movie loudness. The original
+// formula could never go below 327 (about 1 percent), so movie audio remained audible
+// with the voice slider at 0. Clamp to a minimum of 1 instead, which is inaudible,
+// but never pass 0, as Bink will interpret that as "play at full volume".
+static Int calculateMovieAudioVolume()
+{
+	Int volume = (Int) (TheAudio->getVolume(AudioAffect_Speech) * 0.8f * 32768.0f);
+
+	if (volume < 1)
+	{
+		volume = 1;
+	}
+	else if (volume > 32768)
+	{
+		volume = 32768;
+	}
+
+	return volume;
+}
 
 
 //----------------------------------------------------------------------------
@@ -202,12 +223,10 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 		stream->m_player = this;
 		m_firstStream = stream;
 
-		// never let volume go to 0, as Bink will interpret that as "play at full volume".
-		Int mod = (Int) ((TheAudio->getVolume(AudioAffect_Speech) * 0.8f) * 100) + 1;
-		Int volume = (32768*mod)/100;
-		DEBUG_LOG(("BinkVideoPlayer::createStream() - About to set volume (%g -> %d -> %d",
-			TheAudio->getVolume(AudioAffect_Speech), mod, volume));
-		BinkSetVolume( stream->m_handle,0, volume);
+		Int volume = calculateMovieAudioVolume();
+		DEBUG_LOG(("BinkVideoPlayer::createStream() - About to set volume (%g -> %d",
+			TheAudio->getVolume(AudioAffect_Speech), volume));
+		BinkSetVolume( stream->m_handle, 0, volume );
 		DEBUG_LOG(("BinkVideoPlayer::createStream() - set volume"));
 	}
 
@@ -343,6 +362,13 @@ Bool BinkVideoStream::isFrameReady()
 void BinkVideoStream::frameDecompress()
 {
 		BinkDoFrame( m_handle );
+
+		// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 Reapply the audio volume on every decoded
+		// frame. The volume set once on stream creation did not reliably take effect, so movie
+		// audio played at full volume regardless of the Options volume sliders. Reapplying it
+		// during playback keeps movie audio in sync with the speech (voice) volume setting and
+		// also makes volume changes take effect while a movie is playing.
+		BinkSetVolume( m_handle, 0, calculateMovieAudioVolume() );
 }
 
 //============================================================================


### PR DESCRIPTION
bugfix(audio): Fix movie/video audio ignoring volume settings

Fixes GitHub issue #2850 (Major).

Movie audio (Bink Video) bypasses the game's normal Miles audio mixer
entirely and writes straight to DirectSound; the only volume control
is BinkSetVolume(), called once in BinkVideoPlayer::createStream()
before playback starts. Two defects combined to make this ignore the
Options volume sliders in practice:

1. The volume formula ((getVolume(Speech)*0.8*100)+1) * 32768/100 had
   a floor of ~327 out of 32768 (about 1%) at slider 0 -- never
   actually silent, matching the reported "plays at full volume even
   when sliders are 0" (subjectively, a near-silent-but-not-quite
   floor next to actually loud SFX reads as "ignores the slider").
2. The volume is set once, before Bink's sound output has actually
   started (before the first BinkDoFrame), and never reapplied --
   confirmed this matches retail 1.04's own behavior via Thyme's
   reverse-engineered retail binary code, and the EA source's own
   defensive comment ("never let volume go to 0, as Bink will
   interpret that as play at full volume") indicates the original
   developers had already observed volume-setting misbehavior here
   and worked around it blindly rather than fixing it. This is an
   original-game defect, not a regression introduced by this project.

Fix, in the shared Bink video player (Core/, covers both Generals and
GeneralsMD, since FFmpeg is disabled in all build presets/CI and the
Bink path is what actually ships):
- New calculateMovieAudioVolume() helper: same 0.8 loudness scale,
  but clamped to a minimum of 1 (effectively inaudible, ~-90dB)
  instead of 327, while still avoiding literal 0 (which Bink
  interprets as "play at full volume" per the SDK's documented quirk).
- BinkVideoStream::frameDecompress() now reapplies BinkSetVolume()
  after every decoded frame (roughly once per 1/15-1/30s), not just
  once at stream creation, so the volume actually takes effect once
  Bink's audio output is running and live slider changes during
  playback are picked up.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, cross-referencing the third-party Bink SDK's documented
behavior and a community reverse-engineering project (Thyme) to
confirm this is retail-faithful rather than a project regression.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

