### PR TITLE
feat(gui): Show all available maps in the map list (previously limited to ~100)

### DIFF
--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -902,6 +902,16 @@ static Bool addMapCollectionToMapListbox(
 	return true;
 }
 
+#if ENABLE_GUI_HACKS
+// TheSuperHackers @feature pberthold 24/08/2026 Grow the map list to the cached map count, overriding the window's LISTBOXDATA LENGTH.
+static void growMapListboxToCachedMapCount( GameWindow *listbox )
+{
+	const Int neededListLength = (Int)TheMapCache->size();
+	if( neededListLength > GadgetListBoxGetListLength( listbox ) )
+		GadgetListBoxSetListLength( listbox, neededListLength );
+}
+#endif
+
 //-------------------------------------------------------------------------------------------------
 /** Load the listbox with all the map files available to play */
 //-------------------------------------------------------------------------------------------------
@@ -912,6 +922,10 @@ Int populateMapListboxNoReset( GameWindow *listbox, Bool useSystemMaps, Bool isM
 
 	if (!listbox)
 		return -1;
+
+#if ENABLE_GUI_HACKS
+	growMapListboxToCachedMapCount( listbox );
+#endif
 
 	MapListBoxData lbData;
 	lbData.listbox = listbox;


### PR DESCRIPTION
 The map list in Skirmish/LAN/Online is a list box whose capacity is defined by `LISTBOXDATA LENGTH`
  in the corresponding `.wnd` (for example `100` in `WOLMapSelectMenu.wnd`). When more maps are
  available than that capacity, the surplus maps are simply not added to the list — they are silently
  missing, with no error. This is a long-standing annoyance, usually worked around by hand-editing the
  `.wnd` files to a larger `LENGTH`.

  This change grows the map list in `populateMapListboxNoReset` to the number of cached maps (only when
  that exceeds the current capacity), so every available map is listed. `GadgetListBoxSetListLength`
  reallocates the list and copies the existing rows, so this is a safe resize, not an out-of-bounds
  write. Since the change lives in the shared `MapUtil.cpp`, it applies to both Generals and Zero Hour,
  and to every game mode and mod.

  **Verification:** Built with the VC6 Docker toolchain and tested in-game (Skirmish, base game and
  mods) with a ~470-map collection: all maps are now listed, whereas before the list stopped at its
  `.wnd` capacity (about 100).

  **AI assistance:** This change was drafted with AI assistance (Claude), then reviewed, adjusted and
  tested by me. An initial draft used a fixed capacity value; I changed it to size the list to the
  actual map count so the result is genuinely unbounded, and verified it in-game.
