### PR TITLE
feat(saveload): Implement -loadsave command line option

### DIFF
--- a/Core/GameEngine/Include/Common/Snapshot.h
+++ b/Core/GameEngine/Include/Common/Snapshot.h
@@ -51,6 +51,10 @@ public:
 	Snapshot();
 	~Snapshot();
 
+	// Snapshots can disable xfer to be excluded from save game data,
+	// for example dummy implementations in headless mode.
+	virtual Bool isXferEnabled() const { return TRUE; }
+
 protected:
 
 	/// run the "light" crc check on this data structure

--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -862,6 +862,8 @@ public:
 
 	virtual Bool isDummy() const override { return true; }
 
+	virtual Bool isXferEnabled() const override { return FALSE; }
+
 	virtual Int getOnScreenParticleCount() override { return 0; }
 	virtual void doParticles(RenderInfoClass &rinfo) override {}
 	virtual void queueParticleRender() override {}

--- a/Core/GameEngine/Source/Common/CommandLine.cpp
+++ b/Core/GameEngine/Source/Common/CommandLine.cpp
@@ -719,6 +719,18 @@ Int parseVTune ( char *args[], int num )
 
 #endif // defined(RTS_DEBUG)
 
+Int parseLoadSave(char *args[], int num)
+{
+	if (num > 1)
+	{
+		TheWritableGlobalData->m_loadSaveGame = args[1];
+		TheWritableGlobalData->m_shellMapOn = FALSE;
+		TheWritableGlobalData->m_playIntro = FALSE;
+		TheWritableGlobalData->m_playSizzle = FALSE;
+	}
+	return 2;
+}
+
 //=============================================================================
 //=============================================================================
 
@@ -1159,6 +1171,9 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-noshaders", parseNoShaders },
 	{ "-quickstart", parseQuickStart },
 	{ "-useWaveEditor", parseUseWaveEditor },
+
+	// TheSuperHackers @feature bobtista 22/07/2026 Load a save game file from the command line.
+	{ "-loadsave", parseLoadSave },
 
 	// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
 	{ "-forcefullviewport", parseFullViewport },

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
@@ -147,6 +147,7 @@ public:
 protected:
 
 	// snapshot methods
+	virtual Bool isXferEnabled() const override;
 	virtual void crc( Xfer *xfer ) override;
 	virtual void xfer( Xfer *xfer ) override;
 	virtual void loadPostProcess() override;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -1135,6 +1135,14 @@ void W3DTerrainVisual::replaceSkyboxTextures(const AsciiString *oldTexName[5], c
 }
 
 // ------------------------------------------------------------------------------------------------
+/** Terrain visual state is only partially initialized in headless mode, so it is excluded from save game data */
+// ------------------------------------------------------------------------------------------------
+Bool W3DTerrainVisual::isXferEnabled() const
+{
+	return TheGlobalData->m_headless == FALSE;
+}
+
+// ------------------------------------------------------------------------------------------------
 /** CRC */
 // ------------------------------------------------------------------------------------------------
 void W3DTerrainVisual::crc( Xfer *xfer )

--- a/Generals/Code/GameEngine/Include/Common/GameState.h
+++ b/Generals/Code/GameEngine/Include/Common/GameState.h
@@ -171,6 +171,7 @@ public:
 										 SnapshotType which = SNAPSHOT_SAVELOAD );  ///< save a game
 	SaveResult missionSave();																 ///< do a in between mission save
 	SaveCode loadGame( AvailableGameInfo gameInfo );							 ///< load a save file
+	void loadQueuedSaveGame();																 ///< load the save file requested on startup
 	SaveGameInfo *getSaveGameInfo() { return &m_gameInfo; }
 
 	// snapshot interaction

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -350,6 +350,7 @@ public:
 	Bool m_buildMapCache;
 	AsciiString m_initialFile;				///< If this is specified, load a specific map from the command-line
 	AsciiString m_pendingFile;				///< If this is specified, use this map at the next game start
+	AsciiString m_loadSaveGame;				///< If this is specified, load a save game file from the command-line
 
 	std::vector<AsciiString> m_simulateReplays; ///< If not empty, simulate this list of replays and exit.
 	Int m_simulateReplayJobs; ///< Maximum number of processes to use for simulation, or SIMULATE_REPLAYS_SEQUENTIAL for sequential simulation

--- a/Generals/Code/GameEngine/Include/GameLogic/GhostObject.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GhostObject.h
@@ -110,10 +110,10 @@ inline Bool GhostObjectManager::trackAllPlayers() const
 
 // TheSuperHackers @feature bobtista 19/01/2026
 // GhostObjectManager that does nothing for headless mode.
-// Note: Does NOT override crc/xfer/loadPostProcess to maintain save compatibility.
 class GhostObjectManagerDummy : public GhostObjectManager
 {
 public:
+	virtual Bool isXferEnabled() const override { return FALSE; }
 	virtual void reset() override {}
 	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) override { return nullptr; }
 	virtual void removeGhostObject(GhostObject *mod) override {}

--- a/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -382,6 +382,13 @@ void GameState::addSnapshotBlock( AsciiString blockName, Snapshot *snapshot, Sna
 
 	}
 
+	// Snapshots with xfer disabled are not registered, so their blocks are omitted when saving
+	// and are skipped like unknown blocks when loading.
+	if( !snapshot->isXferEnabled() )
+	{
+		return;
+	}
+
 	// add to the list
 	SnapshotBlock blockInfo;
 	blockInfo.snapshot = snapshot;
@@ -731,6 +738,52 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 
 	return SC_OK;
 
+}
+
+// ------------------------------------------------------------------------------------------------
+/** Load the save game requested on startup, after the shell has been initialized */
+// ------------------------------------------------------------------------------------------------
+void GameState::loadQueuedSaveGame()
+{
+	AvailableGameInfo gameInfo;
+	gameInfo.filename = TheGlobalData->m_loadSaveGame;
+	gameInfo.next = nullptr;
+	gameInfo.prev = nullptr;
+
+	TheWritableGlobalData->m_loadSaveGame.clear();
+
+	// getSaveGameInfoFromFile throws when the file is missing, so check before reading it
+	if( doesSaveGameExist( gameInfo.filename ) == FALSE )
+	{
+		DEBUG_LOG(("Save game '%s' was not found", gameInfo.filename.str()));
+		TheGameEngine->setQuitting( TRUE );
+		return;
+	}
+
+	// getSaveGameInfoFromFile throws on a malformed file instead of returning a SaveCode
+	try
+	{
+		AsciiString filepath = getFilePathInSaveDirectory( gameInfo.filename );
+		getSaveGameInfoFromFile( filepath, &gameInfo.saveGameInfo );
+	}
+	catch( ... )
+	{
+		DEBUG_LOG(("Save game '%s' could not be read", gameInfo.filename.str()));
+		TheGameEngine->setQuitting( TRUE );
+		return;
+	}
+
+	// this hides the shell, keeping the menu screens on the stack for when the game ends
+	TheGameLogic->prepareNewGame( GAME_SINGLE_PLAYER, DIFFICULTY_NORMAL, 0 );
+
+	if( loadGame( gameInfo ) != SC_OK )
+	{
+		DEBUG_LOG(("Failed to load save game '%s'", gameInfo.filename.str()));
+		if( TheGameLogic->isInGame() )
+			TheGameLogic->clearGameData( FALSE );
+		TheGameEngine->reset();
+		TheGameEngine->setQuitting( TRUE );
+	}
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -515,6 +515,11 @@ void GameClient::update()
 
 			TheShell->showShellMap(TRUE);
 			TheShell->showShell();
+
+			if (TheGlobalData->m_loadSaveGame.isNotEmpty())
+			{
+				TheGameState->loadQueuedSaveGame();
+			}
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameState.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameState.h
@@ -171,6 +171,7 @@ public:
 										 SnapshotType which = SNAPSHOT_SAVELOAD );  ///< save a game
 	SaveResult missionSave();																 ///< do a in between mission save
 	SaveCode loadGame( AvailableGameInfo gameInfo );							 ///< load a save file
+	void loadQueuedSaveGame();																 ///< load the save file requested on startup
 	SaveGameInfo *getSaveGameInfo() { return &m_gameInfo; }
 
 	// snapshot interaction

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -351,6 +351,7 @@ public:
 	Bool m_buildMapCache;
 	AsciiString m_initialFile;				///< If this is specified, load a specific map from the command-line
 	AsciiString m_pendingFile;				///< If this is specified, use this map at the next game start
+	AsciiString m_loadSaveGame;				///< If this is specified, load a save game file from the command-line
 
 	std::vector<AsciiString> m_simulateReplays; ///< If not empty, simulate this list of replays and exit.
 	Int m_simulateReplayJobs; ///< Maximum number of processes to use for simulation, or SIMULATE_REPLAYS_SEQUENTIAL for sequential simulation

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
@@ -110,10 +110,10 @@ inline Bool GhostObjectManager::trackAllPlayers() const
 
 // TheSuperHackers @feature bobtista 19/01/2026
 // GhostObjectManager that does nothing for headless mode.
-// Note: Does NOT override crc/xfer/loadPostProcess to maintain save compatibility.
 class GhostObjectManagerDummy : public GhostObjectManager
 {
 public:
+	virtual Bool isXferEnabled() const override { return FALSE; }
 	virtual void reset() override {}
 	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) override { return nullptr; }
 	virtual void removeGhostObject(GhostObject *mod) override {}

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -740,6 +740,52 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 
 }
 
+// ------------------------------------------------------------------------------------------------
+/** Load the save game requested on startup, after the shell has been initialized */
+// ------------------------------------------------------------------------------------------------
+void GameState::loadQueuedSaveGame()
+{
+	AvailableGameInfo gameInfo;
+	gameInfo.filename = TheGlobalData->m_loadSaveGame;
+	gameInfo.next = nullptr;
+	gameInfo.prev = nullptr;
+
+	TheWritableGlobalData->m_loadSaveGame.clear();
+
+	// getSaveGameInfoFromFile throws when the file is missing, so check before reading it
+	if( doesSaveGameExist( gameInfo.filename ) == FALSE )
+	{
+		DEBUG_LOG(("Save game '%s' was not found", gameInfo.filename.str()));
+		TheGameEngine->setQuitting( TRUE );
+		return;
+	}
+
+	// getSaveGameInfoFromFile throws on a malformed file instead of returning a SaveCode
+	try
+	{
+		AsciiString filepath = getFilePathInSaveDirectory( gameInfo.filename );
+		getSaveGameInfoFromFile( filepath, &gameInfo.saveGameInfo );
+	}
+	catch( ... )
+	{
+		DEBUG_LOG(("Save game '%s' could not be read", gameInfo.filename.str()));
+		TheGameEngine->setQuitting( TRUE );
+		return;
+	}
+
+	// this hides the shell, keeping the menu screens on the stack for when the game ends
+	TheGameLogic->prepareNewGame( GAME_SINGLE_PLAYER, DIFFICULTY_NORMAL, 0 );
+
+	if( loadGame( gameInfo ) != SC_OK )
+	{
+		DEBUG_LOG(("Failed to load save game '%s'", gameInfo.filename.str()));
+		if( TheGameLogic->isInGame() )
+			TheGameLogic->clearGameData( FALSE );
+		TheGameEngine->reset();
+		TheGameEngine->setQuitting( TRUE );
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 AsciiString GameState::getSaveDirectory() const
 {

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -382,6 +382,13 @@ void GameState::addSnapshotBlock( AsciiString blockName, Snapshot *snapshot, Sna
 
 	}
 
+	// Snapshots with xfer disabled are not registered, so their blocks are omitted when saving
+	// and are skipped like unknown blocks when loading.
+	if( !snapshot->isXferEnabled() )
+	{
+		return;
+	}
+
 	// add to the list
 	SnapshotBlock blockInfo;
 	blockInfo.snapshot = snapshot;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -536,6 +536,11 @@ void GameClient::update()
 
 			TheShell->showShellMap(TRUE);
 			TheShell->showShell();
+
+			if (TheGlobalData->m_loadSaveGame.isNotEmpty())
+			{
+				TheGameState->loadQueuedSaveGame();
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #2999

Now -loadsave <filename> loads a save from the user Save directory during startup in normal or headless mode.

Snapshots can now disable xfer to be excluded from save game data. The particle, terrain visual and ghost object snapshots disable xfer in headless mode, so their blocks are omitted when saving and are skipped like unknown blocks when loading rendered saves headlessly.

Todo:

- [x] Test normal save loaded normally
- [x] Test normal save loaded headlessly
- [x] Test headless save loaded normally
- [x] Test headless save loaded headlessly
- [x] Replicate to Generals

Notes:
If the save file is not found, the game logs the failure and exits after engine initialization. Debug builds show a "File not found" assert first.