### PR TITLE
chore(network): Remove obsolete HTTP Proxy option

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/GameSpy/MainMenuUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/MainMenuUtils.cpp
@@ -854,15 +854,6 @@ static void reallyStartPatchCheck()
 
 	FormatURLFromRegistry(gameURL, mapURL, configURL, motdURL);
 
-	std::string proxy;
-	if (GetStringFromRegistry("", "Proxy", proxy))
-	{
-		if (!proxy.empty())
-		{
-			ghttpSetProxy(proxy.c_str());
-		}
-	}
-
 	// check for a patch first
 	DEBUG_LOG(("Game patch check: [%s]", gameURL.c_str()));
 	DEBUG_LOG(("Map patch check: [%s]", mapURL.c_str()));

--- a/Core/Tools/PATCHGET/CHATAPI.cpp
+++ b/Core/Tools/PATCHGET/CHATAPI.cpp
@@ -451,15 +451,6 @@ static void StartPatchCheck( void )
 
 	FormatURLFromRegistry(gameURL, mapURL, configURL, motdURL);
 
-	std::string proxy;
-	if (GetStringFromRegistry("", "Proxy", proxy))
-	{
-		if (!proxy.empty())
-		{
-			ghttpSetProxy(proxy.c_str());
-		}
-	}
-
 	// check for a patch first
 	checksLeft = 2;
 	cantConnect = false;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -502,18 +502,6 @@ static void saveOptions()
 	}
 
 	//-------------------------------------------------------------------------------------------------
-	// HTTP Proxy
-	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryHTTPProxy"));
-	if (textEntryHTTPProxy && textEntryHTTPProxy->winGetEnabled())
-	{
-		UnicodeString uStr = GadgetTextEntryGetText(textEntryHTTPProxy);
-		AsciiString aStr;
-		aStr.translate(uStr);
-		SetStringInRegistry("", "Proxy", aStr.str());
-		ghttpSetProxy(aStr.str());
-	}
-
-	//-------------------------------------------------------------------------------------------------
 	// Firewall Port Override
 	GameWindow *textEntryFirewallPortOverride = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryFirewallPortOverride"));
 	if (textEntryFirewallPortOverride && textEntryFirewallPortOverride->winGetEnabled())
@@ -1125,16 +1113,15 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		}
 	}
 
-	// HTTP Proxy
-	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryHTTPProxy"));
+	NameKeyType textEntryHTTPProxyID = TheNameKeyGenerator->nameToKey("OptionsMenu.wnd:TextEntryHTTPProxy");
+	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, textEntryHTTPProxyID);
 	if (textEntryHTTPProxy)
-	{
-		UnicodeString uStr;
-		std::string proxy;
-		GetStringFromRegistry("", "Proxy", proxy);
-		uStr.translate(proxy.c_str());
-		GadgetTextEntrySetText(textEntryHTTPProxy, uStr);
-	}
+		textEntryHTTPProxy->winHide(TRUE);
+
+	NameKeyType staticTextHTTPProxyID = TheNameKeyGenerator->nameToKey("OptionsMenu.wnd:StaticTextHTTPProxy");
+	GameWindow *staticTextHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, staticTextHTTPProxyID);
+	if (staticTextHTTPProxy)
+		staticTextHTTPProxy->winHide(TRUE);
 
  	// Firewall Port Override
  	GameWindow *textEntryFirewallPortOverride = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryFirewallPortOverride"));
@@ -1401,9 +1388,6 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 
 		if (textEntryFirewallPortOverride)
 			textEntryFirewallPortOverride->winEnable(FALSE);
-
-		if (textEntryHTTPProxy)
-			textEntryHTTPProxy->winEnable(FALSE);
 
 //		if (checkAudioSurround)
 //			checkAudioSurround->winEnable(FALSE);

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1113,6 +1113,8 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		}
 	}
 
+#if ENABLE_GUI_HACKS
+	// TheSuperHackers @tweak 26/07/2026 Hide the obsolete HTTP Proxy entry and its label
 	NameKeyType textEntryHTTPProxyID = TheNameKeyGenerator->nameToKey("OptionsMenu.wnd:TextEntryHTTPProxy");
 	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, textEntryHTTPProxyID);
 	if (textEntryHTTPProxy)
@@ -1122,6 +1124,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	GameWindow *staticTextHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, staticTextHTTPProxyID);
 	if (staticTextHTTPProxy)
 		staticTextHTTPProxy->winHide(TRUE);
+#endif
 
  	// Firewall Port Override
  	GameWindow *textEntryFirewallPortOverride = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryFirewallPortOverride"));

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1114,7 +1114,8 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	}
 
 #if ENABLE_GUI_HACKS
-	// TheSuperHackers @tweak 26/07/2026 Hide the obsolete HTTP Proxy entry and its label
+	// TheSuperHackers @tweak 26/07/2026 The http proxy feature was obsoleted because it did nothing for the UDP game traffic or match sockets.
+	// Hide the relevant obsoleted UI elements accordingly.
 	NameKeyType textEntryHTTPProxyID = TheNameKeyGenerator->nameToKey("OptionsMenu.wnd:TextEntryHTTPProxy");
 	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, textEntryHTTPProxyID);
 	if (textEntryHTTPProxy)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -521,18 +521,6 @@ static void saveOptions()
 	}
 
 	//-------------------------------------------------------------------------------------------------
-	// HTTP Proxy
-	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryHTTPProxy"));
-	if (textEntryHTTPProxy && textEntryHTTPProxy->winGetEnabled())
-	{
-		UnicodeString uStr = GadgetTextEntryGetText(textEntryHTTPProxy);
-		AsciiString aStr;
-		aStr.translate(uStr);
-		SetStringInRegistry("", "Proxy", aStr.str());
-		ghttpSetProxy(aStr.str());
-	}
-
-	//-------------------------------------------------------------------------------------------------
 	// Firewall Port Override
 	GameWindow *textEntryFirewallPortOverride = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryFirewallPortOverride"));
 	if (textEntryFirewallPortOverride && textEntryFirewallPortOverride->winGetEnabled())
@@ -1157,16 +1145,15 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		}
 	}
 
-	// HTTP Proxy
-	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryHTTPProxy"));
+	NameKeyType textEntryHTTPProxyID = TheNameKeyGenerator->nameToKey("OptionsMenu.wnd:TextEntryHTTPProxy");
+	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, textEntryHTTPProxyID);
 	if (textEntryHTTPProxy)
-	{
-		UnicodeString uStr;
-		std::string proxy;
-		GetStringFromRegistry("", "Proxy", proxy);
-		uStr.translate(proxy.c_str());
-		GadgetTextEntrySetText(textEntryHTTPProxy, uStr);
-	}
+		textEntryHTTPProxy->winHide(TRUE);
+
+	NameKeyType staticTextHTTPProxyID = TheNameKeyGenerator->nameToKey("OptionsMenu.wnd:StaticTextHTTPProxy");
+	GameWindow *staticTextHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, staticTextHTTPProxyID);
+	if (staticTextHTTPProxy)
+		staticTextHTTPProxy->winHide(TRUE);
 
 	// Firewall Port Override
 	GameWindow *textEntryFirewallPortOverride = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryFirewallPortOverride"));
@@ -1437,9 +1424,6 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 
 		if (textEntryFirewallPortOverride)
 			textEntryFirewallPortOverride->winEnable(FALSE);
-
-		if (textEntryHTTPProxy)
-			textEntryHTTPProxy->winEnable(FALSE);
 
 //		if (checkAudioSurround)
 //			checkAudioSurround->winEnable(FALSE);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1146,7 +1146,8 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	}
 
 #if ENABLE_GUI_HACKS
-	// TheSuperHackers @tweak 26/07/2026 Hide the obsolete HTTP Proxy entry and its label
+	// TheSuperHackers @tweak 26/07/2026 The http proxy feature was obsoleted because it did nothing for the UDP game traffic or match sockets.
+	// Hide the relevant obsoleted UI elements accordingly.
 	NameKeyType textEntryHTTPProxyID = TheNameKeyGenerator->nameToKey("OptionsMenu.wnd:TextEntryHTTPProxy");
 	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, textEntryHTTPProxyID);
 	if (textEntryHTTPProxy)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1145,6 +1145,8 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		}
 	}
 
+#if ENABLE_GUI_HACKS
+	// TheSuperHackers @tweak 26/07/2026 Hide the obsolete HTTP Proxy entry and its label
 	NameKeyType textEntryHTTPProxyID = TheNameKeyGenerator->nameToKey("OptionsMenu.wnd:TextEntryHTTPProxy");
 	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, textEntryHTTPProxyID);
 	if (textEntryHTTPProxy)
@@ -1154,6 +1156,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	GameWindow *staticTextHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, staticTextHTTPProxyID);
 	if (staticTextHTTPProxy)
 		staticTextHTTPProxy->winHide(TRUE);
+#endif
 
 	// Firewall Port Override
 	GameWindow *textEntryFirewallPortOverride = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryFirewallPortOverride"));


### PR DESCRIPTION
### What this code did:
The `TextEntryHTTPProxy` option in `OptionsMenu.cpp`:
1. Saved/read an HTTP proxy server address from the Windows Registry (`Proxy`) in `HKLM\SOFTWARE\Electronic Arts\EA Games\Command and Conquer Generals Zero Hour`.
2. Configured GameSpy's `ghttpSetProxy()` for HTTP web requests (MOTD news bulletins and patch checks).

### Background & Reason for Removal:
- **Scope Limitation**: HTTP Proxy only affects HTTP TCP requests (web bulletins). It does **not** proxy peer-to-peer UDP game traffic or match sockets.
- **Player Confusion**: Players frequently misinterpret "Proxy" in the game options as a full network proxy to route multiplayer matches or bypass UDP firewall rules.
- **GUI Cleanliness**: Calling `textEntryHTTPProxy->winHide(TRUE)` in C++ hides the obsolete setting from the Options menu without breaking custom/legacy `.wnd` layout assets.
- **UAC & Registry Safety**: Eliminates 1 of the 4 runtime write to `HKEY_LOCAL_MACHINE` (`HKLM`) that caused Windows UAC permission failures (`ERROR_ACCESS_DENIED`) when playing without Administrator privileges on certain variants of Windows.