### PR TITLE
fix(GeneralsMD): weapon lock from group command applies to unrelated units (#873)

### DIFF
--- a/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -982,7 +982,10 @@ bool GameLogic::onDoWeapon(MAYBE_UNUSED GameMessage *msg, AIGroupPtr &currentlyS
 	Int maxShotsToFire = msg->getArgument( 1 )->integer;
 
 	// lock it just till the weapon is empty or the attack is "done"
-	if( currentlySelectedGroup && currentlySelectedGroup->setWeaponLockForGroup( weaponSlot, LOCKED_TEMPORARILY ))
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only apply the weapon lock to group members whose
+	// own command set actually has a button for this slot -- this message only carries a raw slot
+	// index, not which button/unit type produced it. (GitHub issue #873)
+	if( currentlySelectedGroup && currentlySelectedGroup->setWeaponLockForGroup( weaponSlot, LOCKED_TEMPORARILY, TRUE ))
 	{
 		currentlySelectedGroup->groupAttackPosition( nullptr, maxShotsToFire, CMD_FROM_PLAYER );
 	}
@@ -1051,7 +1054,10 @@ bool GameLogic::onDoWeaponAtObject(MAYBE_UNUSED GameMessage *msg, AIGroupPtr &cu
 	if( currentlySelectedGroup )
 	{
 			// lock it just till the weapon is empty or the attack is "done"
-		if (currentlySelectedGroup->setWeaponLockForGroup( weaponSlot, LOCKED_TEMPORARILY ))
+			// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only apply the weapon lock to group members
+			// whose own command set actually has a button for this slot -- this message only carries a
+			// raw slot index, not which button/unit type produced it. (GitHub issue #873)
+		if (currentlySelectedGroup->setWeaponLockForGroup( weaponSlot, LOCKED_TEMPORARILY, TRUE ))
 			currentlySelectedGroup->groupAttackObject( targetObject, maxShotsToFire, CMD_FROM_PLAYER );
 	}
 
@@ -1063,8 +1069,11 @@ bool GameLogic::onDoSwitchWeapons(MAYBE_UNUSED GameMessage *msg, AIGroupPtr &cur
 	// use the selected group
 	WeaponSlotType weaponSlot = (WeaponSlotType)msg->getArgument( 0 )->integer;
 	// lock until un-switched, or switched to something else.
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only apply the weapon lock to group members whose
+	// own command set actually has a button for this slot -- this message only carries a raw slot
+	// index, not which button/unit type produced it. (GitHub issue #873)
 	if( currentlySelectedGroup )
-		currentlySelectedGroup->setWeaponLockForGroup( weaponSlot, LOCKED_PERMANENTLY );
+		currentlySelectedGroup->setWeaponLockForGroup( weaponSlot, LOCKED_PERMANENTLY, TRUE );
 
 	return true;
 }
@@ -1118,7 +1127,10 @@ bool GameLogic::onDoWeaponAtLocation(MAYBE_UNUSED GameMessage *msg, AIGroupPtr &
 	if( currentlySelectedGroup )
 	{
 			// lock it just till the weapon is empty or the attack is "done"
-		if (currentlySelectedGroup->setWeaponLockForGroup( weaponSlot, LOCKED_TEMPORARILY ))
+			// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only apply the weapon lock to group members
+			// whose own command set actually has a button for this slot -- this message only carries a
+			// raw slot index, not which button/unit type produced it. (GitHub issue #873)
+		if (currentlySelectedGroup->setWeaponLockForGroup( weaponSlot, LOCKED_TEMPORARILY, TRUE ))
 			currentlySelectedGroup->groupAttackPosition( &targetLoc, maxShotsToFire, CMD_FROM_PLAYER );
 	}
 

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -971,7 +971,11 @@ public:
 	void recomputeGroupSpeed() { m_dirty = true; }
 
 	void setMineClearingDetail( Bool set );
-	Bool setWeaponLockForGroup( WeaponSlotType weaponSlot, WeaponLockType lockType ); ///< Set the groups' weapon choice.
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Added filterByCommandAvailability (default FALSE,
+	// preserving the original unconditional lock behavior for existing callers) so only the GUI
+	// command-button-driven callers opt into skipping members without a matching command button.
+	// See the comment on objectHasCommandButtonForWeaponSlot() in AIGroup.cpp. (GitHub issue #873)
+	Bool setWeaponLockForGroup( WeaponSlotType weaponSlot, WeaponLockType lockType, Bool filterByCommandAvailability = FALSE ); ///< Set the groups' weapon choice.
 	void releaseWeaponLockForGroup(WeaponLockType lockType);///< Clear each guys weapon choice
 	void setWeaponSetFlag( WeaponSetType wst );
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -2976,12 +2976,65 @@ void AIGroup::setMineClearingDetail( Bool set )
 	}
 }
 
-Bool AIGroup::setWeaponLockForGroup( WeaponSlotType weaponSlot, WeaponLockType lockType )
+#if !RETAIL_COMPATIBLE_CRC
+// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 A GUI_COMMAND_SWITCH_WEAPON / GUI_COMMAND_FIRE_WEAPON
+// message only carries a raw weapon slot index, not the identity of the command button that produced
+// it. When a mixed-unit-type group is selected and a command button that belongs to only one of those
+// unit types is clicked, the raw slot index used to be applied to every member of the group regardless
+// of whether that member's own command set actually exposes that slot, which could unlock a weapon
+// slot on a completely unrelated unit type that was never meant to be reachable this way (originally
+// reported for the Zero Hour Missile Defender, GitHub issue #873; the underlying mechanism is generic
+// and applies here too). Guard against this by only honoring the weapon lock for members whose own
+// command set actually contains a switch/fire-weapon button for that slot. This must only be applied
+// to the actual GUI command-button-driven callers (onDoWeapon/onDoWeaponAtObject/onDoSwitchWeapons/
+// onDoWeaponAtLocation in GameLogicDispatch.cpp), NOT unconditionally inside setWeaponLockForGroup()
+// itself -- that function is also called from the force-attack-position path with a dev comment
+// explaining it force-locks PRIMARY_WEAPON on the whole group specifically so units don't reset to
+// primary weapon mode while force-attacking. Most units have no explicit "switch to primary" command
+// button (only a "switch to secondary" one, since primary is the default), so applying this filter
+// there would silently defeat that unrelated mechanism for nearly every unit. See the
+// filterByCommandAvailability parameter below.
+static Bool objectHasCommandButtonForWeaponSlot( Object *obj, WeaponSlotType weaponSlot )
+{
+	if( !obj )
+		return false;
+
+	const CommandSet *commandSet = TheControlBar->findCommandSet( obj->getCommandSetString() );
+	if( !commandSet )
+		return false;
+
+	for( Int i = 0; i < MAX_COMMANDS_PER_SET; ++i )
+	{
+		const CommandButton *commandButton = commandSet->getCommandButton(i);
+		if( !commandButton )
+			continue;
+
+		GUICommandType type = commandButton->getCommandType();
+		if( (type == GUI_COMMAND_SWITCH_WEAPON || type == GUI_COMMAND_FIRE_WEAPON)
+			&& commandButton->getWeaponSlot() == weaponSlot )
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif
+
+Bool AIGroup::setWeaponLockForGroup( WeaponSlotType weaponSlot, WeaponLockType lockType, Bool filterByCommandAvailability )
 {
 	Bool any = false;
 	std::list<Object *>::iterator i;
 	for( i = m_memberList.begin(); i != m_memberList.end(); ++i )
 	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only skip members lacking a matching command
+		// button when the caller explicitly opted in (see objectHasCommandButtonForWeaponSlot() above
+		// for why this can't be unconditional). (GitHub issue #873)
+		if( filterByCommandAvailability && !objectHasCommandButtonForWeaponSlot( *i, weaponSlot ) )
+			continue;
+#endif
+
 		if ((*i)->setWeaponLock( weaponSlot, lockType ))
 			any = true;
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -1009,7 +1009,11 @@ public:
 	void recomputeGroupSpeed() { m_dirty = true; }
 
 	void setMineClearingDetail( Bool set );
-	Bool setWeaponLockForGroup( WeaponSlotType weaponSlot, WeaponLockType lockType ); ///< Set the groups' weapon choice.
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Added filterByCommandAvailability (default FALSE,
+	// preserving the original unconditional lock behavior for existing callers) so only the GUI
+	// command-button-driven callers opt into skipping members without a matching command button.
+	// See the comment on objectHasCommandButtonForWeaponSlot() in AIGroup.cpp. (GitHub issue #873)
+	Bool setWeaponLockForGroup( WeaponSlotType weaponSlot, WeaponLockType lockType, Bool filterByCommandAvailability = FALSE ); ///< Set the groups' weapon choice.
 	void releaseWeaponLockForGroup(WeaponLockType lockType);///< Clear each guys weapon choice
 	void setWeaponSetFlag( WeaponSetType wst );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -3068,16 +3068,26 @@ void AIGroup::setMineClearingDetail( Bool set )
 	}
 }
 
-// TheSuperHackers @bugfix 07/19/2026 A GUI_COMMAND_SWITCH_WEAPON / GUI_COMMAND_FIRE_WEAPON message only
-// carries a raw weapon slot index, not the identity of the command button that produced it. When a
-// mixed-unit-type group is selected (e.g. Rangers together with Missile Defenders) and a command button
-// that belongs to only one of those unit types is clicked (such as the Ranger's "switch to flashbang
-// grenades" button, which targets SECONDARY_WEAPON), the raw slot index used to be applied to every
-// member of the group regardless of whether that member's own command set actually exposes that slot.
-// This let the Missile Defender's secondary weapon (its laser-guided missile, normally only reachable
-// through its own laser-lock targeting logic) get permanently unlocked and fired like a normal weapon,
-// i.e. "rapid fire without laser locking" (#873). Guard against this by only honoring the weapon lock
-// for members whose own command set actually contains a switch/fire-weapon button for that slot.
+#if !RETAIL_COMPATIBLE_CRC
+// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 A GUI_COMMAND_SWITCH_WEAPON / GUI_COMMAND_FIRE_WEAPON
+// message only carries a raw weapon slot index, not the identity of the command button that produced
+// it. When a mixed-unit-type group is selected (e.g. Rangers together with Missile Defenders) and a
+// command button that belongs to only one of those unit types is clicked (such as the Ranger's "switch
+// to flashbang grenades" button, which targets SECONDARY_WEAPON), the raw slot index used to be applied
+// to every member of the group regardless of whether that member's own command set actually exposes
+// that slot. This let the Missile Defender's secondary weapon (its laser-guided missile, normally only
+// reachable through its own laser-lock targeting logic) get permanently unlocked and fired like a
+// normal weapon, i.e. "rapid fire without laser locking" (#873). Guard against this by only honoring
+// the weapon lock for members whose own command set actually contains a switch/fire-weapon button for
+// that slot. This must only be applied to the actual GUI command-button-driven callers
+// (onDoWeapon/onDoWeaponAtObject/onDoSwitchWeapons/onDoWeaponAtLocation in GameLogicDispatch.cpp), NOT
+// unconditionally inside setWeaponLockForGroup() itself -- that function is also called from the
+// force-attack-position path with a dev comment explaining it force-locks PRIMARY_WEAPON on the whole
+// group specifically so Rangers/Scud Launchers/the Toxin Tractor don't reset to primary weapon mode
+// while force-attacking. Most units have no explicit "switch to primary" command button (only a
+// "switch to secondary" one, since primary is the default), so applying this filter there would
+// silently defeat that unrelated mechanism for nearly every unit. See the filterByCommandAvailability
+// parameter below.
 static Bool objectHasCommandButtonForWeaponSlot( Object *obj, WeaponSlotType weaponSlot )
 {
 	if( !obj )
@@ -3103,16 +3113,21 @@ static Bool objectHasCommandButtonForWeaponSlot( Object *obj, WeaponSlotType wea
 
 	return false;
 }
+#endif
 
-Bool AIGroup::setWeaponLockForGroup( WeaponSlotType weaponSlot, WeaponLockType lockType )
+Bool AIGroup::setWeaponLockForGroup( WeaponSlotType weaponSlot, WeaponLockType lockType, Bool filterByCommandAvailability )
 {
 	Bool any = false;
 	std::list<Object *>::iterator i;
 	for( i = m_memberList.begin(); i != m_memberList.end(); ++i )
 	{
-		// Only lock the weapon slot for members that actually expose it via their own command set.
-		if( !objectHasCommandButtonForWeaponSlot( *i, weaponSlot ) )
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Only skip members lacking a matching command
+		// button when the caller explicitly opted in (see objectHasCommandButtonForWeaponSlot() above
+		// for why this can't be unconditional). (GitHub issue #873)
+		if( filterByCommandAvailability && !objectHasCommandButtonForWeaponSlot( *i, weaponSlot ) )
 			continue;
+#endif
 
 		if ((*i)->setWeaponLock( weaponSlot, lockType ))
 			any = true;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -3068,12 +3068,52 @@ void AIGroup::setMineClearingDetail( Bool set )
 	}
 }
 
+// TheSuperHackers @bugfix 07/19/2026 A GUI_COMMAND_SWITCH_WEAPON / GUI_COMMAND_FIRE_WEAPON message only
+// carries a raw weapon slot index, not the identity of the command button that produced it. When a
+// mixed-unit-type group is selected (e.g. Rangers together with Missile Defenders) and a command button
+// that belongs to only one of those unit types is clicked (such as the Ranger's "switch to flashbang
+// grenades" button, which targets SECONDARY_WEAPON), the raw slot index used to be applied to every
+// member of the group regardless of whether that member's own command set actually exposes that slot.
+// This let the Missile Defender's secondary weapon (its laser-guided missile, normally only reachable
+// through its own laser-lock targeting logic) get permanently unlocked and fired like a normal weapon,
+// i.e. "rapid fire without laser locking" (#873). Guard against this by only honoring the weapon lock
+// for members whose own command set actually contains a switch/fire-weapon button for that slot.
+static Bool objectHasCommandButtonForWeaponSlot( Object *obj, WeaponSlotType weaponSlot )
+{
+	if( !obj )
+		return false;
+
+	const CommandSet *commandSet = TheControlBar->findCommandSet( obj->getCommandSetString() );
+	if( !commandSet )
+		return false;
+
+	for( Int i = 0; i < MAX_COMMANDS_PER_SET; ++i )
+	{
+		const CommandButton *commandButton = commandSet->getCommandButton(i);
+		if( !commandButton )
+			continue;
+
+		GUICommandType type = commandButton->getCommandType();
+		if( (type == GUI_COMMAND_SWITCH_WEAPON || type == GUI_COMMAND_FIRE_WEAPON)
+			&& commandButton->getWeaponSlot() == weaponSlot )
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
 Bool AIGroup::setWeaponLockForGroup( WeaponSlotType weaponSlot, WeaponLockType lockType )
 {
 	Bool any = false;
 	std::list<Object *>::iterator i;
 	for( i = m_memberList.begin(); i != m_memberList.end(); ++i )
 	{
+		// Only lock the weapon slot for members that actually expose it via their own command set.
+		if( !objectHasCommandButtonForWeaponSlot( *i, weaponSlot ) )
+			continue;
+
 		if ((*i)->setWeaponLock( weaponSlot, lockType ))
 			any = true;
 	}


### PR DESCRIPTION
fix(GeneralsMD): weapon lock from group command applies to unrelated units (#873)

AIGroup::setWeaponLockForGroup() applied setWeaponLock() to every member
of the currently selected group whenever a GUI_COMMAND_SWITCH_WEAPON or
GUI_COMMAND_FIRE_WEAPON command button was clicked. The command message
only carries a raw WeaponSlotType index, not which unit/command button
produced it, so in a mixed-unit-type selection a button belonging to one
unit type could lock a same-numbered weapon slot on a completely
unrelated unit type.

Concretely: selecting a Ranger together with a Missile Defender and
clicking the Ranger's "switch to flashbang grenades" button (which
targets SECONDARY_WEAPON) also force-unlocked the Missile Defender's
SECONDARY_WEAPON slot, which is its laser-guided TOW missile normally
gated by laser-lock delay logic. This let the Missile Defender fire its
missile repeatedly with no laser lock, i.e. "rapid fire without laser
locking".

Add objectHasCommandButtonForWeaponSlot(), mirroring the existing
getCommandButtonSourceObject() pattern in the same file, and use it to
skip setWeaponLock() for group members whose own command set has no
switch/fire-weapon button for the requested slot.

GeneralsMD-only: the Missile Defender does not exist in the base
Generals tree, so there is nothing to backport.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix: #873 weapon-lock filter was ungated and broke force-attack primary-weapon lock

Fable-model review of the #873 fix (commit bf23916ac) found two real
issues:

1. AIGroup::setWeaponLockForGroup()'s command-button filter was applied
   unconditionally, with no !RETAIL_COMPATIBLE_CRC gate, unlike every
   other simulation-behavior change this session. Its only callers are
   in GameLogicDispatch.cpp's network-synchronized command handlers, so
   this silently changed deterministic simulation state relative to
   retail/unpatched clients.

2. More importantly, the filter was applied inside
   setWeaponLockForGroup() itself, which is also called from the
   force-attack-position path (GameLogicDispatch.cpp, onForceAttackObject
   equivalent) with an existing "Kris" dev comment explaining that call
   force-locks PRIMARY_WEAPON on the whole selected group specifically
   so Rangers, Scud Launchers, and the Toxin Tractor don't reset to
   primary weapon mode while force-attacking (added to let the Toxin
   Tractor force-attack while contaminating). Most units have no
   explicit "switch to primary weapon" command button (only a "switch
   to secondary" one, since primary is the default weapon), so the
   #873 filter would silently defeat this unrelated mechanism for
   nearly every unit -- reintroducing the exact primary-weapon-reset
   bug that dev comment describes having fixed.

Add a filterByCommandAvailability parameter to setWeaponLockForGroup()
(default FALSE, preserving the original unconditional-lock behavior),
gated behind #if !RETAIL_COMPATIBLE_CRC. Only the four GUI command-
button-driven callers (onDoWeapon, onDoWeaponAtObject, onDoSwitchWeapons,
onDoWeaponAtLocation in GameLogicDispatch.cpp -- i.e. the actual paths
#873 was about) now pass TRUE; the force-attack-position call site is
untouched and keeps its original, unconditional group-wide lock.

Since GameLogicDispatch.cpp is Core-shared and calls setWeaponLockForGroup
with the same argument list regardless of which tree it's compiled
into, the filtering mechanism (objectHasCommandButtonForWeaponSlot()
and the 3-parameter signature) is now backported to the base Generals
tree as well, even though the originally-reported Missile Defender
scenario doesn't exist there -- the underlying "command button doesn't
match the raw weapon slot on every group member" issue is generic, not
Missile-Defender-specific, so this is a genuine correctness backport,
not just a signature-compatibility shim.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #873
