### PR TITLE
bugfix(behavior): Allow multiple InstantDeathBehavior modules to be processed

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/InstantDeathBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/InstantDeathBehavior.cpp
@@ -124,6 +124,7 @@ void InstantDeathBehavior::onDie( const DamageInfo *damageInfo )
 	if (!isDieApplicable(damageInfo))
 		return;
 
+#if RETAIL_COMPATIBLE_CRC
 	AIUpdateInterface* ai = getObject()->getAIUpdateInterface();
 	if (ai)
 	{
@@ -132,6 +133,7 @@ void InstantDeathBehavior::onDie( const DamageInfo *damageInfo )
 			return;
 		ai->markAsDead();
 	}
+#endif
 
 	const InstantDeathBehaviorModuleData* d = getInstantDeathBehaviorModuleData();
 
@@ -169,6 +171,19 @@ void InstantDeathBehavior::onDie( const DamageInfo *damageInfo )
 			TheWeaponStore->createAndFireTempWeapon(wt, getObject(), getObject()->getPosition());
 		}
 	}
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Stubbjax 21/07/2026 Allow multiple InstantDeathBehaviors to be processed.
+	// Multiple FXListDie, CreateObjectDie and FireWeaponWhenDeadBehavior modules are already supported.
+	AIUpdateInterface* ai = getObject()->getAIUpdateInterface();
+	if (ai)
+	{
+		// has another AI already handled us. (hopefully another InstantDeathBehavior)
+		if (ai->isAiInDeadState())
+			return;
+		ai->markAsDead();
+	}
+#endif
 
 	TheGameLogic->destroyObject(getObject());
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/InstantDeathBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/InstantDeathBehavior.cpp
@@ -124,6 +124,7 @@ void InstantDeathBehavior::onDie( const DamageInfo *damageInfo )
 	if (!isDieApplicable(damageInfo))
 		return;
 
+#if RETAIL_COMPATIBLE_CRC
 	AIUpdateInterface* ai = getObject()->getAIUpdateInterface();
 	if (ai)
 	{
@@ -132,6 +133,7 @@ void InstantDeathBehavior::onDie( const DamageInfo *damageInfo )
 			return;
 		ai->markAsDead();
 	}
+#endif
 
 	const InstantDeathBehaviorModuleData* d = getInstantDeathBehaviorModuleData();
 
@@ -169,6 +171,19 @@ void InstantDeathBehavior::onDie( const DamageInfo *damageInfo )
 			TheWeaponStore->createAndFireTempWeapon(wt, getObject(), getObject()->getPosition());
 		}
 	}
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Stubbjax 21/07/2026 Allow multiple InstantDeathBehaviors to be processed.
+  // Multiple FXListDie, CreateObjectDie and FireWeaponWhenDeadBehavior modules are already supported.
+	AIUpdateInterface* ai = getObject()->getAIUpdateInterface();
+	if (ai)
+	{
+		// has another AI already handled us. (hopefully another InstantDeathBehavior)
+		if (ai->isAiInDeadState())
+			return;
+		ai->markAsDead();
+	}
+#endif
 
 	TheGameLogic->destroyObject(getObject());
 }


### PR DESCRIPTION
This change allows multiple `InstantDeathBehavior` modules to be processed when an object dies.

The `InstantDeathBehavior` module is essentially a composite of the `FXListDie`, `CreateObjectDie` and `FireWeaponWhenDeadBehavior` modules - all of which can be processed multiple times when an object dies. It is counterintuitive that combining such modules into `InstantDeathBehavior` comes with the caveat that multiple instances can no longer be processed.

All cases in the retail data have inverted `DeathTypes` to ensure exclusivity. For example:

```ini
Behavior = InstantDeathBehavior DeathModuleTag_01
  DeathTypes = NONE +DETONATED
End
Behavior = InstantDeathBehavior DeathModuleTag_02
  DeathTypes = NONE +LASERED
  FX = FX_GenericMissileDisintegrate
  OCL = OCL_GenericMissileDisintegrate
End
Behavior = InstantDeathBehavior DeathModuleTag_03
  DeathTypes = ALL -LASERED -DETONATED
  FX = FX_GenericMissileDeath
End
```

However, this does not work when `DeathTypes` are not exclusive, in which case only the first applicable module will trigger. For example, `ModuleTag_13` will never trigger with the following setup:

```ini
Behavior = InstantDeathBehavior ModuleTag_12
  FX = FX_BuildingDie
End
Behavior = InstantDeathBehavior ModuleTag_13
  ExemptStatus = UNDER_CONSTRUCTION
  FX = WeaponFX_BombTruckHighExplosiveBioBombDetonation
  OCL = OCL_PoisonFieldMedium
End
```