### PR TITLE
bugfix(fxlist): Fix unreliable terrain layer selection of particles using CreateAtGroundHeight

### DIFF
--- a/Core/GameEngine/Source/GameClient/FXList.cpp
+++ b/Core/GameEngine/Source/GameClient/FXList.cpp
@@ -625,7 +625,7 @@ protected:
 						newPos.z = TheTerrainLogic->getLayerHeight( newPos.x, newPos.y, layer );
 					}
 					else
-						newPos.z = primary->z + offset.z + m_height.getValue();
+						newPos.z += m_height.getValue();
 
 
 					if (m_orientToObject && mtx)

--- a/Core/GameEngine/Source/GameClient/FXList.cpp
+++ b/Core/GameEngine/Source/GameClient/FXList.cpp
@@ -614,6 +614,7 @@ protected:
 
 					newPos.x = primary->x + offset.x + radius * cos(angle);
 					newPos.y = primary->y + offset.y + radius * sin(angle);
+					newPos.z = primary->z + offset.z;
 					if( m_createAtGroundHeight && TheTerrainLogic )
 					{
 						//old way:


### PR DESCRIPTION
When creating a particle system that uses the `CreateAtGroundHeight` option in the INI, the current terrain layer (for example GROUND, or BRIDGE) was not reliably determined because of an uninitialized variable.

This mostly affects toxin pools on a bridge which end up on the ground layer instead, see the images.

Before (note the particles on the ground):
<img width="1923" height="1081" alt="Screenshot From 2026-07-22 21-56-56" src="https://github.com/user-attachments/assets/8770c483-fd05-437a-81b8-5a282701a4a6" />

After (most of the particles are now on the bridge, some are on the edge and float):
<img width="1923" height="1081" alt="Screenshot From 2026-07-22 21-54-52" src="https://github.com/user-attachments/assets/f13f6a4b-b8e2-4542-b229-eac1d39f6d07" />
