### PR TITLE
fix: W3DLaserDraw produces NaN point data for zero-length lasers (#257)

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
@@ -341,8 +341,16 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 				vector.set( lineMiddle );
 				vector.sub( segmentStart );
 				Real dist = vector.length();
-				Real scaledRadians = dist / halfLength * PI * 0.5f;
-				Real height = cos( scaledRadians );
+				// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Guard against a zero-length line (start == end,
+				// e.g. before the laser has ever been positioned by LaserUpdate::initLaser()). Without this,
+				// dist/halfLength evaluates to 0.0f/0.0f == NaN, which then poisons segmentStart.z via cos(NaN)
+				// and propagates NaN into the points handed to SegmentedLineClass::Set_Points().
+				Real height = 0.0f;
+				if( halfLength > 0.0f )
+				{
+					Real scaledRadians = dist / halfLength * PI * 0.5f;
+					height = cos( scaledRadians );
+				}
 				height *= data->m_arcHeight;
 				segmentStart.z += height;
 
@@ -350,8 +358,13 @@ void W3DLaserDraw::doDrawModule(const Matrix3D* transformMtx)
 				vector.set( lineMiddle );
 				vector.sub( segmentEnd );
 				dist = vector.length();
-				scaledRadians = dist / halfLength * PI * 0.5f;
-				height = cos( scaledRadians );
+				// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Same zero-length-line guard as above.
+				height = 0.0f;
+				if( halfLength > 0.0f )
+				{
+					Real scaledRadians = dist / halfLength * PI * 0.5f;
+					height = cos( scaledRadians );
+				}
 				height *= data->m_arcHeight;
 				segmentEnd.z += height;
 


### PR DESCRIPTION
fix: W3DLaserDraw produces NaN point data for zero-length lasers (#257)

W3DLaserDraw::doDrawModule()'s curved-beam branch (ArcHeight > 0 with
Segments > 1) computes each segment's height offset as
cos(dist / halfLength * PI * 0.5f), where halfLength is half the
laser's start-to-end line length. When a laser's start and end
positions are identical (lineLength == 0, so halfLength == 0 and
dist == 0 too), this divides 0.0f by 0.0f, producing NaN. cos(NaN)
stays NaN and gets added into segmentStart.z/segmentEnd.z, which flow
directly into the point array passed to SegmentedLineClass::Set_Points().

This reproduces very early and reliably: W3DLaserDraw's constructor
sets m_selfDirty = TRUE, so its first doDrawModule() call after
creation always rebuilds positions regardless of whether
LaserUpdate::initLaser() has been called yet, and LaserUpdate's own
constructor zero-initializes both m_startPos and m_endPos -- so any
curved-beam laser drawable that exists before its first real position
update (e.g. on the shell/menu map) hits the zero-length case
immediately.

Guard both divisions (start-point and end-point height calculations)
with halfLength > 0.0f, defaulting the height offset to 0.0f for a
degenerate zero-length line instead of producing NaN. Behavior for all
normal, non-degenerate lines is unchanged.

No RETAIL_COMPATIBLE_CRC gating needed: W3DLaserDraw is a pure
client-side rendering DrawModule (its crc()/xfer() explicitly have no
data to save) that only reads simulation state to build a visual point
array; this fix only changes local floating-point math for that
render-only output, with no effect on game-logic/replay determinism.

Core-shared: a single copy of this file is compiled into both the
Generals and GeneralsMD trees.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #257
