### PR TITLE
bugfix(behavior): Do not fire weapons via the InstantDeathBehavior module while under construction

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/InstantDeathBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/InstantDeathBehavior.cpp
@@ -159,16 +159,23 @@ void InstantDeathBehavior::onDie( const DamageInfo *damageInfo )
 		ObjectCreationList::create(ocl, getObject(), nullptr);
 	}
 
-	listSize = d->m_weapons.size();
-	if (listSize > 0)
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Stubbjax 23/07/2026 Prevent firing weapons when a scaffold is cancelled
+	// or destroyed. This logic matches the condition in the FireWeaponWhenDeadBehavior module.
+	if (!getObject()->getStatusBits().test(OBJECT_STATUS_UNDER_CONSTRUCTION))
+#endif
 	{
-		idx = (size_t)GameLogicRandomValue(0, listSize-1);
-		const WeaponTemplateVec& v = d->m_weapons;
-		DEBUG_ASSERTCRASH(idx>=0&&idx<v.size(),("bad idx"));
-		const WeaponTemplate* wt = v[idx];
-		if (wt)
+		listSize = d->m_weapons.size();
+		if (listSize > 0)
 		{
-			TheWeaponStore->createAndFireTempWeapon(wt, getObject(), getObject()->getPosition());
+			idx = (size_t)GameLogicRandomValue(0, listSize-1);
+			const WeaponTemplateVec& v = d->m_weapons;
+			DEBUG_ASSERTCRASH(idx>=0&&idx<v.size(),("bad idx"));
+			const WeaponTemplate* wt = v[idx];
+			if (wt)
+			{
+				TheWeaponStore->createAndFireTempWeapon(wt, getObject(), getObject()->getPosition());
+			}
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/InstantDeathBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/InstantDeathBehavior.cpp
@@ -159,16 +159,23 @@ void InstantDeathBehavior::onDie( const DamageInfo *damageInfo )
 		ObjectCreationList::create(ocl, getObject(), nullptr);
 	}
 
-	listSize = d->m_weapons.size();
-	if (listSize > 0)
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Stubbjax 23/07/2026 Prevent firing weapons when a scaffold is cancelled
+	// or destroyed. This logic matches the condition in the FireWeaponWhenDeadBehavior module.
+	if (!getObject()->getStatusBits().test(OBJECT_STATUS_UNDER_CONSTRUCTION))
+#endif
 	{
-		idx = (size_t)GameLogicRandomValue(0, listSize-1);
-		const WeaponTemplateVec& v = d->m_weapons;
-		DEBUG_ASSERTCRASH(idx>=0&&idx<v.size(),("bad idx"));
-		const WeaponTemplate* wt = v[idx];
-		if (wt)
+		listSize = d->m_weapons.size();
+		if (listSize > 0)
 		{
-			TheWeaponStore->createAndFireTempWeapon(wt, getObject(), getObject()->getPosition());
+			idx = (size_t)GameLogicRandomValue(0, listSize-1);
+			const WeaponTemplateVec& v = d->m_weapons;
+			DEBUG_ASSERTCRASH(idx>=0&&idx<v.size(),("bad idx"));
+			const WeaponTemplate* wt = v[idx];
+			if (wt)
+			{
+				TheWeaponStore->createAndFireTempWeapon(wt, getObject(), getObject()->getPosition());
+			}
 		}
 	}
 


### PR DESCRIPTION
This change prevents weapons from being fired via the `InstantDeathBehavior` module if the `OBJECT_STATUS_UNDER_CONSTRUCTION` status is set.

This behaviour is already inherent to the `FireWeaponWhenDeadBehavior` module, and behaviour is now consistent between both modules as a result.

Retail data relies on this inherent condition - note `ChinaPowerPlant` does not fire its death weapon when destroyed/cancelled while under construction, despite lacking an `ExemptStatus = UNDER_CONSTRUCTION` field:

```ini
Object ChinaPowerPlant
  Behavior = FireWeaponWhenDeadBehavior ModuleTag_XX
    DeathWeapon = ChinaPowerPlantDeathWeapon
    StartsActive = YES
  End
End
```
However, when utilising the `InstantDeathBehavior` module, this inherent condition no longer applies and the weapon is fired when destroyed/cancelled while under construction:

```ini
Object ChinaPowerPlant
  Behavior = InstantDeathBehavior ModuleTag_XX
    Weapon = ChinaPowerPlantDeathWeapon
  End
End
```

This deviation between behaviours is not visible nor intuitive. An alternative approach would be to remove the inherent condition entirely from both modules and rely on the data-driven `ExemptStatus`. However, this would break retail data and likely cause unnecessary additional work for modders; there is unlikely to ever be a situation where a scaffold should fire a weapon upon destruction/cancellation.