### PR TITLE
fix(worldbuilder): Team Builder tab lags heavily with many teams (#415)

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -332,10 +332,21 @@ void CTeamsDialog::UpdateTeamsList()
 	Bool selected = false;
 	Int inserted = 0;
 
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Populating the list one InsertItem()/SetItemText()
+	// call at a time triggers a synchronous redraw/layout on every single call by default. With many
+	// teams (reported as 20-30+, GitHub issue #415) this made the Team Builder tab -- and its sub-tabs,
+	// since they share the same message loop -- lag heavily or become unresponsive while rebuilding.
+	// Disable redraws for the duration of the rebuild and repaint once at the end instead.
+	pList->SetRedraw(FALSE);
+
+	// AsciiString created once per call instead of once per team below (playerNameForUI() does not
+	// depend on the loop variable).
+	AsciiString curPlayerName = playerNameForUI(m_sides, which);
+
 	for (Int i=0; i<numTeams; i++)
 	{
 		TeamsInfo *ti = m_sides.getTeamInfo(i);
-		if (ti->getDict()->getAsciiString(TheKey_teamOwner) == playerNameForUI(m_sides, which).str())
+		if (ti->getDict()->getAsciiString(TheKey_teamOwner) == curPlayerName)
 		{
 			Bool exists;
 			AsciiString teamName = teamNameForUI(m_sides, i);
@@ -368,6 +379,9 @@ void CTeamsDialog::UpdateTeamsList()
 			pList->EnsureVisible(0, false);
 		}
 	}
+
+	pList->SetRedraw(TRUE);
+	pList->Invalidate();
 }
 
 void CTeamsDialog::OnSelchangePlayerList()

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -336,10 +336,21 @@ void CTeamsDialog::UpdateTeamsList()
 	Bool selected = false;
 	Int inserted = 0;
 
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Populating the list one InsertItem()/SetItemText()
+	// call at a time triggers a synchronous redraw/layout on every single call by default. With many
+	// teams (reported as 20-30+, GitHub issue #415) this made the Team Builder tab -- and its sub-tabs,
+	// since they share the same message loop -- lag heavily or become unresponsive while rebuilding.
+	// Disable redraws for the duration of the rebuild and repaint once at the end instead.
+	pList->SetRedraw(FALSE);
+
+	// AsciiString created once per call instead of once per team below (playerNameForUI() does not
+	// depend on the loop variable).
+	AsciiString curPlayerName = playerNameForUI(m_sides, which);
+
 	for (Int i=0; i<numTeams; i++)
 	{
 		TeamsInfo *ti = m_sides.getTeamInfo(i);
-		if (ti->getDict()->getAsciiString(TheKey_teamOwner) == playerNameForUI(m_sides, which).str())
+		if (ti->getDict()->getAsciiString(TheKey_teamOwner) == curPlayerName)
 		{
 			Bool exists;
 			AsciiString teamName = teamNameForUI(m_sides, i);
@@ -372,6 +383,9 @@ void CTeamsDialog::UpdateTeamsList()
 			pList->EnsureVisible(0, false);
 		}
 	}
+
+	pList->SetRedraw(TRUE);
+	pList->Invalidate();
 }
 
 void CTeamsDialog::OnSelchangePlayerList()


### PR DESCRIPTION
fix(worldbuilder): Team Builder tab lags heavily with many teams (#415)

CTeamsDialog::UpdateTeamsList() repopulates the teams CListCtrl one
InsertItem()/SetItemText() call at a time, with no redraw batching --
by default each of these calls can trigger a synchronous
redraw/layout pass on the control. With enough teams (reported as
20-30+), rebuilding the full list this way made the Team Builder tab,
and its sub-tabs sharing the same message loop, lag heavily or become
unresponsive.

Wrap the rebuild in CListCtrl::SetRedraw(FALSE)/SetRedraw(TRUE) so all
insertions happen without intermediate redraws, followed by a single
Invalidate() to repaint once at the end -- a standard, minimal, safe
Win32/MFC pattern for batch-populating a list control. Also hoisted
the repeated playerNameForUI(m_sides, which) call (which does not
depend on the loop variable) out of the per-team loop, avoiding one
redundant AsciiString construction/comparison per team.

WorldBuilder is a separate tool executable with no gameplay simulation
implications, so no RETAIL_COMPATIBLE_CRC gating applies.

Applies to both Generals and GeneralsMD (identical fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #415
