### PR TITLE
fix(worldbuilder): Select Team Members selection lost on Teams dialog OK (#1391)

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -226,10 +226,29 @@ void CTeamsDialog::OnOK()
 	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in CTeamsDialog::OnOK"));
 
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 AddAndDoUndoable() below runs SidesListUndoable::Do(),
+	// which refreshes the BuildList options panel via BuildList::update() -> loadSides() -> updateCurSide()
+	// -> OnSelchangeBuildList(). That refresh has the side effect of calling PointerTool::clearSelection(),
+	// which wipes out any MapObject selection (e.g. made via the "Select Team Members" button) just before
+	// closing the dialog. OnCancel() never runs this code path, so the selection survived there but was
+	// silently lost on OK. Snapshot the selected map objects and restore them afterward so OK matches
+	// Cancel's behavior. (GitHub issue #1391)
+	std::vector<MapObject*> previouslySelectedObjects;
+	for (MapObject *pObj = MapObject::getFirstMapObject(); pObj; pObj = pObj->getNext()) {
+		if (pObj->isSelected()) {
+			previouslySelectedObjects.push_back(pObj);
+		}
+	}
+
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	SidesListUndoable *pUndo = new SidesListUndoable(m_sides, pDoc);
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
+
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Restore the selection that AddAndDoUndoable() cleared.
+	for (std::vector<MapObject*>::const_iterator it = previouslySelectedObjects.begin(); it != previouslySelectedObjects.end(); ++it) {
+		(*it)->setSelected(true);
+	}
 
 	thePrevCurTeam = m_curTeam;
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -227,10 +227,29 @@ void CTeamsDialog::OnOK()
 	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in CTeamsDialog::OnOK"));
 
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 AddAndDoUndoable() below runs SidesListUndoable::Do(),
+	// which refreshes the BuildList options panel via BuildList::update() -> loadSides() -> updateCurSide()
+	// -> OnSelchangeBuildList(). That refresh has the side effect of calling PointerTool::clearSelection(),
+	// which wipes out any MapObject selection (e.g. made via the "Select Team Members" button) just before
+	// closing the dialog. OnCancel() never runs this code path, so the selection survived there but was
+	// silently lost on OK. Snapshot the selected map objects and restore them afterward so OK matches
+	// Cancel's behavior. (GitHub issue #1391)
+	std::vector<MapObject*> previouslySelectedObjects;
+	for (MapObject *pObj = MapObject::getFirstMapObject(); pObj; pObj = pObj->getNext()) {
+		if (pObj->isSelected()) {
+			previouslySelectedObjects.push_back(pObj);
+		}
+	}
+
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	SidesListUndoable *pUndo = new SidesListUndoable(m_sides, pDoc);
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
+
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Restore the selection that AddAndDoUndoable() cleared.
+	for (std::vector<MapObject*>::const_iterator it = previouslySelectedObjects.begin(); it != previouslySelectedObjects.end(); ++it) {
+		(*it)->setSelected(true);
+	}
 
 	thePrevCurTeam = m_curTeam;
 


### PR DESCRIPTION
fix(worldbuilder): Select Team Members selection lost on Teams dialog OK (#1391)

CTeamsDialog::OnOK() calls pDoc->AddAndDoUndoable(pUndo), which runs
SidesListUndoable::Do(). That refreshes the BuildList options panel
via BuildList::update() -> loadSides() -> updateCurSide() ->
OnSelchangeBuildList(), which has the side effect of calling
PointerTool::clearSelection() ("unselect other stuff") -- wiping the
MO_SELECTED flag on every MapObject, including any selection made via
the "Select Team Members" button just before closing the dialog.
CTeamsDialog::OnCancel() never runs this code path (it just calls
CDialog::OnCancel()), so the selection survived on Cancel but was
silently lost on OK -- exactly the reported, confusing asymmetry.

Snapshot the currently-selected MapObject pointers before
AddAndDoUndoable() runs, then re-apply setSelected(true) to them
immediately afterward, before the dialog actually closes. Safe because
SidesListUndoable::Do() only replaces TheSidesList and rebuilds render
objects -- it never creates or destroys MapObject instances, so the
snapshotted pointers stay valid across the call.

WorldBuilder is a separate tool executable with no gameplay simulation
implications, so no RETAIL_COMPATIBLE_CRC gating applies.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #1391
