### PR TITLE
bugfix(unit-ai): Fix infantry sometimes becoming a passenger instead of capturing an unmanned vehicle

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -747,6 +747,16 @@ void OpenContain::onCollide( Object *other, const Coord3D *loc, const Coord3D *n
 	if (ai->getEnterTarget() != getObject())
 		return;
 
+	// TheSuperHackers @bugfix An infantry unit entering an unmanned vehicle is meant to capture
+	// it and become its pilot (see PhysicsBehavior::onCollide), not ride along as a passenger.
+	// PartitionContactList::processContactList() can call either object's onCollide() first, so
+	// if this collision is handled here before the infantry's own onCollide() runs, we must not
+	// containerize the infantry: doing so would make PhysicsBehavior::onCollide() see the infantry
+	// as already contained by us and bail out (via the getContainedBy() early-return), leaving the
+	// vehicle un-captured while the infantry silently becomes a normal (uncontrolled) passenger.
+	if( other->isKindOf( KINDOF_INFANTRY ) && getObject()->isDisabledByType( DISABLED_UNMANNED ) )
+		return;
+
 	// last-minute change: don't allow units from multiple (different) players to occupy the same
 	// unit. so eject everyone else if they aren't controlled by the same player. (srj)
 	for( ContainedItemsList::iterator it = m_containList.begin(); it != m_containList.end(); )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -843,6 +843,16 @@ void OpenContain::onCollide( Object *other, const Coord3D *loc, const Coord3D *n
 	if (ai->getEnterTarget() != getObject())
 		return;
 
+	// TheSuperHackers @bugfix An infantry unit entering an unmanned vehicle is meant to capture
+	// it and become its pilot (see PhysicsBehavior::onCollide), not ride along as a passenger.
+	// PartitionContactList::processContactList() can call either object's onCollide() first, so
+	// if this collision is handled here before the infantry's own onCollide() runs, we must not
+	// containerize the infantry: doing so would make PhysicsBehavior::onCollide() see the infantry
+	// as already contained by us and bail out (via the getContainedBy() early-return), leaving the
+	// vehicle un-captured while the infantry silently becomes a normal (uncontrolled) passenger.
+	if( other->isKindOf( KINDOF_INFANTRY ) && getObject()->isDisabledByType( DISABLED_UNMANNED ) )
+		return;
+
 	// last-minute change: don't allow units from multiple (different) players to occupy the same
 	// unit. so eject everyone else if they aren't controlled by the same player. (srj)
 	for( ContainedItemsList::iterator it = m_containList.begin(); it != m_containList.end(); )


### PR DESCRIPTION
bugfix(unit-ai): Fix infantry sometimes becoming a passenger instead of capturing an unmanned vehicle

Fixes GitHub issue #2446 (Major), "Empty China Emperor/GLA Battle Bus
may require more than one infantry to capture."

An infantry unit walking into an unmanned (DISABLED_UNMANNED) vehicle
is meant to capture and pilot it -- handled by
PhysicsBehavior::onCollide on the infantry's side (clearDisabled,
setCaptured, defect, then destroy the infantry). But
OpenContain::onCollide on the vehicle's side unconditionally
containerized any entering unit whose AI enter-target matched the
vehicle, with no awareness of the unmanned-pilot special case.

PartitionContactList::processContactList() can invoke either
collision participant's onCollide() first for the same contact. If
the vehicle's OpenContain::onCollide() happened to run first, it
would containerize the infantry as an ordinary passenger; when the
infantry's own PhysicsBehavior::onCollide() then ran second, its
existing "already contained by the object we're colliding with"
early-return check silently skipped the capture logic entirely --
leaving the vehicle uncaptured and the infantry stuck as an inert
passenger instead. Which of the two onCollide() calls ran first
depended on contact-list ordering (plausibly geometry/height-based),
matching the intermittent nature of the report ("may require more
than one infantry" -- later infantry retrying eventually got lucky
with the ordering).

Fix: OpenContain::onCollide() now returns early, before containerizing
anything, when the colliding object is infantry and this object is
DISABLED_UNMANNED -- making the outcome order-independent, since only
PhysicsBehavior::onCollide()'s capture path can then act on that
collision regardless of which handler the partition manager processes
first. This generalizes correctly to the engine's broader "infantry
can capture any unmanned vehicle" mechanic (not special-cased to just
these two units), matching how PhysicsBehavior::onCollide() is itself
written generically.

Mirrored in both Generals and GeneralsMD trees (this logic isn't
shared via Core/).

AI-assisted change: root cause found and fixed by an AI agent (Claude,
via Claude Code) after being asked to investigate this specific
GitHub issue, tracing a genuine collision-processing-order race
between two independent onCollide() handlers.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #2437
