### PR TITLE
bugfix(gameplay): Fix Cash Bounty overpaying for batch-produced units (China Red Guard)

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -575,6 +575,11 @@ public:
 	/// calculate how much money it will take the given player to build this unit
 	Int calcCostToBuild( const Player* player) const;
 
+	/// calculate the monetary value of a single unit of this type for the given player.
+	/// This is the build cost divided by the production batch quantity, if any (see
+	/// ProductionUpdate QuantityModifier, e.g. China Red Guards build two per purchase).
+	Int calcProductionValue( const Player* player) const;
+
 	/// Used only by Skirmish AI. Everyone else should call calcCostToBuild.
 	Int friend_getBuildCost() const { return m_buildCost; }
 

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2362,10 +2362,17 @@ void Player::doBountyForKill(const Object* killer, const Object* victim)
 	if (victim->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 		return;
 
-	Int costToBuild = victim->getTemplate()->calcCostToBuild(victim->getControllingPlayer());
 #if RETAIL_COMPATIBLE_CRC
+	Int costToBuild = victim->getTemplate()->calcCostToBuild(victim->getControllingPlayer());
 	Int bounty = REAL_TO_INT_CEIL(costToBuild * m_cashBountyPercent);
 #else
+	if (m_cashBountyPercent == 0.0f)
+		return;
+
+	// TheSuperHackers @bugfix 19/07/2026 Use the per-unit production value instead of the full build
+	// cost, so batch-produced units (e.g. China Red Guards, built two per purchase) no longer award
+	// a bounty based on the cost of the whole batch.
+	Int costToBuild = victim->getTemplate()->calcProductionValue(victim->getControllingPlayer());
 	// TheSuperHackers @bugfix Stubbjax 20/02/2026 Subtract epsilon to ensure bounty is rounded up correctly.
 	Int bounty = ceil((costToBuild * m_cashBountyPercent) - WWMATH_EPSILON);
 #endif

--- a/Generals/Code/GameEngine/Source/Common/Thing/ThingTemplate.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/ThingTemplate.cpp
@@ -65,6 +65,7 @@
 
 #include "GameLogic/Armor.h"
 #include "GameLogic/Module/AIUpdate.h"
+#include "GameLogic/Module/ProductionUpdate.h"
 #include "GameLogic/Module/SpecialPowerModule.h"
 #include "GameLogic/Object.h"
 #include "GameLogic/Powers.h"
@@ -1400,6 +1401,44 @@ Int ThingTemplate::calcCostToBuild( const Player* player) const
 	Real factionModifier = 1 + player->getProductionCostChangePercent( getName() );
 	factionModifier *= player->getProductionCostChangeBasedOnKindOf( m_kindof );
 	return getBuildCost() * factionModifier * player->getHandicap()->getHandicap(Handicap::BUILDCOST, this);
+}
+
+//-------------------------------------------------------------------------------------------------
+// TheSuperHackers @feature 19/07/2026 Units can be produced in batches for a shared cost via a
+// factory's ProductionUpdate QuantityModifier (e.g. China Red Guards build two per purchase).
+// The monetary value of a single unit is then just its share of the batch production cost.
+//-------------------------------------------------------------------------------------------------
+Int ThingTemplate::calcProductionValue( const Player* player) const
+{
+	Int cost = calcCostToBuild( player );
+
+	Int quantity = 1;
+	for( const ThingTemplate* factoryTemplate = TheThingFactory->firstTemplate();
+			 factoryTemplate != nullptr;
+			 factoryTemplate = factoryTemplate->friend_getNextTemplate() )
+	{
+		const ModuleInfo& moduleInfo = factoryTemplate->getBehaviorModuleInfo();
+		for( Int i = 0; i < moduleInfo.getCount(); ++i )
+		{
+			if( moduleInfo.getNthName( i ) != "ProductionUpdate" )
+				continue;
+
+			const ProductionUpdateModuleData* data = static_cast<const ProductionUpdateModuleData*>( moduleInfo.getNthData( i ) );
+			for( std::vector<QuantityModifier>::const_iterator it = data->m_quantityModifiers.begin(); it != data->m_quantityModifiers.end(); ++it )
+			{
+				const ThingTemplate* productionTemplate = TheThingFactory->findTemplate( it->m_templateName );
+				if( productionTemplate && productionTemplate->isEquivalentTo( this ) && it->m_quantity > quantity )
+				{
+					quantity = it->m_quantity;
+				}
+			}
+		}
+	}
+
+	if( quantity > 1 )
+		cost /= quantity;
+
+	return cost;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -586,6 +586,11 @@ public:
 	/// calculate how much money it will take the given player to build this unit
 	Int calcCostToBuild( const Player* player) const;
 
+	/// calculate the monetary value of a single unit of this type for the given player.
+	/// This is the build cost divided by the production batch quantity, if any (see
+	/// ProductionUpdate QuantityModifier, e.g. China Red Guards build two per purchase).
+	Int calcProductionValue( const Player* player) const;
+
 	/// Used only by Skirmish AI. Everyone else should call calcCostToBuild.
 	Int friend_getBuildCost() const { return m_buildCost; }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2464,10 +2464,17 @@ void Player::doBountyForKill(const Object* killer, const Object* victim)
 	if (victim->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
 		return;
 
-	Int costToBuild = victim->getTemplate()->calcCostToBuild(victim->getControllingPlayer());
 #if RETAIL_COMPATIBLE_CRC
+	Int costToBuild = victim->getTemplate()->calcCostToBuild(victim->getControllingPlayer());
 	Int bounty = REAL_TO_INT_CEIL(costToBuild * m_cashBountyPercent);
 #else
+	if (m_cashBountyPercent == 0.0f)
+		return;
+
+	// TheSuperHackers @bugfix 19/07/2026 Use the per-unit production value instead of the full build
+	// cost, so batch-produced units (e.g. China Red Guards, built two per purchase) no longer award
+	// a bounty based on the cost of the whole batch.
+	Int costToBuild = victim->getTemplate()->calcProductionValue(victim->getControllingPlayer());
 	// TheSuperHackers @bugfix Stubbjax 20/02/2026 Subtract epsilon to ensure bounty is rounded up correctly.
 	Int bounty = ceil((costToBuild * m_cashBountyPercent) - WWMATH_EPSILON);
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingTemplate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingTemplate.cpp
@@ -65,6 +65,7 @@
 
 #include "GameLogic/Armor.h"
 #include "GameLogic/Module/AIUpdate.h"
+#include "GameLogic/Module/ProductionUpdate.h"
 #include "GameLogic/Module/SpecialPowerModule.h"
 #include "GameLogic/Object.h"
 #include "GameLogic/Powers.h"
@@ -1555,6 +1556,44 @@ Int ThingTemplate::calcCostToBuild( const Player* player) const
 	Real factionModifier = 1 + player->getProductionCostChangePercent( getName() );
 	factionModifier *= player->getProductionCostChangeBasedOnKindOf( m_kindof );
 	return getBuildCost() * factionModifier * player->getHandicap()->getHandicap(Handicap::BUILDCOST, this);
+}
+
+//-------------------------------------------------------------------------------------------------
+// TheSuperHackers @feature 19/07/2026 Units can be produced in batches for a shared cost via a
+// factory's ProductionUpdate QuantityModifier (e.g. China Red Guards build two per purchase).
+// The monetary value of a single unit is then just its share of the batch production cost.
+//-------------------------------------------------------------------------------------------------
+Int ThingTemplate::calcProductionValue( const Player* player) const
+{
+	Int cost = calcCostToBuild( player );
+
+	Int quantity = 1;
+	for( const ThingTemplate* factoryTemplate = TheThingFactory->firstTemplate();
+			 factoryTemplate != nullptr;
+			 factoryTemplate = factoryTemplate->friend_getNextTemplate() )
+	{
+		const ModuleInfo& moduleInfo = factoryTemplate->getBehaviorModuleInfo();
+		for( Int i = 0; i < moduleInfo.getCount(); ++i )
+		{
+			if( moduleInfo.getNthName( i ) != "ProductionUpdate" )
+				continue;
+
+			const ProductionUpdateModuleData* data = static_cast<const ProductionUpdateModuleData*>( moduleInfo.getNthData( i ) );
+			for( std::vector<QuantityModifier>::const_iterator it = data->m_quantityModifiers.begin(); it != data->m_quantityModifiers.end(); ++it )
+			{
+				const ThingTemplate* productionTemplate = TheThingFactory->findTemplate( it->m_templateName );
+				if( productionTemplate && productionTemplate->isEquivalentTo( this ) && it->m_quantity > quantity )
+				{
+					quantity = it->m_quantity;
+				}
+			}
+		}
+	}
+
+	if( quantity > 1 )
+		cost /= quantity;
+
+	return cost;
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
bugfix(gameplay): Fix Cash Bounty overpaying for batch-produced units (China Red Guard)

Fixes GitHub issue #2434 (Minor).

Player::doBountyForKill() computed a killed unit's bounty value from
its full ThingTemplate build cost (calcCostToBuild()). China's Red
Guard is produced two-per-purchase via its barracks'
ProductionUpdate QuantityModifier (verified in shipped INI data: the
only such modifier in Zero Hour, ChinaBarracks -> ChinaInfantryRedguard
x2), so a single Red Guard's real cost is half the batch price the
bounty calculation was using -- Cash Bounty paid out roughly double
what a Red Guard kill should be worth.

Upstream PR #2485 attempted a fix by looking up the killed unit's
actual producing object via dynamic_cast; maintainer xezon rejected
it ("This code base does not use dynamic_cast", "This breaks retail
compatibility") and suggested computing the value from the template
itself via a new calcProductionValue()-style method instead. This fix
implements exactly that direction.

New ThingTemplate::calcProductionValue(): starts from
calcCostToBuild(), then scans every ThingTemplate's ProductionUpdate
module data for a QuantityModifier whose target template
isEquivalentTo() this one (the same matching production itself uses,
so reskinned/general-power-variant Red Guards are covered), and
divides the build cost by the largest such batch quantity found. No
dynamic_cast, no dependency on a live producer object -- fully
deterministic from template data alone, matching the maintainer's
guidance.

doBountyForKill() uses this new method only behind
!RETAIL_COMPATIBLE_CRC (the retail path is untouched and byte-
identical); a zero-percent early-out skips the template scan entirely
for players without an active Cash Bounty bonus, avoiding any cost
for the common case.

Mirrored in both Generals and GeneralsMD trees, matching the issue's
Gen+ZH labels.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue,
following the exact fix direction a maintainer had already specified
when rejecting an earlier community PR attempt.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #2434
