### PR TITLE
bugfix(unit-ai): Pause Worker/Dozer build, repair, and supply progress while contained

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -1584,6 +1584,12 @@ UpdateSleepTime DozerAIUpdate::update()
 	if( getObject()->isEffectivelyDead() )
 		return UPDATE_SLEEP_NONE;
 
+	// TheSuperHackers @bugfix 18/07/2026 Pause the Dozer's build/repair behavior while it is
+	// contained (e.g. loaded into a transport). Without this, a Dozer ordered into a vehicle mid-task
+	// keeps ticking construction/repair progress despite being stowed away.
+	if( getObject()->isContained() )
+		return UPDATE_SLEEP_NONE;
+
 	// get and validate our current task
 	DozerTask currentTask = getCurrentTask();
 	if( currentTask != DOZER_TASK_INVALID )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -261,6 +261,12 @@ UpdateSleepTime WorkerAIUpdate::update()
 	if( getObject()->isEffectivelyDead() )
 		return UPDATE_SLEEP_NONE;
 
+	// TheSuperHackers @bugfix 18/07/2026 Pause the Worker's build/repair/supply behavior while it is
+	// contained (e.g. loaded into a transport). Without this, a Worker ordered into a vehicle mid-task
+	// keeps ticking construction/repair progress and delivering supplies despite being stowed away.
+	if( getObject()->isContained() )
+		return UPDATE_SLEEP_NONE;
+
 	// run our own state machine, and the appropriate sub machine
 	m_workerMachine->updateStateMachine();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -1589,6 +1589,12 @@ UpdateSleepTime DozerAIUpdate::update()
 	if( getObject()->isEffectivelyDead() )
 		return UPDATE_SLEEP_NONE;
 
+	// TheSuperHackers @bugfix 18/07/2026 Pause the Dozer's build/repair behavior while it is
+	// contained (e.g. loaded into a transport). Without this, a Dozer ordered into a vehicle mid-task
+	// keeps ticking construction/repair progress despite being stowed away.
+	if( getObject()->isContained() )
+		return UPDATE_SLEEP_NONE;
+
 	// get and validate our current task
 	DozerTask currentTask = getCurrentTask();
 	if( currentTask != DOZER_TASK_INVALID )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -261,6 +261,12 @@ UpdateSleepTime WorkerAIUpdate::update()
 	if( getObject()->isEffectivelyDead() )
 		return UPDATE_SLEEP_NONE;
 
+	// TheSuperHackers @bugfix 18/07/2026 Pause the Worker's build/repair/supply behavior while it is
+	// contained (e.g. loaded into a transport). Without this, a Worker ordered into a vehicle mid-task
+	// keeps ticking construction/repair progress and delivering supplies despite being stowed away.
+	if( getObject()->isContained() )
+		return UPDATE_SLEEP_NONE;
+
 	// run our own state machine, and the appropriate sub machine
 	m_workerMachine->updateStateMachine();
 


### PR DESCRIPTION
bugfix(unit-ai): Pause Worker/Dozer build, repair, and supply progress while contained

Fixes GitHub issue #2447 (Major), "GLA Worker can continue building
after being loaded into vehicle."

WorkerAIUpdate::update() and DozerAIUpdate::update() ticked their
build/repair (and for Worker, supply-delivery) state machine
unconditionally every frame, with no check for whether the unit is
currently contained (loaded into a transport). OpenContain::onContaining(),
the callback fired when a rider is loaded into a container, never
pauses or cancels the rider's AI state machine either. So a Worker or
Dozer mid-construction/repair kept advancing the target's construction
percentage or healing it every logic frame even while safely stowed
inside a vehicle -- letting a player order a mid-task unit into a
transport to keep it safe from harm without losing build/repair
progress, the exploit the issue describes.

Fix: both update() functions now return early (UPDATE_SLEEP_NONE)
when getObject()->isContained() is true, right after the existing
isEffectivelyDead() early-return. This pauses rather than cancels the
task -- state, dock points, and target are untouched, so
build/repair/supply-delivery resumes normally once the unit exits the
transport, but cannot advance while contained.

Mirrored across all four files (WorkerAIUpdate.cpp and
DozerAIUpdate.cpp, in both Generals and GeneralsMD trees -- these
Update modules aren't shared via Core/).

AI-assisted change: implemented by an AI agent (Claude, via Claude
Code) after being asked to investigate this specific GitHub issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

