### PR TITLE
bugfix(unit-ai): Fix train not destroying all faction building types on collision

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -253,6 +253,13 @@ void RailroadBehavior::onCollide( Object *other, const Coord3D *loc, const Coord
 				other->isKindOf( KINDOF_FS_FACTORY ) ||
 				other->isKindOf( KINDOF_FS_BASE_DEFENSE ) ||
 				other->isKindOf( KINDOF_FS_TECHNOLOGY ) ||
+#if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @bugfix 19/07/2026 Also destroy supply centers, internet centers and fake
+				// buildings, so the train destroys all faction building types on collision, as intended.
+				other->isKindOf( KINDOF_FS_SUPPLY_CENTER ) ||
+				other->isKindOf( KINDOF_FS_INTERNET_CENTER ) ||
+				other->isKindOf( KINDOF_FS_FAKE ) ||
+#endif
 				other->isKindOf( KINDOF_REBUILD_HOLE ) )
 		{
 			playImpactSound(other, other->getPosition());

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -256,6 +256,13 @@ void RailroadBehavior::onCollide( Object *other, const Coord3D *loc, const Coord
 				other->isKindOf( KINDOF_FS_FACTORY ) ||
 				other->isKindOf( KINDOF_FS_BASE_DEFENSE ) ||
 				other->isKindOf( KINDOF_FS_TECHNOLOGY ) ||
+#if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @bugfix 19/07/2026 Also destroy supply centers, internet centers and fake
+				// buildings, so the train destroys all faction building types on collision, as intended.
+				other->isKindOf( KINDOF_FS_SUPPLY_CENTER ) ||
+				other->isKindOf( KINDOF_FS_INTERNET_CENTER ) ||
+				other->isKindOf( KINDOF_FS_FAKE ) ||
+#endif
 				other->isKindOf( KINDOF_REBUILD_HOLE ) )
 		{
 			playImpactSound(other, other->getPosition());


### PR DESCRIPTION
bugfix(unit-ai): Fix train not destroying all faction building types on collision

Fixes GitHub issue #2317 (Minor).

RailroadBehavior::onCollide() only destroyed structures matching an
incomplete KindOf list (power plants, factories, base defense,
technology buildings, and rebuild holes), omitting supply centers,
internet centers, and fake/decoy buildings -- so a train colliding
with one of those building types passed through without destroying
it, contrary to the intended "destroys all faction buildings on
collision" behavior.

Fix: added KINDOF_FS_SUPPLY_CENTER, KINDOF_FS_INTERNET_CENTER, and
KINDOF_FS_FAKE to the destroyed-on-collision check. Gated behind
!RETAIL_COMPATIBLE_CRC per this session's established convention for
gameplay-affecting simulation behavior changes.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #2317
