### PR TITLE
bugfix(memory): Keep deallocating destroyed particle systems while the D3D device is not cooperating

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1962,6 +1962,16 @@ AGAIN:
 			if (TheW3DProjectedShadowManager)
 				TheW3DProjectedShadowManager->updateRenderTargetTextures();
 		}
+		else
+		{
+			// TheSuperHackers @bugfix Continue updating the ParticleSystemManager while the Direct3D
+			// device is not cooperating, for example when the Windows account is locked. The game logic
+			// keeps creating new particle systems in that state, but destroyed particle systems are only
+			// deallocated by this update. Skipping it lets particle systems accumulate without bound,
+			// which eventually freezes the game or crashes it with out of memory (#2263).
+			// The particle system update is device independent and updates at most once per logic frame.
+			TheParticleSystemManager->update();
+		}
 
 		Debug_Statistics::End_Statistics();	//record number of polygons rendered in RenderTargetTextures.
 


### PR DESCRIPTION
bugfix(memory): Keep deallocating destroyed particle systems while the D3D device is not cooperating

Fixes GitHub issue #2263 (Major).

Zero Hour moved TheParticleSystemManager->update() out of
GameClient::update() into W3DDisplay::draw(), gated behind a check
that the D3D device is present and cooperating
(TestCooperativeLevel() == D3D_OK). When the Windows session is
locked (or another situation makes the device stop cooperating), that
gate is false every frame, so the update never runs -- but game logic
keeps creating particle systems the whole time. Since destroyed
particle systems are only actually deallocated inside that same
update() call (destroyParticleSystem() just marks m_isDestroyed; the
real deleteInstance() happens when update() sees a system whose own
update() returns false), the destroy queue grows without bound while
locked, eventually freezing the game or crashing it with an
out-of-memory error once the session unlocks and update() has to
process a backlog of tens of thousands of systems at once.

The base Generals tree is unaffected: it still calls this update
unconditionally with no device check, which also confirms the update
itself is device-independent and safe to run regardless of
cooperative level.

Fix: when the device is not cooperating, still call
TheParticleSystemManager->update() (in an added else branch). The
existing m_lastLogicFrameUpdate guard inside update() already limits
it to at most once per logic frame, so this cannot double-update.

GeneralsMD-only change (this code path doesn't exist in the Generals
tree, which already updates unconditionally elsewhere).

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

