### PR TITLE
bugfix(gameplay): Fix production progress jumping when build speed changes mid-build

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -712,9 +712,19 @@ UpdateSleepTime ProductionUpdate::update()
 		totalProductionFrames = production->m_upgradeToResearch->calcTimeToBuild( player );
 
 	// figure out our percent complete
+#if RETAIL_COMPATIBLE_CRC
 	production->m_percentComplete = INT_TO_REAL( production->m_framesUnderConstruction ) /
 																	INT_TO_REAL( totalProductionFrames ) *
 																	100.0f;
+#else
+	// TheSuperHackers @bugfix 19/07/2026 Accumulate build progress at the current production speed
+	// instead of recomputing it from the total elapsed frames. Previously, when the production speed
+	// changed mid-build (for example the low power penalty ending because a power plant came online),
+	// the new speed was retroactively applied to the already elapsed build time as well, causing
+	// queued items to instantly jump forward in progress. Now a speed change only affects the
+	// remaining build time.
+	production->m_percentComplete += 100.0f / INT_TO_REAL( totalProductionFrames );
+#endif
 
 	// if we've reached 100% or more we're done, tada!
 	if( production->m_percentComplete >= 100.0f )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -712,9 +712,19 @@ UpdateSleepTime ProductionUpdate::update()
 		totalProductionFrames = production->m_upgradeToResearch->calcTimeToBuild( player );
 
 	// figure out our percent complete
+#if RETAIL_COMPATIBLE_CRC
 	production->m_percentComplete = INT_TO_REAL( production->m_framesUnderConstruction ) /
 																	INT_TO_REAL( totalProductionFrames ) *
 																	100.0f;
+#else
+	// TheSuperHackers @bugfix 19/07/2026 Accumulate build progress at the current production speed
+	// instead of recomputing it from the total elapsed frames. Previously, when the production speed
+	// changed mid-build (for example the low power penalty ending because a power plant came online),
+	// the new speed was retroactively applied to the already elapsed build time as well, causing
+	// queued items to instantly jump forward in progress. Now a speed change only affects the
+	// remaining build time.
+	production->m_percentComplete += 100.0f / INT_TO_REAL( totalProductionFrames );
+#endif
 
 	// if we've reached 100% or more we're done, tada!
 	if( production->m_percentComplete >= 100.0f )


### PR DESCRIPTION
bugfix(gameplay): Fix production progress jumping when build speed changes mid-build

Fixes GitHub issue #1390 (Major).

ProductionUpdate::update() recomputed a queued item's percent complete
from scratch every frame: m_framesUnderConstruction / calcTimeToBuild()
* 100. calcTimeToBuild() folds in the current low-power production
penalty, so when that penalty changes mid-build (most visibly, a
player's first Power Plant completing and removing the zero-power
penalty), the new (faster) time-to-build is applied retroactively to
all already-elapsed frames, not just the remaining ones -- an item
already past 50% complete can jump straight to 100% and finish
instantly. The same retroactive jump applies to any other mid-build
speed change (faction bonuses, multiple-factory modifiers, etc.).

Fix: accumulate percent complete incrementally at the current
production speed (+= 100/totalProductionFrames per update) instead of
recomputing it from total elapsed frames. A speed change now only
affects the remaining build time, not time already spent. Gated
behind !RETAIL_COMPATIBLE_CRC (retail builds keep the original
bit-exact behavior), matching this session's established convention.
m_percentComplete is already xfer'd in save games, so no save-format
change is needed.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue.
Note from the agent: this has gameplay/balance visibility flagged in
the issue's own discussion (it removes a "free" progress jump some
players may have relied on), so treat as worth a second look before
considering it final.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

