### PR TITLE
Fix CTRL-held drag-select not selecting units (#2098)

### DIFF
--- a/Core/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/Core/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -90,7 +90,13 @@ extern Bool contextCommandForNewSelection(const DrawableList *currentlySelectedD
 	Bool forceFire = TheInGameUI->isInForceAttackMode();
 	Bool forceMove = TheInGameUI->isInForceMoveToMode();
 
-	if (forceFire || forceMove) {
+	// TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only skip context-command evaluation (and thus
+	// leave SelectionInfo unpopulated) for a single-point click while force-attack/force-move (CTRL)
+	// is held, so that click can fall through to the ground/unit force-attack handling in CommandXlat.
+	// Previously this bailed out unconditionally, which meant a real CTRL+drag box-select never got
+	// its SelectionInfo counts populated either, so the drag selected nothing and did not force-fire.
+	// (github.com/TheSuperHackers/GeneralsGameCode issue #2098)
+	if ((forceFire || forceMove) && selectionIsPoint) {
 		return FALSE;
 	}
 


### PR DESCRIPTION
Fix CTRL-held drag-select not selecting units (#2098)

SelectionInfo::contextCommandForNewSelection() bailed out immediately
whenever CTRL (force-attack/force-move mode) was held, regardless of
whether the mouse event was a point click or a real drag-box, leaving the
output SelectionInfo unpopulated in both cases.

For a CTRL+click this is correct: the click falls through to CommandXlat's
MSG_MOUSE_LEFT_CLICK handling, where isPoint is true and force-attack fires.
For a CTRL+drag, the same early bail also left SelectionInfo empty, so
SelectionXlat concluded there was nothing to select; but by the time the
message reached CommandXlat, isPoint was false, so the
"if (isPoint && controllable)" force-attack block was skipped too. Net
result: a real CTRL+drag over units selected nothing and force-fired
nothing, despite the drag box being drawn on screen.

Gated the early bail with selectionIsPoint so it only short-circuits for
genuine point clicks, letting a real drag fall through to the normal
selection-counting logic. CTRL+click force-attack/force-move behavior is
unchanged.

Core-shared (Core/GameEngine/Source/GameClient/SelectionInfo.cpp) — fixes
both Generals and Zero Hour.

TheSuperHackers @bugfix ZsoltFeher 07/20/2026 Only skip context-command
evaluation for a single-point click, not a real drag-box, while
force-attack/force-move (CTRL) is held.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

Fixes #2098
