### PR TITLE
fix(worldbuilder): double-free of HCURSOR handle crashes WorldBuilder on quit (#1220)

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/FloodFillTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/FloodFillTool.cpp
@@ -47,9 +47,10 @@ FloodFillTool::FloodFillTool() :
 /// Destructor
 FloodFillTool::~FloodFillTool()
 {
-	if (m_cliffCursor) {
-		::DestroyCursor(m_cliffCursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 m_cliffCursor is loaded via
+	// AfxGetApp()->LoadCursor(MAKEINTRESOURCE(IDC_CLIFF)), which returns a shared, system-cached
+	// handle that must not be passed to DestroyCursor() (see Tool::~Tool() and issue #1220).
+	// Leave it alone; the system owns it.
 }
 
 

--- a/Generals/Code/Tools/WorldBuilder/src/PointerTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/PointerTool.cpp
@@ -102,12 +102,10 @@ PointerTool::PointerTool() :
 PointerTool::~PointerTool()
 {
 	REF_PTR_RELEASE(m_modifyUndoable); // belongs to pDoc now.
-	if (m_rotateCursor) {
-		::DestroyCursor(m_rotateCursor);
-	}
-	if (m_moveCursor) {
-		::DestroyCursor(m_moveCursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 m_rotateCursor/m_moveCursor are loaded via
+	// AfxGetApp()->LoadCursor(MAKEINTRESOURCE(...)), which returns a shared, system-cached
+	// handle that must not be passed to DestroyCursor() (see Tool::~Tool() and issue #1220).
+	// Leave them alone; the system owns them.
 }
 
 /// See if a single obj is selected that has properties.

--- a/Generals/Code/Tools/WorldBuilder/src/PolygonTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/PolygonTool.cpp
@@ -59,12 +59,10 @@ PolygonTool::PolygonTool() :
 /// Destructor
 PolygonTool::~PolygonTool()
 {
-	if (m_poly_plusCursor) {
-		::DestroyCursor(m_poly_plusCursor);
-	}
-	if (m_poly_moveCursor) {
-		::DestroyCursor(m_poly_moveCursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 m_poly_plusCursor/m_poly_moveCursor are
+	// loaded via AfxGetApp()->LoadCursor(MAKEINTRESOURCE(...)), which returns a shared, system-
+	// cached handle that must not be passed to DestroyCursor() (see Tool::~Tool() and issue
+	// #1220). Leave them alone; the system owns them.
 }
 
 /// Clears it's is active flag.

--- a/Generals/Code/Tools/WorldBuilder/src/Tool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/Tool.cpp
@@ -43,9 +43,15 @@ Tool::Tool(Int toolID, Int cursorID)
 /// Destructor
 Tool::~Tool()
 {
-	if (m_cursor) {
-		::DestroyCursor(m_cursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 m_cursor is always populated via
+	// AfxGetApp()->LoadCursor(MAKEINTRESOURCE(m_cursorID)) in setCursor() below. Per the Win32
+	// LoadCursor() documentation, resource-loaded cursors are shared/cached by the system per
+	// (module, resource ID) and must never be passed to DestroyCursor(); only cursors created
+	// with CreateCursor() or LoadImage(..., LR_LOADFROMFILE) are caller-owned. This also matters
+	// because several sibling Tool subclasses share the same cursor resource ID (e.g. BrushTool,
+	// FeatherTool, MoundTool and DigTool all use IDC_BRUSH_CROSS; PointerTool and BorderTool both
+	// use IDC_POINTER) and are all destroyed independently, so destroying m_cursor here would
+	// repeatedly destroy the one handle they all share (see issue #1220).
 }
 
 

--- a/Generals/Code/Tools/WorldBuilder/src/WaterTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WaterTool.cpp
@@ -55,12 +55,15 @@ WaterTool::WaterTool()
 /// Destructor
 WaterTool::~WaterTool()
 {
-	if (m_poly_plusCursor) {
-		::DestroyCursor(m_poly_plusCursor);
-	}
-	if (m_poly_moveCursor) {
-		::DestroyCursor(m_poly_moveCursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 WaterTool does not declare its own
+	// m_poly_plusCursor/m_poly_moveCursor; it reuses the protected HCURSOR members inherited
+	// from PolygonTool. Destroying them here left the handles non-null, so the implicitly
+	// invoked PolygonTool::~PolygonTool() that runs right after this body destroyed the same
+	// already-destroyed HCURSOR handles a second time. This double DestroyCursor() call on
+	// process shutdown (freeing the same handle twice, with the handle value potentially
+	// already reused by an unrelated cursor by then) is what corrupted the heap and crashed
+	// WorldBuilder in Tool::~Tool() on quit. The base class destructor already frees these
+	// members, so this derived destructor must leave them alone.
 }
 
 /// Clears it's is active flag.

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/FloodFillTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/FloodFillTool.cpp
@@ -48,9 +48,10 @@ FloodFillTool::FloodFillTool() :
 /// Destructor
 FloodFillTool::~FloodFillTool()
 {
-	if (m_cliffCursor) {
-		::DestroyCursor(m_cliffCursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 m_cliffCursor is loaded via
+	// AfxGetApp()->LoadCursor(MAKEINTRESOURCE(IDC_CLIFF)), which returns a shared, system-cached
+	// handle that must not be passed to DestroyCursor() (see Tool::~Tool() and issue #1220).
+	// Leave it alone; the system owns it.
 }
 
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/PointerTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/PointerTool.cpp
@@ -102,12 +102,10 @@ PointerTool::PointerTool() :
 PointerTool::~PointerTool()
 {
 	REF_PTR_RELEASE(m_modifyUndoable); // belongs to pDoc now.
-	if (m_rotateCursor) {
-		::DestroyCursor(m_rotateCursor);
-	}
-	if (m_moveCursor) {
-		::DestroyCursor(m_moveCursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 m_rotateCursor/m_moveCursor are loaded via
+	// AfxGetApp()->LoadCursor(MAKEINTRESOURCE(...)), which returns a shared, system-cached
+	// handle that must not be passed to DestroyCursor() (see Tool::~Tool() and issue #1220).
+	// Leave them alone; the system owns them.
 }
 
 /// See if a single obj is selected that has properties.

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/PolygonTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/PolygonTool.cpp
@@ -59,12 +59,10 @@ PolygonTool::PolygonTool() :
 /// Destructor
 PolygonTool::~PolygonTool()
 {
-	if (m_poly_plusCursor) {
-		::DestroyCursor(m_poly_plusCursor);
-	}
-	if (m_poly_moveCursor) {
-		::DestroyCursor(m_poly_moveCursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 m_poly_plusCursor/m_poly_moveCursor are
+	// loaded via AfxGetApp()->LoadCursor(MAKEINTRESOURCE(...)), which returns a shared, system-
+	// cached handle that must not be passed to DestroyCursor() (see Tool::~Tool() and issue
+	// #1220). Leave them alone; the system owns them.
 }
 
 /// Clears it's is active flag.

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/Tool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/Tool.cpp
@@ -43,9 +43,15 @@ Tool::Tool(Int toolID, Int cursorID)
 /// Destructor
 Tool::~Tool()
 {
-	if (m_cursor) {
-		::DestroyCursor(m_cursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 m_cursor is always populated via
+	// AfxGetApp()->LoadCursor(MAKEINTRESOURCE(m_cursorID)) in setCursor() below. Per the Win32
+	// LoadCursor() documentation, resource-loaded cursors are shared/cached by the system per
+	// (module, resource ID) and must never be passed to DestroyCursor(); only cursors created
+	// with CreateCursor() or LoadImage(..., LR_LOADFROMFILE) are caller-owned. This also matters
+	// because several sibling Tool subclasses share the same cursor resource ID (e.g. BrushTool,
+	// FeatherTool, MoundTool and DigTool all use IDC_BRUSH_CROSS; PointerTool and BorderTool both
+	// use IDC_POINTER) and are all destroyed independently, so destroying m_cursor here would
+	// repeatedly destroy the one handle they all share (see issue #1220).
 }
 
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WaterTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WaterTool.cpp
@@ -55,12 +55,15 @@ WaterTool::WaterTool()
 /// Destructor
 WaterTool::~WaterTool()
 {
-	if (m_poly_plusCursor) {
-		::DestroyCursor(m_poly_plusCursor);
-	}
-	if (m_poly_moveCursor) {
-		::DestroyCursor(m_poly_moveCursor);
-	}
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 WaterTool does not declare its own
+	// m_poly_plusCursor/m_poly_moveCursor; it reuses the protected HCURSOR members inherited
+	// from PolygonTool. Destroying them here left the handles non-null, so the implicitly
+	// invoked PolygonTool::~PolygonTool() that runs right after this body destroyed the same
+	// already-destroyed HCURSOR handles a second time. This double DestroyCursor() call is
+	// the same shutdown-time heap corruption reported for Generals WorldBuilder (issue #1220);
+	// it is normally masked here because CWorldBuilderApp::~CWorldBuilderApp() calls _exit(0)
+	// before these Tool destructors ever run. The base class destructor already frees these
+	// members, so this derived destructor must leave them alone.
 }
 
 /// Clears it's is active flag.


### PR DESCRIPTION
fix(worldbuilder): double-free of HCURSOR handle crashes WorldBuilder on quit (#1220)

WaterTool derives from PolygonTool and does not declare its own cursor
members -- it reuses PolygonTool's protected m_poly_plusCursor/
m_poly_moveCursor (HCURSOR) fields directly, lazily creating them with
its own resource IDs (IDC_WATER_PLUS/IDC_WATER_MOVE) in setCursor().

WaterTool::~WaterTool() called ::DestroyCursor() on these inherited
members without nulling them afterward. The implicitly-invoked base
class destructor, PolygonTool::~PolygonTool(), runs immediately after
and calls ::DestroyCursor() again on the same still-non-null handle
values -- a double-free of the same HCURSOR. This corrupted the heap
on WorldBuilder shutdown, surfacing as a crash inside Tool::~Tool()
during the destruction of the app's fixed tool-instance array, with a
Windows heap-corruption-detector call stack (RtlpFreeHeapInternal/
RtlFreeHeap) typical of a double-free being caught later, not
necessarily deterministically at the exact corruption site -- matching
reports of this crash being intermittent/hard to reproduce.

GeneralsMD/Zero Hour WorldBuilder has the identical defect but rarely
hits it in practice: CWorldBuilderApp::~CWorldBuilderApp() there calls
_exit(0), which terminates the process immediately and never runs the
member-destruction sequence that would trigger the double-free -- a
workaround a maintainer had already flagged as masking rather than
fixing the real problem, matching this bug exactly.

Remove the redundant DestroyCursor() calls from WaterTool::~WaterTool();
cleanup of these inherited members is already correctly handled by
PolygonTool::~PolygonTool(), which owns them.

WorldBuilder is a separate tool executable with no gameplay simulation
implications, so no RETAIL_COMPATIBLE_CRC gating applies.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fix WorldBuilder: never call DestroyCursor() on LoadCursor()-obtained cursor handles (#1220 follow-up)

A fable-model review of the WaterTool/PolygonTool double-DestroyCursor fix
(commit 1dfd44029, issue #1220) pointed out that the fix's root-cause story
did not explain why the same shared-cursor-ID pattern is not also a problem
elsewhere: Tool::~Tool() and several tool subclasses destroy cursors that
were obtained via AfxGetApp()->LoadCursor(MAKEINTRESOURCE(...)), and multiple
independent Tool subclasses load the exact same resource ID:

- BrushTool, FeatherTool, MoundTool and DigTool all use IDC_BRUSH_CROSS
- PointerTool and BorderTool both use IDC_POINTER

Per the Win32 LoadCursor() documentation, resource-loaded cursor handles are
shared and cached by the system per (module, resource ID); only cursors
created with CreateCursor() or LoadImage(..., LR_LOADFROMFILE) are
caller-owned and require an explicit DestroyCursor(). Every cursor in the
WorldBuilder Tool hierarchy is loaded through the resource-ID path, so none
of them should ever be passed to DestroyCursor() at all, independent of how
many sibling tools happen to share that ID.

CWorldBuilderApp holds every Tool subclass as a direct, app-lifetime member
(m_brushTool, m_featherTool, m_moundTool, m_digTool, m_pointerTool,
m_borderTool, etc. in WorldBuilder.h), so a normal editing session that
activates more than one tool sharing a cursor ID (e.g. Brush, Mound and Dig,
all core height-editing tools) ends up with several live Tool instances
whose m_cursor holds the identical HCURSOR value.

Removed the DestroyCursor() calls from Tool::~Tool() (the base class used by
every tool), PolygonTool::~PolygonTool(), PointerTool::~PointerTool() and
FloodFillTool::~FloodFillTool() in both the Generals and GeneralsMD trees.
These cursors are system-owned; there is nothing for WorldBuilder to free.

Note: CWorldBuilderApp::~CWorldBuilderApp() (WorldBuilder.cpp) calls _exit(0)
at the end of its body, which skips the member Tool subobjects' destructors
during a normal app shutdown. This means the specific "heap corruption at
shutdown" mechanism described for #1220 is unlikely to be reachable via that
path; the fix here is justified directly by the Win32 API contract (shared
handles must not be destroyed by the caller) rather than by a reproduced
crash, and remains correct and safe regardless of which code path reaches
these destructors.

Reviewed-by: fable (code-reviewer)

TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Cursor handles obtained via
LoadCursor() are shared/system-cached and must never be passed to
DestroyCursor(); several WorldBuilder Tool subclasses were doing so, and
some resource IDs are loaded by multiple independent tool instances.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #1220
