### PR TITLE
refactor(smudge): Replace custom doubly linked list with std::deque in W3DSmudge

### DIFF
--- a/Core/GameEngine/Include/GameClient/Smudge.h
+++ b/Core/GameEngine/Include/GameClient/Smudge.h
@@ -21,13 +21,13 @@
 #pragma once
 
 #include <Utility/hash_map_adapter.h>
-#include "WW3D2/dllist.h"
 #include "WWMath/vector2.h"
 #include "WWMath/vector3.h"
+#include <deque>
 
 #define SET_SMUDGE_PARAMETERS(smudge,pos,offset,size,opacity) (smudge->m_pos=pos;smudge->m_offset=offset;smudge->m_size=size;smudge->m_opacity=opacity;)
 
-struct Smudge : public DLNodeClass<Smudge>
+struct Smudge
 {
 	typedef void *Identifier;
 
@@ -48,6 +48,8 @@ struct Smudge : public DLNodeClass<Smudge>
 	smudgeVertex m_verts[5];	//5 vertices of this smudge (in counter-clockwise order, starting at top-left, ending in center.)
 };
 
+typedef std::deque<Smudge*> SmudgeQueue;
+
 #ifdef USING_STLPORT
 namespace std
 {
@@ -58,7 +60,7 @@ namespace std
 }
 #endif // USING_STLPORT
 
-struct SmudgeSet : public DLNodeClass<SmudgeSet>
+struct SmudgeSet
 {
 	friend class SmudgeManager;
 
@@ -73,17 +75,19 @@ struct SmudgeSet : public DLNodeClass<SmudgeSet>
 	Smudge *addSmudgeToSet(Smudge::Identifier identifier); ///< add and return a smudge to the set with the given identifier
 	Smudge *findSmudge(Smudge::Identifier identifier); ///< find the smudge that belongs to this identifier
 
-	DLListClass<Smudge> &getUsedSmudgeList() { return m_usedSmudgeList;}
+	SmudgeQueue& getUsedSmudgeList() { return m_usedSmudgeList; }
 	Int getUsedSmudgeCount() { return m_usedSmudgeCount; }	///<active smudges that need rendering.
 
 private:
 	typedef std::hash_map<Smudge::Identifier, Smudge *> SmudgeIdToPtrMap;
 
-	DLListClass<Smudge> m_usedSmudgeList;	///<list of smudges in this set.
+	SmudgeQueue m_usedSmudgeList;	///<list of smudges in this set.
 	SmudgeIdToPtrMap m_usedSmudgeMap;
-	static DLListClass<Smudge> m_freeSmudgeList;	///<list of unused smudges for use by SmudgeSets.
+	static SmudgeQueue m_freeSmudgeList;	///<list of unused smudges for use by SmudgeSets.
 	Int m_usedSmudgeCount;
 };
+
+typedef std::deque<SmudgeSet*> SmudgeSetQueue;
 
 class SmudgeManager
 {
@@ -109,8 +113,8 @@ protected:
 
 	HardwareSmudgeSupport m_hardwareSupportStatus;///< flag whether we verified that the effect is supported by hardware.
 
-	DLListClass<SmudgeSet> m_usedSmudgeSetList;	///<used SmudgeSets
-	DLListClass<SmudgeSet> m_freeSmudgeSetList;	///<unused SmudgeSets ready for re-use.
+	SmudgeSetQueue m_usedSmudgeSetList;	///<used SmudgeSets
+	SmudgeSetQueue m_freeSmudgeSetList;	///<unused SmudgeSets ready for re-use.
 	Int m_smudgeCountLastFrame;	//number of total smudges in manager last frame.
 };
 

--- a/Core/GameEngine/Include/GameClient/Smudge.h
+++ b/Core/GameEngine/Include/GameClient/Smudge.h
@@ -48,7 +48,7 @@ struct Smudge
 	smudgeVertex m_verts[5];	//5 vertices of this smudge (in counter-clockwise order, starting at top-left, ending in center.)
 };
 
-typedef std::deque<Smudge*> SmudgeQueue;
+typedef std::deque<Smudge*> SmudgeDeque;
 
 #ifdef USING_STLPORT
 namespace std
@@ -75,18 +75,18 @@ struct SmudgeSet
 	Smudge *addSmudgeToSet(Smudge::Identifier identifier); ///< add and return a smudge to the set with the given identifier
 	Smudge *findSmudge(Smudge::Identifier identifier); ///< find the smudge that belongs to this identifier
 
-	SmudgeQueue& getUsedSmudgeList() { return m_usedSmudgeList; }
+	SmudgeDeque& getUsedSmudgeList() { return m_usedSmudgeList; }
 	UnsignedInt getUsedSmudgeCount() const { return m_usedSmudgeList.size(); }	///<active smudges that need rendering.
 
 private:
 	typedef std::hash_map<Smudge::Identifier, Smudge *> SmudgeIdToPtrMap;
 
-	SmudgeQueue m_usedSmudgeList;	///<list of smudges in this set.
+	SmudgeDeque m_usedSmudgeList;	///<list of smudges in this set.
 	SmudgeIdToPtrMap m_usedSmudgeMap;
-	static SmudgeQueue m_freeSmudgeList;	///<list of unused smudges for use by SmudgeSets.
+	static SmudgeDeque m_freeSmudgeList;	///<list of unused smudges for use by SmudgeSets.
 };
 
-typedef std::deque<SmudgeSet*> SmudgeSetQueue;
+typedef std::deque<SmudgeSet*> SmudgeSetDeque;
 
 class SmudgeManager
 {
@@ -112,8 +112,8 @@ protected:
 
 	HardwareSmudgeSupport m_hardwareSupportStatus;///< flag whether we verified that the effect is supported by hardware.
 
-	SmudgeSetQueue m_usedSmudgeSetList;	///<used SmudgeSets
-	SmudgeSetQueue m_freeSmudgeSetList;	///<unused SmudgeSets ready for re-use.
+	SmudgeSetDeque m_usedSmudgeSetList;	///<used SmudgeSets
+	SmudgeSetDeque m_freeSmudgeSetList;	///<unused SmudgeSets ready for re-use.
 	Int m_smudgeCountLastFrame;	//number of total smudges in manager last frame.
 };
 

--- a/Core/GameEngine/Include/GameClient/Smudge.h
+++ b/Core/GameEngine/Include/GameClient/Smudge.h
@@ -76,7 +76,7 @@ struct SmudgeSet
 	Smudge *findSmudge(Smudge::Identifier identifier); ///< find the smudge that belongs to this identifier
 
 	SmudgeQueue& getUsedSmudgeList() { return m_usedSmudgeList; }
-	Int getUsedSmudgeCount() { return m_usedSmudgeCount; }	///<active smudges that need rendering.
+	Int getUsedSmudgeCount() const { return m_usedSmudgeList.size(); }	///<active smudges that need rendering.
 
 private:
 	typedef std::hash_map<Smudge::Identifier, Smudge *> SmudgeIdToPtrMap;
@@ -84,7 +84,6 @@ private:
 	SmudgeQueue m_usedSmudgeList;	///<list of smudges in this set.
 	SmudgeIdToPtrMap m_usedSmudgeMap;
 	static SmudgeQueue m_freeSmudgeList;	///<list of unused smudges for use by SmudgeSets.
-	Int m_usedSmudgeCount;
 };
 
 typedef std::deque<SmudgeSet*> SmudgeSetQueue;

--- a/Core/GameEngine/Include/GameClient/Smudge.h
+++ b/Core/GameEngine/Include/GameClient/Smudge.h
@@ -76,7 +76,7 @@ struct SmudgeSet
 	Smudge *findSmudge(Smudge::Identifier identifier); ///< find the smudge that belongs to this identifier
 
 	SmudgeQueue& getUsedSmudgeList() { return m_usedSmudgeList; }
-	Int getUsedSmudgeCount() const { return m_usedSmudgeList.size(); }	///<active smudges that need rendering.
+	UnsignedInt getUsedSmudgeCount() const { return m_usedSmudgeList.size(); }	///<active smudges that need rendering.
 
 private:
 	typedef std::hash_map<Smudge::Identifier, Smudge *> SmudgeIdToPtrMap;

--- a/Core/GameEngine/Include/GameClient/Smudge.h
+++ b/Core/GameEngine/Include/GameClient/Smudge.h
@@ -71,7 +71,6 @@ struct SmudgeSet : public DLNodeClass<SmudgeSet>
 	void resetDraw();
 
 	Smudge *addSmudgeToSet(Smudge::Identifier identifier); ///< add and return a smudge to the set with the given identifier
-	void removeSmudgeFromSet(Smudge *&smudge); ///< remove and invalidate the given smudge
 	Smudge *findSmudge(Smudge::Identifier identifier); ///< find the smudge that belongs to this identifier
 
 	DLListClass<Smudge> &getUsedSmudgeList() { return m_usedSmudgeList;}
@@ -100,7 +99,6 @@ public:
 	void resetDraw(); ///< reset whether all smudges need to be drawn
 
 	SmudgeSet *addSmudgeSet(); ///< add and return a new smudge set
-	void removeSmudgeSet(SmudgeSet *&smudgeSet); ///< remove and invalidate the given smudge set
 	Smudge *findSmudge(Smudge::Identifier identifier); ///< find the smudge from any smudge set
 	Int getSmudgeCountLastFrame() {return m_smudgeCountLastFrame;} ///<return number of smudges submitted last frame.
 	Bool getHardwareSupport() { return m_hardwareSupportStatus != SMUDGE_SUPPORT_NO;}

--- a/Core/GameEngine/Source/GameClient/System/Smudge.cpp
+++ b/Core/GameEngine/Source/GameClient/System/Smudge.cpp
@@ -97,13 +97,6 @@ SmudgeSet *SmudgeManager::addSmudgeSet()
 	return set;
 }
 
-void SmudgeManager::removeSmudgeSet(SmudgeSet *&smudgeSet)
-{
-	smudgeSet->Remove();	//remove from used list
-	m_freeSmudgeSetList.Add_Head(smudgeSet);	//add to free list.
-	smudgeSet = nullptr;
-}
-
 Smudge *SmudgeManager::findSmudge(Smudge::Identifier identifier)
 {
 	SmudgeSet *smudgeSet = m_usedSmudgeSetList.Head();
@@ -163,15 +156,6 @@ Smudge *SmudgeSet::addSmudgeToSet(Smudge::Identifier identifier)
 	m_usedSmudgeMap[identifier] = smudge;
 	m_usedSmudgeCount++;
 	return smudge;
-}
-
-void SmudgeSet::removeSmudgeFromSet(Smudge *&smudge)
-{
-	m_usedSmudgeMap.erase(smudge->m_identifier);
-	smudge->Remove();	//remove from used list.
-	m_freeSmudgeList.Add_Head(smudge);	//add to free list
-	smudge = nullptr;
-	m_usedSmudgeCount--;
 }
 
 Smudge *SmudgeSet::findSmudge(Smudge::Identifier identifier)

--- a/Core/GameEngine/Source/GameClient/System/Smudge.cpp
+++ b/Core/GameEngine/Source/GameClient/System/Smudge.cpp
@@ -43,21 +43,18 @@ SmudgeManager::~SmudgeManager()
 {
 	reset();	//release all smudge sets and smudges to free pool.
 
-	SmudgeSet* head;
-
 	//free memory used by smudge sets
 	while (!m_freeSmudgeSetList.empty()) {
-		head = m_freeSmudgeSetList.front();
+		SmudgeSet* smudgeSet = m_freeSmudgeSetList.front();
 		m_freeSmudgeSetList.pop_front();
-		delete head;
+		delete smudgeSet;
 	}
 
-	Smudge* head2;
 	//free memory used by smudges
 	while (!SmudgeSet::m_freeSmudgeList.empty()) {
-		head2 = SmudgeSet::m_freeSmudgeList.front();
+		Smudge* smudge = SmudgeSet::m_freeSmudgeList.front();
 		SmudgeSet::m_freeSmudgeList.pop_front();
-		delete head2;
+		delete smudge;
 	}
 }
 
@@ -68,14 +65,12 @@ void SmudgeManager::init()
 
 void SmudgeManager::reset()
 {
-	SmudgeSet* head;
-
 	//Return all smudgeSets back to free pool.
 	while (!m_usedSmudgeSetList.empty()) {
-		head = m_usedSmudgeSetList.front();
+		SmudgeSet* smudgeSet = m_usedSmudgeSetList.front();
 		m_usedSmudgeSetList.pop_front();
-		head->reset();	//free all smudges.
-		m_freeSmudgeSetList.push_back(head);
+		smudgeSet->reset();	//free all smudges.
+		m_freeSmudgeSetList.push_back(smudgeSet);
 	}
 }
 
@@ -89,16 +84,16 @@ void SmudgeManager::resetDraw()
 
 SmudgeSet *SmudgeManager::addSmudgeSet()
 {
-	SmudgeSet* set;
 	if (!m_freeSmudgeSetList.empty()) {
-		set = m_freeSmudgeSetList.front();
+		SmudgeSet* smudgeSet = m_freeSmudgeSetList.front();
 		m_freeSmudgeSetList.pop_front();	//remove from free list
-		m_usedSmudgeSetList.push_back(set);	//add to used list.
-		return set;
+		m_usedSmudgeSetList.push_back(smudgeSet);	//add to used list.
+		return smudgeSet;
 	}
-	set=W3DNEW SmudgeSet();
-	m_usedSmudgeSetList.push_back(set);	//add to used list.
-	return set;
+
+	SmudgeSet* smudgeSet = W3DNEW SmudgeSet();
+	m_usedSmudgeSetList.push_back(smudgeSet);	//add to used list.
+	return smudgeSet;
 }
 
 Smudge *SmudgeManager::findSmudge(Smudge::Identifier identifier)
@@ -124,12 +119,10 @@ SmudgeSet::~SmudgeSet()
 
 void SmudgeSet::reset()
 {
-	Smudge* head;
-
 	while (!m_usedSmudgeList.empty()) {
-		head = m_usedSmudgeList.front();
+		Smudge* smudge = m_usedSmudgeList.front();
 		m_usedSmudgeList.pop_front();
-		m_freeSmudgeList.push_front(head);
+		m_freeSmudgeList.push_front(smudge);
 	}
 
 	m_usedSmudgeMap.clear();

--- a/Core/GameEngine/Source/GameClient/System/Smudge.cpp
+++ b/Core/GameEngine/Source/GameClient/System/Smudge.cpp
@@ -31,7 +31,7 @@
 #include "GameClient/Smudge.h"
 
 
-SmudgeQueue SmudgeSet::m_freeSmudgeList;	///<list of unused smudges for use by SmudgeSets.
+SmudgeDeque SmudgeSet::m_freeSmudgeList;	///<list of unused smudges for use by SmudgeSets.
 
 SmudgeManager::SmudgeManager()
 {
@@ -76,7 +76,7 @@ void SmudgeManager::reset()
 
 void SmudgeManager::resetDraw()
 {
-	for (SmudgeSetQueue::iterator it = m_usedSmudgeSetList.begin(); it != m_usedSmudgeSetList.end(); ++it) {
+	for (SmudgeSetDeque::iterator it = m_usedSmudgeSetList.begin(); it != m_usedSmudgeSetList.end(); ++it) {
 		SmudgeSet* smudgeSet = *it;
 		smudgeSet->resetDraw();
 	}
@@ -98,7 +98,7 @@ SmudgeSet *SmudgeManager::addSmudgeSet()
 
 Smudge *SmudgeManager::findSmudge(Smudge::Identifier identifier)
 {
-	for (SmudgeSetQueue::iterator it = m_usedSmudgeSetList.begin(); it != m_usedSmudgeSetList.end(); ++it) {
+	for (SmudgeSetDeque::iterator it = m_usedSmudgeSetList.begin(); it != m_usedSmudgeSetList.end(); ++it) {
 		SmudgeSet* smudgeSet = *it;
 		if (Smudge* smudge = smudgeSet->findSmudge(identifier)) {
 			return smudge;
@@ -122,7 +122,7 @@ void SmudgeSet::reset()
 	while (!m_usedSmudgeList.empty()) {
 		Smudge* smudge = m_usedSmudgeList.front();
 		m_usedSmudgeList.pop_front();
-		m_freeSmudgeList.push_front(smudge);
+		m_freeSmudgeList.push_front(smudge);	// add to free list
 	}
 
 	m_usedSmudgeMap.clear();
@@ -130,7 +130,7 @@ void SmudgeSet::reset()
 
 void SmudgeSet::resetDraw()
 {
-	for (SmudgeQueue::iterator it = m_usedSmudgeList.begin(); it != m_usedSmudgeList.end(); ++it) {
+	for (SmudgeDeque::iterator it = m_usedSmudgeList.begin(); it != m_usedSmudgeList.end(); ++it) {
 		Smudge* smudge = *it;
 		smudge->m_draw = false;
 	}

--- a/Core/GameEngine/Source/GameClient/System/Smudge.cpp
+++ b/Core/GameEngine/Source/GameClient/System/Smudge.cpp
@@ -115,7 +115,6 @@ Smudge *SmudgeManager::findSmudge(Smudge::Identifier identifier)
 
 SmudgeSet::SmudgeSet()
 {
-	m_usedSmudgeCount=0;
 }
 
 SmudgeSet::~SmudgeSet()
@@ -134,7 +133,6 @@ void SmudgeSet::reset()
 	}
 
 	m_usedSmudgeMap.clear();
-	m_usedSmudgeCount = 0;
 }
 
 void SmudgeSet::resetDraw()
@@ -160,7 +158,6 @@ Smudge *SmudgeSet::addSmudgeToSet(Smudge::Identifier identifier)
 	smudge->m_identifier = identifier;
 	m_usedSmudgeList.push_back(smudge);	//add to used list.
 	m_usedSmudgeMap[identifier] = smudge;
-	m_usedSmudgeCount++;
 	return smudge;
 }
 

--- a/Core/GameEngine/Source/GameClient/System/Smudge.cpp
+++ b/Core/GameEngine/Source/GameClient/System/Smudge.cpp
@@ -31,7 +31,7 @@
 #include "GameClient/Smudge.h"
 
 
-DLListClass<Smudge> SmudgeSet::m_freeSmudgeList;	///<list of unused smudges for use by SmudgeSets.
+SmudgeQueue SmudgeSet::m_freeSmudgeList;	///<list of unused smudges for use by SmudgeSets.
 
 SmudgeManager::SmudgeManager()
 {
@@ -46,15 +46,17 @@ SmudgeManager::~SmudgeManager()
 	SmudgeSet* head;
 
 	//free memory used by smudge sets
-	while ((head = m_freeSmudgeSetList.Head ()) != nullptr) {
-		m_freeSmudgeSetList.Remove_Head ();
+	while (!m_freeSmudgeSetList.empty()) {
+		head = m_freeSmudgeSetList.front();
+		m_freeSmudgeSetList.pop_front();
 		delete head;
 	}
 
 	Smudge* head2;
 	//free memory used by smudges
-	while ((head2 = SmudgeSet::m_freeSmudgeList.Head ()) != nullptr) {
-		m_freeSmudgeSetList.Remove_Head ();
+	while (!SmudgeSet::m_freeSmudgeList.empty()) {
+		head2 = SmudgeSet::m_freeSmudgeList.front();
+		SmudgeSet::m_freeSmudgeList.pop_front();
 		delete head2;
 	}
 }
@@ -69,39 +71,41 @@ void SmudgeManager::reset()
 	SmudgeSet* head;
 
 	//Return all smudgeSets back to free pool.
-	while ((head = m_usedSmudgeSetList.Head ()) != nullptr) {
-		m_usedSmudgeSetList.Remove_Head ();
+	while (!m_usedSmudgeSetList.empty()) {
+		head = m_usedSmudgeSetList.front();
+		m_usedSmudgeSetList.pop_front();
 		head->reset();	//free all smudges.
-		m_freeSmudgeSetList.Add_Tail(head);
+		m_freeSmudgeSetList.push_back(head);
 	}
 }
 
 void SmudgeManager::resetDraw()
 {
-	SmudgeSet* smudgeSet = m_usedSmudgeSetList.Head();
-	for (; smudgeSet; smudgeSet = smudgeSet->Succ()) {
+	for (SmudgeSetQueue::iterator it = m_usedSmudgeSetList.begin(); it != m_usedSmudgeSetList.end(); ++it) {
+		SmudgeSet* smudgeSet = *it;
 		smudgeSet->resetDraw();
 	}
 }
 
 SmudgeSet *SmudgeManager::addSmudgeSet()
 {
-	SmudgeSet* set=m_freeSmudgeSetList.Head();
-	if (set) {
-		set->Remove();	//remove from free list
-		m_usedSmudgeSetList.Add_Tail(set);	//add to used list.
+	SmudgeSet* set;
+	if (!m_freeSmudgeSetList.empty()) {
+		set = m_freeSmudgeSetList.front();
+		m_freeSmudgeSetList.pop_front();	//remove from free list
+		m_usedSmudgeSetList.push_back(set);	//add to used list.
 		return set;
 	}
 	set=W3DNEW SmudgeSet();
-	m_usedSmudgeSetList.Add_Tail(set);	//add to used list.
+	m_usedSmudgeSetList.push_back(set);	//add to used list.
 	return set;
 }
 
 Smudge *SmudgeManager::findSmudge(Smudge::Identifier identifier)
 {
-	SmudgeSet *smudgeSet = m_usedSmudgeSetList.Head();
-	for (; smudgeSet; smudgeSet = smudgeSet->Succ()) {
-		if (Smudge *smudge = smudgeSet->findSmudge(identifier)) {
+	for (SmudgeSetQueue::iterator it = m_usedSmudgeSetList.begin(); it != m_usedSmudgeSetList.end(); ++it) {
+		SmudgeSet* smudgeSet = *it;
+		if (Smudge* smudge = smudgeSet->findSmudge(identifier)) {
 			return smudge;
 		}
 	}
@@ -123,9 +127,10 @@ void SmudgeSet::reset()
 {
 	Smudge* head;
 
-	while ((head = m_usedSmudgeList.Head ()) != nullptr) {
-		m_usedSmudgeList.Remove_Head ();
-		m_freeSmudgeList.Add_Head(head);	//add to free list
+	while (!m_usedSmudgeList.empty()) {
+		head = m_usedSmudgeList.front();
+		m_usedSmudgeList.pop_front();
+		m_freeSmudgeList.push_front(head);
 	}
 
 	m_usedSmudgeMap.clear();
@@ -134,8 +139,8 @@ void SmudgeSet::reset()
 
 void SmudgeSet::resetDraw()
 {
-	Smudge* smudge = m_usedSmudgeList.Head();
-	for (; smudge; smudge = smudge->Succ()) {
+	for (SmudgeQueue::iterator it = m_usedSmudgeList.begin(); it != m_usedSmudgeList.end(); ++it) {
+		Smudge* smudge = *it;
 		smudge->m_draw = false;
 	}
 }
@@ -145,14 +150,15 @@ Smudge *SmudgeSet::addSmudgeToSet(Smudge::Identifier identifier)
 	DEBUG_ASSERTCRASH(m_usedSmudgeMap.find(identifier) == m_usedSmudgeMap.end(),
 		("SmudgeSet::addSmudgeToSet: identifier already present"));
 
-	Smudge* smudge = m_freeSmudgeList.Head();
-	if (smudge) {
-		smudge->Remove();	//remove from free list
+	Smudge* smudge;
+	if (!m_freeSmudgeList.empty()) {
+		smudge = m_freeSmudgeList.front();
+		m_freeSmudgeList.pop_front();	//remove from free list
 	} else {
 		smudge = W3DNEW Smudge();
 	}
 	smudge->m_identifier = identifier;
-	m_usedSmudgeList.Add_Tail(smudge);	//add to used list.
+	m_usedSmudgeList.push_back(smudge);	//add to used list.
 	m_usedSmudgeMap[identifier] = smudge;
 	m_usedSmudgeCount++;
 	return smudge;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -362,7 +362,7 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 	//TODO: Optimize out this extra pass!
 	//TODO: Find size of screen rectangle that actually needs copying.
 
-	SmudgeSetQueue::iterator setIt=m_usedSmudgeSetList.begin();	//first set that didn't fit into render batch.
+	SmudgeSetDeque::iterator setIt=m_usedSmudgeSetList.begin();	//first set that didn't fit into render batch.
 	Int count = 0;
 
 	if (setIt != m_usedSmudgeSetList.end())
@@ -371,10 +371,10 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 		SortingRendererClass::Flush();	//draw sorted translucent polys like particles.
 	}
 
-	while (setIt != m_usedSmudgeSetList.end())
+	for(; setIt != m_usedSmudgeSetList.end(); ++setIt)
 	{
 		SmudgeSet* set=*setIt;
-		SmudgeQueue::iterator smudgeIt=set->getUsedSmudgeList().begin();
+		SmudgeDeque::iterator smudgeIt=set->getUsedSmudgeList().begin();
 
 		for (; smudgeIt != set->getUsedSmudgeList().end(); ++smudgeIt)
 		{
@@ -422,8 +422,6 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 
 			count++;	//increment visible smudge count.
 		}
-
-		++setIt;	//advance to next node.
 	}
 
 	m_smudgeCountLastFrame = count;
@@ -469,7 +467,7 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 
 	Int smudgesRemaining=count;
 	setIt=m_usedSmudgeSetList.begin();	//first smudge set that needs rendering.
-	SmudgeQueue::iterator remainingSmudge = (*setIt)->getUsedSmudgeList().begin();	//first smudge that needs rendering.
+	SmudgeDeque::iterator smudgeIt = (*setIt)->getUsedSmudgeList().begin();	//first smudge that needs rendering.
 
 	while (smudgesRemaining)	//keep drawing smudges until we run out.
 	{
@@ -488,14 +486,13 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 
 			while (setIt != m_usedSmudgeSetList.end())
 			{
-				SmudgeQueue& smudgeList = (*setIt)->getUsedSmudgeList();
+				SmudgeDeque& smudgeList = (*setIt)->getUsedSmudgeList();
 
-				while (remainingSmudge != smudgeList.end())
+				for(; smudgeIt != smudgeList.end(); ++smudgeIt)
 				{
-					Smudge* smudge = *remainingSmudge;
+					Smudge* smudge = *smudgeIt;
 					if (!smudge->m_draw)
 					{
-						++remainingSmudge;
 						continue;
 					}
 
@@ -528,13 +525,12 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 					}
 
 					smudgesInRenderBatch++;
-					++remainingSmudge;
 				}
 
 				++setIt;	//advance to next node.
 
 				if (setIt != m_usedSmudgeSetList.end())	//start next batch at beginning of set.
-					remainingSmudge = (*setIt)->getUsedSmudgeList().begin();
+					smudgeIt = (*setIt)->getUsedSmudgeList().begin();
 			}
 		}
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -362,21 +362,23 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 	//TODO: Optimize out this extra pass!
 	//TODO: Find size of screen rectangle that actually needs copying.
 
-	SmudgeSet *set=m_usedSmudgeSetList.Head();	//first set that didn't fit into render batch.
+	SmudgeSetQueue::iterator setIt=m_usedSmudgeSetList.begin();	//first set that didn't fit into render batch.
 	Int count = 0;
 
-	if (set)
+	if (setIt != m_usedSmudgeSetList.end())
 	{
 		//there are possibly some smudges to render, so make sure background particles have finished drawing.
 		SortingRendererClass::Flush();	//draw sorted translucent polys like particles.
 	}
 
-	while (set)
+	while (setIt != m_usedSmudgeSetList.end())
 	{
-		Smudge *smudge=set->getUsedSmudgeList().Head();
+		SmudgeSet* set=*setIt;
+		SmudgeQueue::iterator smudgeIt=set->getUsedSmudgeList().begin();
 
-		for (; smudge; smudge = smudge->Succ())
+		for (; smudgeIt != set->getUsedSmudgeList().end(); ++smudgeIt)
 		{
+			Smudge* smudge=*smudgeIt;
 			if (!smudge->m_draw)
 				continue;
 
@@ -421,7 +423,7 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 			count++;	//increment visible smudge count.
 		}
 
-		set=set->Succ();	//advance to next node.
+		++setIt;	//advance to next node.
 	}
 
 	m_smudgeCountLastFrame = count;
@@ -466,8 +468,8 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 	DX8Wrapper::Set_DX8_Texture_Stage_State(0,D3DTSS_ALPHAOP,D3DTOP_SELECTARG2);
 
 	Int smudgesRemaining=count;
-	set=m_usedSmudgeSetList.Head();	//first smudge set that needs rendering.
-	Smudge	*remainingSmudgeStart=set->getUsedSmudgeList().Head();	//first smudge that needs rendering.
+	setIt=m_usedSmudgeSetList.begin();	//first smudge set that needs rendering.
+	SmudgeQueue::iterator remainingSmudge = (*setIt)->getUsedSmudgeList().begin();	//first smudge that needs rendering.
 
 	while (smudgesRemaining)	//keep drawing smudges until we run out.
 	{
@@ -484,21 +486,24 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 			DynamicVBAccessClass::WriteLockClass lock(&vb_access);
 			VertexFormatXYZNDUV2* verts=lock.Get_Formatted_Vertex_Array();
 
-			while (set)
+			while (setIt != m_usedSmudgeSetList.end())
 			{
-				Smudge *smudge=remainingSmudgeStart;
+				SmudgeQueue& smudgeList = (*setIt)->getUsedSmudgeList();
 
-				for (; smudge; smudge=smudge->Succ())
+				while (remainingSmudge != smudgeList.end())
 				{
+					Smudge* smudge = *remainingSmudge;
 					if (!smudge->m_draw)
+					{
+						++remainingSmudge;
 						continue;
+					}
 
 					Smudge::smudgeVertex *smVerts = smudge->m_verts;
 
 					//Check if we exceeded maximum number of smudges allowed per draw call.
 					if (smudgesInRenderBatch >= count)
 					{
-						remainingSmudgeStart = smudge;
 						goto flushSmudges;
 					}
 
@@ -523,12 +528,13 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 					}
 
 					smudgesInRenderBatch++;
+					++remainingSmudge;
 				}
 
-				set=set->Succ();	//advance to next node.
+				++setIt;	//advance to next node.
 
-				if (set)	//start next batch at beginning of set.
-					remainingSmudgeStart = set->getUsedSmudgeList().Head();
+				if (setIt != m_usedSmudgeSetList.end())	//start next batch at beginning of set.
+					remainingSmudge = (*setIt)->getUsedSmudgeList().begin();
 			}
 		}
 


### PR DESCRIPTION
* Replaces `DLListClass` usages in `W3DSmudge` with `std::deque`. `std::deque` was chosen instead of `std::list` because we only needed removals/insertions at the front/back (no splicing).
* Removes some unused functions to reduce the conversion work
* Replaces bookkeeping field `m_usedSmudgeCount` with the queue's size