### PR TITLE
bugfix(saveload): Show a clear message when loading a save from a newer game version

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -681,12 +681,23 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 
 	// load the save data
 	Bool error = FALSE;
+	// TheSuperHackers @bugfix Loading a save file whose Xfer version is higher than this build
+	// understands is intentionally unsupported (see Xfer::xferVersion), so it is not treated as a
+	// crash bug. Distinguish that specific failure here so the player gets a clear explanation
+	// instead of the generic "file is corrupt or unreadable" message.
+	Bool versionTooNew = FALSE;
 	try
 	{
 
 		// load file
 		xferSaveData( &xferLoad, SNAPSHOT_SAVELOAD );
 
+	}
+	catch( XferStatus xferStatus )
+	{
+		error = TRUE;
+		if( xferStatus == XFER_INVALID_VERSION )
+			versionTooNew = TRUE;
 	}
 	catch( ... )
 	{
@@ -722,7 +733,12 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 		ufilepath.translate(filepath);
 
 		UnicodeString msg;
-		msg.format( TheGameText->fetch("GUI:ErrorLoadingGame"), ufilepath.str() );
+		if( versionTooNew )
+			msg = TheGameText->FETCH_OR_SUBSTITUTE_FORMAT( "GUI:ErrorLoadingGameNewerVersion",
+				L"This save game was created by a newer version of the game and cannot be loaded here. Please update your game.\n\n%ls",
+				ufilepath.str() );
+		else
+			msg.format( TheGameText->fetch("GUI:ErrorLoadingGame"), ufilepath.str() );
 
 		MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -681,12 +681,23 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 
 	// load the save data
 	Bool error = FALSE;
+	// TheSuperHackers @bugfix Loading a save file whose Xfer version is higher than this build
+	// understands is intentionally unsupported (see Xfer::xferVersion), so it is not treated as a
+	// crash bug. Distinguish that specific failure here so the player gets a clear explanation
+	// instead of the generic "file is corrupt or unreadable" message.
+	Bool versionTooNew = FALSE;
 	try
 	{
 
 		// load file
 		xferSaveData( &xferLoad, SNAPSHOT_SAVELOAD );
 
+	}
+	catch( XferStatus xferStatus )
+	{
+		error = TRUE;
+		if( xferStatus == XFER_INVALID_VERSION )
+			versionTooNew = TRUE;
 	}
 	catch( ... )
 	{
@@ -722,7 +733,12 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 		ufilepath.translate(filepath);
 
 		UnicodeString msg;
-		msg.format( TheGameText->fetch("GUI:ErrorLoadingGame"), ufilepath.str() );
+		if( versionTooNew )
+			msg = TheGameText->FETCH_OR_SUBSTITUTE_FORMAT( "GUI:ErrorLoadingGameNewerVersion",
+				L"This save game was created by a newer version of the game and cannot be loaded here. Please update your game.\n\n%ls",
+				ufilepath.str() );
+		else
+			msg.format( TheGameText->fetch("GUI:ErrorLoadingGame"), ufilepath.str() );
 
 		MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
 


### PR DESCRIPTION
bugfix(saveload): Show a clear message when loading a save from a newer game version

Fixes GitHub issue #2465 (Major).

Confirmed by manually parsing the reporter's attached save file: it
was written with GameLogic::xfer version 11 (introduced by the
"save objects in reverse order" fix), while the build that failed to
load it only understands up to version 10. Xfer::xferVersion()
correctly throws XFER_INVALID_VERSION when a save's version exceeds
what the current build supports -- this is intentional, by-design
forward-incompatibility (confirmed against issue #2417, which
documents this as expected), not a version-check logic bug. No fix
was needed in GameLogic::xfer itself; its version comparisons already
correctly use the file's version, not the build's currentVersion,
throughout.

However, GameState::loadGame() caught this exception with the same
generic catch(...) as any other load failure, showing a misleading
"file is corrupt or unreadable" message instead of explaining that
the save is simply from a newer, incompatible build.

Fix: added a catch(XferStatus) clause ahead of the existing catch(...)
to specifically detect XFER_INVALID_VERSION, and show a distinct,
clear error message ("This save game was created by a newer version
of the game and cannot be loaded here...") in that case, using the
existing FETCH_OR_SUBSTITUTE_FORMAT pattern already used elsewhere in
this codebase for new user-facing strings without requiring a
.str/.csf string-table edit.

Mirrored in both Generals and GeneralsMD trees (GameState.cpp is
per-tree).

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue,
including downloading and manually parsing the reporter's attached
binary save file to confirm the exact version mismatch.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

