### PR TITLE
fix(worldbuilder): new map boundaries cannot be removed (#413)

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
@@ -158,6 +158,7 @@ public: // Editing methods.
 	void addBoundary(ICoord2D* boundaryToAdd);
 	void changeBoundary(Int ndx, ICoord2D *border);
 	void removeLastBoundary();
+	void removeBoundary(Int ndx);
 
 	// outNdx must not be null, but outHandle can be.
 	// outHandle: 0 means BL, 1 means TL, 2 means TR, 3 means BR

--- a/Generals/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
@@ -88,6 +88,7 @@ public:
 	void addBoundary(ICoord2D* boundaryToAdd);
 	void changeBoundary(Int ndx, ICoord2D *border);
 	void removeLastBoundary();
+	void removeBoundary(Int ndx);
 
 	// outNdx must not be null, but outHandle can be.
 	// outHandle: 0 means BL, 1 means TL, 2 means TR, 3 means BR

--- a/Generals/Code/Tools/WorldBuilder/src/BorderTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/BorderTool.cpp
@@ -113,6 +113,21 @@ void BorderTool::mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 			currentBorder.y = 0;
 		}
 
+		// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Boundary 0 is the default/main border, always
+		// created spanning the whole map when a new map is made, and other systems (e.g. shroud) rely on
+		// at least one non-degenerate boundary existing. Unlike any other boundary, collapsing it to zero
+		// width/height by dragging it into the origin permanently breaks the map (always shrouded) with
+		// no way to bring it back, since it's the one boundary that can never simply be re-added by the
+		// user like any other. Never let it be dragged smaller than 1x1. (GitHub issue #312)
+		if (m_modifyBorderNdx == 0) {
+			if (currentBorder.x < 1) {
+				currentBorder.x = 1;
+			}
+
+			if (currentBorder.y < 1) {
+				currentBorder.y = 1;
+			}
+		}
 
 		pDoc->changeBoundary(m_modifyBorderNdx, &currentBorder);
 	}
@@ -166,7 +181,10 @@ void BorderTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBu
 	if (m_modifyBorderNdx >= 0) {
 		ICoord2D currentBorder;
 		pDoc->getBoundary(m_modifyBorderNdx, &currentBorder);
-		if (currentBorder.x == 0 || currentBorder.y == 0) {
+		// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Never auto-remove boundary 0, the default/main
+		// border (see the m_modifyBorderNdx == 0 clamp in mouseMoved() above, which already prevents it
+		// from reaching zero width/height by dragging in the first place). (GitHub issue #312)
+		if (m_modifyBorderNdx != 0 && (currentBorder.x == 0 || currentBorder.y == 0)) {
 			pDoc->removeBoundary(m_modifyBorderNdx);
 		}
 		m_modifyBorderNdx = -1;

--- a/Generals/Code/Tools/WorldBuilder/src/BorderTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/BorderTool.cpp
@@ -69,6 +69,13 @@ void BorderTool::mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 		Coord3D new3DPoint;
 		pView->viewToDocCoords(viewPt, &new3DPoint, false);
 
+		current.x = REAL_TO_INT((new3DPoint.x / MAP_XY_FACTOR) + 0.5f);
+		current.y = REAL_TO_INT((new3DPoint.y / MAP_XY_FACTOR) + 0.5f);
+
+		// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 These clamps used to run before the assignments
+		// above and were therefore dead code (immediately overwritten), so a newly-added border being
+		// dragged towards the origin could be given negative extents. Clamp after assigning from the
+		// mouse position instead. (GitHub issue #413)
 		if (current.x < 0) {
 			current.x = 0;
 		}
@@ -77,8 +84,6 @@ void BorderTool::mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 			current.y = 0;
 		}
 
-		current.x = REAL_TO_INT((new3DPoint.x / MAP_XY_FACTOR) + 0.5f);
-		current.y = REAL_TO_INT((new3DPoint.y / MAP_XY_FACTOR) + 0.5f);
 		pDoc->changeBoundary(count - 1, &current);
 		return;
 	}
@@ -170,6 +175,21 @@ void BorderTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBu
 	if (m_addingNewBorder) {
 		m_addingNewBorder = false;
 		// Do the undoable on the last border
+
+		// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 A newly-added border can also end up degenerate
+		// (zero or, before the mouseMoved() clamp-order fix above, negative extents) if it's dragged
+		// straight back onto the origin before release -- the same permanently-invisible-and-unpickable
+		// outcome the modify-path cleanup below already handles. This is never boundary 0 (the default
+		// border is created once by the map constructor, never via this add-new-border path), so no
+		// index-0 protection is needed here. (GitHub issue #413)
+		Int newNdx = pDoc->getNumBoundaries() - 1;
+		if (newNdx >= 0) {
+			ICoord2D newBorder;
+			pDoc->getBoundary(newNdx, &newBorder);
+			if (newBorder.x <= 0 || newBorder.y <= 0) {
+				pDoc->removeBoundary(newNdx);
+			}
+		}
 	}
 
 	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 A boundary is anchored at the origin (0,0), so
@@ -185,6 +205,15 @@ void BorderTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBu
 		// border (see the m_modifyBorderNdx == 0 clamp in mouseMoved() above, which already prevents it
 		// from reaching zero width/height by dragging in the first place). (GitHub issue #312)
 		if (m_modifyBorderNdx != 0 && (currentBorder.x == 0 || currentBorder.y == 0)) {
+			// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Map scripts can reference a boundary by its
+			// raw list index (Parameter::BOUNDARY). Removing anything other than the last boundary shifts
+			// every later boundary's index down by one, silently retargeting any script that referenced
+			// one of them. Warn the user so they know to double check their scripts; removing the actual
+			// last boundary (as the add-new-border path above always does) never shifts anything, so no
+			// warning is needed there. (GitHub issue #413)
+			if (m_modifyBorderNdx != pDoc->getNumBoundaries() - 1) {
+				::AfxMessageBox(_T("Removing this boundary will shift the index of every boundary after it. If any map scripts reference boundaries by number, please double check them."), MB_OK | MB_ICONWARNING);
+			}
 			pDoc->removeBoundary(m_modifyBorderNdx);
 		}
 		m_modifyBorderNdx = -1;

--- a/Generals/Code/Tools/WorldBuilder/src/BorderTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/BorderTool.cpp
@@ -156,4 +156,19 @@ void BorderTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBu
 		m_addingNewBorder = false;
 		// Do the undoable on the last border
 	}
+
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 A boundary is anchored at the origin (0,0), so
+	// dragging its opposite corner onto the origin collapses it to zero width or height. That used to
+	// leave a degenerate, permanently invisible and unselectable entry in the boundary list forever
+	// (findBoundaryNear() already skips zero-sized boundaries, so it could never be picked again).
+	// Actually remove it here instead, completing what dragging the corners together was clearly meant
+	// to do: get rid of an unwanted boundary. (GitHub issue #413)
+	if (m_modifyBorderNdx >= 0) {
+		ICoord2D currentBorder;
+		pDoc->getBoundary(m_modifyBorderNdx, &currentBorder);
+		if (currentBorder.x == 0 || currentBorder.y == 0) {
+			pDoc->removeBoundary(m_modifyBorderNdx);
+		}
+		m_modifyBorderNdx = -1;
+	}
 }

--- a/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -3386,6 +3386,22 @@ void WorldHeightMapEdit::removeLastBoundary()
 	m_boundaries.pop_back();
 }
 
+// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Added to allow removing a specific boundary, not just
+// the most recently added one. Previously the only way to get rid of an unwanted boundary was
+// removeLastBoundary() (last-added only) or dragging its corners together, which just left a
+// degenerate (zero width or height) entry permanently in m_boundaries -- findBoundaryNear() already
+// explicitly skips zero-sized boundaries, so once collapsed this way a boundary could never again be
+// selected or actually removed. (GitHub issue #413)
+void WorldHeightMapEdit::removeBoundary(Int ndx)
+{
+	if (ndx < 0 || ndx >= m_boundaries.size()) {
+		DEBUG_CRASH(("Invalid border remove request. jkmcd"));
+		return;
+	}
+
+	m_boundaries.erase(m_boundaries.begin() + ndx);
+}
+
 void WorldHeightMapEdit::findBoundaryNear(Coord3D *pt, float okDistance, Int *outNdx, Int *outHandle)
 {
 	if (!outNdx) {

--- a/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -3460,6 +3460,16 @@ void WorldHeightMapEdit::findBoundaryNear(Coord3D *pt, float okDistance, Int *ou
 	}
 
 	(*outNdx) = -1;
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 This not-found path never wrote *outHandle at all,
+	// leaving callers' handle output (e.g. BorderTool::mouseDown()'s local `motion`) as uninitialized
+	// stack garbage whenever no boundary handle was near the click point -- the same defect class as
+	// #470's uninitialized Coord3D read. It happened to be harmless in the current BorderTool caller
+	// (which only acts on the handle when *outNdx >= 0, and this path always sets *outNdx = -1), but is
+	// still undefined behavior. Matches GeneralsMD's equivalent write (also null-checked to respect the
+	// "outHandle can be null" contract documented on this function's declaration).
+	if (outHandle) {
+		(*outHandle) = -1;
+	}
 }
 
 

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -2595,6 +2595,11 @@ void CWorldBuilderDoc::removeLastBoundary()
 	m_heightMap->removeLastBoundary();
 }
 
+void CWorldBuilderDoc::removeBoundary(Int ndx)
+{
+	m_heightMap->removeBoundary(ndx);
+}
+
 void CWorldBuilderDoc::findBoundaryNear(Coord3D *pt, float okDistance, Int *outNdx, Int *outHandle)
 {
 	m_heightMap->findBoundaryNear(pt, okDistance, outNdx, outHandle);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
@@ -156,6 +156,7 @@ public: // Editing methods.
 	void addBoundary(ICoord2D* boundaryToAdd);
 	void changeBoundary(Int ndx, ICoord2D *border);
 	void removeLastBoundary();
+	void removeBoundary(Int ndx);
 
 	// outNdx must not be null, but outHandle can be.
 	// outHandle: 0 means BL, 1 means TL, 2 means TR, 3 means BR

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
@@ -88,6 +88,7 @@ public:
 	void addBoundary(ICoord2D* boundaryToAdd);
 	void changeBoundary(Int ndx, ICoord2D *border);
 	void removeLastBoundary();
+	void removeBoundary(Int ndx);
 
 	// outNdx must not be null, but outHandle can be.
 	// outHandle: 0 means BL, 1 means TL, 2 means TR, 3 means BR

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/BorderTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/BorderTool.cpp
@@ -113,6 +113,21 @@ void BorderTool::mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 			currentBorder.y = 0;
 		}
 
+		// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Boundary 0 is the default/main border, always
+		// created spanning the whole map when a new map is made, and other systems (e.g. shroud) rely on
+		// at least one non-degenerate boundary existing. Unlike any other boundary, collapsing it to zero
+		// width/height by dragging it into the origin permanently breaks the map (always shrouded) with
+		// no way to bring it back, since it's the one boundary that can never simply be re-added by the
+		// user like any other. Never let it be dragged smaller than 1x1. (GitHub issue #312)
+		if (m_modifyBorderNdx == 0) {
+			if (currentBorder.x < 1) {
+				currentBorder.x = 1;
+			}
+
+			if (currentBorder.y < 1) {
+				currentBorder.y = 1;
+			}
+		}
 
 		pDoc->changeBoundary(m_modifyBorderNdx, &currentBorder);
 	}
@@ -180,7 +195,10 @@ void BorderTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBu
 	if (m_modifyBorderNdx >= 0) {
 		ICoord2D currentBorder;
 		pDoc->getBoundary(m_modifyBorderNdx, &currentBorder);
-		if (currentBorder.x == 0 || currentBorder.y == 0) {
+		// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Never auto-remove boundary 0, the default/main
+		// border (see the m_modifyBorderNdx == 0 clamp in mouseMoved() above, which already prevents it
+		// from reaching zero width/height by dragging in the first place). (GitHub issue #312)
+		if (m_modifyBorderNdx != 0 && (currentBorder.x == 0 || currentBorder.y == 0)) {
 			pDoc->removeBoundary(m_modifyBorderNdx);
 		}
 		m_modifyBorderNdx = -1;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/BorderTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/BorderTool.cpp
@@ -69,6 +69,13 @@ void BorderTool::mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 		Coord3D new3DPoint;
 		pView->viewToDocCoords(viewPt, &new3DPoint, false);
 
+		current.x = REAL_TO_INT((new3DPoint.x / MAP_XY_FACTOR) + 0.5f);
+		current.y = REAL_TO_INT((new3DPoint.y / MAP_XY_FACTOR) + 0.5f);
+
+		// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 These clamps used to run before the assignments
+		// above and were therefore dead code (immediately overwritten), so a newly-added border being
+		// dragged towards the origin could be given negative extents. Clamp after assigning from the
+		// mouse position instead. (GitHub issue #413)
 		if (current.x < 0) {
 			current.x = 0;
 		}
@@ -77,8 +84,6 @@ void BorderTool::mouseMoved(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 			current.y = 0;
 		}
 
-		current.x = REAL_TO_INT((new3DPoint.x / MAP_XY_FACTOR) + 0.5f);
-		current.y = REAL_TO_INT((new3DPoint.y / MAP_XY_FACTOR) + 0.5f);
 		pDoc->changeBoundary(count - 1, &current);
 		return;
 	}
@@ -184,6 +189,21 @@ void BorderTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBu
 	if (m_addingNewBorder) {
 		m_addingNewBorder = false;
 		// Do the undoable on the last border
+
+		// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 A newly-added border can also end up degenerate
+		// (zero or, before the mouseMoved() clamp-order fix above, negative extents) if it's dragged
+		// straight back onto the origin before release -- the same permanently-invisible-and-unpickable
+		// outcome the modify-path cleanup below already handles. This is never boundary 0 (the default
+		// border is created once by the map constructor, never via this add-new-border path), so no
+		// index-0 protection is needed here. (GitHub issue #413)
+		Int newNdx = pDoc->getNumBoundaries() - 1;
+		if (newNdx >= 0) {
+			ICoord2D newBorder;
+			pDoc->getBoundary(newNdx, &newBorder);
+			if (newBorder.x <= 0 || newBorder.y <= 0) {
+				pDoc->removeBoundary(newNdx);
+			}
+		}
 	}
 
 	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 A boundary is anchored at the origin (0,0), so
@@ -199,6 +219,15 @@ void BorderTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBu
 		// border (see the m_modifyBorderNdx == 0 clamp in mouseMoved() above, which already prevents it
 		// from reaching zero width/height by dragging in the first place). (GitHub issue #312)
 		if (m_modifyBorderNdx != 0 && (currentBorder.x == 0 || currentBorder.y == 0)) {
+			// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Map scripts can reference a boundary by its
+			// raw list index (Parameter::BOUNDARY). Removing anything other than the last boundary shifts
+			// every later boundary's index down by one, silently retargeting any script that referenced
+			// one of them. Warn the user so they know to double check their scripts; removing the actual
+			// last boundary (as the add-new-border path above always does) never shifts anything, so no
+			// warning is needed there. (GitHub issue #413)
+			if (m_modifyBorderNdx != pDoc->getNumBoundaries() - 1) {
+				::AfxMessageBox(_T("Removing this boundary will shift the index of every boundary after it. If any map scripts reference boundaries by number, please double check them."), MB_OK | MB_ICONWARNING);
+			}
 			pDoc->removeBoundary(m_modifyBorderNdx);
 		}
 		m_modifyBorderNdx = -1;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/BorderTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/BorderTool.cpp
@@ -170,4 +170,19 @@ void BorderTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBu
 		m_addingNewBorder = false;
 		// Do the undoable on the last border
 	}
+
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 A boundary is anchored at the origin (0,0), so
+	// dragging its opposite corner onto the origin collapses it to zero width or height. That used to
+	// leave a degenerate, permanently invisible and unselectable entry in the boundary list forever
+	// (findBoundaryNear() already skips zero-sized boundaries, so it could never be picked again).
+	// Actually remove it here instead, completing what dragging the corners together was clearly meant
+	// to do: get rid of an unwanted boundary. (GitHub issue #413)
+	if (m_modifyBorderNdx >= 0) {
+		ICoord2D currentBorder;
+		pDoc->getBoundary(m_modifyBorderNdx, &currentBorder);
+		if (currentBorder.x == 0 || currentBorder.y == 0) {
+			pDoc->removeBoundary(m_modifyBorderNdx);
+		}
+		m_modifyBorderNdx = -1;
+	}
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -3358,6 +3358,22 @@ void WorldHeightMapEdit::removeLastBoundary()
 	m_boundaries.pop_back();
 }
 
+// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Added to allow removing a specific boundary, not just
+// the most recently added one. Previously the only way to get rid of an unwanted boundary was
+// removeLastBoundary() (last-added only) or dragging its corners together, which just left a
+// degenerate (zero width or height) entry permanently in m_boundaries -- findBoundaryNear() already
+// explicitly skips zero-sized boundaries, so once collapsed this way a boundary could never again be
+// selected or actually removed. (GitHub issue #413)
+void WorldHeightMapEdit::removeBoundary(Int ndx)
+{
+	if (ndx < 0 || ndx >= m_boundaries.size()) {
+		DEBUG_CRASH(("Invalid border remove request. jkmcd"));
+		return;
+	}
+
+	m_boundaries.erase(m_boundaries.begin() + ndx);
+}
+
 void WorldHeightMapEdit::findBoundaryNear(Coord3D *pt, float okDistance, Int *outNdx, Int *outHandle)
 {
 	if (!outNdx) {

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -3432,5 +3432,9 @@ void WorldHeightMapEdit::findBoundaryNear(Coord3D *pt, float okDistance, Int *ou
 	}
 
 	(*outNdx) = -1;
-	(*outHandle) = -1;
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Respect the "outHandle can be null" contract
+	// documented on this function's declaration; this write was previously unconditional.
+	if (outHandle) {
+		(*outHandle) = -1;
+	}
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -2652,6 +2652,11 @@ void CWorldBuilderDoc::removeLastBoundary()
 	m_heightMap->removeLastBoundary();
 }
 
+void CWorldBuilderDoc::removeBoundary(Int ndx)
+{
+	m_heightMap->removeBoundary(ndx);
+}
+
 void CWorldBuilderDoc::findBoundaryNear(Coord3D *pt, float okDistance, Int *outNdx, Int *outHandle)
 {
 	m_heightMap->findBoundaryNear(pt, okDistance, outNdx, outHandle);


### PR DESCRIPTION
fix(worldbuilder): new map boundaries cannot be removed (#413)

Map boundaries are anchored at the origin (0,0); only their opposite
corner (x,y) is stored per boundary, and findBoundaryNear() already
treats a boundary with x==0 or y==0 as degenerate and explicitly skips
it when picking. The only removal functions available were
removeLastBoundary() (removes only the most-recently-added boundary)
and dragging a boundary's corner onto the origin, which visually
collapses it to nothing -- but changeBoundary() just overwrites the
stored corner with no check for this degenerate case, so the entry
stayed in the boundary list forever: permanently invisible, and
permanently unselectable/unremovable since findBoundaryNear() already
skips zero-sized entries when picking. There was no way to get rid of
an arbitrary boundary that wasn't the last one added.

Add WorldHeightMapEdit::removeBoundary(Int ndx) /
CWorldBuilderDoc::removeBoundary(Int ndx), removing a specific
boundary by index (unlike removeLastBoundary()'s stack-only removal).
In BorderTool::mouseUp(), after the user finishes dragging an existing
boundary's corner, check whether the result collapsed to zero width or
height and actually remove it in that case, instead of leaving a dead
entry behind -- completing what dragging the corners together was
clearly meant to do.

WorldBuilder is a separate tool executable with no gameplay simulation
implications, so no RETAIL_COMPATIBLE_CRC gating applies.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix(worldbuilder): default map border can be permanently lost (#312)

Boundary index 0 is the default/main map border: WorldHeightMapEdit's
constructor always creates exactly one boundary spanning the whole map
whenever a new map is made, and other systems (e.g. shroud/visible
area) rely on at least one non-degenerate boundary existing. Unlike
any other boundary a user might add, it cannot simply be re-created if
lost -- there is no "add the default border back" action.

Dragging this boundary's corner onto the anchor origin collapsed it to
zero width or height with no protection, same as any other boundary,
which (after the #413 fix in this same session) now actually removes
it from the boundary list. Losing the map's only boundary this way
breaks the map permanently: it renders as always shrouded, and the
border cannot be brought back through the UI.

Never let boundary 0 specifically be dragged smaller than 1x1 in
BorderTool::mouseMoved(), and as a defense-in-depth backstop, never
auto-remove boundary 0 in mouseUp() even if it somehow reaches zero
width/height through some other path. Every other (non-default)
boundary is unaffected and can still be freely collapsed/removed as
fixed in #413.

This does not address the issue's second complaint (boundaries being
anchored at the origin/bottom-left corner limits mission-making
flexibility for small starting areas elsewhere on the map) -- that is
a real but much larger architectural change (reworking boundaries to
store all four corners independently instead of being anchored),
out of scope for this fix.

WorldBuilder is a separate tool executable with no gameplay simulation
implications, so no RETAIL_COMPATIBLE_CRC gating applies.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

fix(worldbuilder): address fable review findings on boundary fixes

Second-pass review (fable model) of the #413/#312 boundary-removal
fixes found two real functional gaps and a pre-existing, adjacent
uninitialized-read bug of the same class as #470. All three addressed
in both trees.

1. BorderTool::mouseMoved()'s "adding new border" branch clamped
   current.x/y to >= 0 BEFORE assigning them from the mouse position,
   making the clamp dead code (immediately overwritten). A newly-added
   border dragged towards the origin could therefore end up with
   negative extents. Moved the clamp to run after the assignment.

2. The #413 degenerate-boundary cleanup in BorderTool::mouseUp() only
   covered the "modify an existing boundary" path (m_modifyBorderNdx),
   not the "just added a new boundary" path (m_addingNewBorder) -- so
   a brand new border dragged straight back onto the origin before
   release was left as a permanent degenerate entry, the exact #413
   symptom via a different path. Added the same degenerate check and
   removeBoundary() call for the newly-added boundary (always the last
   index, so no boundary-0 protection is needed there).

3. Map scripts can reference a boundary by its raw list index
   (Parameter::BOUNDARY, Scripts.h). Before this session's boundary-
   removal work, no boundary could ever actually be removed
   (removeLastBoundary() has zero callers anywhere in either tree --
   confirmed dead code), so boundary indices were always stable for a
   map's lifetime. removeBoundary()'s std::vector::erase() now shifts
   every later boundary's index down by one, which can silently
   retarget a script that referenced one of them, with no warning.
   Building full script-reference remapping was judged too large and
   uncertain a change to make confidently in this pass; instead, warn
   the user via AfxMessageBox when removing anything other than the
   last boundary (removing the actual last boundary, e.g. via the
   add-new-border path, never shifts anything and needs no warning).

4. WorldHeightMapEdit::findBoundaryNear()'s "no boundary found" path
   never wrote *outHandle at all in the Generals tree (only *outNdx),
   leaving callers' handle output (BorderTool::mouseDown()'s local
   `motion`) as uninitialized stack memory -- the same defect class as
   #470's uninitialized Coord3D read, though currently inert in
   practice since the caller only acts on the handle when *outNdx >= 0
   (which this path always sets to -1). Added the missing write,
   respecting the "outHandle can be null" contract documented on the
   function's declaration. GeneralsMD already had this write but
   without the null check for the same contract; added the check there
   too for consistency, even though no current caller passes null.

WorldBuilder is a separate tool executable with no gameplay simulation
implications, so no RETAIL_COMPATIBLE_CRC gating applies.

Applies to both Generals and GeneralsMD (identical fixes).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #413
Fixes #312
