### PR TITLE
fix: patriot-type turrets fire long-range assist weapon at out-of-range targets (#370)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5510,6 +5510,15 @@ void AIAttackState::onExit( StateExitType status )
 
 	obj->clearLeechRangeModeForAllWeapons();
 
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 LOCKED_TEMPORARILY is documented (see WeaponSet.h) to last
+	// until the clip is empty "or current attack state exits", but this exit path never actually released it,
+	// unlike AIHuntState::onExit(). This left an assist-fire request's long range secondary weapon permanently
+	// locked in if the attack state was left before the clip emptied and before the victim died, e.g. via a
+	// stop command, causing the turret to keep using its long range weapon to acquire out-of-range targets. (GitHub issue #370)
+	obj->releaseWeaponLock(LOCKED_TEMPORARILY);
+#endif
+
 	AIUpdateInterface *ai = obj->getAI();
 	if (ai)
 	{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3296,6 +3296,13 @@ void AIUpdateInterface::privateAttackObject( Object *victim, Int maxShotsToFire,
 
 	if (!victim)
 	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 The victim can go away (die) between an assist-fire
+		// request temporarily locking our weapon to the long range secondary and this command actually being
+		// processed. Release that temporary lock here so we fall back to our normal weapon range instead of
+		// keeping the long range weapon locked and using it to acquire an out-of-normal-range target. (GitHub issue #370)
+		getObject()->releaseWeaponLock( LOCKED_TEMPORARILY );
+#endif
 		// Hard to kill em if they're already dead.  jba
 		return;
 	}
@@ -3315,6 +3322,11 @@ void AIUpdateInterface::privateAttackObject( Object *victim, Int maxShotsToFire,
 void AIUpdateInterface::privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource )
 {
 	if (!victim) {
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Release a stale temporary weapon lock (e.g. from an
+		// assist-fire request) when the victim is gone, so we fall back to our normal weapon range. (GitHub issue #370)
+		getObject()->releaseWeaponLock( LOCKED_TEMPORARILY );
+#endif
 		return;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -2756,6 +2756,15 @@ static void makeAssistanceRequest( Object *requestOf, void *userData )
 	if( requestOf == requestData->m_requestingObject )
 		return;
 
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Don't assist-fire if the assisting turret is also the
+	// intended victim. Without this check a turret damaging one of its own kind would request assistance
+	// from its victim, locking the victim's long range secondary weapon and, since it cannot fire at itself,
+	// causing it to acquire a new out-of-normal-range target instead. (GitHub issue #370)
+	if( requestOf == requestData->m_victimObject )
+		return;
+#endif
+
 	// Only request of our kind of people
 	if( !requestOf->getTemplate()->isEquivalentTo( requestData->m_requestingObject->getTemplate() ) )
 		return;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5722,6 +5722,15 @@ void AIAttackState::onExit( StateExitType status )
 
 	obj->clearLeechRangeModeForAllWeapons();
 
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 LOCKED_TEMPORARILY is documented (see WeaponSet.h) to last
+	// until the clip is empty "or current attack state exits", but this exit path never actually released it,
+	// unlike AIHuntState::onExit(). This left an assist-fire request's long range secondary weapon permanently
+	// locked in if the attack state was left before the clip emptied and before the victim died, e.g. via a
+	// stop command, causing the turret to keep using its long range weapon to acquire out-of-range targets. (GitHub issue #370)
+	obj->releaseWeaponLock(LOCKED_TEMPORARILY);
+#endif
+
 	AIUpdateInterface *ai = obj->getAI();
 	if (ai)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3433,6 +3433,13 @@ void AIUpdateInterface::privateAttackObject( Object *victim, Int maxShotsToFire,
 
 	if (!victim)
 	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 The victim can go away (die) between an assist-fire
+		// request temporarily locking our weapon to the long range secondary and this command actually being
+		// processed. Release that temporary lock here so we fall back to our normal weapon range instead of
+		// keeping the long range weapon locked and using it to acquire an out-of-normal-range target. (GitHub issue #370)
+		getObject()->releaseWeaponLock( LOCKED_TEMPORARILY );
+#endif
 		// Hard to kill em if they're already dead.  jba
 		return;
 	}
@@ -3452,6 +3459,11 @@ void AIUpdateInterface::privateAttackObject( Object *victim, Int maxShotsToFire,
 void AIUpdateInterface::privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource )
 {
 	if (!victim) {
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Release a stale temporary weapon lock (e.g. from an
+		// assist-fire request) when the victim is gone, so we fall back to our normal weapon range. (GitHub issue #370)
+		getObject()->releaseWeaponLock( LOCKED_TEMPORARILY );
+#endif
 		return;
 	}
 
@@ -3470,6 +3482,11 @@ void AIUpdateInterface::privateForceAttackObject( Object *victim, Int maxShotsTo
 void AIUpdateInterface::privateGuardRetaliate( Object *victim, const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource )
 {
 	if (!victim) {
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Release a stale temporary weapon lock (e.g. from an
+		// assist-fire request) when the victim is gone, so we fall back to our normal weapon range. (GitHub issue #370)
+		getObject()->releaseWeaponLock( LOCKED_TEMPORARILY );
+#endif
 		return;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -2968,6 +2968,15 @@ static void makeAssistanceRequest( Object *requestOf, void *userData )
 	if( requestOf == requestData->m_requestingObject )
 		return;
 
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Don't assist-fire if the assisting turret is also the
+	// intended victim. Without this check a turret damaging one of its own kind would request assistance
+	// from its victim, locking the victim's long range secondary weapon and, since it cannot fire at itself,
+	// causing it to acquire a new out-of-normal-range target instead. (GitHub issue #370)
+	if( requestOf == requestData->m_victimObject )
+		return;
+#endif
+
 	// Only request of our kind of people
 	if( !requestOf->getTemplate()->isEquivalentTo( requestData->m_requestingObject->getTemplate() ) )
 		return;


### PR DESCRIPTION
fix: patriot-type turrets fire long-range assist weapon at out-of-range targets (#370)

AssistedTargetingUpdate lets a Patriot-type turret ask a nearby turret
of the same kind for help against a distant target: the assisting
turret temporarily locks its SECONDARY weapon (long range, per INI
e.g. AssistingWeaponSlot = SECONDARY) in place of its normal PRIMARY
weapon (short range). Three related defects let that long-range lock
persist or get misapplied well past its intended lifetime, causing the
turret to acquire and fire on targets far outside its normal range,
most visibly with the instant-fire laser Patriot:

1. makeAssistanceRequest() in Weapon.cpp checked that the assisting
   turret wasn't the requester, but not that it wasn't the *victim*
   itself. A turret taking damage from one of its own kind could be
   asked to assist against its own attacker, lock its long-range
   weapon, fail to fire on itself, and use that weapon's range to
   acquire a different, out-of-range target instead.

2. AIUpdateInterface::privateAttackObject/privateForceAttackObject/
   privateGuardRetaliate (AIUpdate.cpp) early-out when their victim
   pointer is null (already destroyed by the time the queued attack
   command runs) without releasing any temporary weapon lock, leaving
   the long-range weapon locked in with nothing to fire at until it
   re-acquires a new, out-of-range target on its own.

3. AIAttackState::onExit() (AIStates.cpp) never released a temporary
   weapon lock on exit, unlike its sibling AIHuntState::onExit().
   WeaponSet.h documents LOCKED_TEMPORARILY as lasting until the clip
   empties "or current attack state exits" — but leaving attack state
   early (e.g. via a stop command) while the assist target was still
   alive left the long-range lock stuck in place indefinitely.

Root-caused by GitHub user Skyaero42 across extensive investigation in
the issue thread; this change implements and verifies all three fixes
against current source, plus the community's own follow-up note that
a stop command could leave the same stale lock behind.

Gated behind !RETAIL_COMPATIBLE_CRC in all three files/trees, since
this changes AI/weapon-lock simulation behavior with replay/multiplayer
determinism implications versus unpatched clients (explicitly flagged
by the issue reporters themselves).

Applies to both Generals and GeneralsMD; GeneralsMD additionally fixes
privateGuardRetaliate, which does not exist in the base Generals tree.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #370
