### PR TITLE
bugfix(aiupdate): Prevent units from deploying when moving

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeployStyleAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeployStyleAIUpdate.cpp
@@ -143,7 +143,14 @@ UpdateSleepTime DeployStyleAIUpdate::update()
 		}
 	}
 
-	if( isInRange || isInGuardIdleState )
+	// TheSuperHackers @bugfix Caball009 27/07/2026 The pathfinding code may use a stricter attack range check than used
+	// in this function, so the range check is insufficient. Objects are not allowed to deploy and attack if they're moving.
+#if RETAIL_COMPATIBLE_CRC
+	if (isInRange || isInGuardIdleState)
+#else
+	// @todo Simplify the code by moving the second branch up so 'isTryingToMove' is checked first.
+	if (!isTryingToMove && (isInRange || isInGuardIdleState))
+#endif
 	{
 		switch( m_state )
 		{


### PR DESCRIPTION
* Closes https://github.com/TheSuperHackers/GeneralsGameCode/issues/176

This PR prevents units from deploying when they're still moving. The issue is most notable with the Nuke Cannon, which deploys and fires just ahead reaching its goal position (see issue).

> The pathfinding code uses `Weapon::isGoalPosWithinAttackRange`, while the deployment code uses `isWithinAttackRange`. The former uses a smaller range than strictly necessary, so that attacks don't fail all the time on moving targets. That's why units deploy just ahead of reaching their goal position.

https://github.com/TheSuperHackers/GeneralsGameCode/issues/176#issuecomment-5084727875

Notes:
- This is probably a very minor nerf because the attack range has been reduced a tiny bit.
- This change assumes that unit movement and deployment are always mutually exclusive.
- This is only an issue for Zero Hour, because of Zero Hour specific changes made to `DeployStyleAIUpdate::update`. No code is replicated to Generals.