### PR TITLE
bugfix(texture): Fix Generals missing texture and vegetation at lowest texture resolution

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
@@ -98,14 +98,6 @@ DDSFileClass::DDSFileClass(const char* name,unsigned reduction_factor)
 	MipLevels=SurfaceDesc.MipMapCount;
 	if (MipLevels==0) MipLevels=1;
 
-	//Adjust the reduction factor to keep textures above some minimum dimensions
-	if (MipLevels <= WW3D::Get_Texture_Min_Dimension())
-		ReductionFactor=0;
-	else
-	{	int mipToDrop=MipLevels-WW3D::Get_Texture_Min_Dimension();
-		if (ReductionFactor >= mipToDrop)
-			ReductionFactor=mipToDrop;
-	}
 
 	if (MipLevels>ReductionFactor) MipLevels-=ReductionFactor;
 	else {


### PR DESCRIPTION
* Fixes #2787 

In General's ```DDSFileClass``` the ```ReductionFactor``` was being set to 0 because it was compared with ```WW3D::Get_Texture_Min_Dimension()``` which is different from its meaning and use. Hence, this adjustment was removed.

Also note that this results in a difference with retail where the vegetation and assets weren't being reduced properly at the lowest setting. I confirmed that the vegetation now looks similar to Zero hour's lowest setting (as opposed to higher detail even at lowest setting in retail generals). I also didn't notice a regression at higher resolutions.

## Retail Generals
<img width="1920" height="1080" alt="retail_generals_shell" src="https://github.com/user-attachments/assets/b7b75acf-6dec-446d-b5bf-1300ea0dffd8" />

## Fixed Generals
<img width="1920" height="1080" alt="fixed_generals_shell" src="https://github.com/user-attachments/assets/45dd8dc7-a0a0-43e9-bce5-7da4793aa7cf" />

