### PR TITLE
fix: looped sounds remain audible after their source becomes shrouded (#60)

### DIFF
--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -54,6 +54,8 @@
 #include "Common/CRCDebug.h"
 #include "Common/GlobalData.h"
 #include "Common/ScopedMutex.h"
+// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Added to re-check shroud status for already-playing looped positional sounds (see #60)
+#include "Common/GameUtility.h"
 
 #include "GameClient/DebugDisplay.h"
 #include "GameClient/Drawable.h"
@@ -63,6 +65,8 @@
 
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/TerrainLogic.h"
+// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Added to re-check shroud status for already-playing looped positional sounds (see #60)
+#include "GameLogic/PartitionManager.h"
 
 #include "Common/file.h"
 
@@ -2200,7 +2204,20 @@ void MilesAudioManager::processPlayingList()
 				volForConsideration /= (m_sound3DVolume > 0.0f ? m_soundVolume : 1.0f);
 				Bool playAnyways = BitIsSet( playing->m_audioEventRTS->getAudioEventInfo()->m_type, ST_GLOBAL)
 					|| playing->m_audioEventRTS->getAudioEventInfo()->m_priority == AP_CRITICAL;
-				if( volForConsideration < m_audioSettings->m_minVolume && !playAnyways )
+
+				// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Looped sounds with the "shrouded" Type
+				// flag were only shroud-checked once at playback start (see canPlayNow() in GameSounds.cpp).
+				// Once playing, this per-frame loop only re-evaluated distance/volume, so a looped sound
+				// (e.g. Helix/Comanche rotor loop) kept playing audibly after its source became shrouded
+				// while still within range. Re-check shroud status here every frame, same as at start, and
+				// stop the sound if it has become shrouded. This only affects sounds whose Type includes
+				// "shrouded"; other looped sounds are unaffected. (#60)
+				Bool becameShrouded = BitIsSet( playing->m_audioEventRTS->getAudioEventInfo()->m_type, ST_SHROUDED)
+					&& !playAnyways
+					&& ThePartitionManager != nullptr
+					&& ThePartitionManager->getShroudStatusForPlayer( rts::getObservedOrLocalPlayerIndex_Safe(), pos ) != CELLSHROUD_CLEAR;
+
+				if( ( volForConsideration < m_audioSettings->m_minVolume && !playAnyways ) || becameShrouded )
 				{
 					stopPlayingAudio(playing);
 				}


### PR DESCRIPTION
fix: looped sounds remain audible after their source becomes shrouded (#60)

A sound whose AudioEventInfo::m_type includes ST_SHROUDED is meant to
be silenced whenever its emitting position is covered by fog of war,
even while still within audible range. This was only checked once, at
playback start, in SoundManager::canPlayNow() (GameSounds.cpp). The
per-frame update loop for already-playing 3D sounds,
MilesAudioManager::processPlayingList(), only re-evaluated
distance/volume cutoffs on every subsequent frame -- never shroud
status -- so a looped sound that started while its source was visible
(e.g. the Helix/Comanche rotor loop) kept playing at full volume after
the source became shrouded, only stopping once it left the sound's
max range entirely.

Re-check shroud status every frame for already-playing 3D sounds,
using the same query (ThePartitionManager->getShroudStatusForPlayer,
compared against CELLSHROUD_CLEAR) and the same ST_GLOBAL/AP_CRITICAL
"always audible" exemption that canPlayNow() already applies at start
time, and stop the sound if it has newly become shrouded. Only sounds
whose Type includes "shrouded" are affected; other looped sounds
(UI audio, always-audible ambience) take the unmodified code path.

No RETAIL_COMPATIBLE_CRC gating: this is client-local audio
presentation code with no effect on gameplay simulation or replay
determinism (same precedent as the earlier #2850 BinkVideoPlayer
volume fix in this session).

Core-shared: a single MilesAudioManager.cpp is compiled into both the
Generals and GeneralsMD device targets.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #60
