### PR TITLE
feat(filesystem): Implement file and directory ignore functionality for local and archive file systems

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(corei_main INTERFACE "Main")
 target_sources(corei_libraries_include PRIVATE
     Libraries/Include/Lib/BaseType.h
     Libraries/Include/Lib/BaseTypeCore.h
+    Libraries/Include/Lib/PathUtil.h
     Libraries/Include/Lib/trig.h
     Libraries/Include/rts/debug.h
     Libraries/Include/rts/profile.h

--- a/Core/GameEngine/CMakeLists.txt
+++ b/Core/GameEngine/CMakeLists.txt
@@ -594,6 +594,7 @@ set(GAMEENGINE_SRC
     Source/Common/INI/INIDamageFX.cpp
     Source/Common/INI/INIDrawGroupInfo.cpp
     Source/Common/INI/INIGameData.cpp
+    Source/Common/INI/INIFileSystem.cpp
     Source/Common/INI/INIMapCache.cpp
     Source/Common/INI/INIMapData.cpp
     Source/Common/INI/INIMappedImage.cpp

--- a/Core/GameEngine/Include/Common/ArchiveFile.h
+++ b/Core/GameEngine/Include/Common/ArchiveFile.h
@@ -64,10 +64,15 @@ public:
 	void									getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const;
 
 	void									addFile(const AsciiString& path, const ArchivedFileInfo *fileInfo); ///< add this file to our directory tree.
+	Bool									ignoreFile(const AsciiString& filename, Bool ignore);
+	Bool									ignoreDirectory(const AsciiString& directory, Bool ignore);
 
 protected:
 	void									getFileListInDirectory(const DetailedArchivedDirectoryInfo *dirInfo, const AsciiString& currentDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const;
 	const ArchivedFileInfo *		getArchivedFileInfo(const AsciiString& filename) const;	///< return the ArchivedFileInfo from the directory tree.
+
+private:
+	void									ignoreDirectory(DetailedArchivedDirectoryInfo *dirInfo, Bool ignore);
 
 protected:
 	File *m_file; ///< file pointer to the archive file on disk.  Kept open so we don't have to continuously open and close the file all the time.

--- a/Core/GameEngine/Include/Common/ArchiveFile.h
+++ b/Core/GameEngine/Include/Common/ArchiveFile.h
@@ -60,13 +60,16 @@ public:
 	void									attachFile(File *file);
 
 	void									getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const;
-	void									getFileListInDirectory(const DetailedArchivedDirectoryInfo *dirInfo, const AsciiString& currentDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const;
 
 	void									addFile(const AsciiString& path, const ArchivedFileInfo *fileInfo); ///< add this file to our directory tree.
 
 protected:
+	void									getFileListInDirectory(const DetailedArchivedDirectoryInfo *dirInfo, const AsciiString& currentDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const;
 	const ArchivedFileInfo *		getArchivedFileInfo(const AsciiString& filename) const;	///< return the ArchivedFileInfo from the directory tree.
 
+protected:
 	File *m_file; ///< file pointer to the archive file on disk.  Kept open so we don't have to continuously open and close the file all the time.
+
+private:
 	DetailedArchivedDirectoryInfo m_rootDirectory;
 };

--- a/Core/GameEngine/Include/Common/ArchiveFile.h
+++ b/Core/GameEngine/Include/Common/ArchiveFile.h
@@ -46,6 +46,8 @@ class File;
 
 class ArchiveFile
 {
+	typedef std::hash_map<AsciiString, ArchivedFileInfo*, rts::hash_path, rts::equal_to_path> ArchivedFileInfoPtrHashMap; // Archived file name to archived file info ptr
+
 public:
 	ArchiveFile();
 	virtual ~ArchiveFile();
@@ -72,4 +74,5 @@ protected:
 
 private:
 	DetailedArchivedDirectoryInfo m_rootDirectory;
+	ArchivedFileInfoPtrHashMap m_absFilenameToFileInfo;
 };

--- a/Core/GameEngine/Include/Common/ArchiveFileSystem.h
+++ b/Core/GameEngine/Include/Common/ArchiveFileSystem.h
@@ -102,6 +102,12 @@ public:
 	AsciiString												m_directoryName;
 	DetailedArchivedDirectoryInfoMap	m_directories;
 	ArchivedFileInfoMap								m_files;
+	Bool m_ignore;
+
+	DetailedArchivedDirectoryInfo()
+		: m_ignore(false)
+	{
+	}
 };
 
 class ArchivedFileInfo
@@ -111,10 +117,12 @@ public:
 	AsciiString m_archiveFilename;
 	UnsignedInt m_offset;
 	UnsignedInt m_size;
+	Bool m_ignore;
 
 	ArchivedFileInfo()
 		: m_offset(0)
 		, m_size(0)
+		, m_ignore(false)
 	{
 	}
 };
@@ -144,6 +152,9 @@ public:
 	virtual Bool	loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite = FALSE) = 0;
 
 	void loadMods();
+
+	Bool ignoreFile(const AsciiString& filename, Bool ignore = true); ///< Ignore all file instances with this name in the Archive System.
+	Bool ignoreDirectory(const AsciiString& directory, Bool ignore = true); ///< Ignore this directory and all its contents in the Archive System.
 
 	ArchivedDirectoryInfo* friend_getArchivedDirectoryInfo(const Char* directory);
 

--- a/Core/GameEngine/Include/Common/ArchiveFileSystem.h
+++ b/Core/GameEngine/Include/Common/ArchiveFileSystem.h
@@ -143,9 +143,6 @@ public:
 
 	virtual Bool	loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite = FALSE) = 0;
 
-	// Unprotected this for copy-protection routines
-	ArchiveFile* getArchiveFile(const AsciiString& filename, FileInstance instance = 0) const;
-
 	void loadMods();
 
 	ArchivedDirectoryInfo* friend_getArchivedDirectoryInfo(const Char* directory);
@@ -160,6 +157,7 @@ protected:
 		AsciiString lastToken; ///< Synonymous for file name if the search directory was a file path
 	};
 
+	ArchiveFile* getArchiveFile(const AsciiString& filename, FileInstance instance = 0) const;
 	ArchivedDirectoryInfoResult getArchivedDirectoryInfo(const Char* directory);
 
 	virtual void loadIntoDirectoryTree(ArchiveFile *archiveFile, Bool overwrite = FALSE);	///< load the archive file's header information and apply it to the global archive directory tree.

--- a/Core/GameEngine/Include/Common/FileSystem.h
+++ b/Core/GameEngine/Include/Common/FileSystem.h
@@ -173,8 +173,8 @@ protected:
 	};
 	typedef std::hash_map<
 		rts::string_key<AsciiString>, FileExistData,
-		rts::string_key_hash<AsciiString>,
-		rts::string_key_equal<AsciiString>/**/> FileExistMap;
+		rts::string_key_hash,
+		rts::string_key_equal> FileExistMap;
 
 	mutable FileExistMap m_fileExist;
 	mutable FastCriticalSectionClass m_fileExistMutex;

--- a/Core/GameEngine/Include/Common/FileSystem.h
+++ b/Core/GameEngine/Include/Common/FileSystem.h
@@ -63,7 +63,7 @@
 //           Type Defines
 //----------------------------------------------------------------------------
 
-typedef std::set<AsciiString, rts::less_than_nocase<AsciiString>/**/> FilenameList;
+typedef std::set<AsciiString, rts::less_than_path> FilenameList;
 typedef FilenameList::iterator FilenameListIter;
 typedef UnsignedByte FileInstance;
 
@@ -173,8 +173,8 @@ protected:
 	};
 	typedef std::hash_map<
 		rts::string_key<AsciiString>, FileExistData,
-		rts::string_key_hash,
-		rts::string_key_equal> FileExistMap;
+		rts::string_key_hash_path,
+		rts::string_key_equal_to_path> FileExistMap;
 
 	mutable FileExistMap m_fileExist;
 	mutable FastCriticalSectionClass m_fileExistMutex;

--- a/Core/GameEngine/Include/Common/FileSystem.h
+++ b/Core/GameEngine/Include/Common/FileSystem.h
@@ -136,6 +136,10 @@ struct FileInfo {
 // from multiple threads.
 //
 // TheSuperHackers @feature Mauller 24/04/2026 Add extension removal functions
+//
+// TheSuperHackers @feature xezon 26/07/2026 Implements ignore functionality for files and directories in the local
+// and archive file systems. Can be called at any time during engine runtime. Can be controlled by data with
+// FileSystemIgnore definitions in Data/INI/FileSystem.ini .
 //===============================
 class FileSystem : public SubsystemInterface
 {
@@ -156,6 +160,9 @@ public:
 	Bool getFileInfo(const AsciiString& filename, FileInfo *fileInfo, FileInstance instance = 0) const; ///< fills in the FileInfo struct for the file given. returns TRUE if successful.
 
 	Bool createDirectory(AsciiString directory); ///< create a directory of the given name.
+
+	Bool ignoreFile(const AsciiString& filename, Bool ignore = true); ///< Ignore this file.
+	Bool ignoreDirectory(const AsciiString& directory, Bool ignore = true); ///< Ignore this directory and all its contents.
 
 	static AsciiString normalizePath(const AsciiString& path);	///< normalizes a file path. The path can refer to a directory. File path must be absolute, but does not need to exist. Returns an empty string on failure.
 	static Bool isPathInDirectory(const AsciiString& testPath, const AsciiString& basePath);	///< determines if a file path is within a base path. Both paths must be absolute, but do not need to exist.

--- a/Core/GameEngine/Include/Common/GameCommon.h
+++ b/Core/GameEngine/Include/Common/GameCommon.h
@@ -51,6 +51,7 @@
 
 // ----------------------------------------------------------------------------------------------
 #include "Lib/BaseType.h"
+#include "Lib/PathUtil.h"
 #include "WWLib/WWCommon.h"
 #include "Common/GameDefines.h"
 

--- a/Core/GameEngine/Include/Common/INI.h
+++ b/Core/GameEngine/Include/Common/INI.h
@@ -225,6 +225,7 @@ public:
 	static void parseTerrainRoadDefinition( INI *ini );
 	static void parseTerrainBridgeDefinition( INI *ini );
 	static void parseMetaMapDefinition( INI *ini );
+	static void parseFileSystemIgnoreDefinition( INI* ini );
 	static void parseFXListDefinition( INI *ini );
 	static void parseObjectCreationListDefinition( INI* ini );
 	static void parseMultiplayerSettingsDefinition( INI* ini );

--- a/Core/GameEngine/Include/Common/INI.h
+++ b/Core/GameEngine/Include/Common/INI.h
@@ -164,17 +164,29 @@ class INI
 	INI& operator=(const INI&) FUNCTION_DELETE;
 
 public:
+
+	typedef UnsignedInt LoadFlags;
+	enum LoadFlags_ CPP_11( : UnsignedInt)
+	{
+		LoadFlags_SearchSubDirs = 1 << 0,
+		LoadFlags_ExpectFileFound = 1 << 1,
+	};
+
+public:
+
 	INI();
 
 	// TheSuperHackers @feature xezon 19/08/2025
 	// Load a specific INI file by name and/or INI files from a directory (and its subdirectories).
 	// For example "Data\INI\Armor" loads "Data\INI\Armor.ini" and all *.ini files in "Data\INI\Armor".
 	// Throws if not a single INI file is found or one is not read correctly.
-	UnsignedInt loadFileDirectory( AsciiString fileDirName, INILoadType loadType, Xfer *pXfer, Bool subdirs = TRUE );
+	UnsignedInt loadFileDirectory( AsciiString fileDirName, INILoadType loadType, Xfer *pXfer,
+		LoadFlags loadFlags = LoadFlags_SearchSubDirs | LoadFlags_ExpectFileFound );
 
 	// Load INI files from a directory (and its subdirectories).
 	// Throws if one INI file is not read correctly.
-	UnsignedInt loadDirectory( AsciiString dirName, INILoadType loadType, Xfer *pXfer, Bool subdirs = TRUE );
+	UnsignedInt loadDirectory( AsciiString dirName, INILoadType loadType, Xfer *pXfer,
+		LoadFlags loadFlags = LoadFlags_SearchSubDirs );
 
 	// Load one specific INI file by name.
 	// Throws if the INI file is not found or is not read correctly.

--- a/Core/GameEngine/Include/Common/LocalFileSystem.h
+++ b/Core/GameEngine/Include/Common/LocalFileSystem.h
@@ -33,6 +33,22 @@
 
 class LocalFileSystem : public SubsystemInterface
 {
+	struct IgnoreFileData
+	{
+	};
+
+	typedef std::hash_map<
+		rts::string_key<AsciiString>, IgnoreFileData,
+		rts::string_key_hash_path,
+		rts::string_key_equal_to_path> IgnoreFileHashMap;
+
+protected:
+	typedef Int IgnoreFileTestFlags;
+	enum IgnoreFileTestFlags_
+	{
+		IgnoreFileTestFlags_SkipParentDirectories = 1 << 0,
+	};
+
 public:
 	virtual ~LocalFileSystem() override {}
 
@@ -43,7 +59,27 @@ public:
 	virtual Bool createDirectory(AsciiString directory) = 0; ///< see FileSystem.h
 	virtual AsciiString normalizePath(const AsciiString& filePath) const = 0;	///< see FileSystem.h
 
+	Bool ignoreFile(const AsciiString& filename, Bool ignore = true); ///< Ignore this file on the disk.
+	Bool ignoreDirectory(const AsciiString& directory, Bool ignore = true); ///< Ignore this directory and all its contents on the disk.
+
 protected:
+	Bool isFileIgnored(const Char* filename, IgnoreFileTestFlags flags = 0) const; ///< Whether the given file or its parent directories are ignored.
+	Bool isDirectoryIgnored(const Char* directory, IgnoreFileTestFlags flags = 0) const; ///< Whether the given directory or its parent directories are ignored.
+
+private:
+	Bool isDirectoryIgnoredRecursive(AsciiString& directory, IgnoreFileTestFlags flags) const;
+	Bool isFileIgnoredInternal(const Char* filename) const;
+	Bool isDirectoryIgnoredInternal(const Char* directory) const;
+	Bool hasIgnoredFile() const;
+	Bool hasIgnoredDirectory() const;
+
+	static void trimLastPathSegmentInplace(AsciiString& path); ///< Removes trailing path segment until and including the last slash.
+	static void trimTrailingSlash(AsciiString& path); ///< Remove trailing forward or backward slashes.
+
+	IgnoreFileHashMap m_ignoreFileHashMap;
+	IgnoreFileHashMap m_ignoreDirectoryHashMap;
+	mutable FastCriticalSectionClass m_ignoreFileMutex;
+	mutable FastCriticalSectionClass m_ignoreDirectoryMutex;
 };
 
 extern LocalFileSystem *TheLocalFileSystem;

--- a/Core/GameEngine/Include/Common/STLTypedefs.h
+++ b/Core/GameEngine/Include/Common/STLTypedefs.h
@@ -245,6 +245,48 @@ namespace rts
 		}
 	};
 
+	// TheSuperHackers @info Functor to compare equal paths with. Ignores case, type of slash and trailing slash.
+	struct equal_to_path
+	{
+		bool operator()(const char* __t1, const char* __t2) const noexcept
+		{
+			return comparePath(__t1, __t2) == 0;
+		}
+
+		bool operator()(const AsciiString& __t1, const AsciiString& __t2) const noexcept
+		{
+			return comparePath(__t1.str(), __t2.str()) == 0;
+		}
+	};
+
+	// TheSuperHackers @info Functor to compare lesser paths with. Ignores case, type of slash and trailing slash.
+	struct less_than_path
+	{
+		bool operator()(const char* __t1, const char* __t2) const noexcept
+		{
+			return comparePath(__t1, __t2) < 0;
+		}
+
+		bool operator()(const AsciiString& __t1, const AsciiString& __t2) const noexcept
+		{
+			return comparePath(__t1.str(), __t2.str()) < 0;
+		}
+	};
+
+	// TheSuperHackers @info Functor to hash paths with. Ignores case, type of slash and trailing slash.
+	struct hash_path
+	{
+		size_t operator()(const char* str) const noexcept
+		{
+			return hashPath(str);
+		}
+
+		size_t operator()(const AsciiString& str) const noexcept
+		{
+			return hashPath(str.str());
+		}
+	};
+
 	// TheSuperHackers @info Structs to help create maps that can use C strings for
 	// lookups without the need to allocate a string.
 	template <typename String>
@@ -297,6 +339,25 @@ namespace rts
 		bool operator()(const string_key<String>& a, const string_key<String>& b) const noexcept
 		{
 			return strcmp(a.c_str(), b.c_str()) == 0;
+		}
+	};
+
+	
+	struct string_key_hash_path
+	{
+		template <typename String>
+		size_t operator()(const string_key<String>& key) const noexcept
+		{
+			return hashPath(key.c_str());
+		}
+	};
+
+	struct string_key_equal_to_path
+	{
+		template <typename String>
+		bool operator()(const string_key<String>& a, const string_key<String>& b) const noexcept
+		{
+			return comparePath(a.c_str(), b.c_str()) == 0;
 		}
 	};
 

--- a/Core/GameEngine/Include/Common/STLTypedefs.h
+++ b/Core/GameEngine/Include/Common/STLTypedefs.h
@@ -114,7 +114,7 @@ namespace rts
 	// specific types.
 	template<typename T> struct hash
 	{
-		size_t operator()(const T& __t) const
+		size_t operator()(const T& __t) const noexcept
 		{
 			std::hash<T> tmp;
 			return tmp(__t);
@@ -126,7 +126,7 @@ namespace rts
 	// the case of pointers.)
 	template<typename T> struct equal_to
 	{
-		Bool operator()(const T& __t1, const T& __t2) const
+		Bool operator()(const T& __t1, const T& __t2) const noexcept
 		{
 			return (__t1 == __t2);
 		}
@@ -137,7 +137,7 @@ namespace rts
 	// the case of pointers, or strings.)
 	template<typename T> struct less_than_nocase
 	{
-		bool operator()(const T& __t1, const T& __t2) const
+		bool operator()(const T& __t1, const T& __t2) const noexcept
 		{
 			return (__t1 < __t2);
 		}
@@ -146,7 +146,7 @@ namespace rts
 #ifdef USING_STLPORT
 	template<> struct hash<NameKeyType>
 	{
-		size_t operator()(NameKeyType nkt) const
+		size_t operator()(NameKeyType nkt) const noexcept
 		{
 			std::hash<UnsignedInt> tmp;
 			return tmp((UnsignedInt)nkt);
@@ -155,7 +155,7 @@ namespace rts
 
 	template<> struct hash<DrawableID>
 	{
-		size_t operator()(DrawableID nkt) const
+		size_t operator()(DrawableID nkt) const noexcept
 		{
 			std::hash<UnsignedInt> tmp;
 			return tmp((UnsignedInt)nkt);
@@ -164,7 +164,7 @@ namespace rts
 
 	template<> struct hash<ObjectID>
 	{
-		size_t operator()(ObjectID nkt) const
+		size_t operator()(ObjectID nkt) const noexcept
 		{
 			std::hash<UnsignedInt> tmp;
 			return tmp((UnsignedInt)nkt);
@@ -173,7 +173,7 @@ namespace rts
 
 	template<> struct hash<ParticleSystemID>
 	{
-		size_t operator()(ParticleSystemID nkt) const
+		size_t operator()(ParticleSystemID nkt) const noexcept
 		{
 			std::hash<UnsignedInt> tmp;
 			return tmp((UnsignedInt)nkt);
@@ -183,7 +183,7 @@ namespace rts
 
 	template<> struct hash<const Char*>
 	{
-		size_t operator()(const Char* s) const
+		size_t operator()(const Char* s) const noexcept
 		{
 #ifdef USING_STLPORT
 			std::hash<const Char*> hasher;
@@ -201,7 +201,7 @@ namespace rts
 	// they are to be used in lots of places.)
 	template<> struct equal_to<const char*>
 	{
-		Bool operator()(const char* s1, const char* s2) const
+		Bool operator()(const char* s1, const char* s2) const noexcept
 		{
 			return strcmp(s1, s2) == 0;
 		}
@@ -209,13 +209,12 @@ namespace rts
 
 	template<> struct hash<AsciiString>
 	{
-		size_t operator()(const AsciiString& ast) const
+		size_t operator()(const AsciiString& ast) const noexcept
 		{
 #ifdef USING_STLPORT
 			std::hash<const char *> tmp;
 			return tmp((const char *) ast.str());
 #else
-			// TheSuperHackers @bugfix xezon 16/03/2024 Re-implements hash function that works with non-STLPort.
 			std::hash<std::string_view> hasher;
 			return hasher(std::string_view(ast.str(), ast.getLength()));
 #endif
@@ -224,7 +223,7 @@ namespace rts
 
 	template<> struct equal_to<AsciiString>
 	{
-		Bool operator()(const AsciiString& __t1, const AsciiString& __t2) const
+		Bool operator()(const AsciiString& __t1, const AsciiString& __t2) const noexcept
 		{
 			return (__t1 == __t2);
 		}
@@ -232,7 +231,7 @@ namespace rts
 
 	template<> struct less_than_nocase<AsciiString>
 	{
-		bool operator()(const AsciiString& __t1, const AsciiString& __t2) const
+		bool operator()(const AsciiString& __t1, const AsciiString& __t2) const noexcept
 		{
 			return (__t1.compareNoCase(__t2) < 0);
 		}
@@ -240,7 +239,7 @@ namespace rts
 
 	template<> struct less_than_nocase<UnicodeString>
 	{
-		bool operator()(const UnicodeString& __t1, const UnicodeString& __t2) const
+		bool operator()(const UnicodeString& __t1, const UnicodeString& __t2) const noexcept
 		{
 			return (__t1.compareNoCase(__t2) < 0);
 		}
@@ -282,20 +281,20 @@ namespace rts
 		const_pointer cstr;
 	};
 
-	template <typename String>
 	struct string_key_hash
 	{
-		typedef typename String::const_pointer const_pointer;
-		size_t operator()(const string_key<String>& key) const
+		template <typename String>
+		size_t operator()(const string_key<String>& key) const noexcept
 		{
+			typedef typename String::const_pointer const_pointer;
 			return hash<const_pointer>()(key.c_str());
 		}
 	};
 
-	template <typename String>
 	struct string_key_equal
 	{
-		bool operator()(const string_key<String>& a, const string_key<String>& b) const
+		template <typename String>
+		bool operator()(const string_key<String>& a, const string_key<String>& b) const noexcept
 		{
 			return strcmp(a.c_str(), b.c_str()) == 0;
 		}

--- a/Core/GameEngine/Include/Common/UnicodeString.h
+++ b/Core/GameEngine/Include/Common/UnicodeString.h
@@ -348,7 +348,7 @@ public:
 		token was found. (note that this modifies 'this' as well, stripping
 		the token off!)
 	*/
-	Bool nextToken(UnicodeString* token, UnicodeString delimiters = UnicodeString::TheEmptyString);
+	Bool nextToken(UnicodeString* token, const WideChar* separators = nullptr);
 
 //
 // You might think it would be a good idea to overload the * operator

--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -110,6 +110,7 @@ static const BlockParse theTypeTable[] =
 	{ "DrawGroupInfo",                  INI::parseDrawGroupNumberDefinition },
 	{ "DynamicGameLOD",                 INI::parseDynamicGameLODDefinition },
 	{ "EvaEvent",                       INI::parseEvaEvent },
+	{ "FileSystemIgnore",               INI::parseFileSystemIgnoreDefinition },
 	{ "FXList",                         INI::parseFXListDefinition },
 	{ "GameData",                       INI::parseGameDataDefinition },
 	{ "HeaderTemplate",                 INI::parseHeaderTemplateDefinition },

--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -189,7 +189,7 @@ INI::INI()
 }
 
 //-------------------------------------------------------------------------------------------------
-UnsignedInt INI::loadFileDirectory( AsciiString fileDirName, INILoadType loadType, Xfer *pXfer, Bool subdirs )
+UnsignedInt INI::loadFileDirectory( AsciiString fileDirName, INILoadType loadType, Xfer *pXfer, LoadFlags loadFlags )
 {
 	UnsignedInt filesRead = 0;
 
@@ -214,10 +214,11 @@ UnsignedInt INI::loadFileDirectory( AsciiString fileDirName, INILoadType loadTyp
 	}
 
 	// Load any additional ini files from a "filename" directory and its subdirectories.
-	filesRead += loadDirectory(iniDir, loadType, pXfer, subdirs);
+	filesRead += loadDirectory(iniDir, loadType, pXfer, loadFlags & ~LoadFlags_ExpectFileFound);
 
 	// Expect to open and load at least one file.
-	if (filesRead == 0)
+	const Bool expectFileFound = (loadFlags & LoadFlags_ExpectFileFound) != 0;
+	if (expectFileFound && filesRead == 0)
 	{
 		throw INI_CANT_OPEN_FILE;
 	}
@@ -230,7 +231,7 @@ UnsignedInt INI::loadFileDirectory( AsciiString fileDirName, INILoadType loadTyp
 	* If we are to load subdirectories, we will load them *after* we load all the
 	* files in the current directory */
 //-------------------------------------------------------------------------------------------------
-UnsignedInt INI::loadDirectory( AsciiString dirName, INILoadType loadType, Xfer *pXfer, Bool subdirs )
+UnsignedInt INI::loadDirectory( AsciiString dirName, INILoadType loadType, Xfer *pXfer, LoadFlags loadFlags )
 {
 	UnsignedInt filesRead = 0;
 
@@ -238,6 +239,7 @@ UnsignedInt INI::loadDirectory( AsciiString dirName, INILoadType loadType, Xfer 
 	if( dirName.isEmpty() )
 		throw INI_INVALID_DIRECTORY;
 
+	const Bool subdirs = (loadFlags & LoadFlags_SearchSubDirs) != 0;
 	FilenameList filenameList;
 	dirName.concat('\\');
 	TheFileSystem->getFileListInDirectory(dirName, "*.ini", filenameList, subdirs);
@@ -266,6 +268,13 @@ UnsignedInt INI::loadDirectory( AsciiString dirName, INILoadType loadType, Xfer 
 			filesRead += load( *it, loadType, pXfer );
 		}
 		++it;
+	}
+
+	// Expect to open and load at least one file.
+	const Bool expectFileFound = (loadFlags & LoadFlags_ExpectFileFound) != 0;
+	if (expectFileFound && filesRead == 0)
+	{
+		throw INI_CANT_OPEN_FILE;
 	}
 
 	return filesRead;

--- a/Core/GameEngine/Source/Common/INI/INIFileSystem.cpp
+++ b/Core/GameEngine/Source/Common/INI/INIFileSystem.cpp
@@ -1,0 +1,86 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2026 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
+
+#include "Common/FileSystem.h"
+#include "Common/INI.h"
+
+struct FileSystemIgnore
+{
+	enum Type
+	{
+		Auto,
+		File,
+		Dir,
+	};
+
+	FileSystemIgnore() : m_type(Auto) {}
+
+	AsciiString m_name;
+	Type m_type;
+
+	static const FieldParse s_fieldParseTable[];
+	static const char *const s_typeNames[];
+};
+
+const char *const FileSystemIgnore::s_typeNames[] =
+{
+	"AUTO",
+	"FILE",
+	"DIR",
+	nullptr
+};
+
+const FieldParse FileSystemIgnore::s_fieldParseTable[] =
+{
+	{ "Name", INI::parseQuotedAsciiString, nullptr, offsetof(FileSystemIgnore, m_name) },
+	{ "Type", INI::parseIndexList, s_typeNames,		offsetof(FileSystemIgnore, m_type) },
+	{ nullptr, nullptr, nullptr, 0 }
+};
+
+void INI::parseFileSystemIgnoreDefinition(INI* ini)
+{
+	DEBUG_ASSERTCRASH(TheFileSystem != nullptr, ("TheFileSystem is null"));
+
+	FileSystemIgnore fsIgnore;
+	ini->initFromINI(&fsIgnore, fsIgnore.s_fieldParseTable);
+
+	if (fsIgnore.m_type == FileSystemIgnore::Auto)
+	{
+		if (isFilePath(fsIgnore.m_name.str()))
+			fsIgnore.m_type = FileSystemIgnore::File;
+		else
+			fsIgnore.m_type = FileSystemIgnore::Dir;
+	}
+
+	switch (fsIgnore.m_type)
+	{
+	case FileSystemIgnore::File:
+		TheFileSystem->ignoreFile(fsIgnore.m_name);
+		break;
+
+	case FileSystemIgnore::Dir:
+		TheFileSystem->ignoreDirectory(fsIgnore.m_name);
+		break;
+
+	default:
+		DEBUG_CRASH(("Unhandled case in parseFileSystemIgnoreDefinition"));
+		break;
+	}
+}

--- a/Core/GameEngine/Source/Common/System/ArchiveFile.cpp
+++ b/Core/GameEngine/Source/Common/System/ArchiveFile.cpp
@@ -117,7 +117,15 @@ void ArchiveFile::addFile(const AsciiString& path, const ArchivedFileInfo *fileI
 		tokenizer.nextToken(&token, "\\/");
 	}
 
-	dirInfo->m_files[fileInfo->m_filename] = *fileInfo;
+	typedef std::pair<ArchivedFileInfoMap::iterator, bool> Result;
+	const Result result = dirInfo->m_files.insert(std::make_pair(fileInfo->m_filename, *fileInfo));
+	if (result.second) {
+		AsciiString filename = path;
+		filename.concat(fileInfo->m_filename);
+		m_absFilenameToFileInfo[filename] = &result.first->second;
+
+		static_assert((std::is_same_v<decltype(dirInfo->m_files), std::map<AsciiString, ArchivedFileInfo>>), "Hash map expects stable references");
+	}
 }
 
 void ArchiveFile::getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const
@@ -184,36 +192,9 @@ void ArchiveFile::attachFile(File *file)
 
 const ArchivedFileInfo * ArchiveFile::getArchivedFileInfo(const AsciiString& filename) const
 {
-	const DetailedArchivedDirectoryInfo *dirInfo = &m_rootDirectory;
-
-	AsciiString token;
-	AsciiString tokenizer = filename;
-	tokenizer.toLower();
-	tokenizer.nextToken(&token, "\\/");
-
-	while (!token.find('.') || tokenizer.find('.'))
-	{
-		DetailedArchivedDirectoryInfoMap::const_iterator it = dirInfo->m_directories.find(token);
-		if (it != dirInfo->m_directories.end())
-		{
-			dirInfo = &it->second;
-		}
-		else
-		{
-			return nullptr;
-		}
-
-		tokenizer.nextToken(&token, "\\/");
-	}
-
-	ArchivedFileInfoMap::const_iterator it = dirInfo->m_files.find(token);
-	if (it != dirInfo->m_files.end())
-	{
-		return &it->second;
-	}
-	else
-	{
+	ArchivedFileInfoPtrHashMap::const_iterator it = m_absFilenameToFileInfo.find(filename);
+	if (it == m_absFilenameToFileInfo.end())
 		return nullptr;
-	}
 
+	return it->second;
 }

--- a/Core/GameEngine/Source/Common/System/ArchiveFile.cpp
+++ b/Core/GameEngine/Source/Common/System/ArchiveFile.cpp
@@ -106,13 +106,11 @@ void ArchiveFile::addFile(const AsciiString& path, const ArchivedFileInfo *fileI
 	while (!token.isEmpty())
 	{
 		DetailedArchivedDirectoryInfoMap::iterator tempiter = dirInfo->m_directories.find(token);
-		if (tempiter == dirInfo->m_directories.end())
-		{
+		if (tempiter == dirInfo->m_directories.end()) {
 			dirInfo = &(dirInfo->m_directories[token]);
 			dirInfo->m_directoryName = token;
 		}
-		else
-		{
+		else {
 			dirInfo = &tempiter->second;
 		}
 
@@ -132,18 +130,12 @@ void ArchiveFile::getFileListInDirectory(const AsciiString& currentDirectory, co
 	tokenizer.nextToken(&token, "\\/");
 
 	while (!token.isEmpty()) {
-
 		DetailedArchivedDirectoryInfoMap::const_iterator it = dirInfo->m_directories.find(token);
-		if (it != dirInfo->m_directories.end())
-		{
-			dirInfo = &it->second;
-		}
-		else
-		{
-			// if the directory doesn't exist, then there aren't any files to be had.
+		// if the directory doesn't exist, then there aren't any files to be had.
+		if (it == dirInfo->m_directories.end())
 			return;
-		}
 
+		dirInfo = &it->second;
 		tokenizer.nextToken(&token, "\\/");
 	}
 
@@ -153,33 +145,31 @@ void ArchiveFile::getFileListInDirectory(const AsciiString& currentDirectory, co
 void ArchiveFile::getFileListInDirectory(const DetailedArchivedDirectoryInfo *dirInfo, const AsciiString& currentDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const
 {
 	DetailedArchivedDirectoryInfoMap::const_iterator diriter = dirInfo->m_directories.begin();
-	while (diriter != dirInfo->m_directories.end()) {
+	for (; diriter != dirInfo->m_directories.end(); ++diriter) {
 		const DetailedArchivedDirectoryInfo *tempDirInfo = &(diriter->second);
-		AsciiString tempdirname;
-		tempdirname = currentDirectory;
-		if ((!tempdirname.isEmpty()) && (!tempdirname.endsWith("\\"))) {
-			tempdirname.concat('\\');
+		AsciiString tempDirName = currentDirectory;
+		if (!tempDirName.isEmpty() && !tempDirName.endsWith("\\")) {
+			tempDirName.concat('\\');
 		}
-		tempdirname.concat(tempDirInfo->m_directoryName);
-		getFileListInDirectory(tempDirInfo, tempdirname, searchName, filenameList, searchSubdirectories);
-		diriter++;
+		tempDirName.concat(tempDirInfo->m_directoryName);
+		getFileListInDirectory(tempDirInfo, tempDirName, searchName, filenameList, searchSubdirectories);
 	}
 
 	ArchivedFileInfoMap::const_iterator fileiter = dirInfo->m_files.begin();
-	while (fileiter != dirInfo->m_files.end()) {
-		if (SearchStringMatches(fileiter->second.m_filename, searchName)) {
+	for (; fileiter != dirInfo->m_files.end(); ++fileiter) {
+		const ArchivedFileInfo &fileInfo = fileiter->second;
+		if (SearchStringMatches(fileInfo.m_filename, searchName)) {
 			AsciiString tempfilename;
 			tempfilename = currentDirectory;
-			if ((!tempfilename.isEmpty()) && (!tempfilename.endsWith("\\"))) {
+			if (!tempfilename.isEmpty() && !tempfilename.endsWith("\\")) {
 				tempfilename.concat('\\');
 			}
-			tempfilename.concat(fileiter->second.m_filename);
+			tempfilename.concat(fileInfo.m_filename);
 			if (filenameList.find(tempfilename) == filenameList.end()) {
 				// only insert into the list if its not already in there.
 				filenameList.insert(tempfilename);
 			}
 		}
-		fileiter++;
 	}
 }
 

--- a/Core/GameEngine/Source/Common/System/ArchiveFile.cpp
+++ b/Core/GameEngine/Source/Common/System/ArchiveFile.cpp
@@ -128,6 +128,59 @@ void ArchiveFile::addFile(const AsciiString& path, const ArchivedFileInfo *fileI
 	}
 }
 
+Bool ArchiveFile::ignoreFile(const AsciiString& filename, Bool ignore)
+{
+	ArchivedFileInfoPtrHashMap::iterator it = m_absFilenameToFileInfo.find(filename);
+	if (it == m_absFilenameToFileInfo.end()) {
+		return false;
+	}
+
+	it->second->m_ignore = ignore;
+	return true;
+}
+
+Bool ArchiveFile::ignoreDirectory(const AsciiString& directory, Bool ignore)
+{
+	DetailedArchivedDirectoryInfo *dirInfo = &m_rootDirectory;
+
+	AsciiString token;
+	AsciiString tokenizer = directory;
+	tokenizer.toLower();
+	tokenizer.nextToken(&token, "\\/");
+
+	while (!token.isEmpty()) {
+		DetailedArchivedDirectoryInfoMap::iterator it = dirInfo->m_directories.find(token);
+		if (it == dirInfo->m_directories.end())
+			return false;
+		dirInfo = &it->second;
+		tokenizer.nextToken(&token, "\\/");
+	}
+
+	ignoreDirectory(dirInfo, ignore);
+	return true;
+}
+
+void ArchiveFile::ignoreDirectory(DetailedArchivedDirectoryInfo *dirInfo, Bool ignore)
+{
+	// Ignore this directory
+	dirInfo->m_ignore = ignore;
+
+	// Ignore all files in this directory
+	ArchivedFileInfoMap::iterator fileIt = dirInfo->m_files.begin();
+	for (; fileIt != dirInfo->m_files.end(); ++fileIt) {
+		ArchivedFileInfo &fileInfo = fileIt->second;
+		fileInfo.m_ignore = ignore;
+	}
+
+	// Ignore subdirectories and its files
+	DetailedArchivedDirectoryInfoMap::iterator dirIt = dirInfo->m_directories.begin();
+	for (; dirIt != dirInfo->m_directories.end(); ++dirIt) {
+		DetailedArchivedDirectoryInfo *tempDirInfo = &(dirIt->second);
+		tempDirInfo->m_ignore = ignore;
+		ignoreDirectory(tempDirInfo, ignore);
+	}
+}
+
 void ArchiveFile::getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const
 {
 	const DetailedArchivedDirectoryInfo *dirInfo = &m_rootDirectory;
@@ -144,6 +197,9 @@ void ArchiveFile::getFileListInDirectory(const AsciiString& currentDirectory, co
 			return;
 
 		dirInfo = &it->second;
+		if (dirInfo->m_ignore)
+			return;
+
 		tokenizer.nextToken(&token, "\\/");
 	}
 
@@ -155,6 +211,8 @@ void ArchiveFile::getFileListInDirectory(const DetailedArchivedDirectoryInfo *di
 	DetailedArchivedDirectoryInfoMap::const_iterator diriter = dirInfo->m_directories.begin();
 	for (; diriter != dirInfo->m_directories.end(); ++diriter) {
 		const DetailedArchivedDirectoryInfo *tempDirInfo = &(diriter->second);
+		if (tempDirInfo->m_ignore)
+			continue;
 		AsciiString tempDirName = currentDirectory;
 		if (!tempDirName.isEmpty() && !tempDirName.endsWith("\\")) {
 			tempDirName.concat('\\');
@@ -166,6 +224,8 @@ void ArchiveFile::getFileListInDirectory(const DetailedArchivedDirectoryInfo *di
 	ArchivedFileInfoMap::const_iterator fileiter = dirInfo->m_files.begin();
 	for (; fileiter != dirInfo->m_files.end(); ++fileiter) {
 		const ArchivedFileInfo &fileInfo = fileiter->second;
+		if (fileInfo.m_ignore)
+			continue;
 		if (SearchStringMatches(fileInfo.m_filename, searchName)) {
 			AsciiString tempfilename;
 			tempfilename = currentDirectory;
@@ -194,6 +254,9 @@ const ArchivedFileInfo * ArchiveFile::getArchivedFileInfo(const AsciiString& fil
 {
 	ArchivedFileInfoPtrHashMap::const_iterator it = m_absFilenameToFileInfo.find(filename);
 	if (it == m_absFilenameToFileInfo.end())
+		return nullptr;
+
+	if (it->second->m_ignore)
 		return nullptr;
 
 	return it->second;

--- a/Core/GameEngine/Source/Common/System/ArchiveFileSystem.cpp
+++ b/Core/GameEngine/Source/Common/System/ArchiveFileSystem.cpp
@@ -236,6 +236,32 @@ void ArchiveFileSystem::loadMods()
 	}
 }
 
+Bool ArchiveFileSystem::ignoreFile( const AsciiString& filename, Bool ignore )
+{
+	Bool wasIgnored = false;
+
+	if (!filename.isEmpty()){
+		ArchiveFileMap::const_iterator it = m_archiveFileMap.begin();
+		for (; it != m_archiveFileMap.end(); ++it) {
+			wasIgnored |= it->second->ignoreFile(filename, ignore);
+		}
+	}
+	return wasIgnored;
+}
+
+Bool ArchiveFileSystem::ignoreDirectory( const AsciiString& directory, Bool ignore )
+{
+	Bool wasIgnored = false;
+
+	if (!directory.isEmpty()) {
+		ArchiveFileMap::const_iterator it = m_archiveFileMap.begin();
+		for (; it != m_archiveFileMap.end(); ++it) {
+			wasIgnored |= it->second->ignoreDirectory(directory, ignore);
+		}
+	}
+	return wasIgnored;
+}
+
 Bool ArchiveFileSystem::doesFileExist(const Char *filename, FileInstance instance) const
 {
 	ArchivedDirectoryInfoResult result = const_cast<ArchiveFileSystem*>(this)->getArchivedDirectoryInfo(filename);
@@ -245,7 +271,14 @@ Bool ArchiveFileSystem::doesFileExist(const Char *filename, FileInstance instanc
 
 	stl::const_range<ArchivedFileLocationMap> range = stl::get_range(result.dirInfo->m_files, result.lastToken, instance);
 
-	return range.valid();
+	if (!range.valid())
+		return false;
+
+	FileInfo fileInfo;
+	ArchiveFile *archiveFile = range.get()->second;
+
+	// Returns null if the file in the archive is ignored.
+	return archiveFile->getFileInfo(filename, &fileInfo);
 }
 
 ArchivedDirectoryInfo* ArchiveFileSystem::friend_getArchivedDirectoryInfo(const Char* directory)

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -572,8 +572,13 @@ Bool AsciiString::isNone() const
 //-----------------------------------------------------------------------------
 Bool AsciiString::nextToken(AsciiString* tok, const char* seps)
 {
-	if (this->isEmpty() || tok == this)
+	DEBUG_ASSERTCRASH(tok != this, ("Tokenizer and Token cannot be the same object"));
+
+	if (this->isEmpty())
+	{
+		tok->clear();
 		return false;
+	}
 
 	if (seps == nullptr)
 		seps = " \n\r\t";

--- a/Core/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/Core/GameEngine/Source/Common/System/FileSystem.cpp
@@ -54,8 +54,6 @@
 #include "Common/LocalFileSystem.h"
 #include "Common/PerfTimer.h"
 
-#include "Lib/PathUtil.h"
-
 
 DECLARE_PERF_TIMER(FileSystem)
 

--- a/Core/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/Core/GameEngine/Source/Common/System/FileSystem.cpp
@@ -330,6 +330,52 @@ Bool FileSystem::createDirectory(AsciiString directory)
 }
 
 //============================================================================
+Bool FileSystem::ignoreFile(const AsciiString& filename, Bool ignore)
+{
+	Bool wasIgnored = FALSE;
+	wasIgnored |= TheLocalFileSystem->ignoreFile(filename, ignore);
+	wasIgnored |= TheArchiveFileSystem->ignoreFile(filename, ignore);
+
+#if ENABLE_FILESYSTEM_EXISTENCE_CACHE
+	if (wasIgnored)
+	{
+		// Remove this file from the existence cache.
+		FastCriticalSectionClass::LockClass lock(m_fileExistMutex);
+		m_fileExist.erase(filename);
+	}
+#endif
+
+	return wasIgnored;
+}
+
+//============================================================================
+Bool FileSystem::ignoreDirectory(const AsciiString& directory, Bool ignore)
+{
+	Bool wasIgnored = FALSE;
+	wasIgnored |= TheLocalFileSystem->ignoreDirectory(directory, ignore);
+	wasIgnored |= TheArchiveFileSystem->ignoreDirectory(directory, ignore);
+
+#if ENABLE_FILESYSTEM_EXISTENCE_CACHE
+	if (wasIgnored)
+	{
+		// Remove all relevant files from the existence cache.
+		FastCriticalSectionClass::LockClass lock(m_fileExistMutex);
+		FileExistMap::const_iterator it = m_fileExist.begin();
+		while (it != m_fileExist.end())
+		{
+			FileExistMap::const_iterator curr = it++;
+			if (startsWithPath(curr->first.c_str(), directory.str()))
+			{
+				m_fileExist.erase(curr->first);
+			}
+		}
+	}
+#endif
+
+	return wasIgnored;
+}
+
+//============================================================================
 // FileSystem::normalizePath
 //============================================================================
 AsciiString FileSystem::normalizePath(const AsciiString& path)

--- a/Core/GameEngine/Source/Common/System/LocalFileSystem.cpp
+++ b/Core/GameEngine/Source/Common/System/LocalFileSystem.cpp
@@ -87,8 +87,167 @@ LocalFileSystem *TheLocalFileSystem = nullptr;
 //         Private Functions
 //----------------------------------------------------------------------------
 
+void LocalFileSystem::trimLastPathSegmentInplace(AsciiString& path)
+{
+	if (const char* end = maxPtr(path.reverseFind('\\'), path.reverseFind('/')))
+	{
+		path.truncateTo(end - path.str());
+	}
+	else
+	{
+		path.clear();
+	}
+}
 
+void LocalFileSystem::trimTrailingSlash(AsciiString& path)
+{
+	path.trimEnd('\\');
+	path.trimEnd('/');
+}
 
 //----------------------------------------------------------------------------
 //         Public Functions
 //----------------------------------------------------------------------------
+
+Bool LocalFileSystem::ignoreFile(const AsciiString& filename, Bool ignore)
+{
+	if (filename.isEmpty())
+		return false;
+
+	if (ignore)
+	{
+		FastCriticalSectionClass::LockClass lock(m_ignoreFileMutex);
+		m_ignoreFileHashMap.insert(std::make_pair(filename, IgnoreFileData()));
+	}
+	else if (!m_ignoreFileHashMap.empty())
+	{
+		FastCriticalSectionClass::LockClass lock(m_ignoreFileMutex);
+		m_ignoreFileHashMap.erase(filename);
+	}
+	return true;
+}
+
+Bool LocalFileSystem::ignoreDirectory(const AsciiString& directory, Bool ignore)
+{
+	if (directory.isEmpty())
+		return false;
+
+	if (ignore)
+	{
+		FastCriticalSectionClass::LockClass lock(m_ignoreDirectoryMutex);
+		m_ignoreDirectoryHashMap[directory];
+	}
+	else
+	{
+		// Lift ignore on this directory and subdirectories
+		{
+			FastCriticalSectionClass::LockClass lock(m_ignoreDirectoryMutex);
+			IgnoreFileHashMap::const_iterator it = m_ignoreDirectoryHashMap.begin();
+			while (it != m_ignoreDirectoryHashMap.end())
+			{
+				IgnoreFileHashMap::const_iterator curr = it++;
+				if (startsWithPath(curr->first.c_str(), directory.str()))
+				{
+					m_ignoreDirectoryHashMap.erase(curr->first);
+				}
+			}
+		}
+
+		// Also lift ignore on files in the directory
+		{
+			FastCriticalSectionClass::LockClass lock(m_ignoreFileMutex);
+			IgnoreFileHashMap::const_iterator it = m_ignoreFileHashMap.begin();
+			while (it != m_ignoreFileHashMap.end())
+			{
+				IgnoreFileHashMap::const_iterator curr = it++;
+				if (startsWithPath(curr->first.c_str(), directory.str()))
+				{
+					m_ignoreFileHashMap.erase(curr->first);
+				}
+			}
+		}
+	}
+	return true;
+}
+
+Bool LocalFileSystem::isFileIgnored(const Char* filename, IgnoreFileTestFlags flags) const
+{
+	if (*filename == '\0')
+		return false;
+
+	// Early out if nothing is ignored.
+	if (!hasIgnoredFile() && !hasIgnoredDirectory())
+		return false;
+
+	if (isFileIgnoredInternal(filename))
+		return true;
+
+	if (flags & IgnoreFileTestFlags_SkipParentDirectories)
+		return false;
+
+	// Also check parent directories.
+	AsciiString recurseDirectory = filename;
+	trimLastPathSegmentInplace(recurseDirectory);
+	return isDirectoryIgnoredRecursive(recurseDirectory, flags);
+}
+
+Bool LocalFileSystem::isDirectoryIgnored(const Char* directory, IgnoreFileTestFlags flags) const
+{
+	if (*directory == '\0')
+		return false;
+
+	// Early out if nothing is ignored.
+	if (!hasIgnoredDirectory())
+		return false;
+
+	if (isDirectoryIgnoredInternal(directory))
+		return true;
+
+	if (flags & IgnoreFileTestFlags_SkipParentDirectories)
+		return false;
+
+	// Also check parent directories.
+	AsciiString recurseDirectory = directory;
+	trimTrailingSlash(recurseDirectory);
+	trimLastPathSegmentInplace(recurseDirectory);
+	return isDirectoryIgnoredRecursive(recurseDirectory, flags);
+}
+
+Bool LocalFileSystem::isDirectoryIgnoredRecursive(AsciiString& directory, IgnoreFileTestFlags flags) const
+{
+	if (directory.isEmpty())
+		return false;
+
+	if (isDirectoryIgnoredInternal(directory.str()))
+		return true;
+
+	if (flags & IgnoreFileTestFlags_SkipParentDirectories)
+		return false;
+
+	trimLastPathSegmentInplace(directory);
+	return isDirectoryIgnoredRecursive(directory, flags);
+}
+
+Bool LocalFileSystem::isFileIgnoredInternal(const Char* filename) const
+{
+	FastCriticalSectionClass::LockClass lock(m_ignoreFileMutex);
+	return m_ignoreFileHashMap.find(IgnoreFileHashMap::key_type::temporary(filename)) != m_ignoreFileHashMap.end();
+}
+
+Bool LocalFileSystem::isDirectoryIgnoredInternal(const Char* directory) const
+{
+	FastCriticalSectionClass::LockClass lock(m_ignoreDirectoryMutex);
+	return m_ignoreDirectoryHashMap.find(IgnoreFileHashMap::key_type::temporary(directory)) != m_ignoreDirectoryHashMap.end();
+}
+
+Bool LocalFileSystem::hasIgnoredFile() const
+{
+	// Not locked for speed
+	return !m_ignoreFileHashMap.empty();
+}
+
+Bool LocalFileSystem::hasIgnoredDirectory() const
+{
+	// Not locked for speed
+	return !m_ignoreDirectoryHashMap.empty();
+}

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -431,20 +431,25 @@ Bool UnicodeString::endsWithNoCase(const WideChar* p) const
 }
 
 //-----------------------------------------------------------------------------
-Bool UnicodeString::nextToken(UnicodeString* tok, UnicodeString delimiters)
+Bool UnicodeString::nextToken(UnicodeString* tok, const WideChar* delimiters)
 {
-	if (this->isEmpty() || tok == this)
-		return false;
+	DEBUG_ASSERTCRASH(tok != this, ("Tokenizer and Token cannot be the same object"));
 
-	if (delimiters.isEmpty())
+	if (this->isEmpty())
+	{
+		tok->clear();
+		return false;
+	}
+
+	if (delimiters == nullptr)
 		delimiters = L" \t\n\r";
 
 	Int offset;
 
-	offset = wcsspn(peek(), delimiters.str());
+	offset = wcsspn(peek(), delimiters);
 	WideChar* start = peek() + offset;
 
-	offset = wcscspn(start, delimiters.str());
+	offset = wcscspn(start, delimiters);
 	WideChar* end = start + offset;
 
 	if (end > start)

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFile.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFile.cpp
@@ -151,17 +151,17 @@ void StdBIGFile::close()
 
 Bool StdBIGFile::getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const
 {
-	const ArchivedFileInfo *tempFileInfo = getArchivedFileInfo(filename);
+	const ArchivedFileInfo *archivedFileInfo = getArchivedFileInfo(filename);
 
-	if (tempFileInfo == nullptr) {
+	if (archivedFileInfo == nullptr) {
 		return FALSE;
 	}
 
-	TheLocalFileSystem->getFileInfo(AsciiString(m_file->getName()), fileInfo);
-
-	// fill in the size info.  Since the size can't be bigger than a JUNK file, the high Int will always be 0.
+	// fill in the size info.  Since the size can't be bigger than a JUNK file, the high int will always be 0.
 	fileInfo->sizeHigh = 0;
-	fileInfo->sizeLow = tempFileInfo->m_size;
+	fileInfo->sizeLow = archivedFileInfo->m_size;
+	fileInfo->timestampHigh = 0;
+	fileInfo->timestampLow = 0;
 
 	return TRUE;
 }

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFile.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFile.cpp
@@ -62,7 +62,7 @@ File* StdBIGFile::openFile( const Char *filename, Int access )
 {
 	const ArchivedFileInfo *fileInfo = getArchivedFileInfo(AsciiString(filename));
 
-	if (fileInfo == nullptr) {
+	if (fileInfo == nullptr || fileInfo->m_ignore) {
 		return nullptr;
 	}
 

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -128,7 +128,7 @@ ArchiveFile * StdBIGFileSystem::openArchiveFile(const Char *filename) {
 	// seek to the beginning of the directory listing.
 	fp->seek(0x10, File::START);
 	// read in each directory listing.
-	ArchivedFileInfo *fileInfo = NEW ArchivedFileInfo;
+	ArchivedFileInfo fileInfo;
 
 	for (Int i = 0; i < numLittleFiles; ++i) {
 		Int filesize = 0;
@@ -139,9 +139,9 @@ ArchiveFile * StdBIGFileSystem::openArchiveFile(const Char *filename) {
 		filesize = betoh(filesize);
 		fileOffset = betoh(fileOffset);
 
-		fileInfo->m_archiveFilename = archiveFileName;
-		fileInfo->m_offset = fileOffset;
-		fileInfo->m_size = filesize;
+		fileInfo.m_archiveFilename = archiveFileName;
+		fileInfo.m_offset = fileOffset;
+		fileInfo.m_size = filesize;
 
 		// read in the path name of the file.
 		Int pathIndex = -1;
@@ -155,8 +155,8 @@ ArchiveFile * StdBIGFileSystem::openArchiveFile(const Char *filename) {
 			--filenameIndex;
 		}
 
-		fileInfo->m_filename = (char *)(buffer + filenameIndex + 1);
-		fileInfo->m_filename.toLower();
+		fileInfo.m_filename = (char *)(buffer + filenameIndex + 1);
+		fileInfo.m_filename.toLower();
 		buffer[filenameIndex + 1] = 0;
 
 		AsciiString path;
@@ -164,16 +164,13 @@ ArchiveFile * StdBIGFileSystem::openArchiveFile(const Char *filename) {
 
 		AsciiString debugpath;
 		debugpath = path;
-		debugpath.concat(fileInfo->m_filename);
+		debugpath.concat(fileInfo.m_filename);
 //		DEBUG_LOG(("StdBIGFileSystem::openArchiveFile - adding file %s to archive file %s, file number %d", debugpath.str(), fileInfo->m_archiveFilename.str(), i));
 
-		archiveFile->addFile(path, fileInfo);
+		archiveFile->addFile(path, &fileInfo);
 	}
 
 	archiveFile->attachFile(fp);
-
-	delete fileInfo;
-	fileInfo = nullptr;
 
 	// leave fp open as the archive file will be using it.
 

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
@@ -134,6 +134,10 @@ File * StdLocalFileSystem::openFile(const Char *filename, Int access, size_t buf
 		return nullptr;
 	}
 
+	if (isFileIgnored(filename)) {
+		return nullptr;
+	}
+
 	std::filesystem::path path = fixFilenameFromWindowsPath(filename, access);
 
 	if (path.empty()) {
@@ -204,6 +208,10 @@ Bool StdLocalFileSystem::doesFileExist(const Char *filename) const
 		return FALSE;
 	}
 
+	if (isFileIgnored(filename)) {
+		return FALSE;
+	}
+
 	std::error_code ec;
 	return std::filesystem::exists(path, ec);
 }
@@ -212,6 +220,9 @@ void StdLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirect
 {
 	AsciiString directory = originalDirectory;
 	directory.concat(currentDirectory);
+
+	if (isDirectoryIgnored(directory.str()))
+		return;
 
 	AsciiString asciisearch = directory;
 	auto searchExt = std::filesystem::path(searchName.str()).extension();
@@ -243,6 +254,11 @@ void StdLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirect
 			// if we haven't already, add this filename to the list.
 			// a stl set should only allow one copy of each filename
 			AsciiString newFilename = iter->path().string().c_str();
+
+			// skip parent directories because they were already tested before.
+			if (isFileIgnored(newFilename.str(), IgnoreFileTestFlags_SkipParentDirectories))
+				continue;
+
 			if (filenameList.find(newFilename) == filenameList.end()) {
 				filenameList.insert(newFilename);
 			}
@@ -278,6 +294,9 @@ Bool StdLocalFileSystem::getFileInfo(const AsciiString& filename, FileInfo *file
 	if (path.empty()) {
 		return FALSE;
 	}
+
+	if (isFileIgnored(filename.str()))
+		return FALSE;
 
 	std::error_code ec;
 	auto file_size = std::filesystem::file_size(path, ec);

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
@@ -130,7 +130,7 @@ File * StdLocalFileSystem::openFile(const Char *filename, Int access, size_t buf
 	//USE_PERF_TIMER(StdLocalFileSystem_openFile)
 
 	// sanity check
-	if (strlen(filename) <= 0) {
+	if (*filename == '\0') {
 		return nullptr;
 	}
 
@@ -210,10 +210,10 @@ Bool StdLocalFileSystem::doesFileExist(const Char *filename) const
 
 void StdLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList & filenameList, Bool searchSubdirectories) const
 {
+	AsciiString directory = originalDirectory;
+	directory.concat(currentDirectory);
 
-	AsciiString asciisearch;
-	asciisearch = originalDirectory;
-	asciisearch.concat(currentDirectory);
+	AsciiString asciisearch = directory;
 	auto searchExt = std::filesystem::path(searchName.str()).extension();
 	if (asciisearch.isEmpty()) {
 		asciisearch = ".";
@@ -226,19 +226,17 @@ void StdLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirect
 	std::replace(fixedDirectory.begin(), fixedDirectory.end(), '\\', '/');
 #endif
 
-	Bool done = FALSE;
 	std::error_code ec;
 
 	auto iter = std::filesystem::directory_iterator(fixedDirectory.c_str(), ec);
-	// The default iterator constructor creates an end iterator
-	done = iter == std::filesystem::directory_iterator();
 
 	if (ec) {
 		DEBUG_LOG(("StdLocalFileSystem::getFileListInDirectory - Error opening directory %s", fixedDirectory.c_str()));
 		return;
 	}
 
-	while (!done)	{
+	// The default iterator constructor creates an end iterator
+	for (; iter != std::filesystem::directory_iterator(); ++iter)	{
 		std::string filenameStr = iter->path().filename().string();
 		if (!iter->is_directory() && iter->path().extension() == searchExt &&
 			(strcmp(filenameStr.c_str(), ".") != 0 && strcmp(filenameStr.c_str(), "..") != 0)) {
@@ -249,9 +247,6 @@ void StdLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirect
 				filenameList.insert(newFilename);
 			}
 		}
-
-		iter++;
-		done = iter == std::filesystem::directory_iterator();
 	}
 
 	if (searchSubdirectories) {
@@ -263,9 +258,7 @@ void StdLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirect
 		}
 
 		// The default iterator constructor creates an end iterator
-		done = iter == std::filesystem::directory_iterator();
-
-		while (!done) {
+		for (; iter != std::filesystem::directory_iterator(); ++iter) {
 			std::string filenameStr = iter->path().filename().string();
 			if(iter->is_directory() &&
 				(strcmp(filenameStr.c_str(), ".") != 0 && strcmp(filenameStr.c_str(), "..") != 0)) {
@@ -274,9 +267,6 @@ void StdLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirect
 				// recursively add files in subdirectories if required.
 				getFileListInDirectory(tempsearchstr, originalDirectory, searchName, filenameList, searchSubdirectories);
 			}
-
-			iter++;
-			done = iter == std::filesystem::directory_iterator();
 		}
 	}
 }
@@ -285,7 +275,7 @@ Bool StdLocalFileSystem::getFileInfo(const AsciiString& filename, FileInfo *file
 {
 	std::filesystem::path path = fixFilenameFromWindowsPath(filename.str(), 0);
 
-	if(path.empty()) {
+	if (path.empty()) {
 		return FALSE;
 	}
 

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
@@ -294,10 +294,10 @@ Bool StdLocalFileSystem::getFileInfo(const AsciiString& filename, FileInfo *file
 
 	// TODO: fix this to be win compatible (time since 1601)
 	auto time = write_time.time_since_epoch().count();
+	fileInfo->sizeHigh = file_size >> 32;
+	fileInfo->sizeLow = file_size & UINT32_MAX;
 	fileInfo->timestampHigh = time >> 32;
 	fileInfo->timestampLow = time & UINT32_MAX;
-	fileInfo->sizeHigh      = file_size >> 32;
-	fileInfo->sizeLow  = file_size & UINT32_MAX;
 
 	return TRUE;
 }

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFile.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFile.cpp
@@ -151,17 +151,17 @@ void Win32BIGFile::close()
 
 Bool Win32BIGFile::getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const
 {
-	const ArchivedFileInfo *tempFileInfo = getArchivedFileInfo(filename);
+	const ArchivedFileInfo *archivedFileInfo = getArchivedFileInfo(filename);
 
-	if (tempFileInfo == nullptr) {
+	if (archivedFileInfo == nullptr) {
 		return FALSE;
 	}
 
-	TheLocalFileSystem->getFileInfo(AsciiString(m_file->getName()), fileInfo);
-
-	// fill in the size info.  Since the size can't be bigger than a JUNK file, the high Int will always be 0.
+	// fill in the size info.  Since the size can't be bigger than a JUNK file, the high int will always be 0.
 	fileInfo->sizeHigh = 0;
-	fileInfo->sizeLow = tempFileInfo->m_size;
+	fileInfo->sizeLow = archivedFileInfo->m_size;
+	fileInfo->timestampHigh = 0;
+	fileInfo->timestampLow = 0;
 
 	return TRUE;
 }

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFile.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFile.cpp
@@ -62,7 +62,7 @@ File* Win32BIGFile::openFile( const Char *filename, Int access )
 {
 	const ArchivedFileInfo *fileInfo = getArchivedFileInfo(AsciiString(filename));
 
-	if (fileInfo == nullptr) {
+	if (fileInfo == nullptr || fileInfo->m_ignore) {
 		return nullptr;
 	}
 

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -127,7 +127,7 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 	// seek to the beginning of the directory listing.
 	fp->seek(0x10, File::START);
 	// read in each directory listing.
-	ArchivedFileInfo *fileInfo = NEW ArchivedFileInfo;
+	ArchivedFileInfo fileInfo;
 	// TheSuperHackers @fix Mauller 23/04/2025 Create new file handle when necessary to prevent memory leak
 	ArchiveFile *archiveFile = NEW Win32BIGFile(filename, AsciiString::TheEmptyString);
 
@@ -140,9 +140,9 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 		filesize = betoh(filesize);
 		fileOffset = betoh(fileOffset);
 
-		fileInfo->m_archiveFilename = archiveFileName;
-		fileInfo->m_offset = fileOffset;
-		fileInfo->m_size = filesize;
+		fileInfo.m_archiveFilename = archiveFileName;
+		fileInfo.m_offset = fileOffset;
+		fileInfo.m_size = filesize;
 
 		// read in the path name of the file.
 		Int pathIndex = -1;
@@ -156,8 +156,8 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 			--filenameIndex;
 		}
 
-		fileInfo->m_filename = (char *)(buffer + filenameIndex + 1);
-		fileInfo->m_filename.toLower();
+		fileInfo.m_filename = (char *)(buffer + filenameIndex + 1);
+		fileInfo.m_filename.toLower();
 		buffer[filenameIndex + 1] = 0;
 
 		AsciiString path;
@@ -165,16 +165,13 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 
 		AsciiString debugpath;
 		debugpath = path;
-		debugpath.concat(fileInfo->m_filename);
+		debugpath.concat(fileInfo.m_filename);
 //		DEBUG_LOG(("Win32BIGFileSystem::openArchiveFile - adding file %s to archive file %s, file number %d", debugpath.str(), fileInfo->m_archiveFilename.str(), i));
 
-		archiveFile->addFile(path, fileInfo);
+		archiveFile->addFile(path, &fileInfo);
 	}
 
 	archiveFile->attachFile(fp);
-
-	delete fileInfo;
-	fileInfo = nullptr;
 
 	// leave fp open as the archive file will be using it.
 

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -184,10 +184,10 @@ Bool Win32LocalFileSystem::getFileInfo(const AsciiString& filename, FileInfo *fi
 		return FALSE;
 	}
 
-	fileInfo->timestampHigh = findData.ftLastWriteTime.dwHighDateTime;
-	fileInfo->timestampLow = findData.ftLastWriteTime.dwLowDateTime;
 	fileInfo->sizeHigh = findData.nFileSizeHigh;
 	fileInfo->sizeLow = findData.nFileSizeLow;
+	fileInfo->timestampHigh = findData.ftLastWriteTime.dwHighDateTime;
+	fileInfo->timestampLow = findData.ftLastWriteTime.dwLowDateTime;
 
 	FindClose(findHandle);
 

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -47,7 +47,7 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access, size_t b
 	//USE_PERF_TIMER(Win32LocalFileSystem_openFile)
 
 	// sanity check
-	if (strlen(filename) <= 0) {
+	if (*filename == '\0') {
 		return nullptr;
 	}
 
@@ -119,51 +119,43 @@ Bool Win32LocalFileSystem::doesFileExist(const Char *filename) const
 	if (_access(filename, 0) == 0) {
 		return TRUE;
 	}
+
 	return FALSE;
 }
 
 void Win32LocalFileSystem::getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList & filenameList, Bool searchSubdirectories) const
 {
-	HANDLE fileHandle = nullptr;
-	WIN32_FIND_DATA findData;
+	AsciiString directory = originalDirectory;
+	directory.concat(currentDirectory);
 
-	AsciiString asciisearch;
-	asciisearch = originalDirectory;
-	asciisearch.concat(currentDirectory);
+	AsciiString asciisearch = directory;
 	asciisearch.concat(searchName);
 
-	Bool done = FALSE;
+	WIN32_FIND_DATA findData;
+	HANDLE fileHandle = FindFirstFile(asciisearch.str(), &findData);
+	Bool done = (fileHandle == INVALID_HANDLE_VALUE);
 
-	fileHandle = FindFirstFile(asciisearch.str(), &findData);
-	done = (fileHandle == INVALID_HANDLE_VALUE);
-
-	while (!done)	{
+	for (; !done; done = (FindNextFile(fileHandle, &findData) == 0))	{
 		if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
 				(strcmp(findData.cFileName, ".") != 0 && strcmp(findData.cFileName, "..") != 0)) {
-			// if we haven't already, add this filename to the list.
+				// if we haven't already, add this filename to the list.
 				// a stl set should only allow one copy of each filename
-				AsciiString newFilename;
-				newFilename = originalDirectory;
-				newFilename.concat(currentDirectory);
+				AsciiString newFilename = directory;
 				newFilename.concat(findData.cFileName);
 				if (filenameList.find(newFilename) == filenameList.end()) {
 					filenameList.insert(newFilename);
 				}
 		}
-
-		done = (FindNextFile(fileHandle, &findData) == 0);
 	}
 	FindClose(fileHandle);
 
 	if (searchSubdirectories) {
-		AsciiString subdirsearch;
-		subdirsearch = originalDirectory;
-		subdirsearch.concat(currentDirectory);
+		AsciiString subdirsearch = directory;
 		subdirsearch.concat("*.");
 		fileHandle = FindFirstFile(subdirsearch.str(), &findData);
-		done = fileHandle == INVALID_HANDLE_VALUE;
+		done = (fileHandle == INVALID_HANDLE_VALUE);
 
-		while (!done) {
+		for (; !done; done = (FindNextFile(fileHandle, &findData) == 0)) {
 			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
 					(strcmp(findData.cFileName, ".") != 0 && strcmp(findData.cFileName, "..") != 0)) {
 
@@ -175,8 +167,6 @@ void Win32LocalFileSystem::getFileListInDirectory(const AsciiString& currentDire
 					// recursively add files in subdirectories if required.
 					getFileListInDirectory(tempsearchstr, originalDirectory, searchName, filenameList, searchSubdirectories);
 			}
-
-			done = (FindNextFile(fileHandle, &findData) == 0);
 		}
 
 		FindClose(fileHandle);

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -51,6 +51,10 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access, size_t b
 		return nullptr;
 	}
 
+	if (isFileIgnored(filename)) {
+		return nullptr;
+	}
+
 	if (access & File::WRITE) {
 		// if opening the file for writing, we need to make sure the directory is there
 		// before we try to create the file.
@@ -116,6 +120,11 @@ void Win32LocalFileSystem::reset()
 Bool Win32LocalFileSystem::doesFileExist(const Char *filename) const
 {
 	//USE_PERF_TIMER(Win32LocalFileSystem_doesFileExist)
+
+	if (isFileIgnored(filename)) {
+		return FALSE;
+	}
+
 	if (_access(filename, 0) == 0) {
 		return TRUE;
 	}
@@ -127,6 +136,9 @@ void Win32LocalFileSystem::getFileListInDirectory(const AsciiString& currentDire
 {
 	AsciiString directory = originalDirectory;
 	directory.concat(currentDirectory);
+
+	if (isDirectoryIgnored(directory.str()))
+		return;
 
 	AsciiString asciisearch = directory;
 	asciisearch.concat(searchName);
@@ -142,6 +154,11 @@ void Win32LocalFileSystem::getFileListInDirectory(const AsciiString& currentDire
 				// a stl set should only allow one copy of each filename
 				AsciiString newFilename = directory;
 				newFilename.concat(findData.cFileName);
+
+				// skip parent directories because they were already tested before.
+				if (isFileIgnored(newFilename.str(), IgnoreFileTestFlags_SkipParentDirectories))
+					continue;
+
 				if (filenameList.find(newFilename) == filenameList.end()) {
 					filenameList.insert(newFilename);
 				}
@@ -176,6 +193,12 @@ void Win32LocalFileSystem::getFileListInDirectory(const AsciiString& currentDire
 
 Bool Win32LocalFileSystem::getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const
 {
+	if (filename.isEmpty())
+		return FALSE;
+
+	if (isFileIgnored(filename.str()))
+		return FALSE;
+
 	WIN32_FIND_DATA findData;
 	HANDLE findHandle = nullptr;
 	findHandle = FindFirstFile(filename.str(), &findData);

--- a/Core/Libraries/Include/Lib/PathUtil.h
+++ b/Core/Libraries/Include/Lib/PathUtil.h
@@ -180,3 +180,17 @@ inline const wchar_t* getExtension(const wchar_t* path)
 
 	return lastDot;
 }
+
+// Returns whether the given path is assumed to be a file path or directory path.
+// Requirements for file path are: Must contain a dot in the trailing name after the last slash.
+inline bool isFilePath(const char* path)
+{
+	return getExtension(path) != nullptr;
+}
+
+// Returns whether the given path is assumed to be a file path or directory path.
+// Requirements for file path are: Must contain a dot in the trailing name after the last slash.
+inline bool isFilePath(const wchar_t* path)
+{
+	return getExtension(path) != nullptr;
+}

--- a/Core/Libraries/Include/Lib/PathUtil.h
+++ b/Core/Libraries/Include/Lib/PathUtil.h
@@ -23,6 +23,123 @@
 #include "BaseType.h"
 #include <string.h>
 
+// Whether the character is a path separator
+inline bool isPathSeparator(unsigned char ch)
+{
+	return ch == '/' || ch == '\\';
+}
+
+// Return a lowercase ascii character. Faster than tolower.
+inline unsigned char toLowerAscii(unsigned char ch)
+{
+	if (ch >= 'A' && ch <= 'Z')
+		ch += 'a' - 'A';
+
+	return ch;
+}
+
+// Compare two ascii paths and ignore case and different types of slashes. Useful for map lookups.
+inline int comparePath(const char* a, const char* b)
+{
+	while (*a && *b)
+	{
+		unsigned char ca = static_cast<unsigned char>(*a);
+		unsigned char cb = static_cast<unsigned char>(*b);
+
+		if (isPathSeparator(ca) && isPathSeparator(cb))
+		{
+			++a;
+			++b;
+			continue;
+		}
+
+		ca = toLowerAscii(ca);
+		cb = toLowerAscii(cb);
+
+		if (ca != cb)
+			return ca - cb;
+
+		++a;
+		++b;
+	}
+
+	// Ignore trailing separators
+	while (isPathSeparator(*a))
+		++a;
+	while (isPathSeparator(*b))
+		++b;
+
+	return static_cast<unsigned char>(*a) - static_cast<unsigned char>(*b);
+}
+
+// Test if an ascii path starts with a given path and ignore case and different types of slashes.
+inline bool startsWithPath(const char* path, const char* prefix)
+{
+	while (*path && *prefix)
+	{
+		unsigned char cp = static_cast<unsigned char>(*path);
+		unsigned char cq = static_cast<unsigned char>(*prefix);
+
+		if (isPathSeparator(cp) && isPathSeparator(cq))
+		{
+			++path;
+			++prefix;
+			continue;
+		}
+
+		cp = toLowerAscii(cp);
+		cq = toLowerAscii(cq);
+
+		if (cp != cq)
+			return false;
+
+		++path;
+		++prefix;
+	}
+
+	// Ignore trailing separators in the prefix
+	while (isPathSeparator(*prefix))
+		++prefix;
+
+	return *prefix == '\0';
+}
+
+// Hash an ascii path by normalizing case and different types of slashes. Useful for hash maps.
+inline size_t hashPath(const char* path)
+{
+	constexpr const UnsignedInt64 FnvOffset = UnsignedInt64(14695981039346656037);
+	constexpr const UnsignedInt64 FnvPrime  = UnsignedInt64(1099511628211);
+
+	// FNV-1a 64-bit
+	UnsignedInt64 hash = FnvOffset;
+
+	// Find end
+	const char* end = path;
+	while (*end)
+		++end;
+
+	// Ignore trailing separators
+	while (end > path && isPathSeparator(end[-1]))
+		--end;
+
+	// Hash normalized characters
+	for (const char* p = path; p != end; ++p)
+	{
+		unsigned char ch = static_cast<unsigned char>(*p);
+
+		if (isPathSeparator(ch))
+			ch = '\\';
+		else
+			ch = toLowerAscii(ch);
+
+		hash ^= ch;
+		hash *= FnvPrime;
+	}
+
+	return (size_t)hash;
+}
+
+// Return file extension part from absolute or relative path when present. Null otherwise.
 inline const char* getExtension(const char* path)
 {
 	const char* lastDot = strrchr(path, '.');
@@ -43,6 +160,7 @@ inline const char* getExtension(const char* path)
 	return lastDot;
 }
 
+// Return file extension part from absolute or relative path when present. Null otherwise.
 inline const wchar_t* getExtension(const wchar_t* path)
 {
 	const wchar_t* lastDot = wcsrchr(path, L'.');

--- a/Core/Libraries/Source/Compression/CMakeLists.txt
+++ b/Core/Libraries/Source/Compression/CMakeLists.txt
@@ -29,10 +29,8 @@ target_include_directories(core_compression INTERFACE
 )
 
 target_link_libraries(core_compression PRIVATE
-    corei_libraries_include
     corei_always
 )
-
 
 target_link_libraries(core_compression PUBLIC
     liblzhl

--- a/Core/Libraries/Source/WWVegas/WWLib/STLUtils.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/STLUtils.h
@@ -123,22 +123,26 @@ Iter advance_in_range(Iter first, Iter last, ptrdiff_t n)
 	return first;
 }
 
-template <typename Key, typename Val>
-range<std::multimap<Key, Val>/**/> get_range(std::multimap<Key, Val>& mm, const Key& key, ptrdiff_t n = 0)
+template <typename Key, typename Val, typename Pr, typename Alloc>
+range<std::multimap<Key, Val, Pr, Alloc>/**/> get_range(std::multimap<Key, Val, Pr, Alloc>& mm, const Key& key, ptrdiff_t n = 0)
 {
-	typedef typename std::multimap<Key, Val>::iterator Iter;
+	typedef std::multimap<Key, Val, Pr, Alloc> Multimap;
+	typedef typename Multimap::iterator Iter;
+
 	const std::pair<Iter, Iter> pair = mm.equal_range(key);
 	const Iter it = advance_in_range(pair.first, pair.second, n);
-	return range<std::multimap<Key, Val>/**/>(it, pair.second);
+	return range<Multimap>(it, pair.second);
 }
 
-template <typename Key, typename Val>
-const_range<std::multimap<Key, Val>/**/> get_range(const std::multimap<Key, Val>& mm, const Key& key, ptrdiff_t n = 0)
+template <typename Key, typename Val, typename Pr, typename Alloc>
+const_range<std::multimap<Key, Val, Pr, Alloc>/**/> get_range(const std::multimap<Key, Val, Pr, Alloc>& mm, const Key& key, ptrdiff_t n = 0)
 {
-	typedef typename std::multimap<Key, Val>::const_iterator Iter;
+	typedef std::multimap<Key, Val, Pr, Alloc> Multimap;
+	typedef typename Multimap::const_iterator Iter;
+
 	const std::pair<Iter, Iter> pair = mm.equal_range(key);
 	const Iter it = advance_in_range(pair.first, pair.second, n);
-	return const_range<std::multimap<Key, Val>/**/>(it, pair.second);
+	return const_range<Multimap>(it, pair.second);
 }
 
 } // namespace stl

--- a/Core/Tools/MapCacheBuilder/Source/WinMain.cpp
+++ b/Core/Tools/MapCacheBuilder/Source/WinMain.cpp
@@ -251,6 +251,11 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	initSubsystem(TheLocalFileSystem, (LocalFileSystem*)new Win32LocalFileSystem);
 	initSubsystem(TheArchiveFileSystem, (ArchiveFileSystem*)new Win32BIGFileSystem);
 	INI ini;
+	// TheSuperHackers @feature xezon 26/07/2026 Loads new FileSystem.ini before any other ini files
+	// to allow configure the file system, such as setting up ignored game files and directories.
+	ini.loadFileDirectory( "Data\\INI\\Default\\FileSystem", INI_LOAD_OVERWRITE, nullptr, INI::LoadFlags_SearchSubDirs );
+	ini.loadFileDirectory( "Data\\INI\\FileSystem", INI_LOAD_OVERWRITE, nullptr, INI::LoadFlags_SearchSubDirs );
+
 	initSubsystem(TheWritableGlobalData, new GlobalData(), "Data\\INI\\Default\\GameData", "Data\\INI\\GameData");
 	initSubsystem(TheGameText, CreateGameTextInterface());
 	initSubsystem(TheScienceStore, new ScienceStore(), "Data\\INI\\Default\\Science", "Data\\INI\\Science");

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -442,6 +442,11 @@ void GameEngine::init()
 
 		initSubsystem(TheArchiveFileSystem, "TheArchiveFileSystem", createArchiveFileSystem(), nullptr); // this MUST come after TheLocalFileSystem creation
 
+	// TheSuperHackers @feature xezon 26/07/2026 Loads new FileSystem.ini before any other ini files
+	// to allow configure the file system, such as setting up ignored game files and directories.
+	ini.loadFileDirectory( "Data\\INI\\Default\\FileSystem", INI_LOAD_OVERWRITE, nullptr, INI::LoadFlags_SearchSubDirs );
+	ini.loadFileDirectory( "Data\\INI\\FileSystem", INI_LOAD_OVERWRITE, nullptr, INI::LoadFlags_SearchSubDirs );
+
     	#ifdef DUMP_PERF_STATS///////////////////////////////////////////////////////////////////////////
 	GetPrecisionTimer(&endTime64);//////////////////////////////////////////////////////////////////
 	sprintf(Buf,"----------------------------------------------------------------------------After TheArchiveFileSystem  = %f seconds",((double)(endTime64-startTime64)/(double)(freq64)));

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -334,6 +334,11 @@ BOOL CWorldBuilderApp::InitInstance()
 
 	INI ini;
 
+	// TheSuperHackers @feature xezon 26/07/2026 Loads new FileSystem.ini before any other ini files
+	// to allow configure the file system, such as setting up ignored game files and directories.
+	ini.loadFileDirectory( "Data\\INI\\Default\\FileSystem", INI_LOAD_OVERWRITE, nullptr, INI::LoadFlags_SearchSubDirs );
+	ini.loadFileDirectory( "Data\\INI\\FileSystem", INI_LOAD_OVERWRITE, nullptr, INI::LoadFlags_SearchSubDirs );
+
 	initSubsystem(TheWritableGlobalData, new GlobalData(), "Data\\INI\\Default\\GameData", "Data\\INI\\GameData");
 
 	TheFramePacer = new FramePacer();


### PR DESCRIPTION
**Merge with Rebase**

This change implements a new feature that allows to ignore files and directories for the local and archive file systems. This pull also contains a number of commits that refactor, simplify and fix relevant code to reach that goal.

This feature is useful for Mods that need to ignore specific game files and/or directories, for example prevent some INI files from loading. It is needed for GeneralsGamePatch2.

On Engine init, a new optional `Data/INI/FileSystem.ini` (and/or INI files inside `Data/INI/FileSystem`)  is loaded early and can be configured with `FileSystemIgnore` definitions:

```ini
FileSystemIgnore
  Name = "Directory/File.ext"
  Type = FILE ; optional type indicator, auto detected otherwise
End

FileSystemIgnore
  Name = "Directory"
  Type = DIR ; optional type indicator, auto detected otherwise
End
```

It is technically also possible to lift file and directory ignore on runtime, but that remains unused.

The file ignore implementation has been optimized for efficiency and simplicity.

## Further thoughts

If we could rely on user supplied command line arguments, then simpler implementations would be possible, such as preventing the Archive File System from loading an archive file or contents inside of it. But because we want to load the ignore configuration from inside an INI file, which can also be inside an Archive, it needs to load the Archive File System normally.

## TODO

- [x] Add pull id to commit titles
- [ ] Replicate in Generals
- [ ] Test each commit compiles on its own