### PR TITLE
fix: superweapon countdown inflated if paused during construction (#215)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -397,6 +397,15 @@ void SpecialPowerModule::startPowerRecharge()
 	{
 		// set the frame we will be 100% available on now
 		m_availableOnFrame = TheGameLogic->getFrame() + getSpecialPowerTemplate()->getReloadTime();
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Skyaero42 19/07/2026 m_availableOnFrame is being set directly here, which
+		// leaves m_pausedOnFrame stale. If the special power's structure was paused (e.g. by a power outage)
+		// at any point before construction completed, the frame count it was paused for gets added on top of
+		// this fresh ready frame the next time the pause is resolved, making the countdown start far longer
+		// than the template's reload time. Reset m_pausedOnFrame here too, matching how a script-driven ready
+		// frame change is already handled elsewhere (see setReadyFrame() in the GeneralsMD tree). (GitHub issue #215)
+		m_pausedOnFrame = TheGameLogic->getFrame();
+#endif
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -420,8 +420,18 @@ void SpecialPowerModule::startPowerRecharge()
 	}
 	else
 	{
+#if RETAIL_COMPATIBLE_CRC
 		// set the frame we will be 100% available on now
 		m_availableOnFrame = TheGameLogic->getFrame() + getSpecialPowerTemplate()->getReloadTime();
+#else
+		// TheSuperHackers @bugfix Skyaero42 19/07/2026 Setting m_availableOnFrame directly leaves
+		// m_pausedOnFrame stale. If the special power's structure was paused (e.g. subdued by a Microwave
+		// Tank) at any point before construction completed, the frame count it was paused for gets added
+		// on top of this fresh ready frame the next time the pause is resolved, making the countdown start
+		// far longer than the template's reload time. setReadyFrame() sets both fields correctly, matching
+		// how a script-driven ready-frame change is already handled. (GitHub issue #215)
+		setReadyFrame(TheGameLogic->getFrame() + getSpecialPowerTemplate()->getReloadTime());
+#endif
 	}
 }
 


### PR DESCRIPTION
fix: superweapon countdown inflated if paused during construction (#215)

SpecialPowerModule::startPowerRecharge() sets m_availableOnFrame
directly for non-SharedNSync special powers, without updating
m_pausedOnFrame. SpecialPowerModule::getReadyFrame() adds the number
of frames elapsed since m_pausedOnFrame back onto m_availableOnFrame
whenever the power's pause is resolved (see pauseCountdown()/the
paused-frame bookkeeping a few lines above in this same file).

If a special-power structure (e.g. a Particle Cannon) is paused for
any reason before its construction completes -- most visibly via a USA
Microwave Tank's subdual damage, but the same startPowerRecharge()
codepath is shared by any pause cause in both trees -- m_pausedOnFrame
was left stuck at whatever frame the pause began, well before
construction (and therefore this recharge) even started. The next time
the pause resolves, getReadyFrame() then adds the entire pause duration
-- measured from that stale, pre-construction frame -- on top of a
freshly-set ready frame, inflating the superweapon's initial countdown
far beyond its template's actual reload time. The earlier construction
was paused, the larger the inflation.

GeneralsMD already has SpecialPowerModule::setReadyFrame(), which
correctly resets m_pausedOnFrame to the current frame whenever
m_availableOnFrame is set directly elsewhere (for exactly this reason,
per its own comment); startPowerRecharge() there is switched to use it
instead of assigning m_availableOnFrame directly. The base Generals
tree's setReadyFrame() is a header-inline virtual that does not reset
m_pausedOnFrame, so instead m_pausedOnFrame is reset inline at the same
call site, matching GeneralsMD's setReadyFrame() behavior.

Root-caused and fix proposed by GitHub users Skyaero42 and Caball009 in
the issue thread; both trees verified against current source before
applying.

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes superweapon
countdown simulation behavior with replay/multiplayer determinism
implications (explicitly noted by the reporter).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #215
