### PR TITLE
fix: single-burst heal and continuous heal aura swallow each other (#240)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -275,6 +275,16 @@ void AutoHealBehavior::pulseHealObject( Object *obj )
 
 	if ( data->m_radius == 0.0f )
 		obj->attemptHealing(data->m_healingAmount, getObject());
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 A SingleBurst radius heal is a one-time pulse, not a
+	// persistent aura. It must not compete for the target's sole-healing-benefactor slot, which exists only
+	// to stop several simultaneous copies of the same *continuous* aura (Ambulance) from re-healing a target
+	// every pulse. Previously a burst heal reaching a target already claimed by an aura was entirely
+	// swallowed, and a burst heal landing first would itself claim the target and swallow the aura's very
+	// next pulse (GitHub issue #240).
+	else if ( data->m_singleBurst )
+		obj->attemptHealing(data->m_healingAmount, getObject());
+#endif
 	else
 		obj->attemptHealingFromSoleBenefactor( data->m_healingAmount, getObject(), data->m_healingDelay );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -290,6 +290,16 @@ void AutoHealBehavior::pulseHealObject( Object *obj )
 
 	if ( data->m_radius == 0.0f )
 		obj->attemptHealing(data->m_healingAmount, getObject());
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 19/07/2026 A SingleBurst radius heal (e.g. the China "Emergency Repair"
+	// special power) is a one-time pulse, not a persistent aura. It must not compete for the target's
+	// sole-healing-benefactor slot, which exists only to stop several simultaneous copies of the same
+	// *continuous* aura (Ambulance, Propaganda Tower) from re-healing a target every pulse. Previously a burst
+	// heal reaching a target already claimed by an aura was entirely swallowed, and a burst heal landing first
+	// would itself claim the target and swallow the aura's very next pulse (GitHub issue #240).
+	else if ( data->m_singleBurst )
+		obj->attemptHealing(data->m_healingAmount, getObject());
+#endif
 	else
 		obj->attemptHealingFromSoleBenefactor( data->m_healingAmount, getObject(), data->m_healingDelay );
 


### PR DESCRIPTION
fix: single-burst heal and continuous heal aura swallow each other (#240)

AutoHealBehavior::pulseHealObject() routes any radius-based heal
(m_radius > 0) through Object::attemptHealingFromSoleBenefactor(),
which lets a healed object be claimed by only one healing-source ID
at a time for the aura's healing-delay window, rejecting any other
source's heal attempt outright while that claim is active. Per
PropagandaTowerBehavior.cpp's own design comment, this exists solely
to stop multiple simultaneous copies of the same continuous aura
(e.g. several Ambulances or Propaganda Towers) from repeatedly
re-healing the same target every pulse.

The gate was applied unconditionally to any radius heal, including
AutoHealBehaviorModuleData::m_singleBurst instances (a one-time pulse,
e.g. China's Emergency Repair special power), which is not a
persistent aura and has no reason to compete for the sole-benefactor
slot. This let a single-burst heal reaching a target already claimed
by an aura get silently swallowed, and conversely let a burst heal
claim the slot first and swallow the aura's very next pulse -- matching
the reported "Ambulance/Propaganda Tower swallow Emergency Repair
burst" behavior, and why unrelated non-radius heals (Junk Repair,
Veterancy) never exhibited it: they bypass this gate entirely via the
m_radius == 0.0f branch.

Route m_singleBurst radius heals through the plain, always-stacking
attemptHealing() instead, leaving the sole-benefactor anti-stacking
behavior intact for actual continuous auras (Ambulance, Propaganda
Tower).

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes heal
simulation behavior with replay/multiplayer determinism implications.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #240
