### PR TITLE
fix: Stop command permanently halts Internet Center hackers (#136)

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3107,6 +3107,19 @@ void AIUpdateInterface::privateIdle(CommandSourceType cmdSource)
 			for (ContainedItemsList::const_iterator it = items->begin(); it != items->end(); ++it)
 			{
 				Object* obj = *it;
+
+#if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Do not forward the Stop command to
+				// hacker passengers of an Internet Center. Unlike a real Stop order, there is nothing
+				// that ever re-issues the hack command afterwards (the only other place that resumes
+				// hacking is ActiveBody::onSubdualChange(), which is specific to the EMP/subdual
+				// disable-and-recover case), so forwarding Stop here would permanently and silently
+				// stop the hackers from generating any more cash, e.g. when Stop is pressed on the
+				// Internet Center itself, including by accident via the Sat Hack hotkey conflict.
+				if (obj && obj->isKindOf(KINDOF_MONEY_HACKER) && getObject()->isKindOf(KINDOF_FS_INTERNET_CENTER))
+					continue;
+#endif
+
 				AIUpdateInterface* ai = obj ? obj->getAI() : nullptr;
 				if (ai)
 					ai->aiIdle(cmdSource);


### PR DESCRIPTION
fix: Stop command permanently halts Internet Center hackers (#136)

AIUpdateInterface::privateIdle() forwards a GUI_COMMAND_STOP issued on
any container to every contained passenger, unconditionally calling
aiIdle() on each of them. For a China Internet Center's hacker
passengers (KINDOF_MONEY_HACKER), this force-exits their
HackInternetAIUpdate state machine out of active hacking -- but unlike
a real Stop order on a mobile unit, nothing ever re-issues the hack
command afterwards. The only other place that resumes hacking,
ActiveBody::onSubdualChange(), only handles the EMP/subdual
disable-and-recover case (it already correctly calls
orderAllPassengersToHackInternet() when an Internet Center comes back
online, a pre-existing "Patch 1.01" fix). So pressing Stop on the
Internet Center -- including by accident, since the Sat Hack upgrade
button happens to share the same default hotkey -- permanently and
silently stops the hackers from generating any further cash, with no
way to resume other than manually re-entering them.

Skip forwarding the Stop command to KINDOF_MONEY_HACKER passengers
specifically when the container is a KINDOF_FS_INTERNET_CENTER,
reusing the same KindOf pair ActiveBody::onSubdualChange() already
uses for the subdual-recovery case, for consistency with existing
code. This is a narrow, code-only exemption for this specific
container/passenger combination -- it does not change Stop-forwarding
behavior for any other container type (e.g. Bunker-garrisoned
infantry, which the issue confirms exhibits the same forwarding
behavior but is a separate, unresolved design question the community
explicitly deferred pending a possible future generic
ForwardUnitCommandsToPassengers INI flag).

Gated behind !RETAIL_COMPATIBLE_CRC, since this changes AI command
simulation behavior with replay/multiplayer determinism implications.

GeneralsMD-only: the China Internet Center does not exist in the base
Generals tree.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #136
