### PR TITLE
fix: Guard Mode acquires targets through fog of war (#86)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -40,6 +40,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
 #include "Common/PerfTimer.h"
+#include "Common/Player.h"
 #include "Common/Team.h"
 #include "Common/Xfer.h"
 #include "GameLogic/AI.h"
@@ -233,6 +234,14 @@ Bool AIGuardMachine::lookForInnerTarget()
 	PartitionFilterSameMapStatus				filterMapStatus(owner);
 	PartitionFilterPolygonTrigger				f3(area);
 	PartitionFilterIsFlying							f4;
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Guard Mode target acquisition scanned for enemies
+	// through fog of war, causing guarding units to visibly turn and lock onto (and thus reveal) enemies
+	// that were not actually visible yet. Apply the same UNFOGGED restriction that normal auto-acquire
+	// targeting (AIUpdateInterface::getNextMoodTarget) already uses for human-controlled players. (GitHub issue #86)
+	Player* controllingPlayer = owner->getControllingPlayer();
+	PartitionFilterFreeOfFog f5(controllingPlayer ? controllingPlayer->getPlayerIndex() : 0);
+#endif
 
 	PartitionFilter *filters[16];
 	Int count = 0;
@@ -240,6 +249,16 @@ Bool AIGuardMachine::lookForInnerTarget()
 	filters[count++] = &f1;
 	filters[count++] = &f2;
 	filters[count++] = &filterMapStatus;
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Only apply the UNFOGGED restriction for human-controlled
+	// players, matching AIUpdateInterface::getNextMoodTarget()'s behavior of leaving computer AI players'
+	// targeting unaffected by shroud. (GitHub issue #86)
+	if (controllingPlayer && controllingPlayer->getPlayerType() == PLAYER_HUMAN)
+	{
+		filters[count++] = &f5;
+	}
+#endif
 
 	Real visionRange = AIGuardMachine::getStdGuardRange(owner);
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
@@ -354,6 +354,15 @@ static Object *TunnelNetworkScan(Object *owner)
 		PartitionFilterRelationship					f1(owner, PartitionFilterRelationship::ALLOW_ENEMIES);
 		PartitionFilterPossibleToAttack			f2(ATTACK_NEW_TARGET, owner, CMD_FROM_AI);
 		PartitionFilterSameMapStatus				filterMapStatus(owner);
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Tunnel Network Guard target acquisition scanned for
+		// enemies through fog of war, causing guarding units to visibly turn and lock onto (and thus reveal)
+		// enemies that were not actually visible yet. Apply the same UNFOGGED restriction that normal
+		// auto-acquire targeting (AIUpdateInterface::getNextMoodTarget) already uses for human-controlled
+		// players. (GitHub issue #86)
+		Player* controllingPlayer = owner->getControllingPlayer();
+		PartitionFilterFreeOfFog filterFogged(controllingPlayer ? controllingPlayer->getPlayerIndex() : 0);
+#endif
 
 		PartitionFilter *filters[16];
 		Int count = 0;
@@ -361,6 +370,16 @@ static Object *TunnelNetworkScan(Object *owner)
 		filters[count++] = &f1;
 		filters[count++] = &f2;
 		filters[count++] = &filterMapStatus;
+
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Only apply the UNFOGGED restriction for human-controlled
+		// players, matching AIUpdateInterface::getNextMoodTarget()'s behavior of leaving computer AI players'
+		// targeting unaffected by shroud. (GitHub issue #86)
+		if (controllingPlayer && controllingPlayer->getPlayerType() == PLAYER_HUMAN)
+		{
+			filters[count++] = &filterFogged;
+		}
+#endif
 
 		Real visionRange = AITNGuardMachine::getStdGuardRange(owner);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -40,6 +40,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
 #include "Common/PerfTimer.h"
+#include "Common/Player.h"
 #include "Common/Team.h"
 #include "Common/Xfer.h"
 #include "Common/ThingTemplate.h"
@@ -241,6 +242,14 @@ Bool AIGuardMachine::lookForInnerTarget()
 	PartitionFilterRelationship					f5(owner, PartitionFilterRelationship::ALLOW_NEUTRAL);
 	PartitionFilterPossibleToEnter			f6(owner, CMD_FROM_AI);
 	PartitionFilterPossibleToHijack			f7(owner, CMD_FROM_AI);
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Guard Mode target acquisition scanned for enemies
+	// through fog of war, causing guarding units to visibly turn and lock onto (and thus reveal) enemies
+	// that were not actually visible yet. Apply the same UNFOGGED restriction that normal auto-acquire
+	// targeting (AIUpdateInterface::getNextMoodTarget) already uses for human-controlled players. (GitHub issue #86)
+	Player* controllingPlayer = owner->getControllingPlayer();
+	PartitionFilterFreeOfFog f8(controllingPlayer ? controllingPlayer->getPlayerIndex() : 0);
+#endif
 
 	PartitionFilter *filters[16];
 	Int count = 0;
@@ -269,6 +278,16 @@ Bool AIGuardMachine::lookForInnerTarget()
 	}
 
 	filters[count++] = &filterMapStatus;
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Only apply the UNFOGGED restriction for human-controlled
+	// players, matching AIUpdateInterface::getNextMoodTarget()'s behavior of leaving computer AI players'
+	// targeting unaffected by shroud. (GitHub issue #86)
+	if (controllingPlayer && controllingPlayer->getPlayerType() == PLAYER_HUMAN)
+	{
+		filters[count++] = &f8;
+	}
+#endif
 
 	Real visionRange = AIGuardMachine::getStdGuardRange(owner);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
@@ -39,6 +39,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
 #include "Common/PerfTimer.h"
+#include "Common/Player.h"
 #include "Common/Team.h"
 #include "Common/Xfer.h"
 #include "Common/ThingTemplate.h"
@@ -248,6 +249,14 @@ Bool AIGuardRetaliateMachine::lookForInnerTarget()
 	PartitionFilterPossibleToEnter			f6(owner, CMD_FROM_AI);
 	PartitionFilterPossibleToHijack			f7(owner, CMD_FROM_AI);
 	PartitionFilterRejectBuildings			f8( owner );
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Guard Mode target acquisition scanned for enemies
+	// through fog of war, causing guarding units to visibly turn and lock onto (and thus reveal) enemies
+	// that were not actually visible yet. Apply the same UNFOGGED restriction that normal auto-acquire
+	// targeting (AIUpdateInterface::getNextMoodTarget) already uses for human-controlled players. (GitHub issue #86)
+	Player* controllingPlayer = owner->getControllingPlayer();
+	PartitionFilterFreeOfFog f9(controllingPlayer ? controllingPlayer->getPlayerIndex() : 0);
+#endif
 
 	PartitionFilter *filters[16];
 	Int count = 0;
@@ -277,6 +286,16 @@ Bool AIGuardRetaliateMachine::lookForInnerTarget()
 	}
 
 	filters[count++] = &filterMapStatus;
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Only apply the UNFOGGED restriction for human-controlled
+	// players, matching AIUpdateInterface::getNextMoodTarget()'s behavior of leaving computer AI players'
+	// targeting unaffected by shroud. (GitHub issue #86)
+	if (controllingPlayer && controllingPlayer->getPlayerType() == PLAYER_HUMAN)
+	{
+		filters[count++] = &f9;
+	}
+#endif
 
 	Real visionRange = AIGuardRetaliateMachine::getStdGuardRange(owner);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
@@ -354,6 +354,15 @@ static Object *TunnelNetworkScan(Object *owner)
 		PartitionFilterRelationship					f1(owner, PartitionFilterRelationship::ALLOW_ENEMIES);
 		PartitionFilterPossibleToAttack			f2(ATTACK_NEW_TARGET, owner, CMD_FROM_AI);
 		PartitionFilterSameMapStatus				filterMapStatus(owner);
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Tunnel Network Guard target acquisition scanned for
+		// enemies through fog of war, causing guarding units to visibly turn and lock onto (and thus reveal)
+		// enemies that were not actually visible yet. Apply the same UNFOGGED restriction that normal
+		// auto-acquire targeting (AIUpdateInterface::getNextMoodTarget) already uses for human-controlled
+		// players. (GitHub issue #86)
+		Player* controllingPlayer = owner->getControllingPlayer();
+		PartitionFilterFreeOfFog filterFogged(controllingPlayer ? controllingPlayer->getPlayerIndex() : 0);
+#endif
 
 		PartitionFilter *filters[16];
 		Int count = 0;
@@ -361,6 +370,16 @@ static Object *TunnelNetworkScan(Object *owner)
 		filters[count++] = &f1;
 		filters[count++] = &f2;
 		filters[count++] = &filterMapStatus;
+
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Only apply the UNFOGGED restriction for human-controlled
+		// players, matching AIUpdateInterface::getNextMoodTarget()'s behavior of leaving computer AI players'
+		// targeting unaffected by shroud. (GitHub issue #86)
+		if (controllingPlayer && controllingPlayer->getPlayerType() == PLAYER_HUMAN)
+		{
+			filters[count++] = &filterFogged;
+		}
+#endif
 
 		Real visionRange = AITNGuardMachine::getStdGuardRange(owner);
 


### PR DESCRIPTION
fix: Guard Mode acquires targets through fog of war (#86)

Guard Mode's target-acquisition scans -- AIGuardMachine::lookForInnerTarget()
(AIGuard.cpp), AIGuardRetaliateMachine::lookForInnerTarget()
(AIGuardRetaliate.cpp, GeneralsMD only), and TunnelNetworkScan()
(AITNGuard.cpp) -- build their PartitionManager filter list from
relationship/attackability/map-status filters, but never checked
fog-of-war/shroud status. This let a guarding unit visibly turn to
face, and start locking onto, an enemy unit that was still covered by
fog of war and not actually visible yet (e.g. a Terrorist raising its
hands, a Gatling Tank's cannon turning and spinning up) -- acting as an
unintended detection/reveal mechanism.

The engine's normal (non-guard) auto-acquire targeting path,
AIUpdateInterface::getNextMoodTarget(), already solves this exact
problem for human-controlled players: it conditionally adds
PartitionFilterFreeOfFog to the scan, but only when
getControllingPlayer()->getPlayerType() == PLAYER_HUMAN, leaving
computer AI players' targeting unaffected by shroud (their existing
"cheat vision"). Apply the same filter, under the same human-player-only
condition, to all three Guard Mode scans, for consistency with this
established engine convention.

This only affects initial target acquisition (the scan that selects a
new target to lock onto); it does not touch retaliation-on-being-hit
logic, which responds to an actual attack rather than a visual scan, so
a unit already engaged in combat that has an enemy retreat into fog is
unaffected.

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes AI targeting
simulation behavior with replay/multiplayer determinism implications.

Applies to both Generals and GeneralsMD; AIGuardRetaliate.cpp is
GeneralsMD-only (no equivalent in the base Generals tree).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #86
