### PR TITLE
bugfix(input): Fix group force-fire capability gated by only the first selected unit

### DIFF
--- a/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -401,6 +401,11 @@ static CanAttackResult canObjectForceAttack( Object *obj, const Object *victim, 
 static CanAttackResult canAnyForceAttack(const DrawableList *allSelected, const Object *victim, const Coord3D *pos )
 {
 	// check to make sure that allSelected can attack obj.
+	// TheSuperHackers @bugfix 19/07/2026 Evaluate every selected object instead of just the first
+	// one. Previously the whole group's ability to force attack was gated by the first object in
+	// the selection list, so a single unit without a weapon (e.g. a Sentry Drone built before a
+	// Humvee) prevented the entire group from force firing.
+	CanAttackResult bestResult = ATTACKRESULT_NOT_POSSIBLE;
 	for (DrawableListCIt cit = allSelected->begin(); cit != allSelected->end(); ++cit)
 	{
 		Drawable *draw = *cit;
@@ -415,10 +420,21 @@ static CanAttackResult canAnyForceAttack(const DrawableList *allSelected, const 
 			continue;
 		}
 
-		return canObjectForceAttack( obj, victim, pos );
+		CanAttackResult result = canObjectForceAttack( obj, victim, pos );
+
+		// CanAttackResult is ordered from worst to best scenario, so keep the best result found.
+		if (result > bestResult)
+		{
+			bestResult = result;
+
+			if (bestResult == ATTACKRESULT_POSSIBLE)
+			{
+				break;
+			}
+		}
 	}
 
-	return ATTACKRESULT_NOT_POSSIBLE;
+	return bestResult;
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
bugfix(input): Fix group force-fire capability gated by only the first selected unit

Fixes GitHub issue #147 (Major).

canAnyForceAttack() returned canObjectForceAttack()'s result for the
first valid object found in the selection and stopped there, so a
whole group's ability to force-attack was determined entirely by
whichever unit happened to be first in the selection list -- a single
selected unit without a weapon (e.g. a Sentry Drone alongside a
Humvee) could make the entire group's force-fire command fail, even
though other selected units were perfectly capable of attacking.

Fix: evaluate every selected object and keep the best CanAttackResult
found (the enum is already ordered worst-to-best), breaking early
only once the best possible result (ATTACKRESULT_POSSIBLE) is
reached.

Shared Core/ code, so this single change covers both Generals and
GeneralsMD.

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

