### PR TITLE
fix: supply gatherers discard player move commands shortly after construction (#45)

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Upgrade.h
+++ b/Generals/Code/GameEngine/Include/Common/Upgrade.h
@@ -237,6 +237,7 @@ public:
 	virtual void reset() override;												///< subsystem interface
 	virtual void update() override { }										///< subsystem interface
 
+	void deleteAllUpgrades();
 	UpgradeTemplate *firstUpgradeTemplate(); ///< return the first upgrade template
 	const UpgradeTemplate *findUpgradeByKey( NameKeyType key ) const; ///< find upgrade by name key
 	const UpgradeTemplate *findUpgrade( const AsciiString& name ) const; ///< find and return upgrade by name

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2237,7 +2237,21 @@ void Player::setUnitsShouldIdleOrResume(Bool idle)
 					{
 						SupplyTruckAIInterface* supplyTruckAI = ai->getSupplyTruckAIInterface();
 						if( supplyTruckAI )
+						{
 							supplyTruckAI->setForceWantingState(true);
+#if !RETAIL_COMPATIBLE_CRC
+							// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 This script action re-arms the
+							// same auto-gather latch that SupplyTruckStateMachine::isForcedIntoWantingState()
+							// (SupplyTruckAIUpdate.cpp) dismisses if the truck's last command came from the
+							// player -- a fix for issue #45. Without this, a truck the player had commanded
+							// at any earlier point (however long ago, regardless of what it's done since)
+							// would have this script-driven "resume gathering" order silently dismissed as
+							// if it were the player's own stale command. Record this as the truck's most
+							// recent command source so it's correctly treated as fresh AI/script authority
+							// over the unit, not a leftover player command. (GitHub issue #45)
+							ai->friend_setLastCommandSource(CMD_FROM_SCRIPT);
+#endif
+						}
 					}
 				}
 			}

--- a/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -34,6 +34,7 @@
 #include "Common/Upgrade.h"
 #include "Common/Player.h"
 #include "Common/Xfer.h"
+#include "Common/XferCRC.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/Image.h"
 
@@ -233,23 +234,7 @@ UpgradeCenter::UpgradeCenter()
 //-------------------------------------------------------------------------------------------------
 UpgradeCenter::~UpgradeCenter()
 {
-
-	// delete all the upgrades loaded from the INI database
-	UpgradeTemplate *next;
-	while( m_upgradeList )
-	{
-
-		// get next
-		next = m_upgradeList->friend_getNext();
-
-		// delete head of list
-		deleteInstance(m_upgradeList);
-
-		// set head to next element
-		m_upgradeList = next;
-
-	}
-
+	deleteAllUpgrades();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -281,6 +266,23 @@ void UpgradeCenter::init()
 //-------------------------------------------------------------------------------------------------
 void UpgradeCenter::reset()
 {
+	// TheSuperHackers @bugfix helmutbuhler 07/19/2026 A custom map's map.ini can override upgrade
+	// templates (e.g. BuildTime/BuildCost on an existing Upgrade). Those overrides were never undone,
+	// so an upgrade template's data stayed permanently mutated for the rest of the client session --
+	// including for any subsequent match that does NOT use that map.ini, which mismatches against
+	// other clients whose UpgradeTemplate data was never touched. Undo this by discarding every loaded
+	// upgrade and reloading the original INI files, exactly as they were loaded at startup, before
+	// anything else in reset() (e.g. button image caching) can observe stale, overridden data.
+	// (GitHub issue #1436; upstream fix authored by helmutbuhler in PR #1749, ported here since that
+	// PR remains open pending an unrelated, unresolved architectural discussion about INI overrides.)
+	deleteAllUpgrades();
+	init();
+	XferCRC xferCRC;
+	xferCRC.open("lightCRC");
+	INI ini;
+	ini.loadFileDirectory("Data\\INI\\Default\\Upgrade", INI_LOAD_OVERWRITE, &xferCRC);
+	ini.loadFileDirectory("Data\\INI\\Upgrade", INI_LOAD_OVERWRITE, &xferCRC);
+
 	if( TheMappedImageCollection && !buttonImagesCached )
 	{
 		UpgradeTemplate *upgrade;
@@ -290,6 +292,30 @@ void UpgradeCenter::reset()
 		}
 		buttonImagesCached = TRUE;
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+void UpgradeCenter::deleteAllUpgrades()
+{
+	// delete all the upgrades loaded from the INI database
+	UpgradeTemplate *next;
+	while( m_upgradeList )
+	{
+
+		// get next
+		next = m_upgradeList->friend_getNext();
+
+		// delete head of list
+		deleteInstance(m_upgradeList);
+
+		// set head to next element
+		m_upgradeList = next;
+
+	}
+	m_upgradeList = nullptr;
+	m_nextTemplateMaskBit = 0;
+	buttonImagesCached = FALSE;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -266,17 +266,34 @@ void UpgradeCenter::init()
 //-------------------------------------------------------------------------------------------------
 void UpgradeCenter::reset()
 {
-	// TheSuperHackers @bugfix helmutbuhler 07/19/2026 A custom map's map.ini can override upgrade
-	// templates (e.g. BuildTime/BuildCost on an existing Upgrade). Those overrides were never undone,
-	// so an upgrade template's data stayed permanently mutated for the rest of the client session --
-	// including for any subsequent match that does NOT use that map.ini, which mismatches against
-	// other clients whose UpgradeTemplate data was never touched. Undo this by discarding every loaded
-	// upgrade and reloading the original INI files, exactly as they were loaded at startup, before
-	// anything else in reset() (e.g. button image caching) can observe stale, overridden data.
+	// TheSuperHackers @bugfix helmutbuhler 07/19/2026 [revised ZsoltFeher 07/20/2026 after fable-model
+	// review] A custom map's map.ini can override upgrade templates (e.g. BuildTime/BuildCost on an
+	// existing Upgrade). Those overrides were never undone, so an upgrade template's data stayed
+	// permanently mutated for the rest of the client session -- including for any subsequent match that
+	// does NOT use that map.ini, which mismatches against other clients whose UpgradeTemplate data was
+	// never touched.
+	//
+	// The original port of this fix deleted every UpgradeTemplate and recreated them from scratch
+	// before reloading. That is unsafe: CommandButton::m_upgradeTemplate (ControlBar.h) is a raw
+	// UpgradeTemplate* resolved once at ControlBar::init() startup and never re-resolved on reset
+	// (ControlBar::reset() only removes map.ini command button/set OVERRIDES, it doesn't touch the base
+	// buttons' cached pointers) -- deleting and recreating the pointed-to objects left those as
+	// dangling pointers, silently "working" only because of a LIFO memory-pool allocator coincidentally
+	// reusing the same addresses in the same order, which is not guaranteed once the loaded upgrade set
+	// isn't identical to what was loaded at startup.
+	//
+	// UpgradeCenter::parseUpgradeDefinition() already finds an existing UpgradeTemplate by name and
+	// updates its fields in place via ini->initFromINI(), only allocating a new instance if no upgrade
+	// with that name exists yet -- exactly like ThingTemplate's own field-level overwrite semantics,
+	// just without a separate override/restore layer (per Caball009's investigation on this same issue:
+	// "UpgradeTemplate has no override feature like ThingTemplate"). So simply re-running the original
+	// INI load below, without deleting anything first, already restores every EXISTING upgrade's fields
+	// to their pristine values in place, with no object recreated and no pointer invalidated. A
+	// completely new Upgrade type introduced only by a map.ini (not overriding an existing name) is
+	// left in the list rather than being torn down -- a much smaller, inert leftover than a dangling
+	// pointer, and outside this issue's reported scope (existing upgrades being mutated).
 	// (GitHub issue #1436; upstream fix authored by helmutbuhler in PR #1749, ported here since that
 	// PR remains open pending an unrelated, unresolved architectural discussion about INI overrides.)
-	deleteAllUpgrades();
-	init();
 	XferCRC xferCRC;
 	xferCRC.open("lightCRC");
 	INI ini;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -662,6 +662,20 @@ TheInGameUI->DEBUG_addFloatingText("exiting docking state", getMachineOwner()->g
 
 	if (update->isForcedIntoWantingState())
 	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 A freshly produced supply gatherer is armed with
+		// a one-shot "auto-gather" latch that fires the next time it goes idle. If the player has already
+		// issued their own command (e.g. moved the unit away right after it spawned) before that latch
+		// resolved, letting it fire anyway would silently override the player's order once their command
+		// finishes and the unit goes idle. Dismiss the latch instead, the same way it is already dismissed
+		// once the unit actually enters the wanting/docking states.
+		if (ai->getLastCommandSource() == CMD_FROM_PLAYER)
+		{
+			update->setForceWantingState(false);
+			return false;
+		}
+#endif
+
 #ifdef DEBUG_SUPPLY_STATE
 AsciiString tmp;
 tmp.format("isForcedIntoWantingState returns true (%s)",statenames[thisState->getID()]);

--- a/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
@@ -237,6 +237,7 @@ public:
 	virtual void reset() override;												///< subsystem interface
 	virtual void update() override { }										///< subsystem interface
 
+	void deleteAllUpgrades();
 	UpgradeTemplate *firstUpgradeTemplate(); ///< return the first upgrade template
 	const UpgradeTemplate *findUpgradeByKey( NameKeyType key ) const; ///< find upgrade by name key
 	const UpgradeTemplate *findUpgrade( const AsciiString& name ) const; ///< find and return upgrade by name

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2325,7 +2325,21 @@ void Player::setUnitsShouldIdleOrResume(Bool idle)
 					{
 						SupplyTruckAIInterface* supplyTruckAI = ai->getSupplyTruckAIInterface();
 						if( supplyTruckAI )
+						{
 							supplyTruckAI->setForceWantingState(true);
+#if !RETAIL_COMPATIBLE_CRC
+							// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 This script action re-arms the
+							// same auto-gather latch that SupplyTruckStateMachine::isForcedIntoWantingState()
+							// (SupplyTruckAIUpdate.cpp) dismisses if the truck's last command came from the
+							// player -- a fix for issue #45. Without this, a truck the player had commanded
+							// at any earlier point (however long ago, regardless of what it's done since)
+							// would have this script-driven "resume gathering" order silently dismissed as
+							// if it were the player's own stale command. Record this as the truck's most
+							// recent command source so it's correctly treated as fresh AI/script authority
+							// over the unit, not a leftover player command. (GitHub issue #45)
+							ai->friend_setLastCommandSource(CMD_FROM_SCRIPT);
+#endif
+						}
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -34,6 +34,7 @@
 #include "Common/Upgrade.h"
 #include "Common/Player.h"
 #include "Common/Xfer.h"
+#include "Common/XferCRC.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/Image.h"
 
@@ -233,23 +234,7 @@ UpgradeCenter::UpgradeCenter()
 //-------------------------------------------------------------------------------------------------
 UpgradeCenter::~UpgradeCenter()
 {
-
-	// delete all the upgrades loaded from the INI database
-	UpgradeTemplate *next;
-	while( m_upgradeList )
-	{
-
-		// get next
-		next = m_upgradeList->friend_getNext();
-
-		// delete head of list
-		deleteInstance(m_upgradeList);
-
-		// set head to next element
-		m_upgradeList = next;
-
-	}
-
+	deleteAllUpgrades();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -281,6 +266,23 @@ void UpgradeCenter::init()
 //-------------------------------------------------------------------------------------------------
 void UpgradeCenter::reset()
 {
+	// TheSuperHackers @bugfix helmutbuhler 07/19/2026 A custom map's map.ini can override upgrade
+	// templates (e.g. BuildTime/BuildCost on an existing Upgrade). Those overrides were never undone,
+	// so an upgrade template's data stayed permanently mutated for the rest of the client session --
+	// including for any subsequent match that does NOT use that map.ini, which mismatches against
+	// other clients whose UpgradeTemplate data was never touched. Undo this by discarding every loaded
+	// upgrade and reloading the original INI files, exactly as they were loaded at startup, before
+	// anything else in reset() (e.g. button image caching) can observe stale, overridden data.
+	// (GitHub issue #1436; upstream fix authored by helmutbuhler in PR #1749, ported here since that
+	// PR remains open pending an unrelated, unresolved architectural discussion about INI overrides.)
+	deleteAllUpgrades();
+	init();
+	XferCRC xferCRC;
+	xferCRC.open("lightCRC");
+	INI ini;
+	ini.loadFileDirectory("Data\\INI\\Default\\Upgrade", INI_LOAD_OVERWRITE, &xferCRC);
+	ini.loadFileDirectory("Data\\INI\\Upgrade", INI_LOAD_OVERWRITE, &xferCRC);
+
 	if( TheMappedImageCollection && !buttonImagesCached )
 	{
 		UpgradeTemplate *upgrade;
@@ -290,6 +292,30 @@ void UpgradeCenter::reset()
 		}
 		buttonImagesCached = TRUE;
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+void UpgradeCenter::deleteAllUpgrades()
+{
+	// delete all the upgrades loaded from the INI database
+	UpgradeTemplate *next;
+	while( m_upgradeList )
+	{
+
+		// get next
+		next = m_upgradeList->friend_getNext();
+
+		// delete head of list
+		deleteInstance(m_upgradeList);
+
+		// set head to next element
+		m_upgradeList = next;
+
+	}
+	m_upgradeList = nullptr;
+	m_nextTemplateMaskBit = 0;
+	buttonImagesCached = FALSE;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -266,17 +266,34 @@ void UpgradeCenter::init()
 //-------------------------------------------------------------------------------------------------
 void UpgradeCenter::reset()
 {
-	// TheSuperHackers @bugfix helmutbuhler 07/19/2026 A custom map's map.ini can override upgrade
-	// templates (e.g. BuildTime/BuildCost on an existing Upgrade). Those overrides were never undone,
-	// so an upgrade template's data stayed permanently mutated for the rest of the client session --
-	// including for any subsequent match that does NOT use that map.ini, which mismatches against
-	// other clients whose UpgradeTemplate data was never touched. Undo this by discarding every loaded
-	// upgrade and reloading the original INI files, exactly as they were loaded at startup, before
-	// anything else in reset() (e.g. button image caching) can observe stale, overridden data.
+	// TheSuperHackers @bugfix helmutbuhler 07/19/2026 [revised ZsoltFeher 07/20/2026 after fable-model
+	// review] A custom map's map.ini can override upgrade templates (e.g. BuildTime/BuildCost on an
+	// existing Upgrade). Those overrides were never undone, so an upgrade template's data stayed
+	// permanently mutated for the rest of the client session -- including for any subsequent match that
+	// does NOT use that map.ini, which mismatches against other clients whose UpgradeTemplate data was
+	// never touched.
+	//
+	// The original port of this fix deleted every UpgradeTemplate and recreated them from scratch
+	// before reloading. That is unsafe: CommandButton::m_upgradeTemplate (ControlBar.h) is a raw
+	// UpgradeTemplate* resolved once at ControlBar::init() startup and never re-resolved on reset
+	// (ControlBar::reset() only removes map.ini command button/set OVERRIDES, it doesn't touch the base
+	// buttons' cached pointers) -- deleting and recreating the pointed-to objects left those as
+	// dangling pointers, silently "working" only because of a LIFO memory-pool allocator coincidentally
+	// reusing the same addresses in the same order, which is not guaranteed once the loaded upgrade set
+	// isn't identical to what was loaded at startup.
+	//
+	// UpgradeCenter::parseUpgradeDefinition() already finds an existing UpgradeTemplate by name and
+	// updates its fields in place via ini->initFromINI(), only allocating a new instance if no upgrade
+	// with that name exists yet -- exactly like ThingTemplate's own field-level overwrite semantics,
+	// just without a separate override/restore layer (per Caball009's investigation on this same issue:
+	// "UpgradeTemplate has no override feature like ThingTemplate"). So simply re-running the original
+	// INI load below, without deleting anything first, already restores every EXISTING upgrade's fields
+	// to their pristine values in place, with no object recreated and no pointer invalidated. A
+	// completely new Upgrade type introduced only by a map.ini (not overriding an existing name) is
+	// left in the list rather than being torn down -- a much smaller, inert leftover than a dangling
+	// pointer, and outside this issue's reported scope (existing upgrades being mutated).
 	// (GitHub issue #1436; upstream fix authored by helmutbuhler in PR #1749, ported here since that
 	// PR remains open pending an unrelated, unresolved architectural discussion about INI overrides.)
-	deleteAllUpgrades();
-	init();
 	XferCRC xferCRC;
 	xferCRC.open("lightCRC");
 	INI ini;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -686,6 +686,20 @@ TheInGameUI->DEBUG_addFloatingText("exiting docking state", getMachineOwner()->g
 
 	if (update->isForcedIntoWantingState())
 	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 A freshly produced supply gatherer is armed with
+		// a one-shot "auto-gather" latch that fires the next time it goes idle. If the player has already
+		// issued their own command (e.g. moved the unit away right after it spawned) before that latch
+		// resolved, letting it fire anyway would silently override the player's order once their command
+		// finishes and the unit goes idle. Dismiss the latch instead, the same way it is already dismissed
+		// once the unit actually enters the wanting/docking states.
+		if (ai->getLastCommandSource() == CMD_FROM_PLAYER)
+		{
+			update->setForceWantingState(false);
+			return false;
+		}
+#endif
+
 #ifdef DEBUG_SUPPLY_STATE
 AsciiString tmp;
 tmp.format("isForcedIntoWantingState returns true (%s)",statenames[thisState->getID()]);


### PR DESCRIPTION
fix: supply gatherers discard player move commands shortly after construction (#45)

When a supply gatherer (Chinook, Supply Truck, or GLA Worker -- all
share SupplyTruckStateMachine/SupplyTruckAIInterface, Chinook/Worker
subclass SupplyTruckAIUpdate) exits its production building,
SupplyCenterProductionExitUpdate arms a one-shot "auto-gather" latch
(setForceWantingState(true)) intended to send it collecting supplies
once it goes idle. That latch is only ever cleared by actually being
consumed inside the wanting/docking states.

If the player issues their own move command shortly after the unit
spawns (e.g. flying a fresh Chinook straight to a drop zone to load
paratroopers instead of letting it auto-gather), that command
correctly takes priority for its own duration -- but does not clear
the latch. Once the player's move finishes and the unit goes idle,
isForcedIntoWantingState() sees the still-armed latch and forces a
transition to the wanting state anyway, issuing a fresh CMD_FROM_AI
dock order that flies the unit away, silently discarding the player's
intent. This matches the community's documented workaround: pressing
Stop immediately after spawn resolves the latch early (via a separate
force-busy path) before a real move command is ever given, masking
the bug for players who developed that habit.

Dismiss the latch instead of honoring it when the unit's last command
source was CMD_FROM_PLAYER, mirroring how it is already dismissed once
the unit actually enters the wanting/docking states. This only affects
the case where a player has explicitly taken control of the unit since
it was created; unattended auto-gather behavior is unchanged.

This does not touch the separate, unresolved community design
discussion in the issue thread about rally-point/waypoint redesign --
out of scope for this narrow timing fix.

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes AI command
simulation behavior with replay/multiplayer determinism implications.

Applies to both Generals and GeneralsMD (identical fix, one shared
state-machine function covers all three factions' gatherers).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix: custom map upgrade overrides mismatch subsequent matches (#1436)

UpgradeCenter::reset() only handled button-image caching; it never
undid INI overrides that a custom map's map.ini applied to upgrade
templates (e.g. changing BuildTime/BuildCost on an existing Upgrade).
Since UpgradeTemplate has no override/restore mechanism of its own
(unlike ThingTemplate), those overridden values stayed permanently
mutated in the UpgradeCenter's in-memory template list for the rest of
the client session -- including for any later match that does NOT use
that map.ini, which then mismatches against other clients whose
UpgradeTemplate data was never touched by that map.

Have reset() discard every loaded upgrade and reload the original INI
files exactly as they were loaded at startup (same paths and
INI_LOAD_OVERWRITE flag as the initial TheUpgradeCenter subsystem
init: Data\INI\Default\Upgrade then Data\INI\Upgrade), before anything
else in reset() (e.g. button image caching) can observe stale,
overridden data. A local, throwaway XferCRC is used for the reload
(matching the original load call's parameter type) rather than the
shared startup xferCRC, since reset() runs mid-session and must not
perturb the accumulated startup INI CRC used for lobby/version
verification.

Extracted the existing destructor's list-teardown loop into a shared
deleteAllUpgrades() helper, reused by both the destructor and reset(),
which also now resets m_nextTemplateMaskBit and buttonImagesCached so
a reloaded upgrade set gets fresh mask bit assignments and re-caches
its button images.

This fix is ported from GitHub PR #1749 (open, authored by community
contributor helmutbuhler, who root-caused and reproduced the issue).
That PR remains unmerged pending a separate, unresolved maintainer
discussion about whether the whole engine should move to a general
INI-override-and-restore mechanism instead of ad-hoc per-subsystem
reload logic -- an architectural decision well beyond the scope of
this session's minimal-fix approach. Porting this specific, narrow,
working fix directly resolves the concrete UpgradeTemplate mismatch
without waiting on that broader redesign.

The related issues #2016, #1976, #1974, #1972 (mismatches in map.ini
handling for the general case, ArmorTemplate, ObjectCreationList, and
PlayerTemplate respectively) are the same class of bug in different
subsystems, but have no equivalent ready-to-port community fix and are
explicitly tied up in that same unresolved architectural discussion --
left deferred rather than improvised.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix: address fable review findings on #1436 and #45

Fable-model review of batch-2 fixes (#86, #45, #41, #2776, #257, #458,
#1436) found two real issues, both fixed here.

1. [CRITICAL] #1436 (UpgradeCenter::reset()) deleted and recreated
   every UpgradeTemplate before reloading INI data. CommandButton::
   m_upgradeTemplate (ControlBar.h) is a raw UpgradeTemplate* resolved
   once at ControlBar::init() startup and never re-resolved on reset
   (ControlBar::reset() only removes map.ini command button/set
   overrides, not the base buttons' cached pointers) -- deleting and
   recreating the pointed-to objects left those as dangling pointers.
   This was silently masked in practice only by UpgradeTemplate's
   memory pool being a LIFO free list that happened to replay the same
   allocation sequence and reuse the same addresses, which is not
   guaranteed once the reloaded upgrade set differs from what was
   loaded at startup (e.g. a partial/failed reload, or any interleaved
   allocation on the same pool).

   UpgradeCenter::parseUpgradeDefinition() already finds an existing
   UpgradeTemplate by name and updates its fields in place via
   ini->initFromINI(), only allocating a new instance if no upgrade
   with that name exists yet. Simply re-running the original INI load
   without deleting anything first already restores every existing
   upgrade's fields to their pristine values in place, with no object
   recreated and no pointer invalidated. Removed the deleteAllUpgrades()
   /init() calls from reset(); deleteAllUpgrades() is still used by the
   destructor, where no dangling-pointer risk exists.

2. #45 (SupplyTruckAIUpdate.cpp) dismisses a supply truck's auto-gather
   latch when its last AI command source was CMD_FROM_PLAYER, to stop
   the auto-gather order from silently overriding a player's own move
   command. But Player::setUnitsShouldIdleOrResume()'s "resume
   trucking" script action (used by campaign/skirmish scripts) also
   arms this same latch directly, without dispatching any AI command
   that would update the truck's last-command-source -- so a truck the
   player had manually commanded at any earlier point (however long
   ago) would have this script-driven resume order silently dismissed
   as if it were the player's own stale command.

   Record CMD_FROM_SCRIPT as the truck's last command source when this
   script action arms the latch, so it's correctly treated as fresh
   script authority over the unit rather than a leftover player
   command.

Both fixes gated behind !RETAIL_COMPATIBLE_CRC, matching the original
fixes they correct. Applied to both Generals and GeneralsMD.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #45
Fixes #1436
