### PR TITLE
refactor(commandxlat): Split evaluateContextCommand into per-command handlers

### DIFF
--- a/Core/GameEngine/Include/GameClient/CommandXlat.h
+++ b/Core/GameEngine/Include/GameClient/CommandXlat.h
@@ -78,7 +78,7 @@ private:
 	GameMessage::Type handleGetRepairedAtCommand( Object *obj, CommandEvaluateType type );
 	GameMessage::Type handleGetHealedAtCommand( Object *obj, CommandEvaluateType type );
 	GameMessage::Type handleHijackVehicleCommand( Drawable *draw, CommandEvaluateType type );
-	GameMessage::Type handleConvertToCarBombCommand( Drawable *draw, Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleConvertObjectToCarBombCommand( Drawable *draw, Object *obj, CommandEvaluateType type );
 	GameMessage::Type handleSabotageBuildingCommand( Drawable *draw, CommandEvaluateType type );
 	GameMessage::Type handleSalvageCommand( Object *obj, CommandEvaluateType type );
 	GameMessage::Type handleEnterObjectCommand( Drawable *draw, Object *obj, CommandEvaluateType type );

--- a/Core/GameEngine/Include/GameClient/CommandXlat.h
+++ b/Core/GameEngine/Include/GameClient/CommandXlat.h
@@ -89,7 +89,7 @@ private:
 	GameMessage::Type handlePickUpPrisonerCommand( Drawable *draw, Object *obj, CommandEvaluateType type );
 #endif
 	GameMessage::Type handleSetRallyPointCommand( const Coord3D *pos, CommandEvaluateType type );
-	GameMessage::Type handleImpossibleAttackHint( const Coord3D *pos );
+	GameMessage::Type handleInvalidShotCommand( const Coord3D *pos );
 	GameMessage::Type handleDefaultMoveCommand( Drawable *draw, Drawable *drawableInWay, const Coord3D *pos, CommandEvaluateType type );
 
 	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;

--- a/Core/GameEngine/Include/GameClient/CommandXlat.h
+++ b/Core/GameEngine/Include/GameClient/CommandXlat.h
@@ -73,10 +73,10 @@ private:
 	GameMessage::Type handleSpecialPowerConstructCommand( const CommandButton *command, Drawable *draw, const Coord3D *pos, CommandEvaluateType type );
 	GameMessage::Type handleSpecialPowerOverrideDestinationCommand( const Coord3D *pos, CommandEvaluateType type );
 	GameMessage::Type handleResumeConstructionCommand( Object *obj, CommandEvaluateType type );
-	GameMessage::Type handleDockCommand( Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleDockAtCommand( Object *obj, CommandEvaluateType type );
 	GameMessage::Type handleRepairObjectCommand( Object *obj, CommandEvaluateType type );
-	GameMessage::Type handleGetRepairedCommand( Object *obj, CommandEvaluateType type );
-	GameMessage::Type handleGetHealedCommand( Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleGetRepairedAtCommand( Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleGetHealedAtCommand( Object *obj, CommandEvaluateType type );
 	GameMessage::Type handleHijackVehicleCommand( Drawable *draw, CommandEvaluateType type );
 	GameMessage::Type handleConvertToCarBombCommand( Drawable *draw, Object *obj, CommandEvaluateType type );
 	GameMessage::Type handleSabotageBuildingCommand( Drawable *draw, CommandEvaluateType type );

--- a/Core/GameEngine/Include/GameClient/CommandXlat.h
+++ b/Core/GameEngine/Include/GameClient/CommandXlat.h
@@ -69,6 +69,28 @@ private:
 	void resolveGuiCommandTarget( const CommandButton *command, Drawable *&draw, Object *&obj );
 
 	GameMessage::Type handleWaypointModeCommand( const Coord3D *pos, Drawable *draw, CommandEvaluateType type );
+	GameMessage::Type handleGuiCommand( const CommandButton *command, Drawable *draw, Object *obj, const Coord3D *pos, CommandEvaluateType type );
+	GameMessage::Type handleSpecialPowerConstructCommand( const CommandButton *command, Drawable *draw, const Coord3D *pos, CommandEvaluateType type );
+	GameMessage::Type handleSpecialPowerOverrideDestinationCommand( const Coord3D *pos, CommandEvaluateType type );
+	GameMessage::Type handleResumeConstructionCommand( Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleDockCommand( Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleRepairObjectCommand( Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleGetRepairedCommand( Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleGetHealedCommand( Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleHijackVehicleCommand( Drawable *draw, CommandEvaluateType type );
+	GameMessage::Type handleConvertToCarBombCommand( Drawable *draw, Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleSabotageBuildingCommand( Drawable *draw, CommandEvaluateType type );
+	GameMessage::Type handleSalvageCommand( Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleEnterObjectCommand( Drawable *draw, Object *obj, CommandEvaluateType type );
+	GameMessage::Type handleAttackObjectCommand( Drawable *draw, Object *obj, CommandEvaluateType type, GameMessage::Type hintType );
+	GameMessage::Type handleCaptureBuildingCommand( Drawable *draw, Object *obj, const Coord3D *pos, CommandEvaluateType type );
+	GameMessage::Type handleHackCommand( Drawable *draw, Object *obj, const Coord3D *pos, CommandEvaluateType type, SpecialPowerType hackPower );
+#ifdef ALLOW_SURRENDER
+	GameMessage::Type handlePickUpPrisonerCommand( Drawable *draw, Object *obj, CommandEvaluateType type );
+#endif
+	GameMessage::Type handleSetRallyPointCommand( const Coord3D *pos, CommandEvaluateType type );
+	GameMessage::Type handleImpossibleAttackHint( const Coord3D *pos );
+	GameMessage::Type handleDefaultMoveCommand( Drawable *draw, Drawable *drawableInWay, const Coord3D *pos, CommandEvaluateType type );
 
 	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };

--- a/Core/GameEngine/Include/GameClient/CommandXlat.h
+++ b/Core/GameEngine/Include/GameClient/CommandXlat.h
@@ -41,7 +41,6 @@ public:
 
 	enum CommandEvaluateType { DO_COMMAND, DO_HINT, EVALUATE_ONLY };
 
-
 	GameMessage::Type evaluateForceAttack( Drawable *draw, const Coord3D *pos, CommandEvaluateType type );
 	GameMessage::Type evaluateContextCommand( Drawable *draw, const Coord3D *pos, CommandEvaluateType type );
 
@@ -64,6 +63,10 @@ private:
 	GameMessage::Type issueSpecialPowerCommand( const CommandButton *command, CommandEvaluateType commandType, Drawable *target, const Coord3D *pos, Object* ignoreSelObj );
 	GameMessage::Type issueFireWeaponCommand( const CommandButton *command, CommandEvaluateType commandType, Drawable *target, const Coord3D *pos );
 	GameMessage::Type issueCombatDropCommand( const CommandButton *command, CommandEvaluateType commandType, Drawable *target, const Coord3D *pos );
+
+	void normalizeContextInputs( Drawable*& draw, Object*& obj, Drawable*& drawableInWay );
+	GameMessage::Type handleWaypointModeCommand( const Coord3D* pos, Drawable* draw, const CommandEvaluateType& type );
+	void normalizeGuiCommandTarget( const CommandButton* command, Drawable*& draw, Object*& obj );
 
 	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };

--- a/Core/GameEngine/Include/GameClient/CommandXlat.h
+++ b/Core/GameEngine/Include/GameClient/CommandXlat.h
@@ -41,6 +41,7 @@ public:
 
 	enum CommandEvaluateType { DO_COMMAND, DO_HINT, EVALUATE_ONLY };
 
+
 	GameMessage::Type evaluateForceAttack( Drawable *draw, const Coord3D *pos, CommandEvaluateType type );
 	GameMessage::Type evaluateContextCommand( Drawable *draw, const Coord3D *pos, CommandEvaluateType type );
 
@@ -64,9 +65,10 @@ private:
 	GameMessage::Type issueFireWeaponCommand( const CommandButton *command, CommandEvaluateType commandType, Drawable *target, const Coord3D *pos );
 	GameMessage::Type issueCombatDropCommand( const CommandButton *command, CommandEvaluateType commandType, Drawable *target, const Coord3D *pos );
 
-	void normalizeContextInputs( Drawable*& draw, Object*& obj, Drawable*& drawableInWay );
-	GameMessage::Type handleWaypointModeCommand( const Coord3D* pos, Drawable* draw, const CommandEvaluateType& type );
-	void normalizeGuiCommandTarget( const CommandButton* command, Drawable*& draw, Object*& obj );
+	void resolveContextTarget( Drawable *&draw, Object *&obj, Drawable *&drawableInWay );
+	void resolveGuiCommandTarget( const CommandButton *command, Drawable *&draw, Object *&obj );
+
+	GameMessage::Type handleWaypointModeCommand( const Coord3D *pos, Drawable *draw, CommandEvaluateType type );
 
 	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };

--- a/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -1655,6 +1655,731 @@ void CommandTranslator::resolveGuiCommandTarget( const CommandButton *command, D
 	}
 }
 
+GameMessage::Type CommandTranslator::handleGuiCommand( const CommandButton *command, Drawable *draw, Object *obj, const Coord3D *pos, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	resolveGuiCommandTarget( command, draw, obj );
+
+	Bool currentlyValid = FALSE;
+	ObjectID objectID = obj ? obj->getID() : INVALID_ID;
+	switch( command->getCommandType() )
+	{
+		//Kris: June 06, 2002
+		//This is a GUI command button that triggers a mode. In any of these modes, only one specific action
+		//can occur. If the mouse isn't over a valid target, then the conditions aren't met and the code will
+		//cause an invalid version of the cursor to be shown -- and should the user click, the action won't take place.
+		case GUICOMMANDMODE_CONVERT_TO_CARBOMB:
+			currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_CONVERT_OBJECT_TO_CARBOMB, obj, InGameUI::SELECTION_ANY );
+			break;
+		case GUICOMMANDMODE_HIJACK_VEHICLE:
+			currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_HIJACK_VEHICLE, obj, InGameUI::SELECTION_ANY );
+			break;
+		case GUICOMMANDMODE_SABOTAGE_BUILDING:
+			currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_SABOTAGE_BUILDING, obj, InGameUI::SELECTION_ANY );
+			break;
+#ifdef ALLOW_SURRENDER
+		case GUICOMMANDMODE_PICK_UP_PRISONER:
+			currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_PICK_UP_PRISONER, obj, InGameUI::SELECTION_ANY );
+			break;
+#endif
+		case GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT:
+		{
+			Object* unit = ThePlayerList->getLocalPlayer()->findMostReadyShortcutSpecialPowerOfType( command->getSpecialPowerTemplate()->getSpecialPowerType() );
+			if( unit )
+				currentlyValid = TheInGameUI->canSelectedObjectsDoSpecialPower( command, obj, pos, InGameUI::SELECTION_ANY, command->getOptions(), unit );
+			else
+				currentlyValid = false;
+			break;
+		}
+		case GUI_COMMAND_SPECIAL_POWER:
+			currentlyValid = TheInGameUI->canSelectedObjectsDoSpecialPower( command, obj, pos, InGameUI::SELECTION_ANY, command->getOptions(), nullptr );
+			break;
+		case GUI_COMMAND_FIRE_WEAPON:
+			currentlyValid = TheInGameUI->canSelectedObjectsEffectivelyUseWeapon( command, obj, pos, InGameUI::SELECTION_ANY );
+			break;
+		case GUI_COMMAND_COMBATDROP:
+			currentlyValid = !obj ? TRUE : TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_COMBATDROP_INTO, obj, InGameUI::SELECTION_ANY );
+			break;
+	}
+
+	if( currentlyValid )
+	{
+		if( type == DO_COMMAND || type == EVALUATE_ONLY )
+		{
+			switch( command->getCommandType() )
+			{
+				case GUICOMMANDMODE_CONVERT_TO_CARBOMB:
+				case GUICOMMANDMODE_HIJACK_VEHICLE:
+				case GUICOMMANDMODE_SABOTAGE_BUILDING:
+					msgType = createEnterMessage( draw, type );
+					break;
+#ifdef ALLOW_SURRENDER
+				case GUICOMMANDMODE_PICK_UP_PRISONER:
+					msgType = issueAttackCommand( draw, type, command->getCommandType() );
+					break;
+#endif
+				case GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT:
+				{
+					Object* unit = ThePlayerList->getLocalPlayer()->findMostReadyShortcutSpecialPowerOfType( command->getSpecialPowerTemplate()->getSpecialPowerType() );
+					if( unit )
+						msgType = issueSpecialPowerCommand( command, type, draw, pos, unit );
+					break;
+				}
+				case GUI_COMMAND_SPECIAL_POWER://lorenzen
+					msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
+					break;
+				case GUI_COMMAND_FIRE_WEAPON:
+					msgType = issueFireWeaponCommand( command, type, draw, pos );
+					break;
+				case GUI_COMMAND_COMBATDROP:
+					msgType = issueCombatDropCommand( command, type, draw, pos );
+					break;
+			}
+
+			// null out the GUI command if we're actually doing something
+			if( type == DO_COMMAND )
+			{
+				TheInGameUI->setGUICommand( nullptr );
+			}
+
+		}
+		else
+		{
+			msgType = GameMessage::MSG_VALID_GUICOMMAND_HINT;
+			hintMessage = TheMessageStream->appendMessage( msgType );
+			hintMessage->appendObjectIDArgument( objectID );
+		}
+	}
+	else	// not currently valid
+	{
+		msgType = GameMessage::MSG_INVALID_GUICOMMAND_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( objectID );
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleSpecialPowerConstructCommand( const CommandButton *command, Drawable *draw, const Coord3D *pos, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+
+	//We're using the build placement interface to determine where to build our special power item.
+	//Because of that, we only care about DO_COMMAND. The context evaluation and hint feedback system
+	//is already taken care of. But what we need to do is trigger the special power to actually build
+	//the object and reset the timer.
+	if( type == DO_COMMAND )
+	{
+		switch( command->getCommandType() )
+		{
+			case GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT:
+			{
+				Object* unit = ThePlayerList->getLocalPlayer()->findMostReadyShortcutSpecialPowerOfType( command->getSpecialPowerTemplate()->getSpecialPowerType() );
+				if( unit )
+					msgType = issueSpecialPowerCommand( command, type, draw, pos, unit );
+				break;
+			}
+			case GUI_COMMAND_SPECIAL_POWER://lorenzen
+				msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
+				break;
+		}
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleSpecialPowerOverrideDestinationCommand( const Coord3D *pos, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// do the command
+		msgType = GameMessage::MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION;
+		if( type == DO_COMMAND )
+		{
+			GameMessage *gameMsg = TheMessageStream->appendMessage( msgType );
+
+			gameMsg->appendLocationArgument( *pos );
+			gameMsg->appendIntegerArgument( SPECIAL_INVALID );
+			gameMsg->appendObjectIDArgument( INVALID_ID );	// no specific source
+
+		}
+
+	}
+	else
+	{
+
+		// generate a hint message
+		msgType = GameMessage::MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleResumeConstructionCommand( Object *obj, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// do the command
+		msgType = GameMessage::MSG_RESUME_CONSTRUCTION;
+		if( type == DO_COMMAND )
+		{
+			GameMessage *resumeMsg = TheMessageStream->appendMessage( msgType );
+
+			resumeMsg->appendObjectIDArgument( obj->getID() );
+
+			pickAndPlayUnitVoiceResponse( TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_RESUME_CONSTRUCTION );
+
+		}
+
+	}
+	else
+	{
+
+		// generate a hint message
+		msgType = GameMessage::MSG_RESUME_CONSTRUCTION_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( obj->getID() );
+
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleDockCommand( Object *obj, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	//
+	// The actual logic is simply to AIUpdate::dock with the target, the hint is the
+	// only part that needs to be more specific.
+	//
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// Give the dock command
+		msgType = GameMessage::MSG_DOCK;
+		if( type == DO_COMMAND )
+		{
+			GameMessage *dockMsg = TheMessageStream->appendMessage( msgType );
+
+			dockMsg->appendObjectIDArgument( obj->getID() );
+
+			// only make sounds if we really did the command messages
+			pickAndPlayUnitVoiceResponse(TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_DOCK);
+		}
+
+	}
+	else
+	{
+
+		// make the hint
+		msgType = GameMessage::MSG_DOCK_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( obj->getID() );
+
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleRepairObjectCommand( Object *obj, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// do the command
+		msgType = GameMessage::MSG_DO_REPAIR;
+		if( type == DO_COMMAND )
+		{
+			GameMessage *healMsg = TheMessageStream->appendMessage( msgType );
+
+			healMsg->appendObjectIDArgument( obj->getID() );
+
+			pickAndPlayUnitVoiceResponse( TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_DO_REPAIR );
+
+		}
+
+	}
+	else
+	{
+
+		// generate a hint message
+		msgType = GameMessage::MSG_DO_REPAIR_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( obj->getID() );
+
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleGetRepairedCommand( Object *obj, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// do the command
+		msgType = GameMessage::MSG_GET_REPAIRED;
+		if( type == DO_COMMAND )
+		{
+			GameMessage *healMsg = TheMessageStream->appendMessage( msgType );
+
+			healMsg->appendObjectIDArgument( obj->getID() );
+
+
+			pickAndPlayUnitVoiceResponse( TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_GET_REPAIRED );
+
+
+		}
+
+	}
+	else
+	{
+
+		// generate a hint message
+		msgType = GameMessage::MSG_GET_REPAIRED_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( obj->getID() );
+
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleGetHealedCommand( Object *obj, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// do the command
+		msgType = GameMessage::MSG_GET_HEALED;
+		if( type == DO_COMMAND )
+		{
+			GameMessage *healMsg = TheMessageStream->appendMessage( msgType );
+
+			healMsg->appendObjectIDArgument( obj->getID() );
+
+			pickAndPlayUnitVoiceResponse( TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_GET_HEALED );
+
+		}
+
+	}
+	else
+	{
+
+		// generate hint message
+		msgType = GameMessage::MSG_GET_HEALED_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType);
+		hintMessage->appendObjectIDArgument( obj->getID() );
+
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleHijackVehicleCommand( Drawable *draw, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// Now, this just tricks the AI  into making the hijacker run towards the target vehicle
+		// I must add a test to keep him from actually entering an enemy vehicle (contained)... Lorenzen
+		msgType = createEnterMessage( draw, type );
+
+	}
+	else
+	{
+
+		msgType = GameMessage::MSG_HIJACK_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( draw->getObject()->getID() );
+
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleConvertToCarBombCommand( Drawable *draw, Object *obj, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// issue the command (convert to carbomb is nearly identical to enter)
+		msgType = createEnterMessage( draw, type );
+
+	}
+	else
+	{
+
+		msgType = GameMessage::MSG_CONVERT_TO_CARBOMB_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( obj->getID() );
+
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleSabotageBuildingCommand( Drawable *draw, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+		msgType = createEnterMessage( draw, type );
+	}
+	else
+	{
+		msgType = GameMessage::MSG_SABOTAGE_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( draw->getObject()->getID() );
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleSalvageCommand( Object *obj, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+
+	GameMessage *msg;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY ) {
+		msgType = GameMessage::MSG_DO_SALVAGE;
+		if (type == DO_COMMAND) {
+			msg = TheMessageStream->appendMessage(msgType);
+			msg->appendLocationArgument(*obj->getPosition());
+			pickAndPlayUnitVoiceResponse(TheInGameUI->getAllSelectedDrawables(), msgType);
+		}
+
+	} else {
+		msgType = GameMessage::MSG_DO_SALVAGE_HINT;
+		msg = TheMessageStream->appendMessage(msgType);
+		msg->appendLocationArgument(*obj->getPosition());
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleEnterObjectCommand( Drawable *draw, Object *obj, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// issue the command
+		msgType = createEnterMessage( draw, type );
+
+	}
+	else
+	{
+
+		msgType = GameMessage::MSG_ENTER_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( obj->getID() );
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleAttackObjectCommand( Drawable *draw, Object *obj, CommandEvaluateType type, GameMessage::Type hintType )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// issue the attack order
+		msgType = issueAttackCommand( draw, type );
+
+	}
+	else
+	{
+
+		// Generate an Attack hint
+		msgType = hintType;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( obj->getID() );
+
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleCaptureBuildingCommand( Drawable *draw, Object *obj, const Coord3D *pos, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	//@TODO: Kris
+	//PRELIMINARY CODE FOR HOOKING IN AUTO SPECIALS --- WILL BE REDONE!
+	Object *source = TheInGameUI->getFirstSelectedDrawable()->getObject();
+	const CommandSet *set = TheControlBar->findCommandSet( source->getCommandSetString() );
+	if( set )
+	{
+		for( Int i = 0; i < MAX_COMMANDS_PER_SET; i++ )
+		{
+			// get command button
+			const CommandButton *command = set->getCommandButton(i);
+			if( command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER )
+			{
+				SpecialPowerType spType = command->getSpecialPowerTemplate()->getSpecialPowerType();
+				if( type == DO_COMMAND || type == EVALUATE_ONLY )
+				{
+					if( spType == SPECIAL_BLACKLOTUS_CAPTURE_BUILDING ||
+							spType == SPECIAL_INFANTRY_CAPTURE_BUILDING )
+					{
+						//Issue the capture building command
+						msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
+						break;
+					}
+				}
+				else if( spType == SPECIAL_BLACKLOTUS_CAPTURE_BUILDING )
+				{
+					//Issue the black lotus hack hint for capturing a building.
+					msgType = GameMessage::MSG_HACK_HINT;
+					hintMessage = TheMessageStream->appendMessage( msgType );
+					hintMessage->appendObjectIDArgument( obj->getID() );
+				}
+				else if( spType == SPECIAL_INFANTRY_CAPTURE_BUILDING )
+				{
+					//Issue the infantry hint for capturing a building
+					msgType = GameMessage::MSG_CAPTUREBUILDING_HINT;
+					hintMessage = TheMessageStream->appendMessage( msgType );
+					hintMessage->appendObjectIDArgument( obj->getID() );
+				}
+			}
+		}
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleHackCommand( Drawable *draw, Object *obj, const Coord3D *pos, CommandEvaluateType type, SpecialPowerType hackPower )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+		//@TODO: Kris
+		//PRELIMINARY CODE FOR HOOKING IN AUTO SPECIALS --- WILL BE REDONE!
+		Object *source = TheInGameUI->getFirstSelectedDrawable()->getObject();
+		const CommandSet *set = TheControlBar->findCommandSet( source->getCommandSetString() );
+		if( set )
+		{
+			for( Int i = 0; i < MAX_COMMANDS_PER_SET; i++ )
+			{
+				// get command button
+				const CommandButton *command = set->getCommandButton(i);
+				if( command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER )
+				{
+					SpecialPowerType spType = command->getSpecialPowerTemplate()->getSpecialPowerType();
+					if( spType == hackPower )
+					{
+						msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
+						break;
+					}
+				}
+			}
+		}
+	}
+	else
+	{
+		msgType = GameMessage::MSG_HACK_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( obj->getID() );
+	}
+
+	return msgType;
+}
+
+#ifdef ALLOW_SURRENDER
+GameMessage::Type CommandTranslator::handlePickUpPrisonerCommand( Drawable *draw, Object *obj, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+
+		// issue the command
+		msgType = issueAttackCommand( draw, type, GUICOMMANDMODE_PICK_UP_PRISONER );
+
+	}
+	else
+	{
+
+		msgType = GameMessage::MSG_PICK_UP_PRISONER_HINT;
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendObjectIDArgument( obj->getID() );
+
+	}
+
+	return msgType;
+}
+#endif
+
+GameMessage::Type CommandTranslator::handleSetRallyPointCommand( const Coord3D *pos, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_SET_RALLY_POINT;
+	GameMessage *hintMessage;
+
+	if (type == DO_COMMAND) {
+		const DrawableList *allSelectedDrawables = TheInGameUI->getAllSelectedDrawables();
+
+		for (DrawableList::const_iterator it = allSelectedDrawables->begin(); it != allSelectedDrawables->end(); ++it) {
+			Drawable *draw = (*it);
+			if (draw && draw->getObject()) {
+				GameMessage *newMsg = TheMessageStream->appendMessage(msgType);
+				newMsg->appendObjectIDArgument(draw->getObject()->getID());
+				newMsg->appendLocationArgument(*pos);
+			}
+		}
+	} else if (type == DO_HINT) {
+		msgType = GameMessage::MSG_SET_RALLY_POINT_HINT;
+		hintMessage = TheMessageStream->appendMessage(msgType);
+		hintMessage->appendLocationArgument(*pos);
+	}
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleImpossibleAttackHint( const Coord3D *pos )
+{
+	GameMessage::Type msgType = GameMessage::MSG_IMPOSSIBLE_ATTACK_HINT;
+	GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
+	hintMessage->appendLocationArgument( *pos );
+
+	return msgType;
+}
+
+GameMessage::Type CommandTranslator::handleDefaultMoveCommand( Drawable *draw, Drawable *drawableInWay, const Coord3D *pos, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+	GameMessage *hintMessage;
+
+	//
+	// NOTE: If you change this command evaluation function in what it will do
+	// if there is nothing picked ... you might want to edit the logic of the
+	// selection translator in that you can only select objects if there is
+	// no "interesting" command to do with the picked drawable ... which is determined
+	// by what we return in this function by default
+	//
+
+	//Before we issue a move order or hint, check to see if we can even move there!
+	Bool validQuickPath = FALSE;
+	// Make sure to only to the check if the shroud is CLEARED.  If it is fogged or shrouded, SKIP THE CHECK.  jba [3/11/2003]
+	if( ThePartitionManager->getShroudStatusForPlayer( ThePlayerList->getLocalPlayer()->getPlayerIndex(), pos ) != CELLSHROUD_CLEAR )
+	{
+		//If it's in the shroud, pretend we can move there -- skip the check.
+		validQuickPath = TRUE;
+	}
+	else
+	{
+		//Can we path there?
+		const DrawableList *allSelectedDrawables = TheInGameUI->getAllSelectedDrawables();
+		for( DrawableList::const_iterator it = allSelectedDrawables->begin(); it != allSelectedDrawables->end(); ++it )
+		{
+			Object *obj = (*it) ? (*it)->getObject() : nullptr;
+			AIUpdateInterface *ai = obj ? obj->getAI() : nullptr;
+			if( ai )
+			{
+				if ( ai->isQuickPathAvailable( pos ) )
+				{
+					validQuickPath = TRUE;
+					break;
+				}
+				// Wait! there are some units that CAN moveTo positions that Quickpath will reject,
+				// namely, Colonel Burton and the CombatBike. Both have CLIFF locomotors.
+				// We must detect whether the position is valid for these, before just invalidating the cursor,
+				// out of hand.
+				if ( ai->hasLocomotorForSurface( LOCOMOTORSURFACE_CLIFF ) )
+				{
+					if ( TheTerrainLogic->isCliffCell( pos->x, pos->y ) )
+					{
+						validQuickPath = TRUE;// yeah, not really quick, but you know...
+						break;
+					}
+				}
+			}
+
+
+		}
+	}
+
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+		// issue command
+		// Note: If draw is valid, then its one of ours and we don't have something more specific
+		// to do. Therefore, lets not issue a move command, and instead we'll return that there
+		// wasn't a command for us to perform.
+
+		if ( draw == nullptr )
+			msgType = issueMoveToLocationCommand( pos, drawableInWay, type );
+	}
+	else
+	{
+		if( !validQuickPath )
+		{
+			msgType = GameMessage::MSG_DO_INVALID_HINT;
+		}
+		else if( TheInGameUI->isInWaypointMode() )
+		{
+			//Waypoint mode
+			msgType = GameMessage::MSG_ADD_WAYPOINT_HINT;
+		}
+		else if( TheInGameUI->isInAttackMoveToMode() )
+		{
+			//THIS CODE WILL NEVER EVER GET CALLED! -- it's a context command now (READ: rip code out)
+			//Attack move
+			msgType = GameMessage::MSG_DO_ATTACKMOVETO_HINT;
+		}
+		else
+		{
+			//Normal and forced move.
+			msgType = GameMessage::MSG_DO_MOVETO_HINT;
+		}
+		hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendLocationArgument( *pos );
+
+	}
+
+	return msgType;
+}
+
 // ------------------------------------------------------------------------------------------------
 /** This method and the order of operations in the check here, determine what command would
 	* actually happen (if type parameter == DO_COMMAND) if the user clicked on the drawable
@@ -1680,11 +2405,10 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 
 	// Kris: Now that we can select non-controllable units/structures, don't allow any actions to be performed.
 	const CommandButton *command = TheInGameUI->getGUICommand();
-	GameMessage::Type msgType = GameMessage::MSG_INVALID;
 
 	if( command && command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON )
 	{
-		msgType = GameMessage::MSG_VALID_GUICOMMAND_HINT;
+		GameMessage::Type msgType = GameMessage::MSG_VALID_GUICOMMAND_HINT;
 		TheMessageStream->appendMessage( msgType );
 		return msgType;
 	}
@@ -1697,795 +2421,152 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 		return GameMessage::MSG_INVALID;
 	}
 
+	if( TheInGameUI->isInWaypointMode() )
 	{
-		if( TheInGameUI->isInWaypointMode() )
-		{
-			return handleWaypointModeCommand( pos, draw, type );
-		}
-
-		CanAttackResult result;
-		GameMessage *hintMessage;
-
-		if(command &&
-			(command->isContextCommand()
-				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER
-				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT))
-		{
-			resolveGuiCommandTarget( command, draw, obj );
-
-			Bool currentlyValid = FALSE;
-			ObjectID objectID = obj ? obj->getID() : INVALID_ID;
-			switch( command->getCommandType() )
-			{
-				//Kris: June 06, 2002
-				//This is a GUI command button that triggers a mode. In any of these modes, only one specific action
-				//can occur. If the mouse isn't over a valid target, then the conditions aren't met and the code will
-				//cause an invalid version of the cursor to be shown -- and should the user click, the action won't take place.
-				case GUICOMMANDMODE_CONVERT_TO_CARBOMB:
-					currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_CONVERT_OBJECT_TO_CARBOMB, obj, InGameUI::SELECTION_ANY );
-					break;
-				case GUICOMMANDMODE_HIJACK_VEHICLE:
-					currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_HIJACK_VEHICLE, obj, InGameUI::SELECTION_ANY );
-					break;
-				case GUICOMMANDMODE_SABOTAGE_BUILDING:
-					currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_SABOTAGE_BUILDING, obj, InGameUI::SELECTION_ANY );
-					break;
-#ifdef ALLOW_SURRENDER
-				case GUICOMMANDMODE_PICK_UP_PRISONER:
-					currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_PICK_UP_PRISONER, obj, InGameUI::SELECTION_ANY );
-					break;
-#endif
-				case GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT:
-				{
-					Object* unit = ThePlayerList->getLocalPlayer()->findMostReadyShortcutSpecialPowerOfType( command->getSpecialPowerTemplate()->getSpecialPowerType() );
-					if( unit )
-						currentlyValid = TheInGameUI->canSelectedObjectsDoSpecialPower( command, obj, pos, InGameUI::SELECTION_ANY, command->getOptions(), unit );
-					else
-						currentlyValid = false;
-					break;
-				}
-				case GUI_COMMAND_SPECIAL_POWER:
-					currentlyValid = TheInGameUI->canSelectedObjectsDoSpecialPower( command, obj, pos, InGameUI::SELECTION_ANY, command->getOptions(), nullptr );
-					break;
-				case GUI_COMMAND_FIRE_WEAPON:
-					currentlyValid = TheInGameUI->canSelectedObjectsEffectivelyUseWeapon( command, obj, pos, InGameUI::SELECTION_ANY );
-					break;
-				case GUI_COMMAND_COMBATDROP:
-					currentlyValid = !obj ? TRUE : TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_COMBATDROP_INTO, obj, InGameUI::SELECTION_ANY );
-					break;
-			}
-
-			if( currentlyValid )
-			{
-				if( type == DO_COMMAND || type == EVALUATE_ONLY )
-				{
-					switch( command->getCommandType() )
-					{
-						case GUICOMMANDMODE_CONVERT_TO_CARBOMB:
-						case GUICOMMANDMODE_HIJACK_VEHICLE:
-						case GUICOMMANDMODE_SABOTAGE_BUILDING:
-							msgType = createEnterMessage( draw, type );
-							break;
-#ifdef ALLOW_SURRENDER
-						case GUICOMMANDMODE_PICK_UP_PRISONER:
-							msgType = issueAttackCommand( draw, type, command->getCommandType() );
-							break;
-#endif
-						case GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT:
-						{
-							Object* unit = ThePlayerList->getLocalPlayer()->findMostReadyShortcutSpecialPowerOfType( command->getSpecialPowerTemplate()->getSpecialPowerType() );
-							if( unit )
-								msgType = issueSpecialPowerCommand( command, type, draw, pos, unit );
-							break;
-						}
-						case GUI_COMMAND_SPECIAL_POWER://lorenzen
-							msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
-							break;
-						case GUI_COMMAND_FIRE_WEAPON:
-							msgType = issueFireWeaponCommand( command, type, draw, pos );
-							break;
-						case GUI_COMMAND_COMBATDROP:
-							msgType = issueCombatDropCommand( command, type, draw, pos );
-							break;
-					}
-
-					// null out the GUI command if we're actually doing something
-					if( type == DO_COMMAND )
-					{
-						TheInGameUI->setGUICommand( nullptr );
-					}
-
-				}
-				else
-				{
-					msgType = GameMessage::MSG_VALID_GUICOMMAND_HINT;
-					hintMessage = TheMessageStream->appendMessage( msgType );
-					hintMessage->appendObjectIDArgument( objectID );
-				}
-			}
-			else	// not currently valid
-			{
-				msgType = GameMessage::MSG_INVALID_GUICOMMAND_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( objectID );
-			}
-
-		}
-		else if( command && (command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_CONSTRUCT
-						 || command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_CONSTRUCT_FROM_SHORTCUT) )
-		{
-			//We're using the build placement interface to determine where to build our special power item.
-			//Because of that, we only care about DO_COMMAND. The context evaluation and hint feedback system
-			//is already taken care of. But what we need to do is trigger the special power to actually build
-			//the object and reset the timer.
-			if( type == DO_COMMAND )
-			{
-				switch( command->getCommandType() )
-				{
-					case GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT:
-					{
-						Object* unit = ThePlayerList->getLocalPlayer()->findMostReadyShortcutSpecialPowerOfType( command->getSpecialPowerTemplate()->getSpecialPowerType() );
-						if( unit )
-							msgType = issueSpecialPowerCommand( command, type, draw, pos, unit );
-						break;
-					}
-					case GUI_COMMAND_SPECIAL_POWER://lorenzen
-						msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
-						break;
-				}
-			}
-		}
-
-
-		// ********************************************************************************************
-		else if( TheInGameUI->canSelectedObjectsOverrideSpecialPowerDestination( pos, InGameUI::SELECTION_ANY, SPECIAL_INVALID ) )
-		{
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// do the command
-				msgType = GameMessage::MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION;
-				if( type == DO_COMMAND )
-				{
-					GameMessage *gameMsg = TheMessageStream->appendMessage( msgType );
-
-					gameMsg->appendLocationArgument( *pos );
-					gameMsg->appendIntegerArgument( SPECIAL_INVALID );
-					gameMsg->appendObjectIDArgument( INVALID_ID );	// no specific source
-
-				}
-
-			}
-			else
-			{
-
-				// generate a hint message
-				msgType = GameMessage::MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-
-			}
-		}
-
-		// ********************************************************************************************
-		else if( draw && !TheInGameUI->isInForceAttackMode() &&
-						 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_RESUME_CONSTRUCTION, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// do the command
-				msgType = GameMessage::MSG_RESUME_CONSTRUCTION;
-				if( type == DO_COMMAND )
-				{
-					GameMessage *resumeMsg = TheMessageStream->appendMessage( msgType );
-
-					resumeMsg->appendObjectIDArgument( obj->getID() );
-
-					pickAndPlayUnitVoiceResponse( TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_RESUME_CONSTRUCTION );
-
-				}
-
-			}
-			else
-			{
-
-				// generate a hint message
-				msgType = GameMessage::MSG_RESUME_CONSTRUCTION_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && !TheInGameUI->isInForceAttackMode() &&
-						 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_DOCK_AT,
-																											obj,
-																											InGameUI::SELECTION_ALL ) )
-		{
-
-			//
-			// The actual logic is simply to AIUpdate::dock with the target, the hint is the
-			// only part that needs to be more specific.
-			//
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// Give the dock command
-				msgType = GameMessage::MSG_DOCK;
-				if( type == DO_COMMAND )
-				{
-					GameMessage *dockMsg = TheMessageStream->appendMessage( msgType );
-
-					dockMsg->appendObjectIDArgument( obj->getID() );
-
- 					// only make sounds if we really did the command messages
- 					pickAndPlayUnitVoiceResponse(TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_DOCK);
-				}
-
-			}
-			else
-			{
-
-				// make the hint
-				msgType = GameMessage::MSG_DOCK_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && !TheInGameUI->isInForceAttackMode() &&
-						 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_REPAIR_OBJECT, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// do the command
-				msgType = GameMessage::MSG_DO_REPAIR;
-				if( type == DO_COMMAND )
-				{
-					GameMessage *healMsg = TheMessageStream->appendMessage( msgType );
-
-					healMsg->appendObjectIDArgument( obj->getID() );
-
-					pickAndPlayUnitVoiceResponse( TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_DO_REPAIR );
-
-				}
-
-			}
-			else
-			{
-
-				// generate a hint message
-				msgType = GameMessage::MSG_DO_REPAIR_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && !TheInGameUI->isInForceAttackMode() &&
-						TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_GET_REPAIRED_AT, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// do the command
-				msgType = GameMessage::MSG_GET_REPAIRED;
-				if( type == DO_COMMAND )
-				{
-					GameMessage *healMsg = TheMessageStream->appendMessage( msgType );
-
-					healMsg->appendObjectIDArgument( obj->getID() );
-
-
-					pickAndPlayUnitVoiceResponse( TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_GET_REPAIRED );
-
-
-				}
-
-			}
-			else
-			{
-
-				// generate a hint message
-				msgType = GameMessage::MSG_GET_REPAIRED_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && !TheInGameUI->isInForceAttackMode() &&
-						 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_GET_HEALED_AT, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// do the command
-				msgType = GameMessage::MSG_GET_HEALED;
-				if( type == DO_COMMAND )
-				{
-					GameMessage *healMsg = TheMessageStream->appendMessage( msgType );
-
-					healMsg->appendObjectIDArgument( obj->getID() );
-
-					pickAndPlayUnitVoiceResponse( TheInGameUI->getAllSelectedDrawables(), GameMessage::MSG_GET_HEALED );
-
-				}
-
-			}
-			else
-			{
-
-				// generate hint message
-				msgType = GameMessage::MSG_GET_HEALED_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType);
-				hintMessage->appendObjectIDArgument( obj->getID() );
-
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && draw->getObject() && !TheInGameUI->isInForceAttackMode() &&
-						 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_HIJACK_VEHICLE,
-																											draw->getObject(),
-																											InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// Now, this just tricks the AI  into making the hijacker run towards the target vehicle
-        // I must add a test to keep him from actually entering an enemy vehicle (contained)... Lorenzen
-        msgType = createEnterMessage( draw, type );
-
-			}
-			else
-			{
-
-				msgType = GameMessage::MSG_HIJACK_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( draw->getObject()->getID() );
-
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && !TheInGameUI->isInForceAttackMode() &&
-						 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_CONVERT_OBJECT_TO_CARBOMB, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// issue the command (convert to carbomb is nearly identical to enter)
-				msgType = createEnterMessage( draw, type );
-
-			}
-			else
-			{
-
-				msgType = GameMessage::MSG_CONVERT_TO_CARBOMB_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-
-			}
-		}
-		// ********************************************************************************************
-		else if( draw && draw->getObject() && !TheInGameUI->isInForceAttackMode() &&
-						 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_SABOTAGE_BUILDING,
-																											draw->getObject(),
-																											InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-        msgType = createEnterMessage( draw, type );
-			}
-			else
-			{
-				msgType = GameMessage::MSG_SABOTAGE_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( draw->getObject()->getID() );
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && !TheInGameUI->isInForceAttackMode() && canSelectionSalvage(obj) )
-		{
-			GameMessage *msg;
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY ) {
-				msgType = GameMessage::MSG_DO_SALVAGE;
-				if (type == DO_COMMAND) {
-					msg = TheMessageStream->appendMessage(msgType);
-					msg->appendLocationArgument(*obj->getPosition());
-					pickAndPlayUnitVoiceResponse(TheInGameUI->getAllSelectedDrawables(), msgType);
-				}
-
-			} else {
-				msgType = GameMessage::MSG_DO_SALVAGE_HINT;
-				msg = TheMessageStream->appendMessage(msgType);
-				msg->appendLocationArgument(*obj->getPosition());
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && !TheInGameUI->isInForceAttackMode() &&
-						 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_ENTER_OBJECT, obj, InGameUI::SELECTION_ANY, true ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// issue the command
-				msgType = createEnterMessage( draw, type );
-
-			}
-			else
-			{
-
-				msgType = GameMessage::MSG_ENTER_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && (result = TheInGameUI->getCanSelectedObjectsAttack( InGameUI::ACTIONTYPE_ATTACK_OBJECT, obj, InGameUI::SELECTION_ANY, TheInGameUI->isInForceAttackMode() )) == ATTACKRESULT_POSSIBLE )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// issue the attack order
-				msgType = issueAttackCommand( draw, type );
-
-			}
-			else
-			{
-
-				// Generate an Attack hint
-				msgType = GameMessage::MSG_DO_ATTACK_OBJECT_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && result == ATTACKRESULT_POSSIBLE_AFTER_MOVING )
-		{
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// issue the attack order
-				msgType = issueAttackCommand( draw, type );
-
-			}
-			else
-			{
-
-				// Generate an Attack hint
-				msgType = GameMessage::MSG_DO_ATTACK_OBJECT_AFTER_MOVING_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_CAPTURE_BUILDING, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			//@TODO: Kris
-			//PRELIMINARY CODE FOR HOOKING IN AUTO SPECIALS --- WILL BE REDONE!
-			Object *source = TheInGameUI->getFirstSelectedDrawable()->getObject();
-			const CommandSet *set = TheControlBar->findCommandSet( source->getCommandSetString() );
-			if( set )
-			{
-				for( Int i = 0; i < MAX_COMMANDS_PER_SET; i++ )
-				{
-					// get command button
-					const CommandButton *command = set->getCommandButton(i);
-					if( command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER )
-					{
-						SpecialPowerType spType = command->getSpecialPowerTemplate()->getSpecialPowerType();
-						if( type == DO_COMMAND || type == EVALUATE_ONLY )
-						{
-							if( spType == SPECIAL_BLACKLOTUS_CAPTURE_BUILDING ||
-									spType == SPECIAL_INFANTRY_CAPTURE_BUILDING )
-							{
-								//Issue the capture building command
-								msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
-								break;
-							}
-						}
-						else if( spType == SPECIAL_BLACKLOTUS_CAPTURE_BUILDING )
-						{
-							//Issue the black lotus hack hint for capturing a building.
-							msgType = GameMessage::MSG_HACK_HINT;
-							hintMessage = TheMessageStream->appendMessage( msgType );
-							hintMessage->appendObjectIDArgument( obj->getID() );
-						}
-						else if( spType == SPECIAL_INFANTRY_CAPTURE_BUILDING )
-						{
-							//Issue the infantry hint for capturing a building
-							msgType = GameMessage::MSG_CAPTUREBUILDING_HINT;
-							hintMessage = TheMessageStream->appendMessage( msgType );
-							hintMessage->appendObjectIDArgument( obj->getID() );
-						}
-					}
-				}
-			}
-		}
-		// ********************************************************************************************
-		else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_DISABLE_VEHICLE_VIA_HACKING, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-				//@TODO: Kris
-				//PRELIMINARY CODE FOR HOOKING IN AUTO SPECIALS --- WILL BE REDONE!
-				Object *source = TheInGameUI->getFirstSelectedDrawable()->getObject();
-				const CommandSet *set = TheControlBar->findCommandSet( source->getCommandSetString() );
-				if( set )
-				{
-					for( Int i = 0; i < MAX_COMMANDS_PER_SET; i++ )
-					{
-						// get command button
-						const CommandButton *command = set->getCommandButton(i);
-						if( command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER )
-						{
-							SpecialPowerType spType = command->getSpecialPowerTemplate()->getSpecialPowerType();
-							if( spType == SPECIAL_BLACKLOTUS_DISABLE_VEHICLE_HACK )
-							{
-								msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
-								break;
-							}
-						}
-					}
-				}
-			}
-			else
-			{
-				msgType = GameMessage::MSG_HACK_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_STEAL_CASH_VIA_HACKING, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-				//@TODO: Kris
-				//PRELIMINARY CODE FOR HOOKING IN AUTO SPECIALS --- WILL BE REDONE!
-				Object *source = TheInGameUI->getFirstSelectedDrawable()->getObject();
-				const CommandSet *set = TheControlBar->findCommandSet( source->getCommandSetString() );
-				if( set )
-				{
-					for( Int i = 0; i < MAX_COMMANDS_PER_SET; i++ )
-					{
-						// get command button
-						const CommandButton *command = set->getCommandButton(i);
-						if( command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER )
-						{
-							SpecialPowerType spType = command->getSpecialPowerTemplate()->getSpecialPowerType();
-							if( spType == SPECIAL_BLACKLOTUS_STEAL_CASH_HACK )
-							{
-								msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
-								break;
-							}
-						}
-					}
-				}
-			}
-			else
-			{
-				msgType = GameMessage::MSG_HACK_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-			}
-
-		}
-		// ********************************************************************************************
-		else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_DISABLE_BUILDING_VIA_HACKING, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-				//@TODO: Kris
-				//PRELIMINARY CODE FOR HOOKING IN AUTO SPECIALS --- WILL BE REDONE!
-				Object *source = TheInGameUI->getFirstSelectedDrawable()->getObject();
-				const CommandSet *set = TheControlBar->findCommandSet( source->getCommandSetString() );
-				if( set )
-				{
-					for( Int i = 0; i < MAX_COMMANDS_PER_SET; i++ )
-					{
-						// get command button
-						const CommandButton *command = set->getCommandButton(i);
-						if( command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER )
-						{
-							SpecialPowerType spType = command->getSpecialPowerTemplate()->getSpecialPowerType();
-							if( spType == SPECIAL_HACKER_DISABLE_BUILDING )
-							{
-								msgType = issueSpecialPowerCommand( command, type, draw, pos, nullptr );
-								break;
-							}
-						}
-					}
-				}
-			}
-			else
-			{
-				msgType = GameMessage::MSG_HACK_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-			}
-		}
-#ifdef ALLOW_SURRENDER
-		// ********************************************************************************************
-		else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_PICK_UP_PRISONER, obj, InGameUI::SELECTION_ANY ) )
-		{
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-
-				// issue the command
-				msgType = issueAttackCommand( draw, type, GUICOMMANDMODE_PICK_UP_PRISONER );
-
-			}
-			else
-			{
-
-				msgType = GameMessage::MSG_PICK_UP_PRISONER_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendObjectIDArgument( obj->getID() );
-
-			}
-
-		}
-#endif
-		// ********************************************************************************************
-		else if ( !draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_SET_RALLY_POINT, nullptr, InGameUI::SELECTION_ALL, FALSE ))
-		{
-			msgType = GameMessage::MSG_SET_RALLY_POINT;
-
-			if (type == DO_COMMAND) {
-				const DrawableList *allSelectedDrawables = TheInGameUI->getAllSelectedDrawables();
-
-				for (DrawableList::const_iterator it = allSelectedDrawables->begin(); it != allSelectedDrawables->end(); ++it) {
-					Drawable *draw = (*it);
-					if (draw && draw->getObject()) {
-						GameMessage *newMsg = TheMessageStream->appendMessage(msgType);
-						newMsg->appendObjectIDArgument(draw->getObject()->getID());
-						newMsg->appendLocationArgument(*pos);
-					}
-				}
-			} else if (type == DO_HINT) {
-				msgType = GameMessage::MSG_SET_RALLY_POINT_HINT;
-				hintMessage = TheMessageStream->appendMessage(msgType);
-				hintMessage->appendLocationArgument(*pos);
-			}
-		}
-
-		// ********************************************************************************************
-		else if( draw && result == ATTACKRESULT_INVALID_SHOT )
-		{
-			msgType = GameMessage::MSG_IMPOSSIBLE_ATTACK_HINT;
-			hintMessage = TheMessageStream->appendMessage( msgType );
-			hintMessage->appendLocationArgument( *pos );
-		}
-
-		// ********************************************************************************************
-		else
-		{
-
-			//
-			// NOTE: If you change this command evaluation function in what it will do
-			// if there is nothing picked ... you might want to edit the logic of the
-			// selection translator in that you can only select objects if there is
-			// no "interesting" command to do with the picked drawable ... which is determined
-			// by what we return in this function by default
-			//
-
-			//Before we issue a move order or hint, check to see if we can even move there!
-			Bool validQuickPath = FALSE;
-			// Make sure to only to the check if the shroud is CLEARED.  If it is fogged or shrouded, SKIP THE CHECK.  jba [3/11/2003]
-			if( ThePartitionManager->getShroudStatusForPlayer( ThePlayerList->getLocalPlayer()->getPlayerIndex(), pos ) != CELLSHROUD_CLEAR )
-			{
-				//If it's in the shroud, pretend we can move there -- skip the check.
-				validQuickPath = TRUE;
-			}
-			else
-			{
-				//Can we path there?
-				const DrawableList *allSelectedDrawables = TheInGameUI->getAllSelectedDrawables();
-				for( DrawableList::const_iterator it = allSelectedDrawables->begin(); it != allSelectedDrawables->end(); ++it )
-				{
-					Object *obj = (*it) ? (*it)->getObject() : nullptr;
-					AIUpdateInterface *ai = obj ? obj->getAI() : nullptr;
-					if( ai )
-          {
-            if ( ai->isQuickPathAvailable( pos ) )
-					  {
-						  validQuickPath = TRUE;
-						  break;
-					  }
-            // Wait! there are some units that CAN moveTo positions that Quickpath will reject,
-            // namely, Colonel Burton and the CombatBike. Both have CLIFF locomotors.
-            // We must detect whether the position is valid for these, before just invalidating the cursor,
-            // out of hand.
-            if ( ai->hasLocomotorForSurface( LOCOMOTORSURFACE_CLIFF ) )
-            {
-              if ( TheTerrainLogic->isCliffCell( pos->x, pos->y ) )
-              {
-						    validQuickPath = TRUE;// yeah, not really quick, but you know...
-						    break;
-              }
-            }
-          }
-
-
-				}
-			}
-
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-				// issue command
-				// Note: If draw is valid, then its one of ours and we don't have something more specific
-				// to do. Therefore, lets not issue a move command, and instead we'll return that there
-				// wasn't a command for us to perform.
-
-				if ( draw == nullptr )
-					msgType = issueMoveToLocationCommand( pos, drawableInWay, type );
-			}
-			else
-			{
-				if( !validQuickPath )
-				{
-					msgType = GameMessage::MSG_DO_INVALID_HINT;
-				}
-				else if( TheInGameUI->isInWaypointMode() )
-				{
-					//Waypoint mode
-					msgType = GameMessage::MSG_ADD_WAYPOINT_HINT;
-				}
-				else if( TheInGameUI->isInAttackMoveToMode() )
-				{
-					//THIS CODE WILL NEVER EVER GET CALLED! -- it's a context command now (READ: rip code out)
-					//Attack move
-					msgType = GameMessage::MSG_DO_ATTACKMOVETO_HINT;
-				}
-				else
-				{
-					//Normal and forced move.
-					msgType = GameMessage::MSG_DO_MOVETO_HINT;
-				}
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendLocationArgument( *pos );
-
-			}
-
-		}
-
+		return handleWaypointModeCommand( pos, draw, type );
 	}
 
-	// return the message type
-	return msgType;
+	CanAttackResult result;
 
+	if(command &&
+		(command->isContextCommand()
+			|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER
+			|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT))
+	{
+		return handleGuiCommand( command, draw, obj, pos, type );
+	}
+	else if( command && (command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_CONSTRUCT
+					 || command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_CONSTRUCT_FROM_SHORTCUT) )
+	{
+		return handleSpecialPowerConstructCommand( command, draw, pos, type );
+	}
+
+
+	// ********************************************************************************************
+	else if( TheInGameUI->canSelectedObjectsOverrideSpecialPowerDestination( pos, InGameUI::SELECTION_ANY, SPECIAL_INVALID ) )
+	{
+		return handleSpecialPowerOverrideDestinationCommand( pos, type );
+	}
+
+	// ********************************************************************************************
+	else if( draw && !TheInGameUI->isInForceAttackMode() &&
+					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_RESUME_CONSTRUCTION, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handleResumeConstructionCommand( obj, type );
+	}
+	// ********************************************************************************************
+	else if( draw && !TheInGameUI->isInForceAttackMode() &&
+					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_DOCK_AT,
+																										obj,
+																										InGameUI::SELECTION_ALL ) )
+	{
+		return handleDockCommand( obj, type );
+	}
+	// ********************************************************************************************
+	else if( draw && !TheInGameUI->isInForceAttackMode() &&
+					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_REPAIR_OBJECT, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handleRepairObjectCommand( obj, type );
+	}
+	// ********************************************************************************************
+	else if( draw && !TheInGameUI->isInForceAttackMode() &&
+					TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_GET_REPAIRED_AT, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handleGetRepairedCommand( obj, type );
+	}
+	// ********************************************************************************************
+	else if( draw && !TheInGameUI->isInForceAttackMode() &&
+					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_GET_HEALED_AT, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handleGetHealedCommand( obj, type );
+	}
+	// ********************************************************************************************
+	else if( draw && draw->getObject() && !TheInGameUI->isInForceAttackMode() &&
+					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_HIJACK_VEHICLE,
+																										draw->getObject(),
+																										InGameUI::SELECTION_ANY ) )
+	{
+		return handleHijackVehicleCommand( draw, type );
+	}
+	// ********************************************************************************************
+	else if( draw && !TheInGameUI->isInForceAttackMode() &&
+					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_CONVERT_OBJECT_TO_CARBOMB, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handleConvertToCarBombCommand( draw, obj, type );
+	}
+	// ********************************************************************************************
+	else if( draw && draw->getObject() && !TheInGameUI->isInForceAttackMode() &&
+					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_SABOTAGE_BUILDING,
+																										draw->getObject(),
+																										InGameUI::SELECTION_ANY ) )
+	{
+		return handleSabotageBuildingCommand( draw, type );
+	}
+	// ********************************************************************************************
+	else if( draw && !TheInGameUI->isInForceAttackMode() && canSelectionSalvage(obj) )
+	{
+		return handleSalvageCommand( obj, type );
+	}
+	// ********************************************************************************************
+	else if( draw && !TheInGameUI->isInForceAttackMode() &&
+					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_ENTER_OBJECT, obj, InGameUI::SELECTION_ANY, true ) )
+	{
+		return handleEnterObjectCommand( draw, obj, type );
+	}
+	// ********************************************************************************************
+	else if( draw && (result = TheInGameUI->getCanSelectedObjectsAttack( InGameUI::ACTIONTYPE_ATTACK_OBJECT, obj, InGameUI::SELECTION_ANY, TheInGameUI->isInForceAttackMode() )) == ATTACKRESULT_POSSIBLE )
+	{
+		return handleAttackObjectCommand( draw, obj, type, GameMessage::MSG_DO_ATTACK_OBJECT_HINT );
+	}
+	// ********************************************************************************************
+	else if( draw && result == ATTACKRESULT_POSSIBLE_AFTER_MOVING )
+	{
+		return handleAttackObjectCommand( draw, obj, type, GameMessage::MSG_DO_ATTACK_OBJECT_AFTER_MOVING_HINT );
+	}
+	// ********************************************************************************************
+	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_CAPTURE_BUILDING, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handleCaptureBuildingCommand( draw, obj, pos, type );
+	}
+	// ********************************************************************************************
+	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_DISABLE_VEHICLE_VIA_HACKING, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handleHackCommand( draw, obj, pos, type, SPECIAL_BLACKLOTUS_DISABLE_VEHICLE_HACK );
+	}
+	// ********************************************************************************************
+	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_STEAL_CASH_VIA_HACKING, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handleHackCommand( draw, obj, pos, type, SPECIAL_BLACKLOTUS_STEAL_CASH_HACK );
+	}
+	// ********************************************************************************************
+	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_DISABLE_BUILDING_VIA_HACKING, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handleHackCommand( draw, obj, pos, type, SPECIAL_HACKER_DISABLE_BUILDING );
+	}
+#ifdef ALLOW_SURRENDER
+	// ********************************************************************************************
+	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_PICK_UP_PRISONER, obj, InGameUI::SELECTION_ANY ) )
+	{
+		return handlePickUpPrisonerCommand( draw, obj, type );
+	}
+#endif
+	// ********************************************************************************************
+	else if ( !draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_SET_RALLY_POINT, nullptr, InGameUI::SELECTION_ALL, FALSE ))
+	{
+		return handleSetRallyPointCommand( pos, type );
+	}
+
+	// ********************************************************************************************
+	else if( draw && result == ATTACKRESULT_INVALID_SHOT )
+	{
+		return handleImpossibleAttackHint( pos );
+	}
+
+	// ********************************************************************************************
+	else
+	{
+		return handleDefaultMoveCommand( draw, drawableInWay, pos, type );
+	}
 }
 
 

--- a/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -1538,29 +1538,18 @@ GameMessage::Type CommandTranslator::evaluateForceAttack( Drawable *draw, const 
 	return retVal;
 }
 
-// ------------------------------------------------------------------------------------------------
-/** This method and the order of operations in the check here, determine what command would
-	* actually happen (if type parameter == DO_COMMAND) if the user clicked on the drawable
-	* 'draw'.  If type == DO_HINT, then the user hasn't actually clicked, but has moused over
-	* the drawable 'draw' and we want to generate a hint message as to what the actual
-	* command would be if clicked
-	* NOTE: draw can be null, in which case we give a hint for the location */
-// ------------------------------------------------------------------------------------------------
-GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
-																														 const Coord3D *pos,
-																														 CommandEvaluateType type )
+void CommandTranslator::normalizeContextInputs(Drawable*& draw, Object*& obj, Drawable*& drawableInWay)
 {
-	Object *obj = draw ? draw->getObject() : nullptr;
-	Drawable *drawableInWay = draw;
-
 	//This piece of code is used to prevent interaction with unselectable objects or masked objects. When we
 	//call this function, we typically pass in both a position and a drawable (if applicable), so if the
 	//drawable is invalid... then convert it to a position to be evaluated instead.
 	//Added: shrubberies are the exception for interactions...
 	//Removed: GS Took out ObjectStatusUnselectable, since that status only prevents selection, not everything
-	if( obj == nullptr ||
-			( obj->getStatusBits().test( OBJECT_STATUS_MASKED ) &&
-			!obj->isKindOf(KINDOF_SHRUBBERY) && !obj->isKindOf(KINDOF_FORCEATTACKABLE) ) )
+	if ( obj == nullptr ||
+		( obj->getStatusBits().test( OBJECT_STATUS_MASKED ) &&
+		!obj->isKindOf(KINDOF_SHRUBBERY) &&
+		!obj->isKindOf(KINDOF_FORCEATTACKABLE) )
+	)
 	{
 		//Nulling out the draw and obj pointer will force the remainder of this code to evaluate
 		//a position interaction.
@@ -1569,121 +1558,162 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 	}
 
 	// If the thing is a mine, and is locally controlled, then we should issue a moveto to its location.
-	if (obj && obj->isLocallyControlled() && obj->isKindOf(KINDOF_MINE)) {
+	if (obj && obj->isLocallyControlled() && obj->isKindOf(KINDOF_MINE))
+	{
 		draw = nullptr;
 		obj = nullptr;
 	}
 
-	if( TheInGameUI->isInForceMoveToMode() )
+	if ( TheInGameUI->isInForceMoveToMode() )
 	{
 		//Nulling out the draw and obj pointer will force the remainder of this code to evaluate
 		//a position interaction.
 		draw = nullptr;
 		obj = nullptr;
-	} else if (TheInGameUI->isInForceAttackMode() ) {
+	}
+	else if (TheInGameUI->isInForceAttackMode() )
+	{
 		// setting the drawableInWay to draw will allow us to force attack in the issue move command
 		// if there is a location to which we should attack.
 		drawableInWay = draw;
 	}
+}
 
+GameMessage::Type CommandTranslator::handleWaypointModeCommand(const Coord3D* pos, Drawable* draw, const CommandEvaluateType& type)
+{
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+
+	//Override any *other* commands with waypoint commands.
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+		if( TheTerrainLogic )
+		{
+			msgType = issueMoveToLocationCommand( pos, draw, type );
+		}
+	}
+	else
+	{
+		msgType = GameMessage::MSG_ADD_WAYPOINT_HINT;
+		GameMessage* hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendLocationArgument( *pos );
+	}
+
+	return msgType;
+}
+
+void CommandTranslator::normalizeGuiCommandTarget( const CommandButton* command, Drawable*& draw, Object*& obj )
+{
+	if( obj && obj->isKindOf( KINDOF_SHRUBBERY ) && !BitIsSet( command->getOptions(), ALLOW_SHRUBBERY_TARGET ) )
+	{
+		//If our object is a shrubbery, and we don't allow targeting it... then null it out.
+		//Nulling out the draw and obj pointer will force the remainder of this code to evaluate
+		//a position interaction.
+		draw = nullptr;
+		obj = nullptr;
+	}
+
+	if( obj && obj->isKindOf( KINDOF_MINE ) && !BitIsSet( command->getOptions(), ALLOW_MINE_TARGET ) )
+	{
+		//If our object is a mine, and we don't allow targeting it... then null it out.
+		//Nulling out the draw and obj pointer will force the remainder of this code to evaluate
+		//a position interaction.
+		draw = nullptr;
+		obj = nullptr;
+	}
+
+	//Kris: September 27, 2002
+	//Added relationship tests to make sure we're not attempting a context-command on a restricted relationship.
+	//This case prevents rebels from using tranq darts on allies.
+	if( obj && BitIsSet( command->getOptions(), COMMAND_OPTION_NEED_OBJECT_TARGET ) )
+	{
+		Relationship relationship = ThePlayerList->getLocalPlayer()->getRelationship( obj->getTeam() );
+
+		switch( relationship )
+		{
+			case ALLIES:
+				if( !BitIsSet( command->getOptions(), NEED_TARGET_ALLY_OBJECT ) )
+				{
+					draw = nullptr;
+					obj = nullptr;
+				}
+				break;
+			case ENEMIES:
+				if( !BitIsSet( command->getOptions(), NEED_TARGET_ENEMY_OBJECT ) )
+				{
+					draw = nullptr;
+					obj = nullptr;
+				}
+				break;
+			case NEUTRAL:
+				if( !BitIsSet( command->getOptions(), NEED_TARGET_NEUTRAL_OBJECT ) )
+				{
+					draw = nullptr;
+					obj = nullptr;
+				}
+				break;
+		}
+	}
+}
+
+// ------------------------------------------------------------------------------------------------
+/** This method and the order of operations in the check here, determine what command would
+	* actually happen (if type parameter == DO_COMMAND) if the user clicked on the drawable
+	* 'draw'.  If type == DO_HINT, then the user hasn't actually clicked, but has moused over
+	* the drawable 'draw' and we want to generate a hint message as to what the actual
+	* command would be if clicked
+	* NOTE: draw can be null, in which case we give a hint for the location */
+// ------------------------------------------------------------------------------------------------
+GameMessage::Type CommandTranslator::evaluateContextCommand(
+	Drawable *draw,
+	const Coord3D *pos,
+	CommandEvaluateType type
+) {
+	Object *obj = draw ? draw->getObject() : nullptr;
+	Drawable *drawableInWay = draw;
+	normalizeContextInputs(draw, obj, drawableInWay);
 
 	// Then we should determine if the game currently prefers selection events. If it does, then return
 	// the invalid message.
-	if (obj) {
-		if (obj->isLocallyControlled() && TheInGameUI->isInPreferSelectionMode()) {
-			return msgType;
-		}
+	if (obj && obj->isLocallyControlled() && TheInGameUI->isInPreferSelectionMode())
+	{
+		return GameMessage::MSG_INVALID;
 	}
 
 	// Kris: Now that we can select non-controllable units/structures, don't allow any actions to be performed.
 	const CommandButton *command = TheInGameUI->getGUICommand();
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
 
 	if (command && command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON)
 	{
 		msgType = GameMessage::MSG_VALID_GUICOMMAND_HINT;
 		TheMessageStream->appendMessage(msgType);
+		return msgType;
 	}
-	else if( TheInGameUI->areSelectedObjectsControllable()
-			|| (command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT))
-	{
-		GameMessage *hintMessage;
 
+	const bool canPerformActions = (
+		TheInGameUI->areSelectedObjectsControllable() ||
+		(command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT)
+	);
+	if ( !canPerformActions )
+	{
+		return GameMessage::MSG_INVALID;
+	}
+
+	{
 		if( TheInGameUI->isInWaypointMode() )
 		{
-			//Override any *other* commands with waypoint commands.
-			if( type == DO_COMMAND || type == EVALUATE_ONLY )
-			{
-				if( TheTerrainLogic )
-				{
-					msgType = issueMoveToLocationCommand( pos, draw, type );
-				}
-			}
-			else
-			{
-				msgType = GameMessage::MSG_ADD_WAYPOINT_HINT;
-				hintMessage = TheMessageStream->appendMessage( msgType );
-				hintMessage->appendLocationArgument( *pos );
-			}
-			return msgType;
+			return handleWaypointModeCommand(pos, draw, type);
 		}
 
 		CanAttackResult result;
+		GameMessage *hintMessage;
 
 		if(command &&
 			(command->isContextCommand()
 				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER
 				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT))
 		{
-			if( obj && obj->isKindOf( KINDOF_SHRUBBERY ) && !BitIsSet( command->getOptions(), ALLOW_SHRUBBERY_TARGET ) )
-			{
-				//If our object is a shrubbery, and we don't allow targeting it... then null it out.
-				//Nulling out the draw and obj pointer will force the remainder of this code to evaluate
-				//a position interaction.
-				draw = nullptr;
-				obj = nullptr;
-			}
-
-			if( obj && obj->isKindOf( KINDOF_MINE ) && !BitIsSet( command->getOptions(), ALLOW_MINE_TARGET ) )
-			{
-				//If our object is a mine, and we don't allow targeting it... then null it out.
-				//Nulling out the draw and obj pointer will force the remainder of this code to evaluate
-				//a position interaction.
-				draw = nullptr;
-				obj = nullptr;
-			}
-
-			//Kris: September 27, 2002
-			//Added relationship tests to make sure we're not attempting a context-command on a restricted relationship.
-			//This case prevents rebels from using tranq darts on allies.
-			if( obj && BitIsSet( command->getOptions(), COMMAND_OPTION_NEED_OBJECT_TARGET ) )
-			{
-				Relationship relationship = ThePlayerList->getLocalPlayer()->getRelationship( obj->getTeam() );
-				switch( relationship )
-				{
-					case ALLIES:
-						if( !BitIsSet( command->getOptions(), NEED_TARGET_ALLY_OBJECT ) )
-						{
-							draw = nullptr;
-							obj = nullptr;
-						}
-						break;
-					case ENEMIES:
-						if( !BitIsSet( command->getOptions(), NEED_TARGET_ENEMY_OBJECT ) )
-						{
-							draw = nullptr;
-							obj = nullptr;
-						}
-						break;
-					case NEUTRAL:
-						if( !BitIsSet( command->getOptions(), NEED_TARGET_NEUTRAL_OBJECT ) )
-						{
-							draw = nullptr;
-							obj = nullptr;
-						}
-						break;
-				}
-			}
+			normalizeGuiCommandTarget( command, draw, obj );
 
 			Bool currentlyValid = FALSE;
 			ObjectID objectID = obj ? obj->getID() : INVALID_ID;

--- a/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -2016,7 +2016,7 @@ GameMessage::Type CommandTranslator::handleHijackVehicleCommand( Drawable *draw,
 	return msgType;
 }
 
-GameMessage::Type CommandTranslator::handleConvertToCarBombCommand( Drawable *draw, Object *obj, CommandEvaluateType type )
+GameMessage::Type CommandTranslator::handleConvertObjectToCarBombCommand( Drawable *draw, Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
 
@@ -2464,7 +2464,7 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_CONVERT_OBJECT_TO_CARBOMB, obj, InGameUI::SELECTION_ANY ) )
 	{
-		return handleConvertToCarBombCommand( draw, obj, type );
+		return handleConvertObjectToCarBombCommand( draw, obj, type );
 	}
 	else if( draw && draw->getObject() && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_SABOTAGE_BUILDING,

--- a/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -1579,28 +1579,6 @@ void CommandTranslator::resolveContextTarget( Drawable *&draw, Object *&obj, Dra
 	}
 }
 
-GameMessage::Type CommandTranslator::handleWaypointModeCommand( const Coord3D *pos, Drawable *draw, CommandEvaluateType type )
-{
-	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-
-	//Override any *other* commands with waypoint commands.
-	if( type == DO_COMMAND || type == EVALUATE_ONLY )
-	{
-		if( TheTerrainLogic )
-		{
-			msgType = issueMoveToLocationCommand( pos, draw, type );
-		}
-	}
-	else
-	{
-		msgType = GameMessage::MSG_ADD_WAYPOINT_HINT;
-		GameMessage* hintMessage = TheMessageStream->appendMessage( msgType );
-		hintMessage->appendLocationArgument( *pos );
-	}
-
-	return msgType;
-}
-
 void CommandTranslator::resolveGuiCommandTarget( const CommandButton *command, Drawable *&draw, Object *&obj )
 {
 	if( obj && obj->isKindOf( KINDOF_SHRUBBERY ) && !BitIsSet( command->getOptions(), ALLOW_SHRUBBERY_TARGET ) )
@@ -1655,10 +1633,31 @@ void CommandTranslator::resolveGuiCommandTarget( const CommandButton *command, D
 	}
 }
 
+GameMessage::Type CommandTranslator::handleWaypointModeCommand( const Coord3D *pos, Drawable *draw, CommandEvaluateType type )
+{
+	GameMessage::Type msgType = GameMessage::MSG_INVALID;
+
+	//Override any *other* commands with waypoint commands.
+	if( type == DO_COMMAND || type == EVALUATE_ONLY )
+	{
+		if( TheTerrainLogic )
+		{
+			msgType = issueMoveToLocationCommand( pos, draw, type );
+		}
+	}
+	else
+	{
+		msgType = GameMessage::MSG_ADD_WAYPOINT_HINT;
+		GameMessage* hintMessage = TheMessageStream->appendMessage( msgType );
+		hintMessage->appendLocationArgument( *pos );
+	}
+
+	return msgType;
+}
+
 GameMessage::Type CommandTranslator::handleGuiCommand( const CommandButton *command, Drawable *draw, Object *obj, const Coord3D *pos, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	resolveGuiCommandTarget( command, draw, obj );
 
@@ -1748,14 +1747,14 @@ GameMessage::Type CommandTranslator::handleGuiCommand( const CommandButton *comm
 		else
 		{
 			msgType = GameMessage::MSG_VALID_GUICOMMAND_HINT;
-			hintMessage = TheMessageStream->appendMessage( msgType );
+			GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 			hintMessage->appendObjectIDArgument( objectID );
 		}
 	}
 	else	// not currently valid
 	{
 		msgType = GameMessage::MSG_INVALID_GUICOMMAND_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( objectID );
 	}
 
@@ -1793,7 +1792,6 @@ GameMessage::Type CommandTranslator::handleSpecialPowerConstructCommand( const C
 GameMessage::Type CommandTranslator::handleSpecialPowerOverrideDestinationCommand( const Coord3D *pos, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -1816,7 +1814,7 @@ GameMessage::Type CommandTranslator::handleSpecialPowerOverrideDestinationComman
 
 		// generate a hint message
 		msgType = GameMessage::MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		TheMessageStream->appendMessage( msgType );
 
 	}
 
@@ -1826,7 +1824,6 @@ GameMessage::Type CommandTranslator::handleSpecialPowerOverrideDestinationComman
 GameMessage::Type CommandTranslator::handleResumeConstructionCommand( Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -1849,7 +1846,7 @@ GameMessage::Type CommandTranslator::handleResumeConstructionCommand( Object *ob
 
 		// generate a hint message
 		msgType = GameMessage::MSG_RESUME_CONSTRUCTION_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( obj->getID() );
 
 	}
@@ -1860,7 +1857,6 @@ GameMessage::Type CommandTranslator::handleResumeConstructionCommand( Object *ob
 GameMessage::Type CommandTranslator::handleDockCommand( Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	//
 	// The actual logic is simply to AIUpdate::dock with the target, the hint is the
@@ -1887,7 +1883,7 @@ GameMessage::Type CommandTranslator::handleDockCommand( Object *obj, CommandEval
 
 		// make the hint
 		msgType = GameMessage::MSG_DOCK_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( obj->getID() );
 
 	}
@@ -1898,7 +1894,6 @@ GameMessage::Type CommandTranslator::handleDockCommand( Object *obj, CommandEval
 GameMessage::Type CommandTranslator::handleRepairObjectCommand( Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -1921,7 +1916,7 @@ GameMessage::Type CommandTranslator::handleRepairObjectCommand( Object *obj, Com
 
 		// generate a hint message
 		msgType = GameMessage::MSG_DO_REPAIR_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( obj->getID() );
 
 	}
@@ -1932,7 +1927,6 @@ GameMessage::Type CommandTranslator::handleRepairObjectCommand( Object *obj, Com
 GameMessage::Type CommandTranslator::handleGetRepairedCommand( Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -1957,7 +1951,7 @@ GameMessage::Type CommandTranslator::handleGetRepairedCommand( Object *obj, Comm
 
 		// generate a hint message
 		msgType = GameMessage::MSG_GET_REPAIRED_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( obj->getID() );
 
 	}
@@ -1968,7 +1962,6 @@ GameMessage::Type CommandTranslator::handleGetRepairedCommand( Object *obj, Comm
 GameMessage::Type CommandTranslator::handleGetHealedCommand( Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -1991,7 +1984,7 @@ GameMessage::Type CommandTranslator::handleGetHealedCommand( Object *obj, Comman
 
 		// generate hint message
 		msgType = GameMessage::MSG_GET_HEALED_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType);
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType);
 		hintMessage->appendObjectIDArgument( obj->getID() );
 
 	}
@@ -2002,7 +1995,6 @@ GameMessage::Type CommandTranslator::handleGetHealedCommand( Object *obj, Comman
 GameMessage::Type CommandTranslator::handleHijackVehicleCommand( Drawable *draw, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -2016,7 +2008,7 @@ GameMessage::Type CommandTranslator::handleHijackVehicleCommand( Drawable *draw,
 	{
 
 		msgType = GameMessage::MSG_HIJACK_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( draw->getObject()->getID() );
 
 	}
@@ -2027,7 +2019,6 @@ GameMessage::Type CommandTranslator::handleHijackVehicleCommand( Drawable *draw,
 GameMessage::Type CommandTranslator::handleConvertToCarBombCommand( Drawable *draw, Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -2040,7 +2031,7 @@ GameMessage::Type CommandTranslator::handleConvertToCarBombCommand( Drawable *dr
 	{
 
 		msgType = GameMessage::MSG_CONVERT_TO_CARBOMB_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( obj->getID() );
 
 	}
@@ -2051,7 +2042,6 @@ GameMessage::Type CommandTranslator::handleConvertToCarBombCommand( Drawable *dr
 GameMessage::Type CommandTranslator::handleSabotageBuildingCommand( Drawable *draw, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -2060,7 +2050,7 @@ GameMessage::Type CommandTranslator::handleSabotageBuildingCommand( Drawable *dr
 	else
 	{
 		msgType = GameMessage::MSG_SABOTAGE_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( draw->getObject()->getID() );
 	}
 
@@ -2093,7 +2083,6 @@ GameMessage::Type CommandTranslator::handleSalvageCommand( Object *obj, CommandE
 GameMessage::Type CommandTranslator::handleEnterObjectCommand( Drawable *draw, Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -2106,7 +2095,7 @@ GameMessage::Type CommandTranslator::handleEnterObjectCommand( Drawable *draw, O
 	{
 
 		msgType = GameMessage::MSG_ENTER_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( obj->getID() );
 	}
 
@@ -2116,7 +2105,6 @@ GameMessage::Type CommandTranslator::handleEnterObjectCommand( Drawable *draw, O
 GameMessage::Type CommandTranslator::handleAttackObjectCommand( Drawable *draw, Object *obj, CommandEvaluateType type, GameMessage::Type hintType )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -2130,7 +2118,7 @@ GameMessage::Type CommandTranslator::handleAttackObjectCommand( Drawable *draw, 
 
 		// Generate an Attack hint
 		msgType = hintType;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( obj->getID() );
 
 	}
@@ -2141,7 +2129,6 @@ GameMessage::Type CommandTranslator::handleAttackObjectCommand( Drawable *draw, 
 GameMessage::Type CommandTranslator::handleCaptureBuildingCommand( Drawable *draw, Object *obj, const Coord3D *pos, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	//@TODO: Kris
 	//PRELIMINARY CODE FOR HOOKING IN AUTO SPECIALS --- WILL BE REDONE!
@@ -2170,14 +2157,14 @@ GameMessage::Type CommandTranslator::handleCaptureBuildingCommand( Drawable *dra
 				{
 					//Issue the black lotus hack hint for capturing a building.
 					msgType = GameMessage::MSG_HACK_HINT;
-					hintMessage = TheMessageStream->appendMessage( msgType );
+					GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 					hintMessage->appendObjectIDArgument( obj->getID() );
 				}
 				else if( spType == SPECIAL_INFANTRY_CAPTURE_BUILDING )
 				{
 					//Issue the infantry hint for capturing a building
 					msgType = GameMessage::MSG_CAPTUREBUILDING_HINT;
-					hintMessage = TheMessageStream->appendMessage( msgType );
+					GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 					hintMessage->appendObjectIDArgument( obj->getID() );
 				}
 			}
@@ -2190,7 +2177,6 @@ GameMessage::Type CommandTranslator::handleCaptureBuildingCommand( Drawable *dra
 GameMessage::Type CommandTranslator::handleHackCommand( Drawable *draw, Object *obj, const Coord3D *pos, CommandEvaluateType type, SpecialPowerType hackPower )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -2219,7 +2205,7 @@ GameMessage::Type CommandTranslator::handleHackCommand( Drawable *draw, Object *
 	else
 	{
 		msgType = GameMessage::MSG_HACK_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( obj->getID() );
 	}
 
@@ -2230,7 +2216,6 @@ GameMessage::Type CommandTranslator::handleHackCommand( Drawable *draw, Object *
 GameMessage::Type CommandTranslator::handlePickUpPrisonerCommand( Drawable *draw, Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	if( type == DO_COMMAND || type == EVALUATE_ONLY )
 	{
@@ -2243,7 +2228,7 @@ GameMessage::Type CommandTranslator::handlePickUpPrisonerCommand( Drawable *draw
 	{
 
 		msgType = GameMessage::MSG_PICK_UP_PRISONER_HINT;
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendObjectIDArgument( obj->getID() );
 
 	}
@@ -2255,7 +2240,6 @@ GameMessage::Type CommandTranslator::handlePickUpPrisonerCommand( Drawable *draw
 GameMessage::Type CommandTranslator::handleSetRallyPointCommand( const Coord3D *pos, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_SET_RALLY_POINT;
-	GameMessage *hintMessage;
 
 	if (type == DO_COMMAND) {
 		const DrawableList *allSelectedDrawables = TheInGameUI->getAllSelectedDrawables();
@@ -2270,14 +2254,14 @@ GameMessage::Type CommandTranslator::handleSetRallyPointCommand( const Coord3D *
 		}
 	} else if (type == DO_HINT) {
 		msgType = GameMessage::MSG_SET_RALLY_POINT_HINT;
-		hintMessage = TheMessageStream->appendMessage(msgType);
+		GameMessage *hintMessage = TheMessageStream->appendMessage(msgType);
 		hintMessage->appendLocationArgument(*pos);
 	}
 
 	return msgType;
 }
 
-GameMessage::Type CommandTranslator::handleImpossibleAttackHint( const Coord3D *pos )
+GameMessage::Type CommandTranslator::handleInvalidShotCommand( const Coord3D *pos )
 {
 	GameMessage::Type msgType = GameMessage::MSG_IMPOSSIBLE_ATTACK_HINT;
 	GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
@@ -2289,7 +2273,6 @@ GameMessage::Type CommandTranslator::handleImpossibleAttackHint( const Coord3D *
 GameMessage::Type CommandTranslator::handleDefaultMoveCommand( Drawable *draw, Drawable *drawableInWay, const Coord3D *pos, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
-	GameMessage *hintMessage;
 
 	//
 	// NOTE: If you change this command evaluation function in what it will do
@@ -2372,7 +2355,7 @@ GameMessage::Type CommandTranslator::handleDefaultMoveCommand( Drawable *draw, D
 			//Normal and forced move.
 			msgType = GameMessage::MSG_DO_MOVETO_HINT;
 		}
-		hintMessage = TheMessageStream->appendMessage( msgType );
+		GameMessage *hintMessage = TheMessageStream->appendMessage( msgType );
 		hintMessage->appendLocationArgument( *pos );
 
 	}
@@ -2426,7 +2409,7 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 		return handleWaypointModeCommand( pos, draw, type );
 	}
 
-	CanAttackResult result;
+	CanAttackResult result = ATTACKRESULT_NOT_POSSIBLE;
 
 	if(command &&
 		(command->isContextCommand()
@@ -2440,21 +2423,15 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 	{
 		return handleSpecialPowerConstructCommand( command, draw, pos, type );
 	}
-
-
-	// ********************************************************************************************
 	else if( TheInGameUI->canSelectedObjectsOverrideSpecialPowerDestination( pos, InGameUI::SELECTION_ANY, SPECIAL_INVALID ) )
 	{
 		return handleSpecialPowerOverrideDestinationCommand( pos, type );
 	}
-
-	// ********************************************************************************************
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_RESUME_CONSTRUCTION, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handleResumeConstructionCommand( obj, type );
 	}
-	// ********************************************************************************************
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_DOCK_AT,
 																										obj,
@@ -2462,25 +2439,21 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 	{
 		return handleDockCommand( obj, type );
 	}
-	// ********************************************************************************************
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_REPAIR_OBJECT, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handleRepairObjectCommand( obj, type );
 	}
-	// ********************************************************************************************
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_GET_REPAIRED_AT, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handleGetRepairedCommand( obj, type );
 	}
-	// ********************************************************************************************
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_GET_HEALED_AT, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handleGetHealedCommand( obj, type );
 	}
-	// ********************************************************************************************
 	else if( draw && draw->getObject() && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_HIJACK_VEHICLE,
 																										draw->getObject(),
@@ -2488,13 +2461,11 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 	{
 		return handleHijackVehicleCommand( draw, type );
 	}
-	// ********************************************************************************************
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_CONVERT_OBJECT_TO_CARBOMB, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handleConvertToCarBombCommand( draw, obj, type );
 	}
-	// ********************************************************************************************
 	else if( draw && draw->getObject() && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_SABOTAGE_BUILDING,
 																										draw->getObject(),
@@ -2502,67 +2473,53 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 	{
 		return handleSabotageBuildingCommand( draw, type );
 	}
-	// ********************************************************************************************
 	else if( draw && !TheInGameUI->isInForceAttackMode() && canSelectionSalvage(obj) )
 	{
 		return handleSalvageCommand( obj, type );
 	}
-	// ********************************************************************************************
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_ENTER_OBJECT, obj, InGameUI::SELECTION_ANY, true ) )
 	{
 		return handleEnterObjectCommand( draw, obj, type );
 	}
-	// ********************************************************************************************
 	else if( draw && (result = TheInGameUI->getCanSelectedObjectsAttack( InGameUI::ACTIONTYPE_ATTACK_OBJECT, obj, InGameUI::SELECTION_ANY, TheInGameUI->isInForceAttackMode() )) == ATTACKRESULT_POSSIBLE )
 	{
 		return handleAttackObjectCommand( draw, obj, type, GameMessage::MSG_DO_ATTACK_OBJECT_HINT );
 	}
-	// ********************************************************************************************
 	else if( draw && result == ATTACKRESULT_POSSIBLE_AFTER_MOVING )
 	{
 		return handleAttackObjectCommand( draw, obj, type, GameMessage::MSG_DO_ATTACK_OBJECT_AFTER_MOVING_HINT );
 	}
-	// ********************************************************************************************
 	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_CAPTURE_BUILDING, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handleCaptureBuildingCommand( draw, obj, pos, type );
 	}
-	// ********************************************************************************************
 	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_DISABLE_VEHICLE_VIA_HACKING, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handleHackCommand( draw, obj, pos, type, SPECIAL_BLACKLOTUS_DISABLE_VEHICLE_HACK );
 	}
-	// ********************************************************************************************
 	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_STEAL_CASH_VIA_HACKING, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handleHackCommand( draw, obj, pos, type, SPECIAL_BLACKLOTUS_STEAL_CASH_HACK );
 	}
-	// ********************************************************************************************
 	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_DISABLE_BUILDING_VIA_HACKING, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handleHackCommand( draw, obj, pos, type, SPECIAL_HACKER_DISABLE_BUILDING );
 	}
 #ifdef ALLOW_SURRENDER
-	// ********************************************************************************************
 	else if( draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_PICK_UP_PRISONER, obj, InGameUI::SELECTION_ANY ) )
 	{
 		return handlePickUpPrisonerCommand( draw, obj, type );
 	}
 #endif
-	// ********************************************************************************************
 	else if ( !draw && TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_SET_RALLY_POINT, nullptr, InGameUI::SELECTION_ALL, FALSE ))
 	{
 		return handleSetRallyPointCommand( pos, type );
 	}
-
-	// ********************************************************************************************
 	else if( draw && result == ATTACKRESULT_INVALID_SHOT )
 	{
-		return handleImpossibleAttackHint( pos );
+		return handleInvalidShotCommand( pos );
 	}
-
-	// ********************************************************************************************
 	else
 	{
 		return handleDefaultMoveCommand( draw, drawableInWay, pos, type );

--- a/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -1854,7 +1854,7 @@ GameMessage::Type CommandTranslator::handleResumeConstructionCommand( Object *ob
 	return msgType;
 }
 
-GameMessage::Type CommandTranslator::handleDockCommand( Object *obj, CommandEvaluateType type )
+GameMessage::Type CommandTranslator::handleDockAtCommand( Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
 
@@ -1924,7 +1924,7 @@ GameMessage::Type CommandTranslator::handleRepairObjectCommand( Object *obj, Com
 	return msgType;
 }
 
-GameMessage::Type CommandTranslator::handleGetRepairedCommand( Object *obj, CommandEvaluateType type )
+GameMessage::Type CommandTranslator::handleGetRepairedAtCommand( Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
 
@@ -1959,7 +1959,7 @@ GameMessage::Type CommandTranslator::handleGetRepairedCommand( Object *obj, Comm
 	return msgType;
 }
 
-GameMessage::Type CommandTranslator::handleGetHealedCommand( Object *obj, CommandEvaluateType type )
+GameMessage::Type CommandTranslator::handleGetHealedAtCommand( Object *obj, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
 
@@ -2437,7 +2437,7 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 																										obj,
 																										InGameUI::SELECTION_ALL ) )
 	{
-		return handleDockCommand( obj, type );
+		return handleDockAtCommand( obj, type );
 	}
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_REPAIR_OBJECT, obj, InGameUI::SELECTION_ANY ) )
@@ -2447,12 +2447,12 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_GET_REPAIRED_AT, obj, InGameUI::SELECTION_ANY ) )
 	{
-		return handleGetRepairedCommand( obj, type );
+		return handleGetRepairedAtCommand( obj, type );
 	}
 	else if( draw && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_GET_HEALED_AT, obj, InGameUI::SELECTION_ANY ) )
 	{
-		return handleGetHealedCommand( obj, type );
+		return handleGetHealedAtCommand( obj, type );
 	}
 	else if( draw && draw->getObject() && !TheInGameUI->isInForceAttackMode() &&
 					 TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_HIJACK_VEHICLE,

--- a/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -1538,7 +1538,7 @@ GameMessage::Type CommandTranslator::evaluateForceAttack( Drawable *draw, const 
 	return retVal;
 }
 
-void CommandTranslator::normalizeContextInputs(Drawable*& draw, Object*& obj, Drawable*& drawableInWay)
+void CommandTranslator::resolveContextTarget( Drawable *&draw, Object *&obj, Drawable *&drawableInWay )
 {
 	//This piece of code is used to prevent interaction with unselectable objects or masked objects. When we
 	//call this function, we typically pass in both a position and a drawable (if applicable), so if the
@@ -1579,7 +1579,7 @@ void CommandTranslator::normalizeContextInputs(Drawable*& draw, Object*& obj, Dr
 	}
 }
 
-GameMessage::Type CommandTranslator::handleWaypointModeCommand(const Coord3D* pos, Drawable* draw, const CommandEvaluateType& type)
+GameMessage::Type CommandTranslator::handleWaypointModeCommand( const Coord3D *pos, Drawable *draw, CommandEvaluateType type )
 {
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
 
@@ -1601,7 +1601,7 @@ GameMessage::Type CommandTranslator::handleWaypointModeCommand(const Coord3D* po
 	return msgType;
 }
 
-void CommandTranslator::normalizeGuiCommandTarget( const CommandButton* command, Drawable*& draw, Object*& obj )
+void CommandTranslator::resolveGuiCommandTarget( const CommandButton *command, Drawable *&draw, Object *&obj )
 {
 	if( obj && obj->isKindOf( KINDOF_SHRUBBERY ) && !BitIsSet( command->getOptions(), ALLOW_SHRUBBERY_TARGET ) )
 	{
@@ -1663,18 +1663,17 @@ void CommandTranslator::normalizeGuiCommandTarget( const CommandButton* command,
 	* command would be if clicked
 	* NOTE: draw can be null, in which case we give a hint for the location */
 // ------------------------------------------------------------------------------------------------
-GameMessage::Type CommandTranslator::evaluateContextCommand(
-	Drawable *draw,
-	const Coord3D *pos,
-	CommandEvaluateType type
-) {
+GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
+																														 const Coord3D *pos,
+																														 CommandEvaluateType type )
+{
 	Object *obj = draw ? draw->getObject() : nullptr;
 	Drawable *drawableInWay = draw;
-	normalizeContextInputs(draw, obj, drawableInWay);
+	resolveContextTarget( draw, obj, drawableInWay );
 
 	// Then we should determine if the game currently prefers selection events. If it does, then return
 	// the invalid message.
-	if (obj && obj->isLocallyControlled() && TheInGameUI->isInPreferSelectionMode())
+	if( obj && obj->isLocallyControlled() && TheInGameUI->isInPreferSelectionMode() )
 	{
 		return GameMessage::MSG_INVALID;
 	}
@@ -1683,18 +1682,17 @@ GameMessage::Type CommandTranslator::evaluateContextCommand(
 	const CommandButton *command = TheInGameUI->getGUICommand();
 	GameMessage::Type msgType = GameMessage::MSG_INVALID;
 
-	if (command && command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON)
+	if( command && command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON )
 	{
 		msgType = GameMessage::MSG_VALID_GUICOMMAND_HINT;
-		TheMessageStream->appendMessage(msgType);
+		TheMessageStream->appendMessage( msgType );
 		return msgType;
 	}
 
-	const bool canPerformActions = (
-		TheInGameUI->areSelectedObjectsControllable() ||
-		(command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT)
-	);
-	if ( !canPerformActions )
+	const Bool canPerformActions = TheInGameUI->areSelectedObjectsControllable()
+		|| ( command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT );
+
+	if( !canPerformActions )
 	{
 		return GameMessage::MSG_INVALID;
 	}
@@ -1702,7 +1700,7 @@ GameMessage::Type CommandTranslator::evaluateContextCommand(
 	{
 		if( TheInGameUI->isInWaypointMode() )
 		{
-			return handleWaypointModeCommand(pos, draw, type);
+			return handleWaypointModeCommand( pos, draw, type );
 		}
 
 		CanAttackResult result;
@@ -1713,7 +1711,7 @@ GameMessage::Type CommandTranslator::evaluateContextCommand(
 				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER
 				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT))
 		{
-			normalizeGuiCommandTarget( command, draw, obj );
+			resolveGuiCommandTarget( command, draw, obj );
 
 			Bool currentlyValid = FALSE;
 			ObjectID objectID = obj ? obj->getID() : INVALID_ID;


### PR DESCRIPTION
Replaces #2714 by @RikuAnt (tracking #1192), rebased onto current main.

`evaluateContextCommand` was ~830 lines. This splits it into per-command handlers, leaving the function as the dispatch chain alone (~180 lines), with no change to behavior:

- `resolveContextTarget` / `resolveGuiCommandTarget` — null out draw/obj so evaluation falls back to a position interaction (masked, mine, force-move/attack; shrubbery/mine/relationship filtering).
- 21 `handleXCommand` helpers — one per arm of the else-if chain.

Since #2765 (merge ZH CommandXlat) and #2805 (move CommandXlat to Core), this lives in `Core/`, which is what #2714 was blocked on.

## Notes
- Handler bodies are statement-for-statement moves of the arms they replace, verified mechanically against the pre-refactor revision.
- Two exceptions, both merges of arms that were identical apart from one constant: `handleAttackObjectCommand` takes the hint type (`ATTACKRESULT_POSSIBLE` / `ATTACKRESULT_POSSIBLE_AFTER_MOVING`), and `handleHackCommand` takes the special power (disable vehicle / steal cash / disable building).
- `handleSetRallyPointCommand` and `handleImpossibleAttackHint` drop a dead `msgType = MSG_INVALID` that was immediately overwritten.
- The `result` assignment stays inside the `ATTACKRESULT_POSSIBLE` condition — two later arms read it, so hoisting it into a helper would have changed behavior.
- Legacy space/mixed indentation in the moved bodies is normalized to tabs; without it those lines land at column 0 once the enclosing scopes are gone.
- Incorporates the #2714 feedback: verbose refactor comments removed, mixed tab/space indentation fixed, braces on their own lines.
