### PR TITLE
fix: unreadable/cloud-placeholder file during startup crashes game launch (#458)

### DIFF
--- a/Core/GameEngine/Source/Common/System/LocalFile.cpp
+++ b/Core/GameEngine/Source/Common/System/LocalFile.cpp
@@ -52,6 +52,7 @@
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <string.h>
 
 #include "Common/LocalFile.h"
 #include "Common/RAMFile.h"
@@ -731,7 +732,25 @@ char* LocalFile::readEntireAndClose()
 	UnsignedInt fileSize = size();
 	char* buffer = NEW char[fileSize];
 
-	read(buffer, fileSize);
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Handle partial or failed reads gracefully.
+	// A cloud-backed file (e.g. an OneDrive/Dropbox/Google Drive placeholder that is only available
+	// online) can report a valid size but then fail to fully read its contents when the sync provider
+	// is paused or there is no internet connection. Previously the return value of read() was ignored,
+	// leaving the tail of the buffer filled with uninitialized heap memory that callers (INI loading,
+	// map cache building, ...) would then parse as if it were valid file data, risking a hang or crash.
+	// Zero-fill anything that could not be read so callers observe deterministic, well-defined data
+	// instead of garbage.
+	const Int bytesRead = read(buffer, fileSize);
+	if (bytesRead < 0)
+	{
+		DEBUG_LOG(("LocalFile::readEntireAndClose - failed to read file '%s'", getName()));
+		memset(buffer, 0, fileSize);
+	}
+	else if ((UnsignedInt)bytesRead < fileSize)
+	{
+		DEBUG_LOG(("LocalFile::readEntireAndClose - short read on file '%s' (%d of %u bytes read)", getName(), bytesRead, fileSize));
+		memset(buffer + bytesRead, 0, fileSize - bytesRead);
+	}
 
 	close();
 

--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -629,7 +629,29 @@ Bool MapCache::addMap(
 
 	DEBUG_LOG(("MapCache::addMap(): caching '%s' because '%s' was not found", fname.str(), lowerFname.str()));
 
-	loadMap(fname); // Just load for querying the data, since we aren't playing this map.
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Do not abort the entire game launch when a single
+	// user map cannot be read or parsed during map cache building. A corrupt map file, or a cloud-backed
+	// placeholder (OneDrive, Dropbox, Google Drive, ...) whose contents are unavailable while the sync
+	// provider is paused or offline, previously threw ERROR_CORRUPT_FILE_FORMAT out of loadMap (or made
+	// loadMap fail to open the file). That exception propagated all the way up to GameEngine::init and
+	// was turned into a RELEASE_CRASH, preventing the game from launching at all. Skip the offending map
+	// instead so cache building and the game can continue.
+	Bool mapLoaded = FALSE;
+	try
+	{
+		mapLoaded = loadMap(fname); // Just load for querying the data, since we aren't playing this map.
+	}
+	catch (...)
+	{
+		DEBUG_LOG(("MapCache::addMap - exception while loading map '%s'; skipping it during cache build", fname.str()));
+		mapLoaded = FALSE;
+	}
+
+	if (!mapLoaded)
+	{
+		resetMap();
+		return FALSE;
+	}
 
 	// The map is now loaded.  Pick out what we need.
 	MapMetaData md;


### PR DESCRIPTION
fix: unreadable/cloud-placeholder file during startup crashes game launch (#458)

Root-caused the most credible technical lead in the issue thread
(community member ChristianGalla's empirical testing: reading a
cloud-backed file such as a OneDrive/Dropbox/Google Drive placeholder
fails when the sync provider is paused or offline, and "there is no
handling of read errors in the current source code").

Two related defects in the startup file-loading path:

1. LocalFile::readEntireAndClose() allocated a buffer of size() bytes
   and called read() without checking its return value. A cloud-backed
   file can report a valid size via stat/attributes but then fail to
   actually deliver its full contents on read (exactly the OneDrive
   paused/offline case), leaving the tail of the buffer filled with
   uninitialized heap memory. Callers (INI loading, map cache building
   via CachedFileInputStream) then parsed that garbage as if it were
   real file data. Now the actual bytes-read count is checked; a
   failed or short read zero-fills the unread portion so callers see
   deterministic, well-defined data instead of garbage, instead of a
   read failure risking a hang or crash further downstream.

2. MapCache::addMap() called loadMap() unguarded while building the
   map cache at startup (scanning every user map under the Documents-
   folder-based Maps directory). loadMap() throws ERROR_CORRUPT_FILE_FORMAT
   on unparseable/undecodable data, or returns FALSE if the file
   can't even be opened -- both realistic outcomes for a corrupt or
   cloud-placeholder map file. Neither was handled: the exception
   propagated out of MapCache::addMap, out of GameEngine::init, and
   was turned into a RELEASE_CRASH, aborting the entire game launch
   over a single bad map file. Now the call is wrapped in try/catch
   and its Bool return is checked; on either failure mode the map is
   skipped (with resetMap() cleanup) and map cache building continues.

Together these turn "one unreadable, cloud-only-placeholder, or
corrupt file in the user's Documents-folder game data crashes the
game at launch" into "that file is skipped/zero-filled and the game
continues to launch normally" -- directly addressing the reported
OneDrive Files-On-Demand launch failures without attempting to solve
cloud-sync behavior itself (e.g. no Windows Cloud Files API pinning,
which would be a much larger, out-of-scope platform feature).

This also fixes a pre-existing robustness bug independent of OneDrive:
previously any single corrupt .map file in the user Maps folder could
abort launch entirely.

No RETAIL_COMPATIBLE_CRC gating needed: both changes are in startup
file-IO/map-cache-building code with no effect on gameplay simulation
or replay determinism.

Core-shared: both files are compiled into both the Generals and
GeneralsMD trees from a single copy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #458
