### PR TITLE
bugfix(saveload): Fix aircraft carrier losing its order when saving

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
@@ -1684,7 +1684,8 @@ void FlightDeckBehavior::xfer( Xfer *xfer )
 	xfer->xferUnsignedInt( &m_startedProductionFrame );
 	xfer->xferUnsignedInt( &m_nextAllowedProductionFrame );
 	xfer->xferObjectID( &m_designatedTarget );
-	Int commandType;
+	// TheSuperHackers @bugfix bobtista 22/07/2026 Seed the temporary from the live command so saving writes the real order and does not overwrite m_designatedCommand with an uninitialized value.
+	Int commandType = (Int)m_designatedCommand;
 	xfer->xferInt( &commandType );
 	m_designatedCommand = (AICommandType)commandType;
 	xfer->xferCoord3D( &m_designatedPosition );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
@@ -1684,8 +1684,6 @@ void FlightDeckBehavior::xfer( Xfer *xfer )
 	xfer->xferUnsignedInt( &m_startedProductionFrame );
 	xfer->xferUnsignedInt( &m_nextAllowedProductionFrame );
 	xfer->xferObjectID( &m_designatedTarget );
-	// TheSuperHackers @bugfix bobtista 22/07/2026 Initialize the transfer value so saving does not
-	// overwrite m_designatedCommand with an uninitialized value.
 	Int commandType = (Int)m_designatedCommand;
 	xfer->xferInt( &commandType );
 	m_designatedCommand = (AICommandType)commandType;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
@@ -1684,7 +1684,8 @@ void FlightDeckBehavior::xfer( Xfer *xfer )
 	xfer->xferUnsignedInt( &m_startedProductionFrame );
 	xfer->xferUnsignedInt( &m_nextAllowedProductionFrame );
 	xfer->xferObjectID( &m_designatedTarget );
-	// TheSuperHackers @bugfix bobtista 22/07/2026 Seed the temporary from the live command so saving writes the real order and does not overwrite m_designatedCommand with an uninitialized value.
+	// TheSuperHackers @bugfix bobtista 22/07/2026 Initialize the transfer value so saving does not
+	// overwrite m_designatedCommand with an uninitialized value.
 	Int commandType = (Int)m_designatedCommand;
 	xfer->xferInt( &commandType );
 	m_designatedCommand = (AICommandType)commandType;


### PR DESCRIPTION
* Fixes #2994 

`FlightDeckBehavior::xfer` reads its designated command into an uninitialized local and then assigns it back to `m_designatedCommand` on both save and load. On save `xferInt` only writes the local out to the file, so the uninitialized stack value is written to the save and copied back over the live command. From then on `hasTakeoffOrders()` falls through to its default case and the carrier stops launching, so the planes already in the air finish their attack and no new ones take off.

Now the local is seeded from `m_designatedCommand` before the xfer, so saving writes the real order and the copy-back is a no-op. This does not change the save layout, so existing saves still load.

Todo:
- [x] Verify in USA 02: force fire terrain, save without loading, confirm the carrier keeps launching planes
- [x] Replicate to Generals — N/A, FlightDeckBehavior (Aircraft Carrier) is Zero Hour only