### PR TITLE
bugfix(savegame): Rebuild shroud grid on load so structures stay visible

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -4766,7 +4766,61 @@ void PartitionManager::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void PartitionManager::loadPostProcess()
 {
+	// TheSuperHackers @bugfix coolswood 23/07/2026 Rebuild the shroud grid on save load so
+	// objects re-apply their lookers. After load the per-cell shroud counters and the pending
+	// undo-queue are restored from the file, but nothing re-applied the object looks that those
+	// counters represent. When the restored undo-queue drains (~m_unlookPersistDuration frames
+	// later) removeLooker fires at every queued position. Static structures never re-look, so
+	// their cells drop to FOGGED and the player's own base becomes gray, unselectable ghosts.
+	// The restored m_partitionLastLook and the cell counters also disagree, so any later
+	// handleShroud() would double-count. The fix mirrors the established
+	// TerrainLogic::setActiveBoundary rebuild: drain the queue, snapshot the explored (FOGGED)
+	// and permanently-revealed (CLEAR) cells, tear the cell grid down to the all-shrouded
+	// default, then make every object re-look fresh onto the clean grid. After this the
+	// undo-queue is empty, every live object owns its looker, and static structures stay CLEAR.
+	ShroudStatusStoreRestore partitionStore;
 
+	// Flush the restored undo-queue so lingering undoes do not fire after the rebuild.
+	processEntirePendingUndoShroudRevealQueue();
+
+	// Remember cells that are explored-but-not-visible (FOGGED).
+	storeFoggedCells(partitionStore, TRUE);
+
+	// Release ghost-object partition data before the cell grid is torn down.
+	TheGhostObjectManager->releasePartitionData();
+
+	// Invalidate every object's sighting state so the later unlook()/unshroud() inside
+	// handleShroud() are no-ops instead of queueing double-undoes or double-counting.
+	for (Object *obj = TheGameLogic->getFirstObject(); obj; obj = obj->getNextObject())
+		obj->friend_prepareForMapBoundaryAdjust();
+
+	// Remember cells that are CLEAR (permanently revealed) after the queue drain.
+	storeFoggedCells(partitionStore, FALSE);
+
+	// Rebuild the cell grid: shutdown deletes m_cells, init re-allocates every cell at
+	// the fully-shrouded default (m_currentShroud = 1).
+	reset();
+	init();
+
+	// Restore permanently-revealed cells with extra lookers.
+	restoreFoggedCells(partitionStore, FALSE);
+
+	// Prevent new ghost objects from being created while the existing ones are restored.
+	TheGhostObjectManager->lockGhostObjects(TRUE);
+
+	// Re-register and re-look every object onto the clean grid. handleShroud() now does
+	// unlook (no-op, SightingInfo is invalid) + look (fresh doShroudReveal), so each object
+	// owns exactly one looker and the undo-queue stays empty.
+	for (Object *obj = TheGameLogic->getFirstObject(); obj; obj = obj->getNextObject())
+		obj->friend_notifyOfNewMapBoundary();
+
+	// Restore explored-but-not-visible (FOGGED) cells and ghost-object partition data.
+	restoreFoggedCells(partitionStore, TRUE);
+	TheGhostObjectManager->restorePartitionData();
+	TheGhostObjectManager->lockGhostObjects(FALSE);
+
+	// Redraw the display/radar from the rebuilt cell state.
+	refreshShroudForLocalPlayer();
 }
 
 //-----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -4776,7 +4776,61 @@ void PartitionManager::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void PartitionManager::loadPostProcess()
 {
+	// TheSuperHackers @bugfix coolswood 23/07/2026 Rebuild the shroud grid on save load so
+	// objects re-apply their lookers. After load the per-cell shroud counters and the pending
+	// undo-queue are restored from the file, but nothing re-applied the object looks that those
+	// counters represent. When the restored undo-queue drains (~m_unlookPersistDuration frames
+	// later) removeLooker fires at every queued position. Static structures never re-look, so
+	// their cells drop to FOGGED and the player's own base becomes gray, unselectable ghosts.
+	// The restored m_partitionLastLook and the cell counters also disagree, so any later
+	// handleShroud() would double-count. The fix mirrors the established
+	// TerrainLogic::setActiveBoundary rebuild: drain the queue, snapshot the explored (FOGGED)
+	// and permanently-revealed (CLEAR) cells, tear the cell grid down to the all-shrouded
+	// default, then make every object re-look fresh onto the clean grid. After this the
+	// undo-queue is empty, every live object owns its looker, and static structures stay CLEAR.
+	ShroudStatusStoreRestore partitionStore;
 
+	// Flush the restored undo-queue so lingering undoes do not fire after the rebuild.
+	processEntirePendingUndoShroudRevealQueue();
+
+	// Remember cells that are explored-but-not-visible (FOGGED).
+	storeFoggedCells(partitionStore, TRUE);
+
+	// Release ghost-object partition data before the cell grid is torn down.
+	TheGhostObjectManager->releasePartitionData();
+
+	// Invalidate every object's sighting state so the later unlook()/unshroud() inside
+	// handleShroud() are no-ops instead of queueing double-undoes or double-counting.
+	for (Object *obj = TheGameLogic->getFirstObject(); obj; obj = obj->getNextObject())
+		obj->friend_prepareForMapBoundaryAdjust();
+
+	// Remember cells that are CLEAR (permanently revealed) after the queue drain.
+	storeFoggedCells(partitionStore, FALSE);
+
+	// Rebuild the cell grid: shutdown deletes m_cells, init re-allocates every cell at
+	// the fully-shrouded default (m_currentShroud = 1).
+	reset();
+	init();
+
+	// Restore permanently-revealed cells with extra lookers.
+	restoreFoggedCells(partitionStore, FALSE);
+
+	// Prevent new ghost objects from being created while the existing ones are restored.
+	TheGhostObjectManager->lockGhostObjects(TRUE);
+
+	// Re-register and re-look every object onto the clean grid. handleShroud() now does
+	// unlook (no-op, SightingInfo is invalid) + look (fresh doShroudReveal), so each object
+	// owns exactly one looker and the undo-queue stays empty.
+	for (Object *obj = TheGameLogic->getFirstObject(); obj; obj = obj->getNextObject())
+		obj->friend_notifyOfNewMapBoundary();
+
+	// Restore explored-but-not-visible (FOGGED) cells and ghost-object partition data.
+	restoreFoggedCells(partitionStore, TRUE);
+	TheGhostObjectManager->restorePartitionData();
+	TheGhostObjectManager->lockGhostObjects(FALSE);
+
+	// Redraw the display/radar from the rebuilt cell state.
+	refreshShroudForLocalPlayer();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

After loading a save game, fog of war creeps over the player's own base within a few seconds: static structures become gray "previously seen" ghosts that can no longer be selected or controlled.

## Root cause

`PartitionManager::loadPostProcess()` was an empty stub. After a save load, the per-cell shroud counters (`m_currentShroud`) and the pending undo-queue are restored from the file (both `PartitionManager::xfer` version 2 and `PartitionCell::xfer`), but nothing re-applies the object looks those counters represent.

When the restored undo-queue drains (~`m_unlookPersistDuration` frames after load), `removeLooker` fires at every queued position. Static structures never re-look (nothing calls `Object::look()`/`handleShroud()` after load), so their cells drop to `FOGGED`. The restored `m_partitionLastLook` and the cell counters also disagree, so any later `handleShroud()` would double-count.

The same empty stub is present in both the Zero Hour and Generals trees.

## Fix

Fill in `PartitionManager::loadPostProcess()` by mirroring the established `TerrainLogic::setActiveBoundary` rebuild (the canonical full-shroud-rebuild pattern, already used for map boundary resize):

1. Drain the restored undo-queue so lingering undoes do not fire after the rebuild (`processEntirePendingUndoShroudRevealQueue`).
2. Snapshot explored-but-not-visible (`FOGGED`) cells via `storeFoggedCells`.
3. Release ghost-object partition data before the cell grid is torn down.
4. Invalidate every object's sighting state (`friend_prepareForMapBoundaryAdjust`) so the later `unlook()`/`unshroud()` inside `handleShroud()` are no-ops instead of double-undoes/double-counts.
5. Remember permanently-revealed (`CLEAR`) cells, then tear the cell grid down to the all-shrouded default (`reset()` + `init()`).
6. Restore permanently-revealed cells.
7. Re-look every object (`friend_notifyOfNewMapBoundary` → each object owns exactly one live looker).
8. Restore explored cells + ghost objects + `refreshShroudForLocalPlayer()`.

After this the undo-queue is empty, every live object owns its looker, and static structures stay `CLEAR` permanently.

All APIs used (`storeFoggedCells`, `restoreFoggedCells`, `ShroudStatusStoreRestore`, `processEntirePendingUndoShroudRevealQueue`, `Object::friend_prepareForMapBoundaryAdjust`, `Object::friend_notifyOfNewMapBoundary`, `GhostObjectManager` methods) already exist and are unchanged.

## Replication

Applied to Zero Hour first, then replicated identically for Generals, per the contribution precedence guideline. The Generals replica is byte-identical.

## Verification

- Built and tested on a cross-platform port based on this tree (macOS). Loading a previously-broken save no longer fogs the player's own base; buildings remain selectable; previously-explored-but-not-visible areas stay gray (`FOGGED`) rather than black (`SHROUDED`), confirming `restoreFoggedCells` preserves explored state.
- No changes to `xfer`, `update`, serialization, or the runtime look/unlook logic — only the previously-empty `loadPostProcess` body.
