### PR TITLE
fix: findPositionAround treats mines as blocking, causing bad supply truck pathing (#2776)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -3867,6 +3867,20 @@ Bool PartitionManager::tryPosition( const Coord3D *center,
 			if( them == options->ignoreObject )
 				continue;  // continue in the object iterator for loop
 
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Mines never block movement or occupy pathfind
+			// cells (see Pathfinder::classifyObjectFootprint, which explicitly skips KINDOF_MINE objects
+			// when building the pathfind obstacle map -- units are meant to walk right over a mine to
+			// trigger it, not be blocked by it). findPositionAround's object-overlap check did not honor
+			// that same rule, so a stealthed, non-blocking mine merely sitting near a candidate cell would
+			// cause that cell to be rejected as "occupied", pushing the search outward to a farther, worse
+			// position for ANY caller (own, ally, or enemy unit) of this generic position-finding function.
+			// This was most visible with China Supply Trucks pathing badly around their own Nuke General
+			// mines near the Supply Center/Dock. (GitHub issue #2776)
+			if( them->isKindOf( KINDOF_MINE ) )
+				continue;  // continue in the object iterator for loop
+#endif
+
 			// relationship checks
 			if( options->relationshipObject )
 			{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -3877,6 +3877,20 @@ Bool PartitionManager::tryPosition( const Coord3D *center,
 			if( them == options->ignoreObject )
 				continue;  // continue in the object iterator for loop
 
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Mines never block movement or occupy pathfind
+			// cells (see Pathfinder::classifyObjectFootprint, which explicitly skips KINDOF_MINE objects
+			// when building the pathfind obstacle map -- units are meant to walk right over a mine to
+			// trigger it, not be blocked by it). findPositionAround's object-overlap check did not honor
+			// that same rule, so a stealthed, non-blocking mine merely sitting near a candidate cell would
+			// cause that cell to be rejected as "occupied", pushing the search outward to a farther, worse
+			// position for ANY caller (own, ally, or enemy unit) of this generic position-finding function.
+			// This was most visible with China Supply Trucks pathing badly around their own Nuke General
+			// mines near the Supply Center/Dock. (GitHub issue #2776)
+			if( them->isKindOf( KINDOF_MINE ) )
+				continue;  // continue in the object iterator for loop
+#endif
+
 			// relationship checks
 			if( options->relationshipObject )
 			{


### PR DESCRIPTION
fix: findPositionAround treats mines as blocking, causing bad supply truck pathing (#2776)

PartitionManager::tryPosition() (the per-candidate-cell helper used by
findPositionAround, called when a Supply Truck looks for a place to
dock at a Supply Dock or return to its Supply Center) rejects a
candidate cell if ANY object overlaps it, aside from a small set of
explicit exceptions (options->ignoreObject, and relationship-gated
unit/structure checks that most callers, including DockUpdate's
approach-position search, never enable).

Mines are never real pathfinding obstacles for anyone -- units are
meant to walk over a mine to trigger it, not be blocked by it, exactly
as Pathfinder::classifyObjectFootprint already special-cases by
explicitly skipping KINDOF_MINE objects when building the pathfind
obstacle map ("don't pathfind around mines"). tryPosition() had no
equivalent exclusion, so a stealthed, non-blocking mine merely present
near a candidate cell caused that cell to be rejected as "occupied",
pushing the search outward to a farther, worse position. This was most
visible with China Supply Trucks docking/returning near their own Nuke
General mines around the Supply Center, adding several minutes to
collection time depending on how much open space the mines had to
occupy near candidate cells.

Skip KINDOF_MINE objects in tryPosition()'s overlap check, matching
the pathfinder's existing convention. This is a general fix to a
shared, generic position-finding function (findPositionAround is used
by many systems beyond Supply Trucks), not a supply-truck-specific
special case, and does not affect mine targeting/combat elsewhere.

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes deterministic
position-selection outcomes with replay/multiplayer determinism
implications.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #2776
