### PR TITLE
bugfix(saveload): Fix aircraft carrier ramp state serialized out of bounds

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
@@ -1701,7 +1701,8 @@ void FlightDeckBehavior::xfer( Xfer *xfer )
 			xfer->xferUnsignedInt( &m_rampUpFrame[ i ] );
 			xfer->xferUnsignedInt( &m_catapultSystemFrame[ i ] );
 			xfer->xferUnsignedInt( &m_lowerRampFrame[ i ] );
-			xfer->xferBool( &m_rampUp[ MAX_RUNWAYS ] );
+			// TheSuperHackers @bugfix bobtista 22/07/2026 Index the ramp state by runway instead of reading and writing one element past the array.
+			xfer->xferBool( &m_rampUp[ i ] );
 		}
 		else
 		{


### PR DESCRIPTION
Fixes #2995 

`FlightDeckBehavior::xfer` serializes the launch ramp state with `xfer->xferBool( &m_rampUp[ MAX_RUNWAYS ] )` inside the `for ( i = 0; i < MAX_RUNWAYS; i++ )` loop. `m_rampUp` is `Bool[ MAX_RUNWAYS ]` and the last member of the class, so indexing it with the constant `MAX_RUNWAYS` reads and writes one element past the array on every save and load. The real `m_rampUp[0]`/`m_rampUp[1]` are never saved or restored, so on load the ramp state reverts to its constructed value and the launch sequence can replay.

Now the ramp state is indexed by the loop variable `i`. This does not change the save layout (same two bools), so existing saves still load.

Todo:
- [x] Replicate to Generals  N/A, FlightDeckBehavior (Aircraft Carrier) is Zero Hour only