### PR TITLE
fix(particlesys): Prevent accumulation of particle systems in headless mode

### DIFF
--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -763,7 +763,11 @@ public:
 	ParticleSystemTemplate *newTemplate( const AsciiString &name );
 
 	/// given a template, instantiate a particle system
-	ParticleSystem *createParticleSystem( const ParticleSystemTemplate *sysTemplate, Bool createSlaves = TRUE );
+#if RETAIL_COMPATIBLE_CRC
+	virtual ParticleSystem *createParticleSystem( const ParticleSystemTemplate *sysTemplate, Bool createSlaves = TRUE );
+#else
+	ParticleSystem* createParticleSystem(const ParticleSystemTemplate* sysTemplate, Bool createSlaves = TRUE);
+#endif
 
 	/** given a template, instantiate a particle system.
 		if attachTo is not null, attach the particle system to the given object.
@@ -839,11 +843,15 @@ private:
 
 // TheSuperHackers @feature bobtista 31/01/2026
 // ParticleSystemManager that does nothing. Used for Headless Mode.
-// Generally does not load particle system templates. Certainly does not create particle systems.
+// Does not load particle system templates and does not create particle systems.
 class ParticleSystemManagerDummy : public ParticleSystemManager
 {
 public:
 #if RETAIL_COMPATIBLE_CRC
+	// The creation of particle systems needs to be handled explicitly,
+	// because they're not destroyed in the update function anymore.
+	virtual ParticleSystem* createParticleSystem(const ParticleSystemTemplate* sysTemplate, Bool createSlaves = TRUE) override { return nullptr; }
+
 	// Must not overload init to keep loading the particle system templates,
 	// which are unfortunately needed to preserve the correct logic crc.
 #else


### PR DESCRIPTION
* Follow up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2740

#2740 removed function `GameClient::updateHeadless`, which ensured that particle systems wouldn't accumulate and take up a lot of memory unnecessarily. This works when `ParticleSystemManagerDummy` overloads the `init` function, but that's not possible with retail compatibility.

This PR adds a dummy overload for `createParticleSystem`, so that no particle systems get created in headless mode.

I tested > 2500 short replays and did not see a mismatch because of this change.