### PR TITLE
bugfix(stability): Fix dangling iterator crash when a map's map.ini defines a new Locomotor

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -557,7 +557,16 @@ void LocomotorStore::reset()
 		Overridable *locoTemp = it->second->deleteOverrides();
 		if (!locoTemp)
 		{
-			m_locomotorTemplates.erase(it);
+			// TheSuperHackers @bugfix Locomotor templates created solely by a map's map.ini
+			// (INI_LOAD_CREATE_OVERRIDES with no pre-existing base template) are marked as
+			// overrides and stored directly in m_locomotorTemplates. deleteOverrides() deletes
+			// such an entry and returns nullptr, so it must be erased here. std::map::erase()
+			// invalidates the erased iterator, so the loop must not go on to compare/increment
+			// it afterwards; capture the next iterator from erase()'s return value instead.
+			// Loading a save game always calls TheGameEngine->reset() (see GameState::loadGame),
+			// so any map with a custom map.ini-only Locomotor would corrupt this map and crash
+			// or misbehave on the very next load.
+			it = m_locomotorTemplates.erase(it);
 		}
 		else
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -569,7 +569,16 @@ void LocomotorStore::reset()
 		Overridable *locoTemp = it->second->deleteOverrides();
 		if (!locoTemp)
 		{
-			m_locomotorTemplates.erase(it);
+			// TheSuperHackers @bugfix Locomotor templates created solely by a map's map.ini
+			// (INI_LOAD_CREATE_OVERRIDES with no pre-existing base template) are marked as
+			// overrides and stored directly in m_locomotorTemplates. deleteOverrides() deletes
+			// such an entry and returns nullptr, so it must be erased here. std::map::erase()
+			// invalidates the erased iterator, so the loop must not go on to compare/increment
+			// it afterwards; capture the next iterator from erase()'s return value instead.
+			// Loading a save game always calls TheGameEngine->reset() (see GameState::loadGame),
+			// so any map with a custom map.ini-only Locomotor would corrupt this map and crash
+			// or misbehave on the very next load.
+			it = m_locomotorTemplates.erase(it);
 		}
 		else
 		{


### PR DESCRIPTION
bugfix(stability): Fix dangling iterator crash when a map's map.ini defines a new Locomotor

Fixes GitHub issue #1345 (Major).

LocomotorStore::reset() walks m_locomotorTemplates (a
std::map<NameKeyType, LocomotorTemplate*>) to remove per-match
overrides. When a locomotor was created entirely by a map's map.ini
(not overriding any base-game locomotor), deleteOverrides() deletes
the entry outright and returns nullptr, and the loop erased it via
plain m_locomotorTemplates.erase(it) -- but std::map::erase()
invalidates the erased iterator, and the for-loop's own
condition/increment then re-evaluated that now-dangling iterator on
the next pass: undefined behavior, heap corruption, and a
state-dependent crash.

TheGameEngine->reset() (which calls LocomotorStore::reset()) is only
ever invoked from the save/load-game paths, never from a normal
mission start -- exactly matching the issue's report that this only
manifests when loading a save from a map with a custom, entirely new
Locomotor definition in its map.ini.

Fix: capture the iterator returned by erase() instead of discarding
it, matching the safe pattern every sibling *Store::reset() already
uses (SpecialPowerStore, CrateSystem, RankInfoStore, ScienceStore) --
this was the sole outlier, a copy-paste omission.

Mirrored in both Generals and GeneralsMD trees.

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, cross-checking against every sibling reset() function
in the same codebase to confirm the correct pattern and identify this
as the sole outlier.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

