### PR TITLE
fix(worldbuilder): Grove Tool ignores tree count on plain click, plants full cluster (#355)

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/GroveTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/GroveTool.cpp
@@ -284,6 +284,26 @@ void GroveTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBui
 
 	pView->viewToDocCoords(m_downPt, &loc);
 
+	loc.z = TheTerrainRenderObject ? TheTerrainRenderObject->getHeightMapHeight( loc.x, loc.y, nullptr ) : 0;
+
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 A plain click (no drag box) always planted a full
+	// recursive grove cluster (up to 1+2+4+8 = 15 trees/shrubs via the hardcoded depth=3 below),
+	// completely ignoring TheGroveOptions->getNumTrees() -- unlike _plantGroveInBox() above, which
+	// correctly plants exactly getNumTrees() trees when dragging a box. This made it impossible to
+	// place a single tree with a plain click even with the tree count set to 1. When the configured
+	// count is 1 (or less), plant exactly one tree at the click point instead of the full grove
+	// algorithm; for any larger count, keep the existing clump-planting behavior. (GitHub issue #355)
+	if (TheGroveOptions->getNumTrees() <= 1) {
+		plantTree( &loc );
+		if (m_headMapObj != nullptr) {
+			AddObjectUndoable *pUndo = new AddObjectUndoable(pDoc, m_headMapObj);
+			pDoc->AddAndDoUndoable(pUndo);
+			REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
+			m_headMapObj = nullptr; // undoable owns it now.
+		}
+		return;
+	}
+
 	WorldHeightMapEdit *pMap = pDoc->GetHeightMap();
 	CPoint bounds;
 	bounds.x = pMap->getXExtent()*MAP_XY_FACTOR;
@@ -295,7 +315,6 @@ void GroveTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBui
 	zeroDir.x = 0.0f;
 	zeroDir.y = 0.0f;
 	zeroDir.z = 0.0f;
-	loc.z = TheTerrainRenderObject ? TheTerrainRenderObject->getHeightMapHeight( loc.x, loc.y, nullptr ) : 0;
 
 	// grow tree grove out from here
 	plantGrove( loc, zeroDir, loc.z, depth, bounds );

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/GroveTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/GroveTool.cpp
@@ -284,6 +284,26 @@ void GroveTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBui
 
 	pView->viewToDocCoords(m_downPt, &loc);
 
+	loc.z = TheTerrainRenderObject ? TheTerrainRenderObject->getHeightMapHeight( loc.x, loc.y, nullptr ) : 0;
+
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 A plain click (no drag box) always planted a full
+	// recursive grove cluster (up to 1+2+4+8 = 15 trees/shrubs via the hardcoded depth=3 below),
+	// completely ignoring TheGroveOptions->getNumTrees() -- unlike _plantGroveInBox() above, which
+	// correctly plants exactly getNumTrees() trees when dragging a box. This made it impossible to
+	// place a single tree with a plain click even with the tree count set to 1. When the configured
+	// count is 1 (or less), plant exactly one tree at the click point instead of the full grove
+	// algorithm; for any larger count, keep the existing clump-planting behavior. (GitHub issue #355)
+	if (TheGroveOptions->getNumTrees() <= 1) {
+		plantTree( &loc );
+		if (m_headMapObj != nullptr) {
+			AddObjectUndoable *pUndo = new AddObjectUndoable(pDoc, m_headMapObj);
+			pDoc->AddAndDoUndoable(pUndo);
+			REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
+			m_headMapObj = nullptr; // undoable owns it now.
+		}
+		return;
+	}
+
 	WorldHeightMapEdit *pMap = pDoc->GetHeightMap();
 	CPoint bounds;
 	bounds.x = pMap->getXExtent()*MAP_XY_FACTOR;
@@ -295,7 +315,6 @@ void GroveTool::mouseUp(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldBui
 	zeroDir.x = 0.0f;
 	zeroDir.y = 0.0f;
 	zeroDir.z = 0.0f;
-	loc.z = TheTerrainRenderObject ? TheTerrainRenderObject->getHeightMapHeight( loc.x, loc.y, nullptr ) : 0;
 
 	// grow tree grove out from here
 	plantGrove( loc, zeroDir, loc.z, depth, bounds );


### PR DESCRIPTION
fix(worldbuilder): Grove Tool ignores tree count on plain click, plants full cluster (#355)

GroveTool::mouseUp()'s non-dragging branch (a plain click, no
selection box drawn) always called plantGrove() with a hardcoded
depth=3, recursively planting up to 1+2+4+8 = 15 trees/shrubs in a
scattered cluster -- completely ignoring TheGroveOptions->getNumTrees(),
the "tree count" option the Grove Options panel exposes to the user.
This differs from the box-drag path, _plantGroveInBox(), which already
correctly plants exactly getNumTrees() trees when the user drags a
selection box. As a result, a plain click always planted a cluster
regardless of the configured count, making it impossible to place a
single tree even with the count set to 1.

When the configured tree count is 1 (or less), plant exactly one tree
at the click point via plantTree() instead of running the recursive
grove algorithm. For any larger configured count, plain-click behavior
is unchanged (still plants a scattered clump via plantGrove(), since
reworking that algorithm to precisely match an arbitrary tree count
without an area to scatter within is a larger change beyond this
issue's specific, narrower complaint about count=1 not working).

WorldBuilder is a separate tool executable with no gameplay simulation
implications, so no RETAIL_COMPATIBLE_CRC gating applies.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #355
