### PR TITLE
fix: Skirmish menu never restores last-played single-player mission map (#457)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -278,7 +278,19 @@ AsciiString SkirmishPreferences::getPreferredMap()
 
 	ret = QuotedPrintableToAsciiString(it->second);
 	ret.trim();
-	if (ret.isEmpty() || !isValidMap(ret, TRUE))
+
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 The Skirmish menu also allows selecting
+	// single-player mission maps for testing (see reallyDoStart(), which derives isSkirmish
+	// from the map's own m_isMultiplayer flag). Validating the saved map against a hardcoded
+	// isMultiplayer=TRUE caused the last-played mission map to always fail validation and be
+	// replaced by the default multiplayer map. Look up the map's actual type instead so the
+	// last-played map (mission or multiplayer) is correctly restored as the default selection.
+	Bool isMultiplayer = TRUE;
+	const MapMetaData *md = TheMapCache ? TheMapCache->findMap(ret) : nullptr;
+	if (md)
+		isMultiplayer = md->m_isMultiplayer;
+
+	if (ret.isEmpty() || !isValidMap(ret, isMultiplayer))
 	{
 		ret = getDefaultMap(TRUE);
 		return ret;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -286,7 +286,19 @@ AsciiString SkirmishPreferences::getPreferredMap()
 
 	ret = QuotedPrintableToAsciiString(it->second);
 	ret.trim();
-	if (ret.isEmpty() || !isValidMap(ret, TRUE))
+
+	// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 The Skirmish menu also allows selecting
+	// single-player mission maps for testing (see reallyDoStart(), which derives isSkirmish
+	// from the map's own m_isMultiplayer flag). Validating the saved map against a hardcoded
+	// isMultiplayer=TRUE caused the last-played mission map to always fail validation and be
+	// replaced by the default multiplayer map. Look up the map's actual type instead so the
+	// last-played map (mission or multiplayer) is correctly restored as the default selection.
+	Bool isMultiplayer = TRUE;
+	const MapMetaData *md = TheMapCache ? TheMapCache->findMap(ret) : nullptr;
+	if (md)
+		isMultiplayer = md->m_isMultiplayer;
+
+	if (ret.isEmpty() || !isValidMap(ret, isMultiplayer))
 	{
 		ret = getDefaultMap(TRUE);
 		return ret;


### PR DESCRIPTION
fix: Skirmish menu never restores last-played single-player mission map (#457)

SkirmishPreferences::getPreferredMap() validated the saved "last played
map" preference with isValidMap(ret, TRUE) -- a hardcoded assumption
that the saved map is always a multiplayer map. But the Skirmish menu
also supports selecting single-player mission maps for testing (see
reallyDoStart(), which derives isSkirmish from the map's own
m_isMultiplayer flag rather than assuming skirmish=multiplayer), and
write() saves whatever map was actually played, mission or
multiplayer alike. Since isValidMap() requires the caller's
isMultiplayer argument to match the map's actual cached type, a saved
mission map always failed this hardcoded check and silently fell back
to the default multiplayer map -- so a map/mission creator who last
tested a mission map via the Skirmish screen would never see it
pre-selected the next time the menu opened.

Look up the saved map's actual type via TheMapCache->findMap() before
validating, instead of assuming isMultiplayer=TRUE, so the last-played
map (mission or multiplayer) is correctly restored as the default
selection.

isValidMap() itself, and its other callers (CustomMatchPreferences and
LANPreferences' equivalent getPreferredMap() implementations, both of
which are genuine network-multiplayer-only contexts where a solo
mission map could never legitimately be selected), are left
untouched -- this fix is scoped to the one call site where the
assumption was actually wrong.

No RETAIL_COMPATIBLE_CRC gating: this is client-side UI/preference-
restoration code with no gameplay-simulation determinism implications.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #457
