### PR TITLE
bugfix(stability): Stop loading BrowserEngine.dll, fixing a shutdown crash

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -911,7 +911,10 @@ void W3DDisplay::init()
 			m_nativeDebugDisplay->setFontWidth( 9 );
 		}
 
-		DX8WebBrowser::Initialize();
+		// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 No longer initializes the embedded web browser.
+		// The retail game never uses it, because the TheWebBrowser subsystem is disabled in GameEngine::init,
+		// but loading BrowserEngine.dll here could crash the game in that DLL on application shutdown.
+		// DX8WebBrowser::Initialize();
 	}
 
 	// we're now online

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -962,7 +962,10 @@ void W3DDisplay::init()
 			m_nativeDebugDisplay->setFontWidth( 9 );
 		}
 
-		DX8WebBrowser::Initialize();
+		// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 No longer initializes the embedded web browser.
+		// The retail game never uses it, because the TheWebBrowser subsystem is disabled in GameEngine::init,
+		// but loading BrowserEngine.dll here could crash the game in that DLL on application shutdown.
+		// DX8WebBrowser::Initialize();
 	}
 
 	// we're now online


### PR DESCRIPTION
bugfix(stability): Stop loading BrowserEngine.dll, fixing a shutdown crash

Fixes GitHub issue #99 (Major).

TheWebBrowser subsystem is disabled in GameEngine::init() in the
original retail EA source (the initSubsystem(TheWebBrowser, ...) call
is commented out there), so TheWebBrowser is always null and every
consumer (WOL terms-of-service screen, ladder message board) already
null-checks it -- the embedded browser feature is dead in the shipped
game and always has been.

Despite that, W3DDisplay::init() still called DX8WebBrowser::Initialize(),
which loads the third-party BrowserEngine.dll, CoInitializes COM, and
creates a browser engine COM object bound to the live D3D8 device --
for a feature that can never actually be used, since browser windows
can only be created through the permanently-null TheWebBrowser. At
shutdown, DX8WebBrowser::Shutdown() runs after WW3D::Shutdown() has
already destroyed the D3D device, and the DLL's (pre-Windows-Vista)
teardown code crashes.

Fix: stop calling DX8WebBrowser::Initialize(), so BrowserEngine.dll
is simply never loaded. No functionality is lost, since it never
worked in retail either. The remaining DX8WebBrowser call sites
(Shutdown/Update/Render/CreateBrowser) are all guarded by a null
browser-pointer check or unreachable via the null TheWebBrowser, so
they're already safe no-ops without Initialize() ever having run.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue,
confirming the maintainer's own suggested direction from the issue
thread (the DLL "appears to be nothing and can be removed without
breaking functionality").

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

bugfix(stability): Stop loading BrowserEngine.dll, fixing a shutdown crash

Fixes GitHub issue #99 (Major).

TheWebBrowser subsystem is disabled in GameEngine::init() in the
original retail EA source (the initSubsystem(TheWebBrowser, ...) call
is commented out there), so TheWebBrowser is always null and every
consumer (WOL terms-of-service screen, ladder message board) already
null-checks it -- the embedded browser feature is dead in the shipped
game and always has been.

Despite that, W3DDisplay::init() still called DX8WebBrowser::Initialize(),
which loads the third-party BrowserEngine.dll, CoInitializes COM, and
creates a browser engine COM object bound to the live D3D8 device --
for a feature that can never actually be used, since browser windows
can only be created through the permanently-null TheWebBrowser. At
shutdown, DX8WebBrowser::Shutdown() runs after WW3D::Shutdown() has
already destroyed the D3D device, and the DLL's (pre-Windows-Vista)
teardown code crashes.

Fix: stop calling DX8WebBrowser::Initialize(), so BrowserEngine.dll
is simply never loaded. No functionality is lost, since it never
worked in retail either. The remaining DX8WebBrowser call sites
(Shutdown/Update/Render/CreateBrowser) are all guarded by a null
browser-pointer check or unreachable via the null TheWebBrowser, so
they're already safe no-ops without Initialize() ever having run.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue,
confirming the maintainer's own suggested direction from the issue
thread (the DLL "appears to be nothing and can be removed without
breaking functionality").

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

