### PR TITLE
fix: LAN lobby game list resets scroll position on any room change (#201)

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/LANGameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/LANGameInfo.cpp
@@ -210,6 +210,13 @@ void LANDisplayGameList( GameWindow *gameListbox, LANGameInfo *gameList )
 			selectedPtr = (LANGameInfo *)GadgetListBoxGetItemData(gameListbox, selectedIndex, 0);
 		}
 
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Preserve the user's scroll position across the
+		// full clear-and-repopulate below. Without this, the LAN lobby game list jumps back to the top
+		// any time any game is created/closed anywhere on the network, even if the user is mid-scroll
+		// and the change is unrelated to what they're looking at. This mirrors the equivalent save/restore
+		// already done for the GameSpy/WOL online lobby list in RefreshGameListBox() (LobbyUtils.cpp).
+		Int prevTopVisible = GadgetListBoxGetTopVisibleEntry(gameListbox);
+
 		GadgetListBoxReset(gameListbox);
 
 		while (gameList)
@@ -237,6 +244,11 @@ void LANDisplayGameList( GameWindow *gameListbox, LANGameInfo *gameList )
 			GadgetListBoxSetSelected(gameListbox, indexToSelect);
 		else
 			HideGameInfoWindow(TRUE);
+
+		// TheSuperHackers @bugfix ZsoltFeher 07/19/2026 Restore the scroll position saved off above.
+		// GadgetListBoxSetTopVisibleEntry() internally clamps to the (possibly now shorter) list, so
+		// this is safe even if games were removed above the user's previous scroll position.
+		GadgetListBoxSetTopVisibleEntry(gameListbox, prevTopVisible);
 	}
 }
 


### PR DESCRIPTION
fix: LAN lobby game list resets scroll position on any room change (#201)

LANDisplayGameList() rebuilds the LAN lobby's game-room listbox from
scratch (GadgetListBoxReset() + full repopulate) every time the LAN
game list changes -- i.e. whenever ANY room is created, closed, or
updated anywhere on the network, not just ones related to what the
user is currently viewing. The existing code already saved and
restored the *selected* row around this rebuild, but never saved or
restored the scroll position (top-visible-entry), so a user scrolled
partway down the list would get snapped back to the top on the very
next unrelated room event.

The sibling GameSpy/WOL online lobby list already handles this
correctly in RefreshGameListBox() (LobbyUtils.cpp), saving
GadgetListBoxGetTopVisibleEntry() before clearing and restoring it via
GadgetListBoxSetTopVisibleEntry() after repopulating -- the LAN list
just never received the equivalent treatment. Apply the same save/
restore around LANDisplayGameList()'s clear-and-repopulate.
GadgetListBoxSetTopVisibleEntry() already self-clamps to the current
list length, so this is safe even if games were removed above the
user's previous scroll position.

No RETAIL_COMPATIBLE_CRC gating: client-side UI code with no gameplay
simulation or replay determinism implications, matching the un-gated
WOL precedent.

Core-shared: LANGameInfo.cpp is compiled into both the Generals and
GeneralsMD targets from a single copy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #201
