### PR TITLE
fix(worldbuilder): crash using Select Team Members with <neutral> player (#1358)

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -429,10 +429,11 @@ void CTeamsDialog::OnCopyteam()
 void CTeamsDialog::OnSelectTeamMembers()
 {
 	// TheSuperHackers @bugfix Caball009 07/20/2026 The <neutral> player (m_curTeam == -1) has no real
-	// team info, so m_sides.getTeamInfo(m_curTeam) returns nullptr and dereferencing ->getDict() crashed
-	// WorldBuilder. Neutral map objects are tagged with NEUTRAL_TEAM_INTERNAL_STR as their
-	// TheKey_originalOwner (see GroveTool.cpp/RoadTool.cpp/ScorchTool.cpp), so use that directly instead
-	// of looking up a (nonexistent) team's dictionary. (GitHub issue #1358)
+	// team info. m_sides.getTeamInfo(m_curTeam) has no valid entry for team == -1, so it hits its
+	// out-of-range path (DEBUG_CRASH + throw), crashing WorldBuilder. Neutral map objects are tagged
+	// with NEUTRAL_TEAM_INTERNAL_STR as their TheKey_originalOwner (see
+	// GroveTool.cpp/RoadTool.cpp/ScorchTool.cpp), so use that directly instead of looking up a
+	// (nonexistent) team's dictionary. (GitHub issue #1358)
 	Int count = 0;
 	AsciiString teamName = (m_curTeam == -1) ? NEUTRAL_TEAM_INTERNAL_STR : m_sides.getTeamInfo(m_curTeam)->getDict()->getAsciiString(TheKey_teamName);
 	Coord3D pos;

--- a/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -23,6 +23,7 @@
 #include "WorldBuilder.h"
 #include "teamsdialog.h"
 #include "CFixTeamOwnerDialog.h"
+#include "mapobjectprops.h"
 
 #include "Common/WellKnownKeys.h"
 #include "GameLogic/SidesList.h"
@@ -427,9 +428,13 @@ void CTeamsDialog::OnCopyteam()
 
 void CTeamsDialog::OnSelectTeamMembers()
 {
+	// TheSuperHackers @bugfix Caball009 07/20/2026 The <neutral> player (m_curTeam == -1) has no real
+	// team info, so m_sides.getTeamInfo(m_curTeam) returns nullptr and dereferencing ->getDict() crashed
+	// WorldBuilder. Neutral map objects are tagged with NEUTRAL_TEAM_INTERNAL_STR as their
+	// TheKey_originalOwner (see GroveTool.cpp/RoadTool.cpp/ScorchTool.cpp), so use that directly instead
+	// of looking up a (nonexistent) team's dictionary. (GitHub issue #1358)
 	Int count = 0;
-	Dict d = *m_sides.getTeamInfo(m_curTeam)->getDict();
-	AsciiString teamName = d.getAsciiString(TheKey_teamName);
+	AsciiString teamName = (m_curTeam == -1) ? NEUTRAL_TEAM_INTERNAL_STR : m_sides.getTeamInfo(m_curTeam)->getDict()->getAsciiString(TheKey_teamName);
 	Coord3D pos;
 	MapObject *pObj;
 	for (pObj=MapObject::getFirstMapObject(); pObj; pObj=pObj->getNext()) {

--- a/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -2344,13 +2344,15 @@ void WbView3d::drawLabels(HDC hdc)
 					case 3: name = pMapObj->getProperties()->getAsciiString(TheKey_waypointPathLabel3, &exists); break;
 					default: name.clear();
 				}
-				// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only use pos for waypoint path
-				// labels when waypoints are actually shown. When m_showWaypoints is false, pos is
-				// left uninitialized for waypoint MapObjects (the isWaypoint()+m_showWaypoints
-				// branch above is skipped and waypoints have no ThingTemplate), so using pos here
-				// read garbage stack memory and crashed WorldBuilder when hiding waypoints while
-				// labels were still shown.
-				if (!name.isEmpty() && m_showWaypoints) {
+				// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only use pos for a waypoint's own path
+				// labels when waypoints are actually shown. When m_showWaypoints is false, pos is left
+				// uninitialized for waypoint MapObjects (the isWaypoint()+m_showWaypoints branch above
+				// is skipped and waypoints have no ThingTemplate), so using pos here read garbage stack
+				// memory and crashed WorldBuilder when hiding waypoints while labels were still shown.
+				// Gated on isWaypoint() specifically (not applied to regular objects) since a regular
+				// object's name label always has a validly-assigned pos regardless of m_showWaypoints,
+				// via the getThingTemplate() branch above, and should keep rendering either way.
+				if (!name.isEmpty() && (!pMapObj->isWaypoint() || m_showWaypoints)) {
 					CPoint pt;
 					Vector3 world, screen;
 					world.Set( pos.x+MAP_XY_FACTOR/2, pos.y, pos.z );

--- a/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -2344,7 +2344,13 @@ void WbView3d::drawLabels(HDC hdc)
 					case 3: name = pMapObj->getProperties()->getAsciiString(TheKey_waypointPathLabel3, &exists); break;
 					default: name.clear();
 				}
-				if (!name.isEmpty()) {
+				// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only use pos for waypoint path
+				// labels when waypoints are actually shown. When m_showWaypoints is false, pos is
+				// left uninitialized for waypoint MapObjects (the isWaypoint()+m_showWaypoints
+				// branch above is skipped and waypoints have no ThingTemplate), so using pos here
+				// read garbage stack memory and crashed WorldBuilder when hiding waypoints while
+				// labels were still shown.
+				if (!name.isEmpty() && m_showWaypoints) {
 					CPoint pt;
 					Vector3 world, screen;
 					world.Set( pos.x+MAP_XY_FACTOR/2, pos.y, pos.z );

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -433,10 +433,11 @@ void CTeamsDialog::OnCopyteam()
 void CTeamsDialog::OnSelectTeamMembers()
 {
 	// TheSuperHackers @bugfix Caball009 07/20/2026 The <neutral> player (m_curTeam == -1) has no real
-	// team info, so m_sides.getTeamInfo(m_curTeam) returns nullptr and dereferencing ->getDict() crashed
-	// WorldBuilder. Neutral map objects are tagged with NEUTRAL_TEAM_INTERNAL_STR as their
-	// TheKey_originalOwner (see GroveTool.cpp/RoadTool.cpp/ScorchTool.cpp), so use that directly instead
-	// of looking up a (nonexistent) team's dictionary. (GitHub issue #1358)
+	// team info. m_sides.getTeamInfo(m_curTeam) has no valid entry for team == -1, so it hits its
+	// out-of-range path (DEBUG_CRASH + throw), crashing WorldBuilder. Neutral map objects are tagged
+	// with NEUTRAL_TEAM_INTERNAL_STR as their TheKey_originalOwner (see
+	// GroveTool.cpp/RoadTool.cpp/ScorchTool.cpp), so use that directly instead of looking up a
+	// (nonexistent) team's dictionary. (GitHub issue #1358)
 	Int count = 0;
 	AsciiString teamName = (m_curTeam == -1) ? NEUTRAL_TEAM_INTERNAL_STR : m_sides.getTeamInfo(m_curTeam)->getDict()->getAsciiString(TheKey_teamName);
 	Coord3D pos;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -23,6 +23,7 @@
 #include "WorldBuilder.h"
 #include "teamsdialog.h"
 #include "CFixTeamOwnerDialog.h"
+#include "mapobjectprops.h"
 
 #include "Common/WellKnownKeys.h"
 #include "GameLogic/SidesList.h"
@@ -431,9 +432,13 @@ void CTeamsDialog::OnCopyteam()
 
 void CTeamsDialog::OnSelectTeamMembers()
 {
+	// TheSuperHackers @bugfix Caball009 07/20/2026 The <neutral> player (m_curTeam == -1) has no real
+	// team info, so m_sides.getTeamInfo(m_curTeam) returns nullptr and dereferencing ->getDict() crashed
+	// WorldBuilder. Neutral map objects are tagged with NEUTRAL_TEAM_INTERNAL_STR as their
+	// TheKey_originalOwner (see GroveTool.cpp/RoadTool.cpp/ScorchTool.cpp), so use that directly instead
+	// of looking up a (nonexistent) team's dictionary. (GitHub issue #1358)
 	Int count = 0;
-	Dict d = *m_sides.getTeamInfo(m_curTeam)->getDict();
-	AsciiString teamName = d.getAsciiString(TheKey_teamName);
+	AsciiString teamName = (m_curTeam == -1) ? NEUTRAL_TEAM_INTERNAL_STR : m_sides.getTeamInfo(m_curTeam)->getDict()->getAsciiString(TheKey_teamName);
 	Coord3D pos;
 	MapObject *pObj;
 	for (pObj=MapObject::getFirstMapObject(); pObj; pObj=pObj->getNext()) {

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -2479,7 +2479,12 @@ void WbView3d::drawLabels(HDC hdc)
 					case 3: name = pMapObj->getProperties()->getAsciiString(TheKey_waypointPathLabel3, &exists); break;
 					default: name.clear();
 				}
-				if (!name.isEmpty() && m_showWaypoints) {
+				// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Gate the m_showWaypoints check on
+				// isWaypoint() specifically, not applied to regular objects, since a regular object's
+				// name label always has a validly-assigned pos regardless of m_showWaypoints (via the
+				// getThingTemplate() branch above) and should keep rendering either way. Previously
+				// hiding waypoints also incorrectly hid regular object name labels. (GitHub issue #470)
+				if (!name.isEmpty() && (!pMapObj->isWaypoint() || m_showWaypoints)) {
 					CPoint pt;
 					Vector3 world, screen;
 					world.Set( pos.x+MAP_XY_FACTOR/2, pos.y, pos.z );


### PR DESCRIPTION
fix(worldbuilder): crash using Select Team Members with <neutral> player (#1358)

CTeamsDialog::OnSelectTeamMembers() unconditionally called
m_sides.getTeamInfo(m_curTeam)->getDict(). The <neutral> player is
represented internally as m_curTeam == -1, which has no real team
info -- getTeamInfo(-1) returns nullptr, and dereferencing ->getDict()
on it crashed WorldBuilder.

Neutral map objects are tagged with NEUTRAL_TEAM_INTERNAL_STR (the
string "team") as their TheKey_originalOwner property, exactly as
GroveTool.cpp/RoadTool.cpp/ScorchTool.cpp already do when placing
neutral objects. Use that directly as the team name to match against
when m_curTeam == -1, instead of looking up a (nonexistent) team's
dictionary.

Root-caused and fix proposed by GitHub user Caball009 in the issue
thread; verified against current source and applied to both trees.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix(worldbuilder): crash hiding waypoints while labels still shown (#470)

WbView3d::drawLabels() declares Coord3D pos as an uninitialized local
per map object. It's only assigned inside the isWaypoint()+m_showWaypoints
branch (waypoints) or the getThingTemplate() branch (regular objects);
a waypoint object with m_showWaypoints == false hits neither branch,
leaving pos as uninitialized stack garbage.

The following loop unconditionally reads waypoint path label
properties (TheKey_waypointPathLabel1/2/3) -- set on any waypoint that
is part of a linked waypoint path, common in real maps -- and if such
a label exists, used pos (still uninitialized in this case) to build a
Vector3 and call m_camera->Project(), reading garbage stack memory.
This crashed WorldBuilder specifically when hiding waypoints while
labels were still shown; hiding labels first avoided the crash by
short-circuiting the whole loop via the outer isNamesVisible() guard
before pos was ever touched -- matching the community's own reported
workaround and hypothesis ("labels depend on waypoints").

Add the missing m_showWaypoints check to the waypoint-path-label
branch, matching how the corresponding code in the GeneralsMD/Zero
Hour WorldBuilder tree already guards this correctly -- this bug only
existed in the base Generals WorldBuilder tree.

WorldBuilder is a separate tool executable that does not participate
in game simulation/replay, so no RETAIL_COMPATIBLE_CRC gating applies.

Generals-only: GeneralsMD's WorldBuilder already had this guard.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix(worldbuilder): narrow #470 label fix scope, correct #1358 comment

Follow-up from an opus code review of the WorldBuilder fixes committed
earlier this session (issues #1358, #470, #413, #312).

1. wbview3d.cpp (both trees): the #470 fix's `&& m_showWaypoints`
   guard wrapped the entire label-drawing block, including the i==0
   iteration that draws a *regular* (non-waypoint) object's own
   ThingTemplate name label. That label's pos is always validly
   assigned via the getThingTemplate() branch above, regardless of
   m_showWaypoints, so gating it too was an unintended scope increase:
   toggling "show waypoints" off now also hid unrelated object name
   labels. Narrow the guard to isWaypoint() specifically
   (`!isWaypoint() || m_showWaypoints`), so only a waypoint's own
   labels (name and path labels) are affected, matching the actual
   uninitialized-pos defect the fix addresses. This corrects the same
   latent over-broad-scope issue already present in GeneralsMD before
   this session (verified: GeneralsMD had the identical
   `&& m_showWaypoints` guard pre-existing, not something this session
   introduced there) as well as fixing the newly-added Generals-side
   guard.

2. teamsdialog.cpp (both trees): corrected the #1358 bugfix comment,
   which inaccurately described the crash as
   "getTeamInfo(m_curTeam) returns nullptr, dereferencing ->getDict()
   crashed". Verified against SidesList::getTeamInfo() (SidesList.h):
   for team == -1 it takes the out-of-range path (DEBUG_CRASH + throw
   ERROR_BAD_ARG), not a null return -- the `return nullptr;` after the
   throw is unreachable. The fix itself (avoiding the call entirely for
   m_curTeam == -1) was already correct regardless of the exact crash
   mechanism; only the comment was wrong.

A third review finding (CTeamsDialog::OnCopyteam() has the same
unguarded getTeamInfo(m_curTeam) pattern) was investigated and found
NOT to need a fix: OnUpdateUI() already disables the Copy Team button
whenever m_curTeam == -1 (isDefault defaults to true, disabling
copyteam/del/moveup/movedown), unlike OnSelectTeamMembers's button
which had no such guard -- explaining why #1358 was reachable via
normal UI interaction and OnCopyteam is not.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #1358
Fixes #470
