### PR TITLE
fix: garrisoned infantry fire from building's ground position when model lacks enough fire points (#267)

### DIFF
--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -658,6 +658,13 @@ public:
 	virtual void init() override;					///< from subsystem interface
 	virtual void reset() override;					///< from subsystem interface
 	virtual void update() override;				///< from subsystem interface
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix c001ac1d 07/19/2026 Re-run command button post-processing (button images,
+	// among other things) after a map.ini has loaded new/edited CommandButton or CommandSet entries.
+	// postProcessCommands() is otherwise only ever called once, from init(), at game startup, so any
+	// command button added or edited via map.ini never got its image resolved. (GitHub issue #276)
+	virtual void postProcessLoad() override;
+#endif
 
 	/// mark the UI as dirty so the context of everything is re-evaluated
 	void markUIDirty();

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2560,6 +2560,20 @@ void ControlBar::postProcessCommands()
 	}
 }
 
+#if !RETAIL_COMPATIBLE_CRC
+//-------------------------------------------------------------------------------------------------
+// TheSuperHackers @bugfix c001ac1d 07/19/2026 postProcessCommands() is otherwise only ever called
+// once, from init(), at game startup, so a CommandButton added or edited via a custom map's map.ini
+// never got its ButtonImage resolved. TheControlBar is not registered with TheSubsystemList (it is
+// constructed and owned separately), so this must be called explicitly after a map.ini load rather
+// than automatically via TheSubsystemList->postProcessLoadAll(). (GitHub issue #276)
+//-------------------------------------------------------------------------------------------------
+void ControlBar::postProcessLoad()
+{
+	postProcessCommands();
+}
+#endif
+
 //-------------------------------------------------------------------------------------------------
 /** set the command for the button identified by the window name
 	* NOTE that parent may be nullptr, it only helps to speed up the search for a particular

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/GarrisonContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/GarrisonContain.h
@@ -201,6 +201,14 @@ private:
 	GarrisonPointData		m_garrisonPointData[ MAX_GARRISON_POINTS ];		///< the garrison point placement data
 	Int									m_garrisonPointsInUse;
 	Coord3D							m_garrisonPoint[ MAX_GARRISON_POINT_CONDITIONS ][ MAX_GARRISON_POINTS ];		///< the garrison point positions (in world coords) for pristine, damaged, and really damaged
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Number of real FIREPOINT bones found in the art
+	// for each damage condition. Garrison point indices beyond this count are padding slots that
+	// default to the structure's own (ground-level) position instead of a real muzzle bone. That
+	// padding position is used below/inside the building's footprint and can cause self-damage from
+	// splash weapons and an unfairly short effective firing range. See putObjectAtGarrisonPoint().
+	Int									m_garrisonPointBoneCount[ MAX_GARRISON_POINT_CONDITIONS ];
+#endif
 	Coord3D							m_exitRallyPoint;												///< Point to rally at when exiting structure (if possible)
 
 	Bool		m_garrisonPointsInitialized;							///< TRUE once we have loaded the garrison point positions from the art

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
@@ -1506,8 +1506,15 @@ void GarrisonContain::xfer( Xfer *xfer )
 	Int i;
 
 	// version
-	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Bumped to 2 to persist m_garrisonPointBoneCount.
-#if RETAIL_COMPATIBLE_XFER_SAVE
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 [fixed gating ZsoltFeher 07/20/2026 after
+	// fable-model review: RETAIL_COMPATIBLE_CRC and RETAIL_COMPATIBLE_XFER_SAVE are independent
+	// macros, so gating the version bump on XFER_SAVE alone while the field xfer below was gated on
+	// CRC alone meant a RETAIL_COMPATIBLE_XFER_SAVE=0, RETAIL_COMPATIBLE_CRC=1 build stamped saves as
+	// version 2 without actually writing the new field, corrupting every subsequent field read on
+	// load. Match the combined-macro convention already used for this exact situation elsewhere (see
+	// JetAIUpdate.cpp's m_afterburners/m_resetTimer version-2 gating).] Bumped to 2 to persist
+	// m_garrisonPointBoneCount.
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
 #else
 	XferVersion currentVersion = 2;
@@ -1621,10 +1628,11 @@ void GarrisonContain::xfer( Xfer *xfer )
 	// garrison points initialized
 	xfer->xferBool( &m_garrisonPointsInitialized );
 
-#if !RETAIL_COMPATIBLE_CRC
+#if !(RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE)
 	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Persist the real fire point bone counts so the
 	// fire-port reuse fix in putObjectAtGarrisonPoint() stays correct after a save/load, instead of
-	// silently reverting to the padding/ground-level position until this object is recreated.
+	// silently reverting to the padding/ground-level position until this object is recreated. Gated
+	// to match the version-bump condition above exactly (see the comment there).
 	if( version >= 2 )
 		xfer->xferUser( m_garrisonPointBoneCount, sizeof( Int ) * MAX_GARRISON_POINT_CONDITIONS );
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
@@ -176,7 +176,23 @@ void GarrisonContain::putObjectAtGarrisonPoint( Object *obj,
 	}
 
 	// get the position we're going to use
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 If this garrison point index has no matching
+	// real FIREPOINT bone in the art (i.e. it is one of the padding slots that default to the
+	// structure's own ground-level position), reuse the closest real fire point bone instead, the
+	// same way OpenContain::putObjAtNextFirePoint() already reuses fire points for TransportContain
+	// passengers. Without this, garrisoned units beyond the number of fire ports on the model fire
+	// from underneath/inside the building, which both damages themselves with splash weapons and
+	// gives them a shorter effective firing range than an attacker measuring to the building's
+	// actual geometry edge.
+	Int realBoneCount = m_garrisonPointBoneCount[ conditionIndex ];
+	Int effectivePointIndex = ( realBoneCount > 0 && pointIndex >= realBoneCount )
+														 ? ( pointIndex % realBoneCount )
+														 : pointIndex;
+	Coord3D pos = m_garrisonPoint[ conditionIndex ][ effectivePointIndex ];
+#else
 	Coord3D pos = m_garrisonPoint[ conditionIndex ][ pointIndex ];
+#endif
 
 	// set the object position
 	obj->setPosition( &pos );
@@ -496,6 +512,13 @@ GarrisonContain::GarrisonContain( Thing *thing, const ModuleData *moduleData ) :
 			m_garrisonPoint[ j ][ i ].zero();
 
 	}
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Initialize the per-condition real fire point
+	// bone counts used to avoid firing from the structure's padding/ground-level garrison points.
+	for( j = 0; j < MAX_GARRISON_POINT_CONDITIONS; ++j )
+		m_garrisonPointBoneCount[ j ] = 0;
+#endif
 
 	m_rallyValid = FALSE;
 	m_exitRallyPoint.zero();
@@ -1114,6 +1137,12 @@ void GarrisonContain::loadGarrisonPoints()
 		count = structure->getMultiLogicalBonePosition("FIREPOINT", MAX_GARRISON_POINTS, m_garrisonPoint[ conditionIndex ], nullptr);
 
 		if ( count > 0) gBonesFound = TRUE;
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Remember how many of the garrison point
+		// slots are backed by a real FIREPOINT bone, so excess occupants can reuse a real bone
+		// instead of the padding position (see putObjectAtGarrisonPoint()).
+		m_garrisonPointBoneCount[ conditionIndex ] = count;
+#endif
 
 		// damaged garrisoned
 		clearFlags.clear();
@@ -1128,6 +1157,10 @@ void GarrisonContain::loadGarrisonPoints()
 		count = structure->getMultiLogicalBonePosition("FIREPOINT", MAX_GARRISON_POINTS, m_garrisonPoint[ conditionIndex ], nullptr);
 
 		if ( count > 0) gBonesFound = TRUE;
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 See identical comment above for GARRISON_POINT_PRISTINE.
+		m_garrisonPointBoneCount[ conditionIndex ] = count;
+#endif
 
 		// really damaged garrisoned
 		clearFlags.clear();
@@ -1142,6 +1175,10 @@ void GarrisonContain::loadGarrisonPoints()
 		count = structure->getMultiLogicalBonePosition("FIREPOINT", MAX_GARRISON_POINTS, m_garrisonPoint[ conditionIndex ], nullptr);
 
 		if ( count > 0) gBonesFound = TRUE;
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 See identical comment above for GARRISON_POINT_PRISTINE.
+		m_garrisonPointBoneCount[ conditionIndex ] = count;
+#endif
 
 		// restore the original condition flags
 		draw->replaceModelConditionFlags( originalFlags );
@@ -1469,7 +1506,12 @@ void GarrisonContain::xfer( Xfer *xfer )
 	Int i;
 
 	// version
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Bumped to 2 to persist m_garrisonPointBoneCount.
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -1578,6 +1620,14 @@ void GarrisonContain::xfer( Xfer *xfer )
 
 	// garrison points initialized
 	xfer->xferBool( &m_garrisonPointsInitialized );
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Persist the real fire point bone counts so the
+	// fire-port reuse fix in putObjectAtGarrisonPoint() stays correct after a save/load, instead of
+	// silently reverting to the padding/ground-level position until this object is recreated.
+	if( version >= 2 )
+		xfer->xferUser( m_garrisonPointBoneCount, sizeof( Int ) * MAX_GARRISON_POINT_CONDITIONS );
+#endif
 
 	// rally valid
 	xfer->xferBool( &m_rallyValid );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1080,6 +1080,18 @@ UpdateSleepTime ChinookAIUpdate::update()
 			}
 		}
 	}
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix diqezit 07/19/2026 SupplyTruckAIUpdate::isIdle() returns false while this
+	// Chinook is guarding or attacking, so the landing trigger above never ran, and units could never be
+	// loaded into (or evacuated from) a guarding/attacking Chinook -- they would only get in/out if the
+	// player explicitly pressed Stop first. Allow landing for waiting passengers even while not idle, as
+	// long as we're in stable level flight with no pending command or in-progress airfield healing, so we
+	// don't interrupt those. (GitHub issue #54)
+	else if (waitingToEnterOrExit && m_flightStatus == CHINOOK_FLYING && !m_hasPendingCommand && m_airfieldForHealing == INVALID_ID)
+	{
+		setMyState(LANDING, nullptr, nullptr, CMD_FROM_AI);
+	}
+#endif
 
 	return SupplyTruckAIUpdate::update();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1081,13 +1081,22 @@ UpdateSleepTime ChinookAIUpdate::update()
 		}
 	}
 #if !RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @bugfix diqezit 07/19/2026 SupplyTruckAIUpdate::isIdle() returns false while this
-	// Chinook is guarding or attacking, so the landing trigger above never ran, and units could never be
-	// loaded into (or evacuated from) a guarding/attacking Chinook -- they would only get in/out if the
-	// player explicitly pressed Stop first. Allow landing for waiting passengers even while not idle, as
-	// long as we're in stable level flight with no pending command or in-progress airfield healing, so we
-	// don't interrupt those. (GitHub issue #54)
-	else if (waitingToEnterOrExit && m_flightStatus == CHINOOK_FLYING && !m_hasPendingCommand && m_airfieldForHealing == INVALID_ID)
+	// TheSuperHackers @bugfix diqezit 07/19/2026 [narrowed ZsoltFeher 07/20/2026 after fable-model
+	// review] SupplyTruckAIUpdate::isIdle() returns false while this Chinook is guarding or attacking,
+	// so the landing trigger above never ran, and units could never be loaded into (or evacuated from)
+	// a guarding/attacking Chinook -- they would only get in/out if the player explicitly pressed Stop
+	// first. Allow landing for waiting passengers even while not idle, but ONLY while in a generic
+	// (non-Chinook-specific) AI state such as guard or attack -- getAIStateType() < ChinookAIStateType_FIRST
+	// excludes every one of this class's own states (TAKING_OFF, LANDING, MOVE_TO_AND_EVAC,
+	// MOVE_TO_COMBAT_DROP, etc; see the enum's own "must be distinct numerically from AIStateType"
+	// comment above). Without this exclusion, a Chinook actively executing a player-issued
+	// move-and-evacuate or combat-drop order -- itself not idle, and (for move-and-evacuate
+	// specifically) only entered in the first place because waitingToEnterOrExit was already true, see
+	// aiDoCommand()'s AICMD_MOVE_TO_POSITION_AND_EVACUATE handling elsewhere in this file -- would have
+	// that in-progress order cancelled and be force-landed at its CURRENT position on the very next
+	// frame, instead of at the player's ordered destination. (GitHub issue #54)
+	else if (waitingToEnterOrExit && m_flightStatus == CHINOOK_FLYING && !m_hasPendingCommand && m_airfieldForHealing == INVALID_ID
+		&& getAIStateType() < ChinookAIStateType_FIRST)
 	{
 		setMyState(LANDING, nullptr, nullptr, CMD_FROM_AI);
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -397,6 +397,15 @@ void WeaponTemplate::postProcessLoad()
 		return;
 	}
 
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 postProcessLoad() must be safe to call more than
+	// once: TheSubsystemList->postProcessLoadAll() (see GameLogic::tryStartNewGame, GitHub issue #276)
+	// re-runs every registered subsystem's postProcessLoad() after a map.ini load, and WeaponStore's
+	// override calls this for every WeaponTemplate. The OCL name strings below used to be cleared
+	// after being resolved the first time, so any second call saw them as empty and nulled out
+	// m_fireOCLs/m_projectileDetonationOCLs for every weapon in the game -- silently deleting every
+	// weapon's fire/detonation OCL effects (which spawn real objects, simulation-relevant) from the
+	// second postProcessLoad() call onward. Keep the name strings intact so re-resolving is idempotent,
+	// matching the pattern ThingTemplate::resolveNames() already documents for this exact hazard.
 	if (m_projectileName.isEmpty())
 	{
 		m_projectileTmpl = nullptr;
@@ -419,7 +428,6 @@ void WeaponTemplate::postProcessLoad()
 			m_fireOCLs[i] = TheObjectCreationListStore->findObjectCreationList(m_fireOCLNames[i].str() );
 			DEBUG_ASSERTCRASH(m_fireOCLs[i], ("OCL %s not found in a weapon!",m_fireOCLNames[i].str()));
 		}
-		m_fireOCLNames[i].clear();
 
 		// And the other OCL if there is one
 		if (m_projectileDetonationOCLNames[i].isEmpty() )
@@ -431,7 +439,6 @@ void WeaponTemplate::postProcessLoad()
 			m_projectileDetonationOCLs[i] = TheObjectCreationListStore->findObjectCreationList(m_projectileDetonationOCLNames[i].str() );
 			DEBUG_ASSERTCRASH(m_projectileDetonationOCLs[i], ("OCL %s not found in a weapon!",m_projectileDetonationOCLNames[i].str()));
 		}
-		m_projectileDetonationOCLNames[i].clear();
 	}
 
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1192,6 +1192,22 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 	// before loading the map, load the map.ini file in the same directory.
 	loadMapINI( TheGlobalData->m_mapName );
 
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix c001ac1d 07/19/2026 A custom map's map.ini can add or edit data (e.g.
+	// Weapon ProjectileObject references, CommandButton entries) that some subsystems only resolve
+	// once, in a post-process step that normally only runs right after their initial startup INI load
+	// (e.g. WeaponStore::postProcessLoad() fixing up ProjectileObject references, or ControlBar's
+	// command button image caching). Since map.ini loads after that initial post-process step already
+	// ran, any new or edited data from map.ini never got its post-process step, e.g. projectiles
+	// silently failing to launch or new command buttons showing no image. Re-run post-processing for
+	// every subsystem, and separately for TheControlBar (which is not registered with
+	// TheSubsystemList), now that map.ini has been loaded. (GitHub issue #276)
+	if (TheSubsystemList)
+		TheSubsystemList->postProcessLoadAll();
+	if (TheControlBar)
+		TheControlBar->postProcessLoad();
+#endif
+
 	// load a map
 	TheTerrainLogic->loadMap( TheGlobalData->m_mapName, false );
 	// anytime the world's size changes, must reset the partition mgr

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GarrisonContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GarrisonContain.h
@@ -229,6 +229,14 @@ private:
 	GarrisonPointData		m_garrisonPointData[ MAX_GARRISON_POINTS ];		///< the garrison point placement data
 	Int									m_garrisonPointsInUse;
 	Coord3D							m_garrisonPoint[ MAX_GARRISON_POINT_CONDITIONS ][ MAX_GARRISON_POINTS ];		///< the garrison point positions (in world coords) for pristine, damaged, and really damaged
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Number of real FIREPOINT bones found in the art
+	// for each damage condition. Garrison point indices beyond this count are padding slots that
+	// default to the structure's own (ground-level) position instead of a real muzzle bone. That
+	// padding position is used below/inside the building's footprint and can cause self-damage from
+	// splash weapons and an unfairly short effective firing range. See putObjectAtGarrisonPoint().
+	Int									m_garrisonPointBoneCount[ MAX_GARRISON_POINT_CONDITIONS ];
+#endif
 	Coord3D							m_exitRallyPoint;												///< Point to rally at when exiting structure (if possible)
 
   std::vector<StationPointData> m_stationPointList;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
@@ -177,7 +177,23 @@ void GarrisonContain::putObjectAtGarrisonPoint( Object *obj,
 	}
 
 	// get the position we're going to use
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 If this garrison point index has no matching
+	// real FIREPOINT bone in the art (i.e. it is one of the padding slots that default to the
+	// structure's own ground-level position), reuse the closest real fire point bone instead, the
+	// same way OpenContain::putObjAtNextFirePoint() already reuses fire points for TransportContain
+	// passengers. Without this, garrisoned units beyond the number of fire ports on the model fire
+	// from underneath/inside the building, which both damages themselves with splash weapons and
+	// gives them a shorter effective firing range than an attacker measuring to the building's
+	// actual geometry edge.
+	Int realBoneCount = m_garrisonPointBoneCount[ conditionIndex ];
+	Int effectivePointIndex = ( realBoneCount > 0 && pointIndex >= realBoneCount )
+														 ? ( pointIndex % realBoneCount )
+														 : pointIndex;
+	Coord3D pos = m_garrisonPoint[ conditionIndex ][ effectivePointIndex ];
+#else
 	Coord3D pos = m_garrisonPoint[ conditionIndex ][ pointIndex ];
+#endif
 
 	// set the object position
 	obj->setPosition( &pos );
@@ -525,6 +541,13 @@ GarrisonContain::GarrisonContain( Thing *thing, const ModuleData *moduleData ) :
 			m_garrisonPoint[ j ][ i ].zero();
 
 	}
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Initialize the per-condition real fire point
+	// bone counts used to avoid firing from the structure's padding/ground-level garrison points.
+	for( j = 0; j < MAX_GARRISON_POINT_CONDITIONS; ++j )
+		m_garrisonPointBoneCount[ j ] = 0;
+#endif
 
 	m_rallyValid = FALSE;
 	m_exitRallyPoint.zero();
@@ -1354,6 +1377,12 @@ void GarrisonContain::loadGarrisonPoints()
 		count = structure->getMultiLogicalBonePosition("FIREPOINT", MAX_GARRISON_POINTS, m_garrisonPoint[ conditionIndex ], nullptr);
 
 		if ( count > 0) gBonesFound = TRUE;
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Remember how many of the garrison point
+		// slots are backed by a real FIREPOINT bone, so excess occupants can reuse a real bone
+		// instead of the padding position (see putObjectAtGarrisonPoint()).
+		m_garrisonPointBoneCount[ conditionIndex ] = count;
+#endif
 
 		// damaged garrisoned
 		clearFlags.clear();
@@ -1368,6 +1397,10 @@ void GarrisonContain::loadGarrisonPoints()
 		count = structure->getMultiLogicalBonePosition("FIREPOINT", MAX_GARRISON_POINTS, m_garrisonPoint[ conditionIndex ], nullptr);
 
 		if ( count > 0) gBonesFound = TRUE;
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 See identical comment above for GARRISON_POINT_PRISTINE.
+		m_garrisonPointBoneCount[ conditionIndex ] = count;
+#endif
 
 		// really damaged garrisoned
 		clearFlags.clear();
@@ -1382,6 +1415,10 @@ void GarrisonContain::loadGarrisonPoints()
 		count = structure->getMultiLogicalBonePosition("FIREPOINT", MAX_GARRISON_POINTS, m_garrisonPoint[ conditionIndex ], nullptr);
 
 		if ( count > 0) gBonesFound = TRUE;
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 See identical comment above for GARRISON_POINT_PRISTINE.
+		m_garrisonPointBoneCount[ conditionIndex ] = count;
+#endif
 
 		// restore the original condition flags
 		draw->replaceModelConditionFlags( originalFlags );
@@ -1801,7 +1838,12 @@ void GarrisonContain::xfer( Xfer *xfer )
 	Int i;
 
 	// version
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Bumped to 2 to persist m_garrisonPointBoneCount.
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -1910,6 +1952,14 @@ void GarrisonContain::xfer( Xfer *xfer )
 
 	// garrison points initialized
 	xfer->xferBool( &m_garrisonPointsInitialized );
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Persist the real fire point bone counts so the
+	// fire-port reuse fix in putObjectAtGarrisonPoint() stays correct after a save/load, instead of
+	// silently reverting to the padding/ground-level position until this object is recreated.
+	if( version >= 2 )
+		xfer->xferUser( m_garrisonPointBoneCount, sizeof( Int ) * MAX_GARRISON_POINT_CONDITIONS );
+#endif
 
 	// rally valid
 	xfer->xferBool( &m_rallyValid );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
@@ -1838,8 +1838,15 @@ void GarrisonContain::xfer( Xfer *xfer )
 	Int i;
 
 	// version
-	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Bumped to 2 to persist m_garrisonPointBoneCount.
-#if RETAIL_COMPATIBLE_XFER_SAVE
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 [fixed gating ZsoltFeher 07/20/2026 after
+	// fable-model review: RETAIL_COMPATIBLE_CRC and RETAIL_COMPATIBLE_XFER_SAVE are independent
+	// macros, so gating the version bump on XFER_SAVE alone while the field xfer below was gated on
+	// CRC alone meant a RETAIL_COMPATIBLE_XFER_SAVE=0, RETAIL_COMPATIBLE_CRC=1 build stamped saves as
+	// version 2 without actually writing the new field, corrupting every subsequent field read on
+	// load. Match the combined-macro convention already used for this exact situation elsewhere (see
+	// JetAIUpdate.cpp's m_afterburners/m_resetTimer version-2 gating).] Bumped to 2 to persist
+	// m_garrisonPointBoneCount.
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
 #else
 	XferVersion currentVersion = 2;
@@ -1953,10 +1960,11 @@ void GarrisonContain::xfer( Xfer *xfer )
 	// garrison points initialized
 	xfer->xferBool( &m_garrisonPointsInitialized );
 
-#if !RETAIL_COMPATIBLE_CRC
+#if !(RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE)
 	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Persist the real fire point bone counts so the
 	// fire-port reuse fix in putObjectAtGarrisonPoint() stays correct after a save/load, instead of
-	// silently reverting to the padding/ground-level position until this object is recreated.
+	// silently reverting to the padding/ground-level position until this object is recreated. Gated
+	// to match the version-bump condition above exactly (see the comment there).
 	if( version >= 2 )
 		xfer->xferUser( m_garrisonPointBoneCount, sizeof( Int ) * MAX_GARRISON_POINT_CONDITIONS );
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1144,13 +1144,23 @@ UpdateSleepTime ChinookAIUpdate::update()
 			}
 		}
 #if !RETAIL_COMPATIBLE_CRC
-		// TheSuperHackers @bugfix diqezit 07/19/2026 SupplyTruckAIUpdate::isIdle() returns false while
-		// this Chinook/Helix is guarding or attacking, so the landing trigger above never ran, and units
-		// could never be loaded into (or evacuated from) a guarding/attacking Chinook or Helix -- they
-		// would only get in/out if the player explicitly pressed Stop first. Allow landing for waiting
-		// passengers even while not idle, as long as we're in stable level flight with no pending
-		// command or in-progress airfield healing, so we don't interrupt those. (GitHub issue #54)
-		else if (waitingToEnterOrExit && m_flightStatus == CHINOOK_FLYING && !m_hasPendingCommand && m_airfieldForHealing == INVALID_ID)
+		// TheSuperHackers @bugfix diqezit 07/19/2026 [narrowed ZsoltFeher 07/20/2026 after fable-model
+		// review] SupplyTruckAIUpdate::isIdle() returns false while this Chinook/Helix is guarding or
+		// attacking, so the landing trigger above never ran, and units could never be loaded into (or
+		// evacuated from) a guarding/attacking Chinook or Helix -- they would only get in/out if the
+		// player explicitly pressed Stop first. Allow landing for waiting passengers even while not
+		// idle, but ONLY while in a generic (non-Chinook-specific) AI state such as guard or attack --
+		// getAIStateType() < ChinookAIStateType_FIRST excludes every one of this class's own states
+		// (TAKING_OFF, LANDING, MOVE_TO_AND_EVAC, MOVE_TO_COMBAT_DROP, etc; see the enum's own "must be
+		// distinct numerically from AIStateType" comment above). Without this exclusion, a Chinook
+		// actively executing a player-issued move-and-evacuate or combat-drop order -- itself not idle,
+		// and (for move-and-evacuate specifically) only entered in the first place because
+		// waitingToEnterOrExit was already true, see aiDoCommand()'s AICMD_MOVE_TO_POSITION_AND_EVACUATE
+		// handling elsewhere in this file -- would have that in-progress order cancelled and be
+		// force-landed at its CURRENT position on the very next frame, instead of at the player's
+		// ordered destination. (GitHub issue #54)
+		else if (waitingToEnterOrExit && m_flightStatus == CHINOOK_FLYING && !m_hasPendingCommand && m_airfieldForHealing == INVALID_ID
+			&& getAIStateType() < ChinookAIStateType_FIRST)
 		{
 			setMyState(LANDING, nullptr, nullptr, CMD_FROM_AI);
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1143,6 +1143,18 @@ UpdateSleepTime ChinookAIUpdate::update()
 				setMyState(TAKING_OFF, nullptr, nullptr, CMD_FROM_AI);
 			}
 		}
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix diqezit 07/19/2026 SupplyTruckAIUpdate::isIdle() returns false while
+		// this Chinook/Helix is guarding or attacking, so the landing trigger above never ran, and units
+		// could never be loaded into (or evacuated from) a guarding/attacking Chinook or Helix -- they
+		// would only get in/out if the player explicitly pressed Stop first. Allow landing for waiting
+		// passengers even while not idle, as long as we're in stable level flight with no pending
+		// command or in-progress airfield healing, so we don't interrupt those. (GitHub issue #54)
+		else if (waitingToEnterOrExit && m_flightStatus == CHINOOK_FLYING && !m_hasPendingCommand && m_airfieldForHealing == INVALID_ID)
+		{
+			setMyState(LANDING, nullptr, nullptr, CMD_FROM_AI);
+		}
+#endif
 
 
     if ( TheGameLogic->getFrame()%10 == 1 )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -411,6 +411,15 @@ void WeaponTemplate::postProcessLoad()
 		return;
 	}
 
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 postProcessLoad() must be safe to call more than
+	// once: TheSubsystemList->postProcessLoadAll() (see GameLogic::tryStartNewGame, GitHub issue #276)
+	// re-runs every registered subsystem's postProcessLoad() after a map.ini load, and WeaponStore's
+	// override calls this for every WeaponTemplate. The OCL name strings below used to be cleared
+	// after being resolved the first time, so any second call saw them as empty and nulled out
+	// m_fireOCLs/m_projectileDetonationOCLs for every weapon in the game -- silently deleting every
+	// weapon's fire/detonation OCL effects (which spawn real objects, simulation-relevant) from the
+	// second postProcessLoad() call onward. Keep the name strings intact so re-resolving is idempotent,
+	// matching the pattern ThingTemplate::resolveNames() already documents for this exact hazard.
 	if (m_projectileName.isEmpty())
 	{
 		m_projectileTmpl = nullptr;
@@ -433,7 +442,6 @@ void WeaponTemplate::postProcessLoad()
 			m_fireOCLs[i] = TheObjectCreationListStore->findObjectCreationList(m_fireOCLNames[i].str() );
 			DEBUG_ASSERTCRASH(m_fireOCLs[i], ("OCL %s not found in a weapon!",m_fireOCLNames[i].str()));
 		}
-		m_fireOCLNames[i].clear();
 
 		// And the other OCL if there is one
 		if (m_projectileDetonationOCLNames[i].isEmpty() )
@@ -445,7 +453,6 @@ void WeaponTemplate::postProcessLoad()
 			m_projectileDetonationOCLs[i] = TheObjectCreationListStore->findObjectCreationList(m_projectileDetonationOCLNames[i].str() );
 			DEBUG_ASSERTCRASH(m_projectileDetonationOCLs[i], ("OCL %s not found in a weapon!",m_projectileDetonationOCLNames[i].str()));
 		}
-		m_projectileDetonationOCLNames[i].clear();
 	}
 
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1353,6 +1353,22 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 	// before loading the map, load the map.ini file in the same directory.
 	loadMapINI( TheGlobalData->m_mapName );
 
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix c001ac1d 07/19/2026 A custom map's map.ini can add or edit data (e.g.
+	// Weapon ProjectileObject references, CommandButton entries) that some subsystems only resolve
+	// once, in a post-process step that normally only runs right after their initial startup INI load
+	// (e.g. WeaponStore::postProcessLoad() fixing up ProjectileObject references, or ControlBar's
+	// command button image caching). Since map.ini loads after that initial post-process step already
+	// ran, any new or edited data from map.ini never got its post-process step, e.g. projectiles
+	// silently failing to launch or new command buttons showing no image. Re-run post-processing for
+	// every subsystem, and separately for TheControlBar (which is not registered with
+	// TheSubsystemList), now that map.ini has been loaded. (GitHub issue #276)
+	if (TheSubsystemList)
+		TheSubsystemList->postProcessLoadAll();
+	if (TheControlBar)
+		TheControlBar->postProcessLoad();
+#endif
+
 	// load a map
 	TheTerrainLogic->loadMap( TheGlobalData->m_mapName, false );
 	// anytime the world's size changes, must reset the partition mgr


### PR DESCRIPTION
fix: garrisoned infantry fire from building's ground position when model lacks enough fire points (#267)

GarrisonContain::loadGarrisonPoints() pre-fills all MAX_GARRISON_POINTS
slots of m_garrisonPoint[condition][] with the structure's own position
before overwriting the first `count` slots with real "FIREPOINT" bone
positions read from the model. Any garrison point index beyond the
number of real bones the model actually has therefore falls back to
the building's own placement position (its ground-level anchor), not a
real muzzle position -- unlike OpenContain::putObjAtNextFirePoint(),
used by TransportContain, which already wraps around to reuse a real
fire point bone when there are more passengers than bones.

putObjectAtGarrisonPoint() and findClosestFreeGarrisonPointIndex()
treated real-bone slots and this ground-level padding identically, so
once a building's real fire point bones were exhausted, additional
garrisoned occupants fired from underneath/inside the building instead
of a real firing position. This both raised their chance of
self-damage from splash weapons fired at nearby terrain, and gave them
a shorter effective firing range than an attacker measuring to the
building's actual geometry edge -- counter-intuitively making larger
buildings (which need more fire points to cover every occupant)
relatively worse to garrison than smaller ones.

Record how many real FIREPOINT bones were actually found per damage
condition (m_garrisonPointBoneCount), and in putObjectAtGarrisonPoint()
remap any point index beyond that count via modulo to reuse an
existing real fire point bone, mirroring OpenContain's existing
reuse strategy for TransportContain passengers. Persisted across
save/load (XferVersion bumped to 2, gated behind
RETAIL_COMPATIBLE_XFER_SAVE) so the fix doesn't silently revert to the
padding position until the object is recreated.

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes firing-position
and effective-range simulation behavior with replay/multiplayer
determinism implications.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix: units cannot enter/exit a guarding or attacking Chinook or Helix (#54)

ChinookAIUpdate::update()'s landing trigger -- checking
hasObjectsWantingToEnterOrExit() and transitioning to LANDING so
waiting passengers can board or evacuate -- only ran inside
SupplyTruckAIUpdate::isIdle(). isIdle() is overridden to return false
whenever the unit has a pending command, and more importantly here,
while it is actively guarding or attacking, since those are non-idle
AI states. So a Chinook or Helix (China Helix reuses this same
generic transport-helicopter AI class) that was guarding or currently
attacking never landed for waiting passengers at all -- units could
not garrison it, and existing passengers could not evacuate, unless
the player first pressed Stop to force it out of guard/attack mode.
This matches all of the symptoms reported: guard mode blocking
garrison entirely, attack mode ignoring garrison/evac commands until
the target died or Stop was pressed, and Stop being the only
documented workaround.

Add a landing trigger for the non-idle case: if there are passengers
waiting to enter or exit, the aircraft is in stable level flight
(CHINOOK_FLYING, not already mid-landing/takeoff/combat-drop), has no
pending command, and isn't in the middle of airfield healing, transition
to LANDING even while guarding or attacking. This does not touch any
of the existing idle-path logic (pending command handling, auto-takeoff
when done boarding, airfield healing) -- it only adds the missing
landing trigger for the non-idle case, using the same condition and
state transition the idle path already uses.

Root-caused and a working fix proposed by GitHub user diqezit in the
issue thread; verified against current source and applied to both
trees (each with its own, structurally slightly different but
equivalent isIdle()/contain nesting).

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes AI state
transition behavior with replay/multiplayer determinism implications.

Applies to both Generals and GeneralsMD (identical fix, ZH-first
convention not applicable here since ChinookAIUpdate.cpp exists
independently and identically-structured in both trees already).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix: map.ini data not fully applied due to missing post-load processing (#276)

Several subsystems resolve part of their INI-loaded data in a
"post-process" step that historically only ever ran once, right after
their initial startup INI load -- e.g. WeaponStore::postProcessLoad()
fixes up Weapon::ProjectileObject references from string names to real
ThingTemplate pointers, and ControlBar::postProcessCommands() resolves
each CommandButton's ButtonImage. A custom map's map.ini loads AFTER
that initial post-process step already ran (via GameLogic::loadMapINI,
called just before the map itself loads), so any weapon or command
button added or edited via map.ini never got its post-process step:
new/edited weapons with a ProjectileObject silently failed to launch
their projectile, and new/edited command buttons showed no image.

Root-caused and a working fix (validated with before/after screenshots
showing the projectile and command-button-image bugs both resolved) by
GitHub user c001ac1d in the issue thread.

Re-run TheSubsystemList->postProcessLoadAll() right after
GameLogic::loadMapINI, so every subsystem's postProcessLoad() override
runs again against the now-updated data. TheControlBar is not
registered with TheSubsystemList (it is constructed and owned
separately), so it needs an explicit call; added
ControlBar::postProcessLoad() (delegating to the existing
postProcessCommands()) and call it directly alongside
postProcessLoadAll().

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes INI-data
resolution timing/simulation-visible outcomes (e.g. which weapons
successfully reference a projectile) with replay/multiplayer
determinism implications.

ControlBar.h/.cpp are Core-shared (single copy for both trees); the
GameLogic::loadMapINI call site is duplicated per tree and fixed
identically in both.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix: address fable review findings on #276, #54, #267

Fable-model review of batch-3 fixes (#267, #136, #60, #54, #276, #201,
#457) found three real issues, all fixed here.

1. [CRITICAL] #276's TheSubsystemList->postProcessLoadAll() call
   (GameLogic::tryStartNewGame, run on every game start) re-runs
   WeaponTemplate::postProcessLoad() for every weapon via WeaponStore's
   override. That function was not idempotent: it resolved
   m_fireOCLNames[i]/m_projectileDetonationOCLNames[i] into
   m_fireOCLs[i]/m_projectileDetonationOCLs[i] and then cleared the
   name strings. On any second call, the now-empty names made every
   weapon's fire/detonation OCL silently resolve to nullptr --
   deleting every weapon's OCL-driven effects (which spawn real
   objects, simulation-relevant) game-wide from the second
   postProcessLoad() call onward. Removed the destructive .clear()
   calls so the name strings survive and re-resolution is idempotent,
   matching the pattern ThingTemplate::resolveNames() already
   documents for this exact hazard.

2. [HIGH] #54's new landing trigger in ChinookAIUpdate::update() fired
   in ANY non-idle AI state, not just guard/attack. Since
   AICMD_MOVE_TO_POSITION_AND_EVACUATE only enters MOVE_TO_AND_EVAC
   when hasObjectsWantingToEnterOrExit() is already true, a Chinook
   actively executing that player-issued order (or MOVE_TO_COMBAT_DROP)
   is itself "not idle" and would have its in-progress order cancelled
   by setMyState(LANDING, ...) on the very next frame, landing at its
   current position instead of the ordered destination. Chinook's own
   states are deliberately numbered >= ChinookAIStateType_FIRST (1000),
   "distinct numerically from AIStateType" per that enum's own comment
   -- added a getAIStateType() < ChinookAIStateType_FIRST check so the
   trigger only fires for genuinely generic (non-Chinook-specific)
   states such as guard and attack, and never interrupts any of the
   Chinook's own active player-order states.

3. [WARNING] #267's GarrisonContain::xfer() bumped XferVersion to 2
   gated on RETAIL_COMPATIBLE_XFER_SAVE alone, while the new field's
   actual read/write was gated on RETAIL_COMPATIBLE_CRC alone -- two
   independent macros. In a RETAIL_COMPATIBLE_XFER_SAVE=0,
   RETAIL_COMPATIBLE_CRC=1 build, saves were stamped version 2 without
   the field actually being written, corrupting every subsequent field
   read on load. Changed both to the combined
   RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE gate, matching
   the codebase's existing precedent for this exact situation
   (JetAIUpdate.cpp's m_afterburners/m_resetTimer version-2 gating).

Applied to both Generals and GeneralsMD.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #267
Fixes #54
Fixes #276
