### PR TITLE
fix: weapon-bonus change resets reload progress instead of preserving it (#89)

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -2051,8 +2051,38 @@ void Weapon::onWeaponBonusChange(const Object *source)
 
 	if( needUpdate )
 	{
+#if RETAIL_COMPATIBLE_CRC
 		m_whenLastReloadStarted = TheGameLogic->getFrame();
 		m_whenWeCanFireAgain = m_whenLastReloadStarted + newDelay;
+#else
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Preserve reload progress proportionally instead of
+		// unconditionally resetting the reload timer to the current frame. Previously, any weapon-affecting
+		// bonus (e.g. the Propaganda Center's rate-of-fire bonus) being added to or removed from a unit while
+		// its weapon was mid-reload discarded all reload progress and restarted the reload from the current
+		// frame using the new duration, which let players fire slow-reloading weapons (e.g. the Nuke Cannon)
+		// far more often than intended by simply toggling the bonus on and off. (GitHub issue #89)
+		const UnsignedInt now = TheGameLogic->getFrame();
+		const Int oldTotal = (Int)m_whenWeCanFireAgain - (Int)m_whenLastReloadStarted;
+		Int newRemaining = newDelay;
+		if (oldTotal > 0)
+		{
+			Int oldRemaining = (Int)m_whenWeCanFireAgain - (Int)now;
+			if (oldRemaining < 0)
+				oldRemaining = 0;
+			newRemaining = (oldRemaining * newDelay) / oldTotal;
+		}
+		if (newRemaining < 0)
+			newRemaining = 0;
+		else if (newRemaining > newDelay)
+			newRemaining = newDelay;
+
+		Int newStart = (Int)now + newRemaining - newDelay;
+		if (newStart < 0)
+			newStart = 0;
+
+		m_whenWeCanFireAgain = now + (UnsignedInt)newRemaining;
+		m_whenLastReloadStarted = (UnsignedInt)newStart;
+#endif
 
 		if (source->isReloadTimeShared())
 		{


### PR DESCRIPTION
fix: weapon-bonus change resets reload progress instead of preserving it (#89)

Weapon::onWeaponBonusChange() recomputes the reload delay whenever a
weapon-affecting bonus (e.g. the China Propaganda Center's rate-of-fire
bonus) is added to or removed from a unit mid-reload, but unconditionally
reset the timer to a fresh full duration starting from the current frame:

    m_whenLastReloadStarted = TheGameLogic->getFrame();
    m_whenWeCanFireAgain = m_whenLastReloadStarted + newDelay;

This discarded all reload progress made so far, so toggling a
rate-of-fire bonus on and off let players fire slow-reloading weapons
(most visibly the China Nuke Cannon) far more often than intended,
since every bonus change effectively reset the wait to whatever the new
(possibly much shorter) duration was.

Preserve reload progress proportionally instead: compute the fraction
of the old reload duration already elapsed, and apply that same
fraction of the new duration as the remaining wait, clamped to
[0, newDelay] to avoid an out-of-range result. E.g. 5/10 frames elapsed
(50% done) under a 10-frame reload becomes 4/8 frames remaining (still
50% done) if the bonus change makes the new total 8 frames, rather than
resetting to a full 8/8.

Confirmed onWeaponBonusChange() only exists in the GeneralsMD/Zero Hour
tree; the base Generals tree has no equivalent code path, so no
backport is needed.

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes weapon-reload
simulation behavior with replay/multiplayer determinism implications.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #89
