### PR TITLE
Fix missing faction bib feedback in BuildAssistant::isLocationClearOfObjects (#2134)

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -721,6 +721,10 @@ LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos
 		{
 			if (them->testStatus(OBJECT_STATUS_IS_USING_ABILITY) || (them->getAI() && them->getAI()->isBusy()))
 			{
+				// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Draw the faction bib here too, matching every other
+				// LBC_OBJECTS_IN_THE_WAY return path in this function, so the player gets visual feedback on why
+				// placement is blocked.
+				TheTerrainVisual->addFactionBib( them, TRUE );
 				return LBC_OBJECTS_IN_THE_WAY;
 			}
 		}


### PR DESCRIPTION
Fix missing faction bib feedback in BuildAssistant::isLocationClearOfObjects (#2134)

The busy-allied-unit exploit-prevention branch (Patch 1.01, Nov 5 2003 -
"prevent busy units like a hacking Black Lotus from being moved by trying to
place a building") returned LBC_OBJECTS_IN_THE_WAY without calling
TheTerrainVisual->addFactionBib first, unlike every other
LBC_OBJECTS_IN_THE_WAY return path in this same function, which all draw the
bib to give the player visual feedback on why placement is blocked here.

This branch only exists in the Zero Hour tree (GeneralsMD); the base
Generals BuildAssistant::isLocationClearOfObjects does not contain this
exploit-prevention check at all, so no corresponding change applies there.

TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Draw the faction bib here too,
matching every other LBC_OBJECTS_IN_THE_WAY return path in this function.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #2134
