### PR TITLE
chore: Remove redundant void argument from functions (3)

### DIFF
--- a/Core/Libraries/Source/debug/debug_stack.inl
+++ b/Core/Libraries/Source/debug/debug_stack.inl
@@ -25,7 +25,7 @@ DBGHELP(SymInitialize,
 
 DBGHELP(SymGetOptions,
         DWORD,
-        (void))
+        ())
 
 DBGHELP(SymSetOptions,
         DWORD,

--- a/Core/Tools/Autorun/ARGS.cpp
+++ b/Core/Tools/Autorun/ARGS.cpp
@@ -263,7 +263,7 @@ Command_Line_Arguments::Command_Line_Arguments ( HINSTANCE current_instance_hand
 //   09/01/1997  ML/MG : Created.
 //=============================================================================
 
-Command_Line_Arguments::~Command_Line_Arguments ( void )
+Command_Line_Arguments::~Command_Line_Arguments ()
 {
 	//--------------------------------------------------------------------------
 	// reset all data...
@@ -285,7 +285,7 @@ Command_Line_Arguments::~Command_Line_Arguments ( void )
 //   09/01/1997  ML/MG : Created.
 //=============================================================================
 
-int Command_Line_Arguments::Get_argc ( void )
+int Command_Line_Arguments::Get_argc ()
 {
 	//--------------------------------------------------------------------------
 	// debug checks - make sure we at least have the application name

--- a/Core/Tools/Autorun/ARGS.h
+++ b/Core/Tools/Autorun/ARGS.h
@@ -53,7 +53,7 @@ class Command_Line_Arguments
 		Command_Line_Arguments ( HINSTANCE, LPTSTR );
 		Command_Line_Arguments ( LPTSTR )    {};
 		Command_Line_Arguments ( HINSTANCE );
-		~Command_Line_Arguments( void );
+		~Command_Line_Arguments();
 
 		const char *	Get_argv( int argument_index );
 		int		 		Get_argc();

--- a/Core/Tools/Autorun/CDCNTRL.cpp
+++ b/Core/Tools/Autorun/CDCNTRL.cpp
@@ -88,7 +88,7 @@ void Last_Error_Text ( LPCTSTR szPrefix, HRESULT hr );
  * HISTORY:                                                                                    *
  *   2/17/99 2:03AM ST : Created                                                               *
  *=============================================================================================*/
-CDControlClass::CDControlClass(void)
+CDControlClass::CDControlClass()
 {
 }
 
@@ -105,7 +105,7 @@ CDControlClass::CDControlClass(void)
  * HISTORY:                                                                                    *
  *   2/17/99 2:03AM ST : Created                                                               *
  *=============================================================================================*/
-CDControlClass::~CDControlClass(void)
+CDControlClass::~CDControlClass()
 {
 }
 
@@ -908,7 +908,7 @@ bool CDControlClass::Auto_Eject_Volume_95 (HANDLE vwin32, char drive)
  * HISTORY:                                                                                    *
  *   2/17/99 0:26AM ST : Created                                                               *
  *=============================================================================================*/
-HANDLE WINAPI CDControlClass::Open_VWin32 (void)
+HANDLE WINAPI CDControlClass::Open_VWin32 ()
 {
 	assert (WinVersion.Is_Win9x());
 	HANDLE result = CreateFile ( TEXT("\\\\.\\vwin32"), 0, 0, nullptr, 0, FILE_FLAG_DELETE_ON_CLOSE, nullptr);

--- a/Core/Tools/Autorun/CDCNTRL.h
+++ b/Core/Tools/Autorun/CDCNTRL.h
@@ -48,8 +48,8 @@
 class CDControlClass {
 
 	public:
-		CDControlClass(void);
-		~CDControlClass(void);
+		CDControlClass();
+		~CDControlClass();
 
 		/*
 		** Force the CD tray to open on the specified drive.
@@ -85,7 +85,7 @@ class CDControlClass {
 		/*
 		** Win9x functions.
 		*/
-		HANDLE WINAPI Open_VWin32 (void);
+		HANDLE WINAPI Open_VWin32 ();
 		bool WINAPI Close_VWin32 (HANDLE vwin32);
 		bool WINAPI Unlock_Logical_Volume (HANDLE vwin32, char drive);
 		bool WINAPI Lock_Logical_Volume (HANDLE vwin32, char drive, char lock_level, short permissions);

--- a/Core/Tools/Autorun/CallbackHook.h
+++ b/Core/Tools/Autorun/CallbackHook.h
@@ -44,7 +44,7 @@ class CallbackHook
 		virtual ~CallbackHook()
 			{}
 
-		virtual bool DoCallback(void) const
+		virtual bool DoCallback() const
 			{return false;}
 
 	protected:
@@ -66,7 +66,7 @@ template<class T> class Callback : public CallbackHook
 			{
 			}
 
-		virtual bool DoCallback(void) const
+		virtual bool DoCallback() const
 			{
 			if (mCallback != nullptr)
 				{

--- a/Core/Tools/Autorun/DrawButton.cpp
+++ b/Core/Tools/Autorun/DrawButton.cpp
@@ -325,7 +325,7 @@ bool DrawButton::Is_Mouse_In_Region ( int mouse_x, int mouse_y )
 //   07/15/1996  MML : Created.
 //=============================================================================
 
-char *DrawButton::Return_Bitmap ( void )
+char *DrawButton::Return_Bitmap ()
 {
 	if ( ButtonState == PRESSED_STATE ) {
 		return ( PressedBitmap );

--- a/Core/Tools/Autorun/DrawButton.h
+++ b/Core/Tools/Autorun/DrawButton.h
@@ -54,29 +54,29 @@ class DrawButton
 		DrawButton ( int id, RECT button_rect, const char *normal, const char *focus, const char *pressed, const char *string, TTFontClass *fontptr );
 		DrawButton ( int id, RECT button_rect, const char *normal, const char *focus, const char *pressed, const wchar_t *string, TTFontClass *fontptr );
 
-		char			*Return_Normal_Bitmap	( void )						{ return NormalBitmap;	};
-		char			*Return_Pressed_Bitmap	( void )						{ return PressedBitmap; };
-		char			*Return_Focus_Bitmap 	( void )						{ return FocusBitmap;	};
-		char			*Return_Bitmap 			( void );
+		char			*Return_Normal_Bitmap	()						{ return NormalBitmap;	};
+		char			*Return_Pressed_Bitmap	()						{ return PressedBitmap; };
+		char			*Return_Focus_Bitmap 	()						{ return FocusBitmap;	};
+		char			*Return_Bitmap 			();
 
-		bool	 		Draw_Bitmaps		   	( void )						{ return( UseBitmaps ); };
+		bool	 		Draw_Bitmaps		   	()						{ return( UseBitmaps ); };
 
 		void			Draw_Text				( HDC hDC );
 
-		BUTTON_STATE 	Get_State			   	( void )						{ return ButtonState;	};
+		BUTTON_STATE 	Get_State			   	()						{ return ButtonState;	};
 		bool	 		Is_Mouse_In_Region 		( int mouse_x, int mouse_y );
-		int				Return_Id			   	( void )						{ return Id; };
-		int				Return_X_Pos 		   	( void )						{ return rect.left; };
-		int				Return_Y_Pos		   	( void )						{ return rect.top; };
-		int				Return_Width		   	( void )						{ return( rect.right - rect.left ); };
-		int				Return_Height		   	( void )						{ return( rect.bottom - rect.top ); };
-		int				Return_Stretched_Width	( void )						{ return( StretchedWidth ); };
-		int				Return_Stretched_Height	( void )						{ return( StretchedHeight ); };
+		int				Return_Id			   	()						{ return Id; };
+		int				Return_X_Pos 		   	()						{ return rect.left; };
+		int				Return_Y_Pos		   	()						{ return rect.top; };
+		int				Return_Width		   	()						{ return( rect.right - rect.left ); };
+		int				Return_Height		   	()						{ return( rect.bottom - rect.top ); };
+		int				Return_Stretched_Width	()						{ return( StretchedWidth ); };
+		int				Return_Stretched_Height	()						{ return( StretchedHeight ); };
 		void	 		Return_Area			   	( RECT *area );
 		void	 		Return_Area			   	( Rect *area );
 		void	 		Return_Text_Area	   	( Rect *area );
-		TTFontClass		*Return_Font_Ptr		( void )						{ return( MyFontPtr ); };
-		wchar_t			*Return_Text			( void )						{ return( String ); };
+		TTFontClass		*Return_Font_Ptr		()						{ return( MyFontPtr ); };
+		wchar_t			*Return_Text			()						{ return( String ); };
 		void	 		Set_State				( BUTTON_STATE state )			{ ButtonState = state; };
 		int				Set_Stretched_Width		( int  );
 		int				Set_Stretched_Height	( int  );

--- a/Core/Tools/Autorun/GETCD.cpp
+++ b/Core/Tools/Autorun/GETCD.cpp
@@ -87,7 +87,7 @@ GetCDClass	CDList;
  *   05/26/1994 SW	:	Created.											*
  *   12/04/1995 ST	:	fixed for Win95										*
  *==========================================================================*/
-GetCDClass::GetCDClass( void )
+GetCDClass::GetCDClass()
 {
 	char path[]={ "a:\\" };
 
@@ -142,7 +142,7 @@ GetCDClass::GetCDClass( void )
  *   05/26/1994 SW: Created.													*
  *   12/4/95    ST: fixed for Win95												*
  *==============================================================================*/
-GetCDClass::~GetCDClass(void)
+GetCDClass::~GetCDClass()
 {
 //	if(cdDrive_addrp.seg)
 //		DPMI_real_free(cdDrive_addrp);		// free up those conventional buffers

--- a/Core/Tools/Autorun/GameText.cpp
+++ b/Core/Tools/Autorun/GameText.cpp
@@ -137,10 +137,10 @@ class GameTextManager : public GameTextInterface
 		GameTextManager();
 		virtual ~GameTextManager();
 
-		virtual void					init( void );						///< Initlaizes the text system
-		virtual void					deinit( void );					///< De-initlaizes the text system
-		virtual void					update( void ) {};			///< update text manager
-		virtual void					reset( void );					///< Resets the text system
+		virtual void					init();						///< Initlaizes the text system
+		virtual void					deinit();					///< De-initlaizes the text system
+		virtual void					update() {};			///< update text manager
+		virtual void					reset();					///< Resets the text system
 
 		virtual const wchar_t * fetch( const Char *label );		///< Returns the associated labeled unicode text
 	protected:
@@ -207,7 +207,7 @@ GameTextInterface *TheGameText = nullptr;
 // CreateGameTextInterface
 //============================================================================
 
-GameTextInterface* CreateGameTextInterface( void )
+GameTextInterface* CreateGameTextInterface()
 {
 	return new GameTextManager;
 }
@@ -246,7 +246,7 @@ GameTextManager::~GameTextManager()
 
 extern char szArgvPath[];
 
-void GameTextManager::init( void )
+void GameTextManager::init()
 {
 	const Char *strFile = "autorun.str";
 	const Char *csfFile = "autorun.csf";
@@ -338,7 +338,7 @@ void GameTextManager::init( void )
 // GameTextManager::deinit
 //============================================================================
 
-void GameTextManager::deinit( void )
+void GameTextManager::deinit()
 {
 	delete [] m_stringInfo;
 	m_stringInfo = nullptr;
@@ -371,7 +371,7 @@ void GameTextManager::deinit( void )
 // GameTextManager::reset
 //============================================================================
 
-void GameTextManager::reset( void )
+void GameTextManager::reset()
 {
 }
 

--- a/Core/Tools/Autorun/GameText.h
+++ b/Core/Tools/Autorun/GameText.h
@@ -61,14 +61,14 @@ class GameTextInterface
 
 		virtual ~GameTextInterface() {};
 
-		virtual void					init( void ) = 0;						///< Initlaizes the text system
+		virtual void					init() = 0;						///< Initlaizes the text system
 		virtual const wchar_t * fetch( const char *label ) = 0;		///< Returns the associated labeled unicode text
 
 };
 
 
 extern GameTextInterface *TheGameText;
-extern GameTextInterface* CreateGameTextInterface( void );
+extern GameTextInterface* CreateGameTextInterface();
 
 //----------------------------------------------------------------------------
 //           Inlining

--- a/Core/Tools/Autorun/GetCD.h
+++ b/Core/Tools/Autorun/GetCD.h
@@ -196,14 +196,14 @@ struct	StopType {
 class	GetCDClass
 {
 	public:
-		GetCDClass	( void );							// This is the default constructor
-		~GetCDClass	( void );							// This is the destructor
+		GetCDClass	();							// This is the default constructor
+		~GetCDClass	();							// This is the destructor
 
-		inline	int		Get_First_CD_Drive		( void );
-		inline	int		Get_Next_CD_Drive		( void );
-		inline	int		Get_Number_Of_Drives	( void )	{ return( CDCount ); };
-		inline	int		Get_Index				( void )	{ return( CDIndex ); };
-		inline	void	Reset_Index				( void )	{ CDIndex = 0; };
+		inline	int		Get_First_CD_Drive		();
+		inline	int		Get_Next_CD_Drive		();
+		inline	int		Get_Number_Of_Drives	()	{ return( CDCount ); };
+		inline	int		Get_Index				()	{ return( CDIndex ); };
+		inline	void	Reset_Index				()	{ CDIndex = 0; };
 
 		int		Get_CD_Drive_For_This_Volume	( const char *volume_name );
 		const char *	Get_Volume_For_This_CD_Drive	( const char *path, char *volume_name );
@@ -230,7 +230,7 @@ class	GetCDClass
  *   12/4/95    ST : fixed for Win95										*
  *==========================================================================*/
 
-inline int GetCDClass::Get_First_CD_Drive(void)
+inline int GetCDClass::Get_First_CD_Drive()
 {
 	CDIndex = 0;
 	return (Get_Next_CD_Drive());
@@ -249,7 +249,7 @@ inline int GetCDClass::Get_First_CD_Drive(void)
  *    5/21/96 3:50PM ST : Created																	*
  *==================================================================================*/
 
-inline int GetCDClass::Get_Next_CD_Drive(void)
+inline int GetCDClass::Get_Next_CD_Drive()
 {
 	if (CDCount){
 		if (CDIndex >= CDCount) {
@@ -277,8 +277,8 @@ class RedBookClass : public GetCDClass
 {
 	public:
 
-		RedBookClass(void);					// This is the default constructor
-		~RedBookClass(void);					// This is the destructor
+		RedBookClass();					// This is the default constructor
+		~RedBookClass();					// This is the destructor
 		ULONG		RedToHS(ULONG i);
 		ULONG		MSFtoRed(UBYTE m, UBYTE s, UBYTE f);
 		void		FullCDVolume(UBYTE chan);
@@ -286,8 +286,8 @@ class RedBookClass : public GetCDClass
 		void		Play_CD_MSL(UWORD min_sec, UWORD len);
 		void		PlayMSF(UBYTE startM, UBYTE startS, UBYTE startF,
 						UBYTE endM, UBYTE endS, UBYTE endF, UBYTE chan);
-		UWORD		CheckCDMusic(void);
-		void		StopCDMusic(void);
+		UWORD		CheckCDMusic();
+		void		StopCDMusic();
 
 	private:
 

--- a/Core/Tools/Autorun/IGR.cpp
+++ b/Core/Tools/Autorun/IGR.cpp
@@ -44,7 +44,7 @@ IGROptionsClass *OnlineOptions = nullptr;
  * HISTORY:                                                                                  *
  *   07/05/00 JeffB: Initial coding																				*
  *===========================================================================================*/
-bool IGROptionsClass::Init( void )
+bool IGROptionsClass::Init()
 {
 	int	size;
 	int	returnValue;
@@ -96,7 +96,7 @@ bool IGROptionsClass::Init( void )
  * HISTORY:                                                                                    *
  *   07/05/00 JeffB: Initial coding					                                           *
  *=============================================================================================*/
-bool IGROptionsClass::Is_Auto_Login_Allowed( void )
+bool IGROptionsClass::Is_Auto_Login_Allowed()
 {
 	return(( options & IGR_NO_AUTO_LOGIN ) == 0 );
 }
@@ -113,7 +113,7 @@ bool IGROptionsClass::Is_Auto_Login_Allowed( void )
  * HISTORY:                                                                                    *
  *   07/05/00 JeffB: Initial coding					                                           *
  *=============================================================================================*/
-bool IGROptionsClass::Is_Storing_Nicks_Allowed( void )
+bool IGROptionsClass::Is_Storing_Nicks_Allowed()
 {
 	return(( options & IGR_NEVER_STORE_NICKS ) == 0 );
 }
@@ -130,7 +130,7 @@ bool IGROptionsClass::Is_Storing_Nicks_Allowed( void )
  * HISTORY:                                                                                    *
  *   07/05/00 JeffB: Initial coding					                                           *
  *=============================================================================================*/
-bool IGROptionsClass::Is_Running_Reg_App_Allowed( void )
+bool IGROptionsClass::Is_Running_Reg_App_Allowed()
 {
 	return(( options & IGR_NEVER_RUN_REG_APP ) == 0 );
 }

--- a/Core/Tools/Autorun/IGR.h
+++ b/Core/Tools/Autorun/IGR.h
@@ -47,18 +47,18 @@ class IGROptionsClass
 {
 	public:
 		// Constructor
-		IGROptionsClass( void ) : valid( false ), options( 0 ) {};
+		IGROptionsClass() : valid( false ), options( 0 ) {};
 
 		// Destructor
-		~IGROptionsClass( void ) {};
+		~IGROptionsClass() {};
 
 		// Initialize. Read value(s) from registry
-		bool Init( void );
+		bool Init();
 
 		// Check various options
-		bool Is_Auto_Login_Allowed( void );
-		bool Is_Storing_Nicks_Allowed( void );
-		bool Is_Running_Reg_App_Allowed( void );
+		bool Is_Auto_Login_Allowed();
+		bool Is_Storing_Nicks_Allowed();
+		bool Is_Running_Reg_App_Allowed();
 
 		// Set various options
 		bool Set_Options( IGROptionsType options );

--- a/Core/Tools/Autorun/Locale_API.cpp
+++ b/Core/Tools/Autorun/Locale_API.cpp
@@ -112,7 +112,7 @@ wchar_t *	Remove_Quotes_Around_String ( wchar_t *old_string );
 // make using the single vs. multi language files more transparent to the program.
 //=============================================================================
 
-bool Locale_Use_Multi_Language_Files ( void )
+bool Locale_Use_Multi_Language_Files ()
 {
 #if( USE_MULTI_FILE_FORMAT )
 	return true;
@@ -288,7 +288,7 @@ int Locale_Init	( int language, char *file )
 /* restore	 															*/
 /************************************************************************/
 
-void Locale_Restore ( void )
+void Locale_Restore ()
 {
 	delete TheGameText;
 	TheGameText = nullptr;

--- a/Core/Tools/Autorun/Locale_API.h
+++ b/Core/Tools/Autorun/Locale_API.h
@@ -59,4 +59,4 @@ const char*		Locale_GetString				( int StringID, char *String );
 const wchar_t*	Locale_GetString				( int StringID, wchar_t *String=nullptr );
 */
 bool			Locale_Use_Multi_Language_Files	();
-//int				Locale_Get_Language_ID 			( void )	{ return LanguageID; };
+//int				Locale_Get_Language_ID 			()	{ return LanguageID; };

--- a/Core/Tools/Autorun/Locale_API.h
+++ b/Core/Tools/Autorun/Locale_API.h
@@ -52,11 +52,11 @@ extern	int		SubLanguage;
 /* LOCALE API                                                               */
 /****************************************************************************/
 int				Locale_Init						( int language, char *file );
-void			Locale_Restore					( void );
+void			Locale_Restore					();
 const wchar_t* Locale_GetString( const char *id, wchar_t *buffer = nullptr, int size = _MAX_PATH );
 /*
 const char*		Locale_GetString				( int StringID, char *String );
 const wchar_t*	Locale_GetString				( int StringID, wchar_t *String=nullptr );
 */
-bool			Locale_Use_Multi_Language_Files	( void );
+bool			Locale_Use_Multi_Language_Files	();
 //int				Locale_Get_Language_ID 			( void )	{ return LanguageID; };

--- a/Core/Tools/Autorun/POINT.h
+++ b/Core/Tools/Autorun/POINT.h
@@ -72,7 +72,7 @@ template<class T> class TRect;
 template<class T>
 class TPoint2D {
 	public:
-		TPoint2D(void) {}		// Default constructor does nothing by design.
+		TPoint2D() {}		// Default constructor does nothing by design.
 		TPoint2D(T x, T y) : X(x), Y(y) {}
 
 		// Equality comparison operators.
@@ -97,11 +97,11 @@ class TPoint2D {
 		TPoint2D<T> const Cross_Product(TPoint2D<T> const & rvalue) const {return(TPoint2D<T>(T(Y - rvalue.Y), T(rvalue.X - X)));}
 
 		// Negation operator -- simple and effective
-		TPoint2D<T> const operator - (void) const {return(TPoint2D<T>(T(-X), T(-Y)));}
+		TPoint2D<T> const operator - () const {return(TPoint2D<T>(T(-X), T(-Y)));}
 
 		// Vector support functions.
-		T Length(void) const {return(T(sqrt(double(X*X + Y*Y))));}
-		TPoint2D<T> const Normalize(void) const {
+		T Length() const {return(T(sqrt(double(X*X + Y*Y))));}
+		TPoint2D<T> const Normalize() const {
 			double len = sqrt(X*X + Y*Y);
 			if (len != 0.0) {
 				return(TPoint2D<T>((T)(X / len), (T)(Y / len)));
@@ -125,12 +125,12 @@ class TPoint2D {
 class Point2D : public TPoint2D<int>
 {
 	public:
-		Point2D(void) {}		// Default constructor does nothing by design.
+		Point2D() {}		// Default constructor does nothing by design.
 		Point2D(int x, int y) : TPoint2D<int>(x, y) {}
 		Point2D(Point2DStruct const & rvalue) : TPoint2D<int>(rvalue.X, rvalue.Y) {}
 		Point2D(TPoint2D<int> const & rvalue) : TPoint2D<int>(rvalue) {}
 
-		operator Point2DStruct (void) const {Point2DStruct pt;pt.X = X;pt.Y = Y;return(pt);}
+		operator Point2DStruct () const {Point2DStruct pt;pt.X = X;pt.Y = Y;return(pt);}
 
 		Point2D const & operator += (Point2D const & rvalue) {X += rvalue.X;Y += rvalue.Y;return(*this);}
 		Point2D const & operator -= (Point2D const & rvalue) {X -= rvalue.X;Y -= rvalue.Y;return(*this);}
@@ -172,7 +172,7 @@ class TPoint3D : public TPoint2D<T> {
 		using BASECLASS::Y;
 
 	public:
-		TPoint3D(void) {}		// Default constructor does nothing by design.
+		TPoint3D() {}		// Default constructor does nothing by design.
 		TPoint3D(T x, T y, T z) : BASECLASS(x, y), Z(z) {}
 		TPoint3D(BASECLASS const & rvalue, T z /*= 0*/) : BASECLASS(rvalue), Z(z) {}
 
@@ -202,11 +202,11 @@ class TPoint3D : public TPoint2D<T> {
 		TPoint3D<T> const Cross_Product(TPoint3D<T> const & rvalue) const {return TPoint3D<T>(Y * rvalue.Z - Z * rvalue.Y, Z * rvalue.X - X * rvalue.Z, X * rvalue.Y - Y * rvalue.X);}
 
 		// Negation operator -- simple and effective
-		TPoint3D<T> const operator - (void) const {return(TPoint3D<T>(-X, -Y, -Z));}
+		TPoint3D<T> const operator - () const {return(TPoint3D<T>(-X, -Y, -Z));}
 
 		// Vector support functions.
-		T Length(void) const {return(T(sqrt(double(X*X + Y*Y + Z*Z))));}
-		TPoint3D<T> const Normalize(void) const {
+		T Length() const {return(T(sqrt(double(X*X + Y*Y + Z*Z))));}
+		TPoint3D<T> const Normalize() const {
 			double len = sqrt(X*X + Y*Y + Z*Z);
 			if (len != 0.0) {
 				return(TPoint3D<T>((T)(X / len), (T)(Y / len), (T)(Z / len)));

--- a/Core/Tools/Autorun/RECT.h
+++ b/Core/Tools/Autorun/RECT.h
@@ -52,7 +52,7 @@ template<class T>
 class TRect
 {
 	public:
-		TRect(void) {}		// Default constructor does nothing by design.
+		TRect() {}		// Default constructor does nothing by design.
 		TRect(T x, T y, T w, T h) : X(x), Y(y), Width(w), Height(h) {}
 		TRect(TPoint2D<T> const & point, T w, T h) : X(point.X), Y(point.Y), Width(w), Height(h) {}
 
@@ -82,28 +82,28 @@ class TRect
 		/*
 		**	Determine is rectangle is valid.
 		*/
-		bool Is_Valid(void) const {return(Width > 0 && Height > 0);}
+		bool Is_Valid() const {return(Width > 0 && Height > 0);}
 		__declspec(property(get=Is_Valid)) bool IsValid;
 
 		/*
 		**	Returns size of rectangle if each discrete location within it is presumed
 		**	to be of size 1.
 		*/
-		int Size(void) const {return(int(Width) * int(Height));}
+		int Size() const {return(int(Width) * int(Height));}
 
 		/*
 		**	Fetch points of rectangle (used as a convenience for the programmer).
 		*/
-		TPoint2D<T> Top_Left(void) const {return(TPoint2D<T>(X, Y));}
+		TPoint2D<T> Top_Left() const {return(TPoint2D<T>(X, Y));}
 		__declspec(property(get=Top_Left)) TPoint2D<T> TopLeft;
 
-		TPoint2D<T> Top_Right(void) const {return(TPoint2D<T>(T(X + Width - 1), Y));}
+		TPoint2D<T> Top_Right() const {return(TPoint2D<T>(T(X + Width - 1), Y));}
 		__declspec(property(get=Top_Right)) TPoint2D<T> TopRight;
 
-		TPoint2D<T> Bottom_Left(void) const {return(TPoint2D<T>(X, T(Y + Height - 1)));}
+		TPoint2D<T> Bottom_Left() const {return(TPoint2D<T>(X, T(Y + Height - 1)));}
 		__declspec(property(get=Bottom_Left)) TPoint2D<T> BottomLeft;
 
-		TPoint2D<T> Bottom_Right(void) const {return(TPoint2D<T>(T(X + Width - 1), T(Y + Height - 1)));}
+		TPoint2D<T> Bottom_Right() const {return(TPoint2D<T>(T(X + Width - 1), T(Y + Height - 1)));}
 		__declspec(property(get=Bottom_Right)) TPoint2D<T> BottomRight;
 
 

--- a/Core/Tools/Autorun/TTFont.cpp
+++ b/Core/Tools/Autorun/TTFont.cpp
@@ -559,7 +559,7 @@ UINT TTFontClass::Get_Double_Byte_Char	( const char *string, int *num_bytes ) co
  * HISTORY:                                                                                    *
  *   05/26/1997 JLB : Created.                                                                 *
  *=============================================================================================*/
-int TTFontClass::Get_Width( void ) const
+int TTFontClass::Get_Width() const
 {
 	return( MaxCharWidth - Overhang );
 }
@@ -579,7 +579,7 @@ int TTFontClass::Get_Width( void ) const
  * HISTORY:                                                                                    *
  *   05/26/1997 JLB : Created.                                                                 *
  *=============================================================================================*/
-int TTFontClass::Get_Height( void ) const
+int TTFontClass::Get_Height() const
 {
 	return( Height );
 }
@@ -1396,7 +1396,7 @@ FontManagerClass::FontManagerClass ( HDC hdc )
  * HISTORY:                                                                                    *
  *   03/26/1998 MML : Created.                                                                 *
  *=============================================================================================*/
-FontManagerClass::~FontManagerClass ( void )
+FontManagerClass::~FontManagerClass ()
 {
 	delete TTButtonFontPtr;
 	TTButtonFontPtr = nullptr;

--- a/Core/Tools/Autorun/TTFont.h
+++ b/Core/Tools/Autorun/TTFont.h
@@ -202,7 +202,7 @@ class TTFontClass
 			BYTE	quality				= PROOF_QUALITY,
 			BYTE	pitchAndFamily		= FF_DONTCARE );
 
-		virtual ~TTFontClass(void)
+		virtual ~TTFontClass()
 			{
 				if ( Font != nullptr ) {
 					DeleteObject( Font );
@@ -215,13 +215,13 @@ class TTFontClass
 		virtual int		Char_Pixel_Width		( HDC hdc, char const * string, int *num_bytes=nullptr ) const;
 		virtual int		String_Pixel_Width		( HDC hdc, char const * string ) const;
 		virtual void	String_Pixel_Bounds		( HDC hdc, const char * string, Rect& bounds ) const;
-		virtual int		Get_Width				( void ) const;
-		virtual int		Get_Height				( void ) const;
+		virtual int		Get_Width				() const;
+		virtual int		Get_Height				() const;
 		virtual int		Set_XSpacing			( HDC hdc, int x );
 		virtual int		Set_YSpacing			( int y );
 		virtual int		Find_Text_VLength		( HDC hdc, char *str, int width );
-		virtual HFONT	Get_Font_Ptr			( void )		{ return Font; };
-		virtual int		IsFontDBCS				( void ) const	{ return ((CharSet==SHIFTJIS_CHARSET)||(CharSet==HANGEUL_CHARSET)||(CharSet==CHINESEBIG5_CHARSET)); };	// [OYO]
+		virtual HFONT	Get_Font_Ptr			()		{ return Font; };
+		virtual int		IsFontDBCS				() const	{ return ((CharSet==SHIFTJIS_CHARSET)||(CharSet==HANGEUL_CHARSET)||(CharSet==CHINESEBIG5_CHARSET)); };	// [OYO]
 		virtual UINT	Get_Double_Byte_Char	( const char *string, int *num_bytes=nullptr ) const;
 
 		virtual Point2D	Print(
@@ -278,7 +278,7 @@ class FontManagerClass
 {
 	public:
 		FontManagerClass		( HDC hdc );
-		~FontManagerClass		( void );
+		~FontManagerClass		();
 		TTFontClass * Get_Font	( TextPrintType flags )	{ return( Font_From_TPF( flags ));  };
 };
 

--- a/Core/Tools/Autorun/WSYS_File.cpp
+++ b/Core/Tools/Autorun/WSYS_File.cpp
@@ -170,7 +170,7 @@ Bool File::open( const Char *filename, Int access )
 	*/
 //=================================================================
 
-void File::close( void )
+void File::close()
 {
 	if( m_open )
 	{
@@ -192,7 +192,7 @@ void File::close( void )
 	*/
 //=================================================================
 
-Int File::size( void )
+Int File::size()
 {
 	Int pos = seek( 0, CURRENT );
 	Int size = seek( 0, END );
@@ -206,7 +206,7 @@ Int File::size( void )
 // File::position
 //============================================================================
 
-Int File::position( void )
+Int File::position()
 {
 	return seek(0, CURRENT);
 }

--- a/Core/Tools/Autorun/WSYS_RAMFile.cpp
+++ b/Core/Tools/Autorun/WSYS_RAMFile.cpp
@@ -196,7 +196,7 @@ Bool RAMFile::open( File *file )
 	*/
 //=================================================================
 
-void RAMFile::close( void )
+void RAMFile::close()
 {
 	delete [] m_data;
 	m_data = nullptr;

--- a/Core/Tools/Autorun/WSYS_RAMFile.h
+++ b/Core/Tools/Autorun/WSYS_RAMFile.h
@@ -76,7 +76,7 @@ class RAMFile : public File
 
 
 		virtual Bool	open( const Char *filename, Int access = 0 );				///< Open a file for access
-		virtual void	close( void );																			///< Close the file
+		virtual void	close();																			///< Close the file
 		virtual Int		read( void *buffer, Int bytes );										///< Read the specified number of bytes in to buffer: See File::read
 		virtual Int		write( void *buffer, Int bytes );										///< Write the specified number of bytes from the buffer: See File::write
 		virtual Int		seek( Int new_pos, seekMode mode = CURRENT );				///< Set file position: See File::seek

--- a/Core/Tools/Autorun/WSYS_StdFile.cpp
+++ b/Core/Tools/Autorun/WSYS_StdFile.cpp
@@ -191,7 +191,7 @@ error:
 	*/
 //=================================================================
 
-void StdFile::close( void )
+void StdFile::close()
 {
 	File::close();
 }

--- a/Core/Tools/Autorun/WSYS_StdFile.h
+++ b/Core/Tools/Autorun/WSYS_StdFile.h
@@ -74,7 +74,7 @@ class StdFile : public File
 
 
 		virtual Bool	open( const Char *filename, Int access = 0 );				///< Open a fioe for access
-		virtual void	close( void );																			///< Close the file
+		virtual void	close();																			///< Close the file
 		virtual Int		read( void *buffer, Int bytes );										///< Read the specified number of bytes in to buffer: See File::read
 		virtual Int		write( void *buffer, Int bytes );										///< Write the specified number of bytes from the buffer: See File::write
 		virtual Int		seek( Int new_pos, seekMode mode = CURRENT );				///< Set file position: See File::seek

--- a/Core/Tools/Autorun/WSYS_file.h
+++ b/Core/Tools/Autorun/WSYS_file.h
@@ -109,7 +109,7 @@ class File
 
 
 		virtual Bool	open( const Char *filename, Int access = 0 );				///< Open a file for access
-		virtual void	close( void );																			///< Close the file !!! File object no longer valid after this call !!!
+		virtual void	close();																			///< Close the file !!! File object no longer valid after this call !!!
 
 		virtual Int		read( void *buffer, Int bytes ) = 0 ;						/**< Read the specified number of bytes from the file in to the
 																																			  *  memory pointed at by buffer. Returns the number of bytes read.
@@ -130,16 +130,16 @@ class File
 																																				*  END: means seek the specified number of bytes back from the end of the file
 																																				*/
 		virtual Bool	printf ( const Char *format, ...);									///< Prints formatted string to text file
-		virtual Int		size( void );																				///< Returns the size of the file
-		virtual Int		position( void );																		///< Returns the current read/write position
+		virtual Int		size();																				///< Returns the size of the file
+		virtual Int		position();																		///< Returns the current read/write position
 
 
 		void					setName( const Char *name );												///< Set the name of the file
-		Char*					getName( void );																		///< Returns a pointer to the name of the file
+		Char*					getName();																		///< Returns a pointer to the name of the file
 		Bool					getName( Char *buffer, Int max );										///< Copies the name of the file to the buffer
-		Int						getAccess( void );																	///< Returns file's access flags
+		Int						getAccess();																	///< Returns file's access flags
 
-		void					deleteOnClose ( void );															///< Causes the File object to delete itself when it closes
+		void					deleteOnClose ();															///< Causes the File object to delete itself when it closes
 };
 
 
@@ -149,9 +149,9 @@ class File
 //           Inlining
 //----------------------------------------------------------------------------
 
-inline Char* File::getName( void ) { return m_name;};
-inline Int File::getAccess( void ) { return m_access;};
-inline void File::deleteOnClose( void ) { m_deleteOnClose = TRUE;};
+inline Char* File::getName() { return m_name;};
+inline Int File::getAccess() { return m_access;};
+inline void File::deleteOnClose() { m_deleteOnClose = TRUE;};
 
 
 

--- a/Core/Tools/Autorun/WinFix.cpp
+++ b/Core/Tools/Autorun/WinFix.cpp
@@ -71,7 +71,7 @@ WindowsVersionInfo WinVersion;
  * HISTORY:                                                                                    *
  *  04/09/98 jdl : Created.                                                                    *
  *=============================================================================================*/
-WindowsVersionInfo::WindowsVersionInfo(void) :
+WindowsVersionInfo::WindowsVersionInfo() :
 	WindowsVersion(0),
 	MajorVersionNumber(0),
 	MinorVersionNumber(0),
@@ -267,7 +267,7 @@ WindowsVersionInfo::WindowsVersionInfo(void) :
  * HISTORY:                                                                                    *
  *   3/30/99 10:29PM ST : Created                                                              *
  *=============================================================================================*/
-char *WindowsVersionInfo::Version_String(void)
+char *WindowsVersionInfo::Version_String()
 {
 	static char _ver95[]   	= {"Windows 95 "};
 	static char _ver98[]   	= {"Windows 98 "};
@@ -319,7 +319,7 @@ char *WindowsVersionInfo::Version_String(void)
  *   10/30/1995 BRR : Created.															*
  *=========================================================================*/
 
-char * WindowsVersionInfo::Version_Name(void)
+char * WindowsVersionInfo::Version_Name()
 {
 	return ( VersionName );
 }
@@ -340,7 +340,7 @@ char * WindowsVersionInfo::Version_Name(void)
  *   10/30/1995 BRR : Created.												*
  *==========================================================================*/
 
-bool WindowsVersionInfo::Meets_Minimum_Version_Requirements	( void )
+bool WindowsVersionInfo::Meets_Minimum_Version_Requirements	()
 {
 //	return(( !IsWin95 && ( Version() >= 400 ))? true : false );
 	return(( Version() >= 400 )? true : false );

--- a/Core/Tools/Autorun/WinFix.h
+++ b/Core/Tools/Autorun/WinFix.h
@@ -57,26 +57,26 @@
 class WindowsVersionInfo
 {
 	public:
-		WindowsVersionInfo	(void);
-		~WindowsVersionInfo	(void) {}
+		WindowsVersionInfo	();
+		~WindowsVersionInfo	() {}
 
-		int 	Major								( void ) const { return( MajorVersionNumber ); }
-		int 	Minor								( void ) const { return( MinorVersionNumber ); }
-		int 	Build								( void ) const { return( BuildNumber ); }
-		bool 	Is_Win9x							( void ) const { return( IsWin9x ); }									// Win 9x
-		bool 	Is_Win95							( void ) const { return( IsWin95 ); }									// Win 95
-		bool 	Is_Win98							( void ) const { return( IsWin98 ); }									// Win 98
-		bool 	Is_WinNT							( void ) const { return( IsWinNT ); }									// Win NT
-		bool 	Is_WinNT4							( void ) const { return( IsWinNT && MajorVersionNumber == 4 ); }		// Win NT
-		bool	Is_WinNT5							( void ) const { return( IsWinNT && MajorVersionNumber == 5 ); }		// Win NT
-		bool	Is_Win_2000							( void ) const { return( IsWin2000 ); }								// Win 2000
-		bool	Is_Win_XP							( void ) const { return( IsWinXP ); }									// Win XP
-		int		Version								( void ) const { return( WindowsVersion );	}
-		int		IsOSR2Release						( void ) const { return( RunningOSR2 );		}
-		const char * Info							( void ) const { return( &AdditionalInfo[0] ); }
-		char *	Version_String						( void );
-		char *	Version_Name						( void );
-		bool	Meets_Minimum_Version_Requirements	( void );
+		int 	Major								() const { return( MajorVersionNumber ); }
+		int 	Minor								() const { return( MinorVersionNumber ); }
+		int 	Build								() const { return( BuildNumber ); }
+		bool 	Is_Win9x							() const { return( IsWin9x ); }									// Win 9x
+		bool 	Is_Win95							() const { return( IsWin95 ); }									// Win 95
+		bool 	Is_Win98							() const { return( IsWin98 ); }									// Win 98
+		bool 	Is_WinNT							() const { return( IsWinNT ); }									// Win NT
+		bool 	Is_WinNT4							() const { return( IsWinNT && MajorVersionNumber == 4 ); }		// Win NT
+		bool	Is_WinNT5							() const { return( IsWinNT && MajorVersionNumber == 5 ); }		// Win NT
+		bool	Is_Win_2000							() const { return( IsWin2000 ); }								// Win 2000
+		bool	Is_Win_XP							() const { return( IsWinXP ); }									// Win XP
+		int		Version								() const { return( WindowsVersion );	}
+		int		IsOSR2Release						() const { return( RunningOSR2 );		}
+		const char * Info							() const { return( &AdditionalInfo[0] ); }
+		char *	Version_String						();
+		char *	Version_Name						();
+		bool	Meets_Minimum_Version_Requirements	();
 
 	private:
 		/*-----------------------------------------------------------------------

--- a/Core/Tools/Autorun/Wnd_File.h
+++ b/Core/Tools/Autorun/Wnd_File.h
@@ -95,7 +95,7 @@
 #ifdef RTS_DEBUG
 void __cdecl Msg( int line, const char *file, const char *fmt, ... );
 void __cdecl Msg( int line, const char *filename, const wchar_t *fmt, unsigned int codepage=1252, ... );
-void 	Delete_Msg_File( void );
+void 	Delete_Msg_File();
 #else
 #define Msg
 #define Delete_Msg_File()
@@ -116,19 +116,19 @@ class StandardFileClass
 		StandardFileClass();
 		~StandardFileClass();
 		bool 	Open 				( const char *file_name, int open_mode );
-		bool 	Close				( void );
+		bool 	Close				();
 		int 	Read 				( void *buffer, unsigned long int bytes_to_read );
 		int 	Write				( void *buffer, unsigned long int bytes_to_write );
 		bool 	Seek 				( int distance, int seek_file_position );
-		int 	Tell 				( void );
-		int 	Query_Size			( void );
-		bool 	Query_Open			( void );
-		char *	Query_Name_String	( void );
-     	int		End_Of_File			( void );
-		int		Flush	  	 		( void );
+		int 	Tell 				();
+		int 	Query_Size			();
+		bool 	Query_Open			();
+		char *	Query_Name_String	();
+	int		End_Of_File			();
+		int		Flush	  	 		();
 
 		#if( SUPPORT_STREAMS )
-		FILE *Query_File_Stream_Pointer( void );
+		FILE *Query_File_Stream_Pointer();
 		#endif
 
 	private:
@@ -136,7 +136,7 @@ class StandardFileClass
 		//
 		// private class functions...
 		//
-		void Reset( void );
+		void Reset();
 		//
 		// private class data...
 		//

--- a/Core/Tools/Autorun/Wnd_file.cpp
+++ b/Core/Tools/Autorun/Wnd_file.cpp
@@ -73,9 +73,9 @@ char DebugFile	[ MAX_PATH ] = { '\0' };
 //-----------------------------------------------------------------------------
 // non-class private functions in this module...
 //-----------------------------------------------------------------------------
-// int Get_Internal_File_Handle( void );
+// int Get_Internal_File_Handle();
 // #if( SUPPORT_STREAMS )
-//	 FILE *Get_Internal_File_Stream( void );
+//	 FILE *Get_Internal_File_Stream();
 // #endif
 
 

--- a/Core/Tools/Autorun/Wnd_file.cpp
+++ b/Core/Tools/Autorun/Wnd_file.cpp
@@ -85,7 +85,7 @@ char DebugFile	[ MAX_PATH ] = { '\0' };
 #if(0)
 #ifndef RTS_DEBUG
 void __cdecl Msg( int, char *, char *, ... ) { };	// line, file, fmt
-void 	Delete_Msg_File ( void )  { };
+void 	Delete_Msg_File ()  { };
 #endif
 #endif
 
@@ -274,7 +274,7 @@ void __cdecl Msg( int line, const char *filename, const wchar_t *fmt, UINT codep
 // Delete_Msg_File
 //----------------------------------------------------------------------
 
-void Delete_Msg_File ( void )
+void Delete_Msg_File ()
 {
 	DWORD	nBytes;
 	char	buff	[ 300 ];
@@ -326,7 +326,7 @@ void Delete_Msg_File ( void )
 // StandardFileClass::StandardFileClass
 //------------------------------------------------------------------------------
 
-StandardFileClass::StandardFileClass( void )
+StandardFileClass::StandardFileClass()
 {
 	//
 	// reset all internal data
@@ -338,7 +338,7 @@ StandardFileClass::StandardFileClass( void )
 // StandardFileClass::~StandardFileClass
 //------------------------------------------------------------------------------
 
-StandardFileClass::~StandardFileClass( void )
+StandardFileClass::~StandardFileClass()
 {
 	//
 	// make sure this file got shut down before we destruct
@@ -516,7 +516,7 @@ bool StandardFileClass::Open( const char *no_path_file_name, int open_mode )
 // bool StandardFileClass::Close
 //------------------------------------------------------------------------------
 
-bool StandardFileClass::Close( void )
+bool StandardFileClass::Close()
 {
 	int status;
 
@@ -819,7 +819,7 @@ bool StandardFileClass::Seek( int distance, int seek_file_position )
 //
 // return file position
 //
-int StandardFileClass::Tell( void )
+int StandardFileClass::Tell()
 {
 	int file_pos;
 
@@ -879,7 +879,7 @@ int StandardFileClass::Tell( void )
 // int StandardFileClass::Query_Size
 //------------------------------------------------------------------------------
 
-int StandardFileClass::Query_Size( void )
+int StandardFileClass::Query_Size()
 {
 	int size;
 
@@ -928,7 +928,7 @@ int StandardFileClass::Query_Size( void )
 // int StandardFileClass::Query_Size
 //------------------------------------------------------------------------------
 
-bool StandardFileClass::Query_Open( void )
+bool StandardFileClass::Query_Open()
 {
 	return( Currently_Open );
 }
@@ -937,7 +937,7 @@ bool StandardFileClass::Query_Open( void )
 // char *StandardFileClass::Query_Name_String
 //------------------------------------------------------------------------------
 
-char *StandardFileClass::Query_Name_String( void )
+char *StandardFileClass::Query_Name_String()
 {
 	return( File_Name );
 }
@@ -949,7 +949,7 @@ char *StandardFileClass::Query_Name_String( void )
 // FILE *StandardFileClass::Query_File_Stream_Pointer
 //------------------------------------------------------------------------------
 
-FILE *StandardFileClass::Query_File_Stream_Pointer( void )
+FILE *StandardFileClass::Query_File_Stream_Pointer()
 {
 	return( File_Stream_Ptr );
 }
@@ -965,7 +965,7 @@ FILE *StandardFileClass::Query_File_Stream_Pointer( void )
 // void StandardFileClass::Reset
 //------------------------------------------------------------------------------
 
-void StandardFileClass::Reset( void )
+void StandardFileClass::Reset()
 {
 	//
 	// reset all internal data
@@ -981,7 +981,7 @@ void StandardFileClass::Reset( void )
 }
 
 
-int StandardFileClass::End_Of_File	( void )
+int StandardFileClass::End_Of_File	()
 {
 	#if( SUPPORT_HANDLES )
    	return( TRUE );
@@ -996,7 +996,7 @@ int StandardFileClass::End_Of_File	( void )
 	#endif
 }
 
-int StandardFileClass::Flush ( void )
+int StandardFileClass::Flush ()
 {
 	#if( SUPPORT_STREAMS )
 	ASSERT( File_Stream_Ptr != nullptr );
@@ -1507,7 +1507,7 @@ bool Find_File( char const *file_name )
 //
 // private...
 //
-int Get_Internal_File_Handle( void )
+int Get_Internal_File_Handle()
 {
 	static bool _initialized = FALSE;
 	int i;

--- a/Core/Tools/Autorun/autorun.cpp
+++ b/Core/Tools/Autorun/autorun.cpp
@@ -324,7 +324,7 @@ char		szCDDrive[ MAX_PATH ];
 //-----------------------------------------------------------------------------
 void 		Cant_Find_MessageBox		( HINSTANCE hInstance, const char *szPath );
 HPALETTE	CreateDIBPalette 			( LPBITMAPINFO lpbmi, LPINT lpiNumColors );
-void		Debug_Date_And_Time_Stamp	( void );
+void		Debug_Date_And_Time_Stamp	();
 
 void 		Error_Message				( HINSTANCE hInstance, int title, int string, const char *path );
 void 		Error_Message				( HINSTANCE hInstance, const char * title, const char * string, const char *path );
@@ -333,13 +333,13 @@ bool		Is_On_CD					( const char * );
 HBITMAP 	LoadResourceBitmap			( HMODULE hInstance, LPCTSTR lpString, HPALETTE FAR *lphPalette, bool loading_a_button=FALSE );
 HBITMAP 	LoadResourceButton			( HMODULE hInstance, LPCTSTR lpString, HPALETTE FAR lphPalette );
 BOOL 		Options						( Command_Line_Arguments *Orgs );
-void		Prog_End					( void );
+void		Prog_End					();
 bool		Prompt_For_CD				( HWND window_handle, char *volume_name, const char * message1, const char * message2, int *cd_drive );
 void		Reformat_Volume_Name		( const char *volume_name, char *new_volume_name );
 int			Show_Message				( HWND window_handle, const char * message_num1, const char * message_num2 );
 int			Show_Message				( HWND window_handle, int message_num1 );
-void		Stop_Sound_Playing			( void );
-BOOL 		Valid_Environment 			( void );
+void		Stop_Sound_Playing			();
+BOOL 		Valid_Environment 			();
 
 BOOL 		CALLBACK	Dialog_Box_Proc	( HWND window_handle, UINT message, WPARAM w_param, LPARAM l_param );
 LRESULT 	CALLBACK	Wnd_Proc 		( HWND hWnd, UINT iMessage, WPARAM wParam, LPARAM lParam );
@@ -864,7 +864,7 @@ int PASCAL WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpszCmd
 //   01/22/2001  MML : Created.
 //=============================================================================
 
-void Prog_End ( void )
+void Prog_End ()
 {
 	//==========================================================================
 	// UnLock the CD!
@@ -925,7 +925,7 @@ void Prog_End ( void )
 //   06/04/1996  MML : Created.
 //=============================================================================
 
-int Main::MessageLoop( void )
+int Main::MessageLoop()
 {
 	MSG msg;
 
@@ -973,7 +973,7 @@ int Main::MessageLoop( void )
 //   06/04/1996  MML : Created.
 //=============================================================================
 
-void MainWindow::Register( void )
+void MainWindow::Register()
 {
 	//--------------------------------------------------------------------------
 	// Structure used to register Windows class.
@@ -1041,7 +1041,7 @@ void MainWindow::Register( void )
 //   06/04/1996  MML : Created.
 //=============================================================================
 
-MainWindow::MainWindow( void )
+MainWindow::MainWindow()
 {
 	char szTitle[ _MAX_PATH ];
 	hWnd = 0;
@@ -1225,7 +1225,7 @@ LRESULT MainWindow::Window_Proc( HWND hWnd, UINT iMessage, WPARAM wParam, LPARAM
 //   06/04/1996  MML : Created.
 //=============================================================================
 
-BOOL MainWindow::Is_Product_Registered( void )
+BOOL MainWindow::Is_Product_Registered()
 {
 	HKEY	phKey;
 	BOOL	result = FALSE;
@@ -4588,7 +4588,7 @@ BOOL CALLBACK  Dialog_Box_Proc( HWND window_handle, UINT message, WPARAM w_param
 //   06/04/1999  MML : Created.
 //=============================================================================
 
-void Stop_Sound_Playing ( void )
+void Stop_Sound_Playing ()
 {
 	PlaySound( nullptr, nullptr, SND_ASYNC | SND_FILENAME );
 }
@@ -4792,7 +4792,7 @@ BOOL Options( Command_Line_Arguments *Orgs )
 //   06/04/1996  MML : Created.
 //=============================================================================
 
-BOOL Valid_Environment ( void )
+BOOL Valid_Environment ()
 {
 	bool result = 0;
 
@@ -5185,7 +5185,7 @@ void LaunchObjectClass::SetArgs ( char *args )
 	}
 }
 
-unsigned int LaunchObjectClass::Launch ( void )
+unsigned int LaunchObjectClass::Launch ()
 {
 	char 	filepath	[_MAX_PATH];
 	char 	dir			[_MAX_DIR];
@@ -5273,7 +5273,7 @@ unsigned int LaunchObjectClass::Launch ( void )
 	return( result );
 }
 
-void Debug_Date_And_Time_Stamp ( void )
+void Debug_Date_And_Time_Stamp ()
 {
 	//-------------------------------------------------------------------------
 	//	tm_sec	- Seconds after minute (0 - 59)

--- a/Core/Tools/Autorun/autorun.h
+++ b/Core/Tools/Autorun/autorun.h
@@ -169,8 +169,8 @@ class LaunchObjectClass
 
 		void			SetPath				( char *path );
 		void			SetArgs				( char *args );
-		unsigned int	Launch				( void );
-		bool			Launch_A_Program	( void )			{ return( LaunchSomething ); };
+		unsigned int	Launch				();
+		bool			Launch_A_Program	()			{ return( LaunchSomething ); };
 		void			Set_Launch			( bool value )		{ LaunchSomething = value; };
 
 	public:
@@ -191,7 +191,7 @@ class Main
 		static HINSTANCE hPrevInstance;
 		static HMODULE hModule;
 		static int nCmdShow;
-		static int MessageLoop( void );
+		static int MessageLoop();
 };
 
 //-------------------------------------------------------------------------
@@ -206,9 +206,9 @@ class Window
 		HWND hWnd;
 
 	public:
-		HWND GetHandle( void ) 		{ return hWnd; }
+		HWND GetHandle() 		{ return hWnd; }
 		BOOL Show( int nCmdShow ) 	{ return ShowWindow( hWnd, nCmdShow ); }
-		void Update( void ) 		{ UpdateWindow( hWnd ); }
+		void Update() 		{ UpdateWindow( hWnd ); }
 		virtual LRESULT Window_Proc( HWND hWnd, UINT iMessage, WPARAM wParam, LPARAM lParam ) = 0;
 };
 
@@ -223,9 +223,9 @@ class MainWindow : public Window
 
 	public:
 
-		MainWindow( void );
+		MainWindow();
 
-		static void		Register		  		( void );
+		static void		Register		  		();
 		static void	  	Reset_Class_Name		( char *string )
 			{
 				if ( string != nullptr && string[0] != '\0' ) {
@@ -233,7 +233,7 @@ class MainWindow : public Window
 				}
 			};
 
-		BOOL			Is_Product_Registered	( void );
+		BOOL			Is_Product_Registered	();
 		void	 		Create_Buttons	  		( HWND hWnd, RECT *dlg_rect );
 		unsigned int	Run_Auto_Update			( HWND hWnd, RECT *rect );
 		unsigned int	Run_Demo 		  		( HWND hWnd, RECT *rect, int cd_drive );

--- a/Core/Tools/Autorun/gimex.h
+++ b/Core/Tools/Autorun/gimex.h
@@ -209,7 +209,7 @@ typedef struct
 
 /* Example Information Functions */
 
-GABOUT * GCALL aboutbmp(void);
+GABOUT * GCALL aboutbmp();
 int      GCALL isbmp(GSTREAM *g);
 
 /* Example Import Functions */

--- a/Core/Tools/Autorun/locale.cpp
+++ b/Core/Tools/Autorun/locale.cpp
@@ -117,7 +117,7 @@ int LOCALE_isinitialized()
 ;
 ; #include "realfont.h"
 ;
-; int LOCALE_init(void)
+; int LOCALE_init()
 ;
 ; DESCRIPTION
 ;
@@ -170,7 +170,7 @@ int LOCALE_init()
 ;
 ; #include "realfont.h"
 ;
-; void LOCALE_restore(void)
+; void LOCALE_restore()
 ;
 ; DESCRIPTION
 ;
@@ -276,7 +276,7 @@ void LOCALE_setbank(int BankIndex)
 ;
 ; #include "realfont.h"
 ;
-; int LOCALE_getbank(void)
+; int LOCALE_getbank()
 ;
 ; DESCRIPTION
 ;
@@ -317,7 +317,7 @@ int LOCALE_getbank()
 ;
 ; #include "realfont.h"
 ;
-; int LOCALE_getbanklanguageid(void)
+; int LOCALE_getbanklanguageid()
 ;
 ; DESCRIPTION
 ;
@@ -358,7 +358,7 @@ int LOCALE_getbanklanguageid()
 ;
 ; #include "realfont.h"
 ;
-; int LOCALE_getbankstringcount(void)
+; int LOCALE_getbankstringcount()
 ;
 ; DESCRIPTION
 ;
@@ -611,7 +611,7 @@ int LOCALE_loadtable(const char* PathName, int LanguageID)
 ;
 ; #include "realfont.h"
 ;
-; void LOCALE_freetable(void)
+; void LOCALE_freetable()
 ;
 ; DESCRIPTION
 ;

--- a/Core/Tools/Autorun/locale.cpp
+++ b/Core/Tools/Autorun/locale.cpp
@@ -98,7 +98,7 @@ static LOCALE_INSTANCE	*lx			= nullptr;
 /*************************************************************************/
 
 /* helper function to make assertions for initialization clearer */
-int LOCALE_isinitialized( void )
+int LOCALE_isinitialized()
 {
     if ( lx == nullptr ) {
 //        TRACE("LOCALE API is not initialized - call LOCALE_init before calling LOCALE functions\n");
@@ -143,7 +143,7 @@ int LOCALE_isinitialized( void )
 ;
 */
 
-int LOCALE_init(void)
+int LOCALE_init()
 {
     int ok = 0;
 
@@ -194,7 +194,7 @@ int LOCALE_init(void)
 ;
 */
 
-void LOCALE_restore(void)
+void LOCALE_restore()
 {
     int i;
 
@@ -299,7 +299,7 @@ void LOCALE_setbank(int BankIndex)
 ;
 */
 
-int LOCALE_getbank(void)
+int LOCALE_getbank()
 {
     ASSERT(LOCALE_isinitialized()); /* must call LOCALE_init before calling this function */
     return lx->BankIndex;
@@ -340,7 +340,7 @@ int LOCALE_getbank(void)
 ;
 */
 
-int LOCALE_getbanklanguageid(void)
+int LOCALE_getbanklanguageid()
 {
     ASSERT(LOCALE_isinitialized()); /* must call LOCALE_init before calling this function */
     ASSERT(lx->pBank[lx->BankIndex]);       /* must load a table into bank before calling this function */
@@ -381,7 +381,7 @@ int LOCALE_getbanklanguageid(void)
 ;
 */
 
-int LOCALE_getbankstringcount(void)
+int LOCALE_getbankstringcount()
 {
     int StringCount = 0;
 
@@ -635,7 +635,7 @@ int LOCALE_loadtable(const char* PathName, int LanguageID)
 ;
 */
 
-void LOCALE_freetable(void)
+void LOCALE_freetable()
 {
 	if( lx != nullptr ) {
 

--- a/Core/Tools/Autorun/locale.h
+++ b/Core/Tools/Autorun/locale.h
@@ -44,18 +44,18 @@ const char *	LOCALE_getstr( const void *localefile, int stringid );
 #define			LOCALE_BANK_COUNT   8
 
 /* initialization/restore */
-int				LOCALE_init( void );										/* call before calling any other LOCALE functions */
-void			LOCALE_restore( void );										/* free all memory/resources allocated by LOCALE */
+int				LOCALE_init();										/* call before calling any other LOCALE functions */
+void			LOCALE_restore();										/* free all memory/resources allocated by LOCALE */
 
 /* attributes */
 void			LOCALE_setbank( int bankindex );							/* bankindex >= 0 && bankindex < LOCALE_BANK_COUNT */
-int				LOCALE_getbank( void );										/* returns current bank id */
-int				LOCALE_getbanklanguageid( void );							/* returns language id of the current bank */
-int				LOCALE_getbankstringcount( void );							/* returns the string string count in the current bank */
+int				LOCALE_getbank();										/* returns current bank id */
+int				LOCALE_getbanklanguageid();							/* returns language id of the current bank */
+int				LOCALE_getbankstringcount();							/* returns the string string count in the current bank */
 
 /* operations */
 int				LOCALE_loadtable( const char *pathname, int languageid );	/* load table into the current bank */
-void			LOCALE_freetable( void );									/* free table in the current bank */
+void			LOCALE_freetable();									/* free table in the current bank */
 const char *	LOCALE_getstring( int stringid );							/* use values in the .h file created by locomoto */
 
 /* maintain backwards compatibility */

--- a/Core/Tools/Babylon/Babylon.cpp
+++ b/Core/Tools/Babylon/Babylon.cpp
@@ -38,7 +38,7 @@ char AppTitle[200];
 CBabylonDlg *MainDLG = nullptr;
 
 static const char *AppName = "Babylon:";
-static int AlreadyRunning( void );
+static int AlreadyRunning();
 static HWND FoundWindow = nullptr;
 /////////////////////////////////////////////////////////////////////////////
 // CBabylonApp
@@ -169,7 +169,7 @@ static BOOL CALLBACK EnumAllWindowsProc(HWND hWnd, LPARAM lParam);
 static BOOL CALLBACK EnumAllWindowsProcExact(HWND hWnd, LPARAM lParam);
 static const char *szSearchTitle;
 
-static int AlreadyRunning( void )
+static int AlreadyRunning()
 {
 	BOOL found = FALSE;
 
@@ -182,7 +182,7 @@ static int AlreadyRunning( void )
 
 //--------------------------------------------------------------------------------
 
-int ExcelRunning( void )
+int ExcelRunning()
 {
 	BOOL found = FALSE;
 

--- a/Core/Tools/Babylon/Babylon.h
+++ b/Core/Tools/Babylon/Babylon.h
@@ -52,7 +52,7 @@ public:
 	DECLARE_MESSAGE_MAP()
 };
 
-int ExcelRunning( void );
+int ExcelRunning();
 extern TransDB				*BabylonstrDB;
 extern TransDB				*MainDB;
 extern char						BabylonstrFilename[];

--- a/Core/Tools/Babylon/BabylonDlg.cpp
+++ b/Core/Tools/Babylon/BabylonDlg.cpp
@@ -76,7 +76,7 @@ static void print_to_log_and_update_progress ( const char *text )
 	mainDlg->SetProgress ( cb_count );
 }
 
-static void cb_progress ( void )
+static void cb_progress ()
 {
 	cb_count++;
 	mainDlg->SetProgress ( cb_count );
@@ -109,7 +109,7 @@ static void init_info ( INFO *info )
 
 static int progress_count;
 
-static void progress_cb ( void )
+static void progress_cb ()
 {
 	progress_count++;
 	if ( MainDLG )
@@ -1035,7 +1035,7 @@ static int getLabelCount( char *filename )
 	return count;
 }
 
-int CBabylonDlg::LoadStrFile ( TransDB *db, const char *filename, void (*cb) ( void ) )
+int CBabylonDlg::LoadStrFile ( TransDB *db, const char *filename, void (*cb) () )
 {
 	FILE *file = nullptr;
 	BabylonLabel *label = nullptr;
@@ -1149,7 +1149,7 @@ exit:
 
 }
 
-int		CBabylonDlg::CanProceed ( void )
+int		CBabylonDlg::CanProceed ()
 {
 
 	if ( MainDB->IsChanged ())
@@ -1184,7 +1184,7 @@ retry:
 }
 
 
-int		CBabylonDlg::CanOperate ( void )
+int		CBabylonDlg::CanOperate ()
 {
 	if ( operate_always )
 	{

--- a/Core/Tools/Babylon/BabylonDlg.h
+++ b/Core/Tools/Babylon/BabylonDlg.h
@@ -79,21 +79,21 @@ public:
 	int RetranslateText ( BabylonText *text, BabylonText *label );
 	void VerifyDialog( TransDB *db, LangID langid);
 	void VerifyTranslations( TransDB *db, LangID langid ) ;
-	int	CanProceed ( void );
-	int	CanOperate ( void );
-	int SaveMainDB ( void );
+	int	CanProceed ();
+	int	CanOperate ();
+	int SaveMainDB ();
 	int UpdateLabel ( BabylonLabel *source, BabylonLabel *destination, UPDATEINFO &info, int update = TRUE, int skip = FALSE);
 	int UpdateDB ( TransDB *source, TransDB *destination, int update = TRUE);
-	void ProgressComplete ( void );
+	void ProgressComplete ();
 	void SetProgress ( int pos );
 	void InitProgress ( int range );
-	int SaveLog ( void );
+	int SaveLog ();
 	void Status ( const char *string, int log = TRUE);
 	void Log ( const char *string, LogFormat format = NEW_LINE );
 	CBabylonDlg(CWnd* pParent = nullptr);	// standard constructor
 	virtual ~CBabylonDlg();
-	int LoadStrFile ( TransDB *db, const char *fileaname, void (*cb ) (void ) = nullptr );
-	void Ready ( void ) { Status ( "Ready", FALSE ); ProgressComplete(); };
+	int LoadStrFile ( TransDB *db, const char *fileaname, void (*cb ) () = nullptr );
+	void Ready () { Status ( "Ready", FALSE ); ProgressComplete(); };
 
 // Dialog Data
 	//{{AFX_DATA(CBabylonDlg)

--- a/Core/Tools/Babylon/ExportDlg.h
+++ b/Core/Tools/Babylon/ExportDlg.h
@@ -36,9 +36,9 @@ class CExportDlg : public CDialog
 // Construction
 public:
 
-	LangID			Language ( void )			{ return langid; };
-	char*				Filename ( void )			{ return filename; };
-	TROPTIONS*	Options ( void )			{ return &options; };
+	LangID			Language ()			{ return langid; };
+	char*				Filename ()			{ return filename; };
+	TROPTIONS*	Options ()			{ return &options; };
 
 	CExportDlg(CWnd* pParent = nullptr);   // standard constructor
 

--- a/Core/Tools/Babylon/GenerateDlg.h
+++ b/Core/Tools/Babylon/GenerateDlg.h
@@ -45,9 +45,9 @@ class CGenerateDlg : public CDialog
 public:
 	CGenerateDlg(CWnd* pParent = nullptr);   // standard constructor
 
-	char*					FilePrefix	( void )		{ return filename; };
-	GNOPTIONS*		Options			( void )		{ return &options; };
-	LangID*				Langauges		( void )		{ return langids; };
+	char*					FilePrefix	()		{ return filename; };
+	GNOPTIONS*		Options			()		{ return &options; };
+	LangID*				Langauges		()		{ return langids; };
 
 // Dialog Data
 	//{{AFX_DATA(CGenerateDlg)

--- a/Core/Tools/Babylon/Report.h
+++ b/Core/Tools/Babylon/Report.h
@@ -46,9 +46,9 @@ class CReport : public CDialog
 public:
 	CReport(CWnd* pParent = nullptr);   // standard constructor
 
-	char*					Filename	( void )			{ return filename; };
-	RPOPTIONS*		Options			( void )		{ return &options; };
-	LangID*				Langauges		( void )		{ return langids; };
+	char*					Filename	()			{ return filename; };
+	RPOPTIONS*		Options			()		{ return &options; };
+	LangID*				Langauges		()		{ return langids; };
 
 // Dialog Data
 	//{{AFX_DATA(CReport)

--- a/Core/Tools/Babylon/TransDB.cpp
+++ b/Core/Tools/Babylon/TransDB.cpp
@@ -106,7 +106,7 @@ LANGINFO *GetLangInfo ( char *language )
 	return nullptr;
 }
 
-TransDB* FirstTransDB ( void )
+TransDB* FirstTransDB ()
 {
 	ListNode *first;
 
@@ -227,7 +227,7 @@ void					TransDB::RemoveObsolete ( BabylonText *text )
 	}
 }
 
-int					TransDB::NumLabelsChanged ( void )
+int					TransDB::NumLabelsChanged ()
 {
 	BabylonLabel	*label;
 	ListSearch sh;
@@ -248,7 +248,7 @@ int					TransDB::NumLabelsChanged ( void )
 	return changed;
 }
 
-int					TransDB::NumLabels ( void )
+int					TransDB::NumLabels ()
 {
 
 	return labels.NumItems();
@@ -356,7 +356,7 @@ BabylonText*			TransDB::FindText		( int id )
 	return (BabylonText *) text_id_bin->Get ( id );
 }
 
-BabylonText*			TransDB::FindNextText		( void )
+BabylonText*			TransDB::FindNextText		()
 {
 
 	return (BabylonText *) text_bin->GetNext ( );
@@ -367,14 +367,14 @@ BabylonText*			TransDB::FindObsolete		( OLECHAR *name )
 	return (BabylonText *) obsolete_bin->Get ( name );
 }
 
-BabylonText*			TransDB::FindNextObsolete		( void )
+BabylonText*			TransDB::FindNextObsolete		()
 {
 
 	return (BabylonText *) obsolete_bin->GetNext ( );
 
 }
 
-int					TransDB::Clear				( void )
+int					TransDB::Clear				()
 {
 	ListSearch sh;
 	BabylonLabel *label;
@@ -422,7 +422,7 @@ int					TransDB::Clear				( void )
 	return count;
 }
 
-void					TransDB::ClearChanges				( void )
+void					TransDB::ClearChanges				()
 {
 	ListSearch sh;
 	BabylonLabel *label;
@@ -444,7 +444,7 @@ void					TransDB::ClearChanges				( void )
 	NotChanged ();
 }
 
-void					TransDB::ClearProcessed				( void )
+void					TransDB::ClearProcessed				()
 {
 	ListSearch sh;
 	BabylonLabel *label;
@@ -458,7 +458,7 @@ void					TransDB::ClearProcessed				( void )
 	NotProcessed ();
 }
 
-void					TransDB::ClearMatched				( void )
+void					TransDB::ClearMatched				()
 {
 	ListSearch sh;
 	BabylonLabel *label;
@@ -472,7 +472,7 @@ void					TransDB::ClearMatched				( void )
 	NotMatched ();
 }
 
-void					TransDB::AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes, void (*cb) ( void ) )
+void					TransDB::AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes, void (*cb) () )
 {
 	HTREEITEM		item;
 	HTREEITEM		ilabels, iobsolete;
@@ -526,7 +526,7 @@ void					TransDB::AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes, voi
 
 }
 
-TransDB*			TransDB::Next				( void )
+TransDB*			TransDB::Next				()
 {
 	ListNode *next;
 
@@ -541,7 +541,7 @@ TransDB*			TransDB::Next				( void )
 
 }
 
-void BabylonLabel::init ( void )
+void BabylonLabel::init ()
 {
 	db = nullptr;
 	comment = nullptr;
@@ -550,7 +550,7 @@ void BabylonLabel::init ( void )
 	name = nullptr;
 }
 
-BabylonLabel::BabylonLabel ( void )
+BabylonLabel::BabylonLabel ()
 {
 	init ();
 	name = new OLEString ( );
@@ -572,7 +572,7 @@ BabylonLabel::~BabylonLabel ( )
 	delete listener;
 }
 
-void					BabylonLabel::Remove			( void )
+void					BabylonLabel::Remove			()
 {
 	if ( db )
 	{
@@ -609,7 +609,7 @@ void					BabylonLabel::AddText			( BabylonText *new_text )
 	new_text->SetLabel ( this );
 }
 
-int					BabylonLabel::Clear				( void )
+int					BabylonLabel::Clear				()
 {
 	ListSearch sh;
 	BabylonText *txt;
@@ -633,7 +633,7 @@ int					BabylonLabel::Clear				( void )
 	return count;
 }
 
-BabylonLabel*			BabylonLabel::Clone				( void )
+BabylonLabel*			BabylonLabel::Clone				()
 {
 	BabylonLabel *clone = new BabylonLabel();
 	BabylonText *txt;
@@ -722,7 +722,7 @@ void					BabylonLabel::SetDB				( TransDB *new_db )
 
 }
 
-void					BabylonLabel::ClearChanges				( void )
+void					BabylonLabel::ClearChanges				()
 {
 	BabylonText *ntext;
 	ListSearch sh;
@@ -740,7 +740,7 @@ void					BabylonLabel::ClearChanges				( void )
 
 }
 
-void					BabylonLabel::ClearProcessed				( void )
+void					BabylonLabel::ClearProcessed				()
 {
 	BabylonText *ntext;
 	ListSearch sh;
@@ -758,7 +758,7 @@ void					BabylonLabel::ClearProcessed				( void )
 
 }
 
-void					BabylonLabel::ClearMatched				( void )
+void					BabylonLabel::ClearMatched				()
 {
 	BabylonText *ntext;
 	ListSearch sh;
@@ -776,7 +776,7 @@ void					BabylonLabel::ClearMatched				( void )
 
 }
 
-int					BabylonLabel::AllMatched				( void )
+int					BabylonLabel::AllMatched				()
 {
 	BabylonText *ntext;
 	ListSearch sh;
@@ -796,7 +796,7 @@ int					BabylonLabel::AllMatched				( void )
 	return TRUE;
 }
 
-BabylonText::BabylonText( void )
+BabylonText::BabylonText()
 {
 	init ();
 	text = new OLEString (  );
@@ -804,7 +804,7 @@ BabylonText::BabylonText( void )
 
 }
 
-int BabylonText::IsSent ( void )
+int BabylonText::IsSent ()
 {
 	return sent;
 }
@@ -874,7 +874,7 @@ void					BabylonLabel::AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes
 
 }
 
-void BabylonText::init ( void )
+void BabylonText::init ()
 {
 	db = nullptr;
 	label = nullptr;
@@ -925,7 +925,7 @@ void					BabylonText::SetDB				( TransDB *new_db )
 
 }
 
-void					BabylonText::Remove			( void )
+void					BabylonText::Remove			()
 {
 	if ( label )
 	{
@@ -933,7 +933,7 @@ void					BabylonText::Remove			( void )
 	}
 }
 
-int						BabylonText::IsDialog ( void )
+int						BabylonText::IsDialog ()
 {
 
 	return strcmp (WaveSB(), "" );
@@ -1123,7 +1123,7 @@ Translation*			BabylonText::GetTranslation		( LangID langid )
 	return trans;
 }
 
-int					BabylonText::Clear				( void )
+int					BabylonText::Clear				()
 {
 	ListSearch sh;
 	Translation *trans;
@@ -1146,7 +1146,7 @@ int					BabylonText::Clear				( void )
 	return count;
 }
 
-BabylonText*			BabylonText::Clone				( void )
+BabylonText*			BabylonText::Clone				()
 {
 	BabylonText *clone = new BabylonText();
 	Translation *trans;
@@ -1168,7 +1168,7 @@ BabylonText*			BabylonText::Clone				( void )
 	return clone;
 }
 
-void					BabylonText::ClearChanges				( void )
+void					BabylonText::ClearChanges				()
 {
 	Translation *trans;
 	ListSearch sh;
@@ -1186,7 +1186,7 @@ void					BabylonText::ClearChanges				( void )
 
 }
 
-void					BabylonText::ClearProcessed				( void )
+void					BabylonText::ClearProcessed				()
 {
 	Translation *trans;
 	ListSearch sh;
@@ -1204,7 +1204,7 @@ void					BabylonText::ClearProcessed				( void )
 
 }
 
-void					BabylonText::ClearMatched				( void )
+void					BabylonText::ClearMatched				()
 {
 	Translation *trans;
 	ListSearch sh;
@@ -1222,7 +1222,7 @@ void					BabylonText::ClearMatched				( void )
 
 }
 
-void					BabylonText::AssignID ( void )
+void					BabylonText::AssignID ()
 {
 	if ( id != -1 )
 	{
@@ -1268,7 +1268,7 @@ void					BabylonText::Set ( char *string )
 	Changed ();
 }
 
-void					BabylonText::InvalidateAllWaves			( void  )
+void					BabylonText::InvalidateAllWaves			()
 {
 	Translation *trans;
 	ListSearch sh;
@@ -1286,7 +1286,7 @@ void					BabylonText::InvalidateAllWaves			( void  )
 
 }
 
-void					BabylonText::InvalidateWave			( void )
+void					BabylonText::InvalidateWave			()
 {
 
 	WaveInfo.SetValid ( FALSE );
@@ -1361,7 +1361,7 @@ void					BabylonText::AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes 
 
 }
 
-Translation::Translation ( void )
+Translation::Translation ()
 {
 	text = new OLEString (  );
 	comment = new OLEString (  );
@@ -1376,7 +1376,7 @@ Translation::~Translation ( )
 	delete comment;
 }
 
-int Translation::IsSent ( void )
+int Translation::IsSent ()
 {
 	return sent;
 }
@@ -1391,7 +1391,7 @@ void					Translation::SetDB				( TransDB *new_db )
 	db = new_db;
 }
 
-Translation*			Translation::Clone				( void )
+Translation*			Translation::Clone				()
 {
 	Translation *clone = new Translation();
 
@@ -1637,13 +1637,13 @@ int TransDB::Errors ( CBabylonDlg *dlg )
 	return errors;
 }
 
-CWaveInfo::CWaveInfo ( void )
+CWaveInfo::CWaveInfo ()
 {
 	wave_valid = FALSE;
 	missing = TRUE;
 }
 
-void TransDB::VerifyDialog( LangID langid, void (*cb) (void) )
+void TransDB::VerifyDialog( LangID langid, void (*cb) () )
 {
 	BabylonLabel *label;
 	ListSearch sh_label;

--- a/Core/Tools/Babylon/TransDB.h
+++ b/Core/Tools/Babylon/TransDB.h
@@ -102,14 +102,14 @@ class CWaveInfo
 
 	public:
 
-	CWaveInfo ( void );
-	int						Valid		( void )									{ return wave_valid; };
-	DWORD					Lo			( void )									{ return wave_size_lo; };
-	DWORD					Hi			( void )									{ return wave_size_hi; };
+	CWaveInfo ();
+	int						Valid		()									{ return wave_valid; };
+	DWORD					Lo			()									{ return wave_size_lo; };
+	DWORD					Hi			()									{ return wave_size_hi; };
 	void					SetValid( int new_valid )					{ wave_valid = new_valid; };
 	void					SetLo		( DWORD new_lo )					{ wave_size_lo = new_lo; };
 	void					SetHi		( DWORD new_hi )					{ wave_size_hi = new_hi; };
-	int						Missing ( void )									{ return missing; };
+	int						Missing ()									{ return missing; };
 	void					SetMissing ( int val )						{ missing = val;  };
 };
 
@@ -123,19 +123,19 @@ class DBAttribs
 
 	public:
 
-	DBAttribs( void )													{ parent = nullptr; changed = FALSE; processed = FALSE; match = nullptr; };
+	DBAttribs()													{ parent = nullptr; changed = FALSE; processed = FALSE; match = nullptr; };
 
 	void	SetParent ( DBAttribs *new_parent )	{ parent = new_parent; };
-	int		IsChanged ( void )									{ return changed; };
-	void	Changed ( void )										{ changed = TRUE; if ( parent ) parent->Changed(); };
-	void	NotChanged ( void )									{ changed = FALSE; };
-	char	ChangedSymbol ( void )							{ return changed ? '*' :' '; };
-	int		IsProcessed ( void )								{ return processed; };
-	void	Processed ( void )									{ processed = TRUE; };
-	void	NotProcessed ( void )								{ processed = FALSE; };
-	void*	Matched ( void )										{ return match; };
+	int		IsChanged ()									{ return changed; };
+	void	Changed ()										{ changed = TRUE; if ( parent ) parent->Changed(); };
+	void	NotChanged ()									{ changed = FALSE; };
+	char	ChangedSymbol ()							{ return changed ? '*' :' '; };
+	int		IsProcessed ()								{ return processed; };
+	void	Processed ()									{ processed = TRUE; };
+	void	NotProcessed ()								{ processed = FALSE; };
+	void*	Matched ()										{ return match; };
 	void	Match ( void* new_match )						{ match = new_match; };
-	void	NotMatched ( void )									{ match = nullptr; };
+	void	NotMatched ()									{ match = nullptr; };
 
 
 };
@@ -159,34 +159,34 @@ class Translation : public DBAttribs
 
 	CWaveInfo			WaveInfo;
 
-	Translation ( void );
+	Translation ();
 	~Translation ( );
 
 	void					SetDB				( TransDB *new_db );
-	Translation*	Clone				( void );
+	Translation*	Clone				();
 	void					SetLangID		( LangID new_id )					{ langid = new_id; };
-	TransDB*			DB					( void )									{ return db; };
-	void					ClearChanges (void)										{ NotChanged(); };
-	void					ClearProcessed (void)									{ NotProcessed(); };
-	void					ClearMatched (void)										{ NotMatched(); };
-	int						Clear				( void )									{ return 0;};
+	TransDB*			DB					()									{ return db; };
+	void					ClearChanges ()										{ NotChanged(); };
+	void					ClearProcessed ()									{ NotProcessed(); };
+	void					ClearMatched ()										{ NotMatched(); };
+	int						Clear				()									{ return 0;};
 	void					Set					( OLECHAR *string )				{ text->Set ( string ); Changed();};
 	void					Set					( char *string )					{ text->Set ( string ); Changed(); };
-	OLECHAR*			Get					( void )									{ return text->Get (); };
-	int						Len					( void )									{ return text->Len (); };
-	char*					GetSB				( void )									{ return text->GetSB (); };
+	OLECHAR*			Get					()									{ return text->Get (); };
+	int						Len					()									{ return text->Len (); };
+	char*					GetSB				()									{ return text->GetSB (); };
 	void					SetComment	( OLECHAR *string )				{ comment->Set ( string ); Changed(); };
 	void					SetComment	( char *string )					{ comment->Set ( string ); Changed(); };
-	OLECHAR*			Comment			( void )									{ return comment->Get(); };
-	char*					CommentSB		( void )									{ return comment->GetSB(); };
-	int						Revision		( void )									{ return revision; };
+	OLECHAR*			Comment			()									{ return comment->Get(); };
+	char*					CommentSB		()									{ return comment->GetSB(); };
+	int						Revision		()									{ return revision; };
 	void					SetRevision	( int new_rev )						{ revision = new_rev; Changed(); };
-	LangID				GetLangID		( void )									{ return langid; };
-	const char*		Language		( void )									{ return GetLangName ( langid );};
+	LangID				GetLangID		()									{ return langid; };
+	const char*		Language		()									{ return GetLangName ( langid );};
 	void					AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes = FALSE );
 	int						TooLong			( int maxlen );
 	int						ValidateFormat ( BabylonText *text );
-	int						IsSent ( void );
+	int						IsSent ();
 	void						Sent ( int val );
 };
 
@@ -205,12 +205,12 @@ class BabylonText : public DBAttribs
 	int						retranslate;
 	int						sent;
 
-	void init ( void );
+	void init ();
 
 	public:
 	CWaveInfo			WaveInfo;
 
-	BabylonText( void );
+	BabylonText();
 	~BabylonText( );
 
 	void					AddTranslation ( Translation *trans );
@@ -218,45 +218,45 @@ class BabylonText : public DBAttribs
 	Translation*	NextTranslation ( ListSearch &sh );
 	Translation*	GetTranslation ( LangID langid );
 	void					SetDB				( TransDB *new_db );
-	void					ClearChanges ( void );
-	void					ClearProcessed ( void );
-	void					ClearMatched ( void );
-	int						Clear				( void );
-	BabylonText*			Clone				( void );
-	void					Remove			( void );
-	void					AssignID		( void );
+	void					ClearChanges ();
+	void					ClearProcessed ();
+	void					ClearMatched ();
+	int						Clear				();
+	BabylonText*			Clone				();
+	void					Remove			();
+	void					AssignID		();
 	void					Set					( OLECHAR *string );
 	void					Set					( char *string );
 	void					SetID				( int new_id )						{ id = new_id; Changed(); };
-	int						ID					( void )									{ return id; };
-	void					LockText		( void )									{ text->Lock(); };
-	TransDB*			DB					( void )									{ return db; };
-	OLECHAR*			Get					( void )									{ return text->Get (); } ;
-	int						Len					( void )									{ return text->Len (); };
-	char*					GetSB				( void )									{ return text->GetSB (); } ;
+	int						ID					()									{ return id; };
+	void					LockText		()									{ text->Lock(); };
+	TransDB*			DB					()									{ return db; };
+	OLECHAR*			Get					()									{ return text->Get (); } ;
+	int						Len					()									{ return text->Len (); };
+	char*					GetSB				()									{ return text->GetSB (); } ;
 	void					SetWave			( OLECHAR *string )				{ wavefile->Set ( string ); Changed(); InvalidateAllWaves (); };
 	void					SetWave			( char *string )					{ wavefile->Set ( string ); Changed(); InvalidateAllWaves (); };
 	void					SetLabel		( BabylonLabel *new_label )		{ label = new_label; };
 	void					SetRetranslate ( int flag = TRUE )		{ retranslate = flag;};
-	int						Retranslate ( void )									{ return retranslate; };
-	OLECHAR*			Wave				( void )									{ return wavefile->Get (); } ;
-	char*					WaveSB			( void )									{ return wavefile->GetSB (); } ;
-	BabylonLabel*			Label				( void )									{ return label; } ;
-	int						Revision		( void )									{ return revision; } ;
+	int						Retranslate ()									{ return retranslate; };
+	OLECHAR*			Wave				()									{ return wavefile->Get (); } ;
+	char*					WaveSB			()									{ return wavefile->GetSB (); } ;
+	BabylonLabel*			Label				()									{ return label; } ;
+	int						Revision		()									{ return revision; } ;
 	void					SetRevision	( int new_rev )						{ revision = new_rev; Changed(); } ;
-	void					IncRevision ( void )									{ revision++; Changed(); };
+	void					IncRevision ()									{ revision++; Changed(); };
 	void					AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes = FALSE );
-	int						LineNumber	( void )									{ return line_number; };
+	int						LineNumber	()									{ return line_number; };
 	void					SetLineNumber	( int line )						{ line_number = line; Changed(); };
-	void					FormatMetaString ( void )							{ text->FormatMetaString (); Changed();};
-	int						IsDialog ( void );
+	void					FormatMetaString ()							{ text->FormatMetaString (); Changed();};
+	int						IsDialog ();
 	int						DialogIsPresent ( const char *path, LangID langid = LANGID_US  );
 	int						DialogIsValid ( const char *path, LangID langid = LANGID_US, int check = TRUE );
 	int						ValidateDialog( const char *path, LangID langid = LANGID_US );
-	void					InvalidateAllWaves ( void );
-	void					InvalidateWave ( void );
+	void					InvalidateAllWaves ();
+	void					InvalidateWave ();
 	void					InvalidateWave ( LangID langid );
-	int						IsSent ( void );
+	int						IsSent ();
 	void						Sent ( int val );
 
 };
@@ -276,33 +276,33 @@ class BabylonLabel : public DBAttribs
 	unsigned int	line_number;
 	List					text;
 
-	void init ( void );
+	void init ();
 
 	public:
 
-	BabylonLabel ( void );
+	BabylonLabel ();
 	~BabylonLabel ( );
 
-	int						Clear				( void );
-	void					ClearChanges ( void );
-	void					ClearProcessed ( void );
-	void					ClearMatched ( void );
-	int						AllMatched	( void );
-	void					Remove			( void );
+	int						Clear				();
+	void					ClearChanges ();
+	void					ClearProcessed ();
+	void					ClearMatched ();
+	int						AllMatched	();
+	void					Remove			();
 	void					AddText			( BabylonText *new_text );
 	void					RemoveText	( BabylonText *new_text );
 	BabylonText*			FirstText		( ListSearch& sh );
 	BabylonText*			NextText		( ListSearch& sh);
 	BabylonText*			FindText		( OLECHAR *find_text );
 	void					SetDB				( TransDB *new_db );
-	BabylonLabel*			Clone				( void );
-	int						NumStrings	( void )									{ return text.NumItems(); };
+	BabylonLabel*			Clone				();
+	int						NumStrings	()									{ return text.NumItems(); };
 	void					SetMaxLen		( int max )								{ max_len = max; Changed(); };
-	int						MaxLen			( void )									{ return max_len; };
+	int						MaxLen			()									{ return max_len; };
 	void					SetLineNumber( int line )							{ line_number = line; Changed(); };
-	int						LineNumber	( void )									{ return line_number; };
-	TransDB*			DB					( void )									{ return db;};
-	void					LockName		( void )									{ name->Lock(); };
+	int						LineNumber	()									{ return line_number; };
+	TransDB*			DB					()									{ return db;};
+	void					LockName		()									{ name->Lock(); };
 	void					SetName			( OLECHAR *string )				{ name->Set ( string ); Changed(); };
 	void					SetName			( char *string )					{ name->Set ( string ); Changed(); };
 	void					SetComment	( OLECHAR *string )				{ comment->Set ( string ); Changed(); };
@@ -314,18 +314,18 @@ class BabylonLabel : public DBAttribs
 	void					SetListener	( char *string )					{ listener->Set ( string ); Changed(); };
 	void					SetListener	( OLECHAR *string )				{ listener->Set ( string ); Changed(); };
 
-	OLECHAR*			Name				( void )									{ return name->Get (); };
-	OLECHAR*			Comment			( void )									{ return comment->Get(); };
-	OLECHAR*			Context			( void )									{ return context->Get(); };
-	OLECHAR*			Speaker			( void )									{ return speaker->Get(); };
-	OLECHAR*			Listener		( void )									{ return listener->Get(); };
+	OLECHAR*			Name				()									{ return name->Get (); };
+	OLECHAR*			Comment			()									{ return comment->Get(); };
+	OLECHAR*			Context			()									{ return context->Get(); };
+	OLECHAR*			Speaker			()									{ return speaker->Get(); };
+	OLECHAR*			Listener		()									{ return listener->Get(); };
 
 
-	char*					NameSB	 		( void )									{ return name->GetSB (); };
-	char*					CommentSB		( void )									{ return comment->GetSB(); };
-	char*					ContextSB		( void )									{ return context->GetSB(); };
-	char*					SpeakerSB		( void )									{ return speaker->GetSB(); };
-	char*					ListenerSB	( void )									{ return listener->GetSB(); };
+	char*					NameSB	 		()									{ return name->GetSB (); };
+	char*					CommentSB		()									{ return comment->GetSB(); };
+	char*					ContextSB		()									{ return context->GetSB(); };
+	char*					SpeakerSB		()									{ return speaker->GetSB(); };
+	char*					ListenerSB	()									{ return listener->GetSB(); };
 
 	void					AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes = FALSE );
 
@@ -360,7 +360,7 @@ class TransDB : public DBAttribs
 	~TransDB ( );
 
 	void					InvalidateDialog( LangID langid );
-	void					VerifyDialog( LangID langid, void (*cb) ( void ) = nullptr  );
+	void					VerifyDialog( LangID langid, void (*cb) () = nullptr  );
 	int						ReportDialog( DLGREPORT *report, LangID langid, void (*print) ( const char *)= nullptr, PMASK pmask= PMASK_ALL );
 	int						ReportTranslations( TRNREPORT *report, LangID langid, void (*print) ( const char *) = nullptr, PMASK pmask = PMASK_ALL );
 	void					ReportDuplicates ( CBabylonDlg *dlg = nullptr );
@@ -371,11 +371,11 @@ class TransDB : public DBAttribs
 	void					RemoveText	( BabylonText *text );
 	void					RemoveObsolete	( BabylonText *text );
 	int						Errors		( CBabylonDlg *dlg = nullptr );
-	int						HasErrors ( void ) { return checked_for_errors ? last_error_count != 0 : FALSE; };
+	int						HasErrors () { return checked_for_errors ? last_error_count != 0 : FALSE; };
 	int						Warnings		( CBabylonDlg *dlg = nullptr );
-	int						NumLabelsChanged	( void );
-	int						NumLabels		( void );
-	int						NumObsolete		( void ) { return num_obsolete; };
+	int						NumLabelsChanged	();
+	int						NumLabels		();
+	int						NumObsolete		() { return num_obsolete; };
 	BabylonLabel*			FirstLabel	( ListSearch& sh );
 	BabylonLabel*			NextLabel		( ListSearch& sh);
 	BabylonText*			FirstObsolete	( ListSearch& sh );
@@ -384,24 +384,24 @@ class TransDB : public DBAttribs
 	BabylonText*			FindText		( OLECHAR *text );
 	BabylonText*			FindSubText	( OLECHAR *text, int item = 0 );
 	BabylonText*			FindText		( int id );
-	BabylonText*			FindNextText ( void );
+	BabylonText*			FindNextText ();
 	BabylonText*			FindObsolete		( OLECHAR *text );
-	BabylonText*			FindNextObsolete ( void );
-	int						Clear				( void );
-	void					ClearChanges ( void );
-	void					ClearProcessed ( void );
-	void					ClearMatched ( void );
-	TransDB*			Next				( void );
-	void					AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes = FALSE, void (*cb) ( void ) = nullptr );
-	char*					Name				( void )							{ return name;};
-	void					EnableIDs		( void )							{ next_string_id = START_STRING_ID; };
-	int						NewID				( void )							{ if ( next_string_id != -1)  return next_string_id++; else return -1; };
-	int						ID					( void )							{ return next_string_id; };
+	BabylonText*			FindNextObsolete ();
+	int						Clear				();
+	void					ClearChanges ();
+	void					ClearProcessed ();
+	void					ClearMatched ();
+	TransDB*			Next				();
+	void					AddToTree		( CTreeCtrl *tc, HTREEITEM parent, int changes = FALSE, void (*cb) () = nullptr );
+	char*					Name				()							{ return name;};
+	void					EnableIDs		()							{ next_string_id = START_STRING_ID; };
+	int						NewID				()							{ if ( next_string_id != -1)  return next_string_id++; else return -1; };
+	int						ID					()							{ return next_string_id; };
 	void					SetID				( int new_id )				{ next_string_id = new_id; };
-	int						IsValid			( void )							{ return valid; };
-	void					InValid			( void )							{ valid = FALSE; };
-	int						DuplicatesAllowed ( void )				{ return flags & TRANSDB_OPTION_DUP_TEXT;};
-	int						MultiTextAllowed ( void )					{ return flags & TRANSDB_OPTION_MULTI_TEXT;};
+	int						IsValid			()							{ return valid; };
+	void					InValid			()							{ valid = FALSE; };
+	int						DuplicatesAllowed ()				{ return flags & TRANSDB_OPTION_DUP_TEXT;};
+	int						MultiTextAllowed ()					{ return flags & TRANSDB_OPTION_MULTI_TEXT;};
 	void					AllowDupiclates ( int yes = TRUE) { yes ? flags |= TRANSDB_OPTION_DUP_TEXT : flags &= ~(TRANSDB_OPTION_DUP_TEXT ); };
 	void					AllowMultiText  ( int yes = TRUE) { yes ? flags |= TRANSDB_OPTION_MULTI_TEXT : flags &= ~(TRANSDB_OPTION_MULTI_TEXT ); };
 };
@@ -415,11 +415,11 @@ class DupNode : public ListNode
 	public:
 	DupNode ( BabylonText *dup, BabylonText *orig ) { original = orig; duplicate = dup, SetPriority ( orig->LineNumber ());};
 
-	BabylonText *Duplicate ( void ) { return duplicate; };
-	BabylonText *Original ( void ) { return original; };
+	BabylonText *Duplicate () { return duplicate; };
+	BabylonText *Original () { return original; };
 
 };
 
 
 
-extern TransDB* FirstTransDB ( void );
+extern TransDB* FirstTransDB ();

--- a/Core/Tools/Babylon/VIEWDBSII.h
+++ b/Core/Tools/Babylon/VIEWDBSII.h
@@ -32,8 +32,8 @@ public:
 
 	void OnClose();
 	BOOL OnInitDialog();
-	HTREEITEM create_changes_view ( void );
-	HTREEITEM create_full_view ( void );
+	HTREEITEM create_changes_view ();
+	HTREEITEM create_full_view ();
 
 // Dialog Data
 	//{{AFX_DATA(VIEWDBSII)

--- a/Core/Tools/Babylon/VerifyDlg.cpp
+++ b/Core/Tools/Babylon/VerifyDlg.cpp
@@ -205,7 +205,7 @@ void VerifyDlg::OnPause()
 
 }
 
-void VerifyDlg::CloseAudio ( void )
+void VerifyDlg::CloseAudio ()
 {
 	#if 0
 	if ( stream )

--- a/Core/Tools/Babylon/VerifyDlg.h
+++ b/Core/Tools/Babylon/VerifyDlg.h
@@ -42,7 +42,7 @@ class VerifyDlg : public CDialog
 // Construction
 public:
 	VerifyDlg(BabylonText *ntext, LangID langid, const char *path, CWnd* pParent = nullptr);   // standard constructor
-	void CloseAudio ( void );
+	void CloseAudio ();
 
 // Dialog Data
 	//{{AFX_DATA(VerifyDlg)

--- a/Core/Tools/Babylon/ViewDBsDlg.cpp
+++ b/Core/Tools/Babylon/ViewDBsDlg.cpp
@@ -65,7 +65,7 @@ END_MESSAGE_MAP()
 // CViewDBsDlg message handlers
 
 static int label_count;
-static void progress_cb ( void )
+static void progress_cb ()
 {
 	label_count++;
 	if ( MainDLG )
@@ -74,7 +74,7 @@ static void progress_cb ( void )
 	}
 }
 
-HTREEITEM VIEWDBSII::create_full_view ( void )
+HTREEITEM VIEWDBSII::create_full_view ()
 {
 	CTreeCtrl *tc = ( CTreeCtrl *) GetDlgItem ( IDC_TREEVIEW );
 	HTREEITEM	root;
@@ -118,7 +118,7 @@ HTREEITEM VIEWDBSII::create_full_view ( void )
 	return root;
 }
 
-HTREEITEM VIEWDBSII::create_changes_view ( void )
+HTREEITEM VIEWDBSII::create_changes_view ()
 {
 	CTreeCtrl *tc = ( CTreeCtrl *) GetDlgItem ( IDC_TREEVIEW );
 	HTREEITEM	root;

--- a/Core/Tools/Babylon/XLStuff.cpp
+++ b/Core/Tools/Babylon/XLStuff.cpp
@@ -367,7 +367,7 @@ error:
 
 }
 
-int OpenExcel ( void )
+int OpenExcel ()
 {
 	LPDISPATCH dispatch;
 
@@ -457,7 +457,7 @@ error_access:
 }
 
 
-void CloseExcel ( void )
+void CloseExcel ()
 {
 	CloseWorkBook ();
 
@@ -592,7 +592,7 @@ int SaveWorkBook ( const char *filename, int protect )
 
 }
 
-void CloseWorkBook ( void )
+void CloseWorkBook ()
 {
 	if ( workbook )
 	{
@@ -604,7 +604,7 @@ void CloseWorkBook ( void )
 
 }
 
-void SelectActiveSheet ( void )
+void SelectActiveSheet ()
 {
 	LPDISPATCH dispatch;
 

--- a/Core/Tools/Babylon/XLStuff.h
+++ b/Core/Tools/Babylon/XLStuff.h
@@ -243,15 +243,15 @@ enum {
 
 
 
-int OpenExcel ( void );
-void CloseExcel ( void );
+int OpenExcel ();
+void CloseExcel ();
 int NewWorkBook ( const char *path );
 int SaveWorkBook ( const char *filename, int protect = FALSE );
 int OpenWorkBook ( const char *filename );
-void CloseWorkBook ( void );
+void CloseWorkBook ();
 int PutCell ( int row, int column, const OLECHAR *string, int val );
 int PutSeparator ( int row );
 int PutSection ( int row, const OLECHAR *title );
-void SelectActiveSheet ( void );
+void SelectActiveSheet ();
 int GetInt ( int row, int cell );
 int GetString ( int row, int cell, OLECHAR *buffer );

--- a/Core/Tools/Babylon/bin.cpp
+++ b/Core/Tools/Babylon/bin.cpp
@@ -45,7 +45,7 @@ Bin::~Bin ( )
 
 
 
-void Bin::Clear ( void )
+void Bin::Clear ()
 {
 	int count = num_buckets;
 	sh_item = nullptr;
@@ -74,7 +74,7 @@ void*				Bin::Get					( OLECHAR *text1, OLECHAR *text2 )
 	return nullptr;
 }
 
-void*				Bin::GetNext			( void )
+void*				Bin::GetNext			()
 {
 	BinItem *item;
 
@@ -128,7 +128,7 @@ BinItem*		Bin::GetBinItem		( OLECHAR *text1, OLECHAR *text2)
 	return GetNextBinItem ();
 }
 
-BinItem*		Bin::GetNextBinItem ( void )
+BinItem*		Bin::GetNextBinItem ()
 {
 	if ( sh_item )
 	{
@@ -277,7 +277,7 @@ BinID::~BinID ( )
 
 
 
-void BinID::Clear ( void )
+void BinID::Clear ()
 {
 	int count = num_buckets;
 

--- a/Core/Tools/Babylon/bin.h
+++ b/Core/Tools/Babylon/bin.h
@@ -55,13 +55,13 @@ class Bin
 	Bin ( int size = 256 );
 	~Bin ();
 
-	void				Clear				( void );
+	void				Clear				();
 	void*				Get					( OLECHAR *text1, OLECHAR *text2 = nullptr );
-	void*				GetNext			( void );
+	void*				GetNext			();
 	void				Add					( void *item, OLECHAR *text1, OLECHAR *text2 = nullptr );
 	BinItem*		GetBinItem	( OLECHAR *text1, OLECHAR *text2 = nullptr );
 	BinItem*		GetBinItem	( void *item );
-	BinItem*		GetNextBinItem	( void );
+	BinItem*		GetNextBinItem	();
 	void				Remove			( void *item );
 	void				Remove			( OLECHAR *text1, OLECHAR *text2 = nullptr );
 	void				Remove			( BinItem *item );
@@ -90,7 +90,7 @@ class BinID
 	BinID ( int size = 256 );
 	~BinID ();
 
-	void				Clear				( void );
+	void				Clear				();
 	void*				Get					( int id );
 	void				Add					( void *item, int id  );
 	BinIDItem*	GetBinIDItem	( int id );

--- a/Core/Tools/Babylon/expimp.cpp
+++ b/Core/Tools/Babylon/expimp.cpp
@@ -40,7 +40,7 @@ static OLECHAR oletrans[100*1024];
 static CBabylonDlg *progress_dlg;
 static int progress_count;
 
-static void progress_cb ( void )
+static void progress_cb ()
 {
 	progress_count ++;
 
@@ -212,7 +212,7 @@ static void writeText ( BabylonText *text, int row )
 	writeLabel ( label, row );
 }
 
-static int export_trans ( TransDB *db, LangID langid, TROPTIONS *options, void (*cb) (void ), int write )
+static int export_trans ( TransDB *db, LangID langid, TROPTIONS *options, void (*cb) (), int write )
 {
 	BabylonLabel *label;
 	BabylonText *text;
@@ -539,7 +539,7 @@ int ExportTranslations ( TransDB *db, const char *filename, LangID langid, TROPT
 }
 
 
-static int import_trans ( TransDB *db, LangID langid, void (*cb) ( void ), CBabylonDlg *dlg )
+static int import_trans ( TransDB *db, LangID langid, void (*cb) (), CBabylonDlg *dlg )
 {
 	int row = 3;
 	int id;
@@ -734,7 +734,7 @@ done:
 	return count;
 }
 
-static int update_sent_trans ( TransDB *db, LangID langid, void (*cb) ( void ), CBabylonDlg *dlg )
+static int update_sent_trans ( TransDB *db, LangID langid, void (*cb) (), CBabylonDlg *dlg )
 {
 	int row = 3;
 	int id;

--- a/Core/Tools/Babylon/list.cpp
+++ b/Core/Tools/Babylon/list.cpp
@@ -25,7 +25,7 @@
 #include <assert.h>
 #include "list.h"
 
-ListNode::ListNode	( void )
+ListNode::ListNode	()
 {
 	prev = next = this;
 	pri = NORMAL_PRIORITY;
@@ -60,14 +60,14 @@ void				ListNode::Link ( ListNode *node)
 	node->prev = next;
 }
 
-void				ListNode::Remove			( void )
+void				ListNode::Remove			()
 {
 	prev->next = next;
 	next->prev = prev;
 	prev = next = this;		/* so we know that the node is not in a list */
 }
 
-ListNode*		ListNode::Next				( void )
+ListNode*		ListNode::Next				()
 {
 	if ( next->IsHead ( ) )
 	{
@@ -77,7 +77,7 @@ ListNode*		ListNode::Next				( void )
 	return next;
 }
 
-ListNode*		ListNode::Prev				( void )
+ListNode*		ListNode::Prev				()
 {
 	if ( prev->IsHead () )
 	{
@@ -87,7 +87,7 @@ ListNode*		ListNode::Prev				( void )
 	return prev;
 }
 
-ListNode*		ListNode::NextLoop		( void )
+ListNode*		ListNode::NextLoop		()
 {
 	ListNode *next_node = next;
 
@@ -105,7 +105,7 @@ ListNode*		ListNode::NextLoop		( void )
 
 }
 
-ListNode*		ListNode::PrevLoop		( void )
+ListNode*		ListNode::PrevLoop		()
 {
 	ListNode *prev_node = prev;
 
@@ -122,7 +122,7 @@ ListNode*		ListNode::PrevLoop		( void )
 	return prev_node;
 }
 
-void*				ListNode::Item				( void )
+void*				ListNode::Item				()
 {
 
 	assert ( !IsHead () );
@@ -137,18 +137,18 @@ void				ListNode::SetItem			( void *new_item )
 	item = new_item	;
 }
 
-int					ListNode::InList			( void )
+int					ListNode::InList			()
 {
 
 	return prev != this;
 }
 
-int					ListNode::IsHead			( void )
+int					ListNode::IsHead			()
 {
 	return item == &this->item;
 }
 
-int					ListNode::Priority		( void )
+int					ListNode::Priority		()
 {
 	return pri;
 
@@ -162,7 +162,7 @@ void				ListNode::SetPriority ( int new_pri )
 
 }
 
-List::List ( void )
+List::List ()
 {
 
 	SetItem ( &this->item );
@@ -231,7 +231,7 @@ void				List::Merge			( List *list )
 
 }
 
-int					List::NumItems  ( void )
+int					List::NumItems  ()
 {
 	int count = 0;
 	ListNode *node;
@@ -268,21 +268,21 @@ void*				List::Item			( int list_index )
 	return nullptr;
 }
 
-ListNode*		List::FirstNode ( void )
+ListNode*		List::FirstNode ()
 {
 	assert ( IsHead ());
 	return Next ();
 
 }
 
-ListNode*		List::LastNode ( void )
+ListNode*		List::LastNode ()
 {
 	assert ( IsHead ());
 	return Prev ();
 
 }
 
-int					List::IsEmpty		( void )
+int					List::IsEmpty		()
 {
 	assert ( IsHead ());
 
@@ -290,7 +290,7 @@ int					List::IsEmpty		( void )
 
 }
 
-void				List::Empty			( void )
+void				List::Empty			()
 {
 	assert ( IsHead ());
 	Remove ();

--- a/Core/Tools/Babylon/list.h
+++ b/Core/Tools/Babylon/list.h
@@ -34,20 +34,20 @@ class ListNode
 
 	public:
 
-							ListNode		( void );
+							ListNode		();
 	void				Append			( ListNode *node );
 	void				Prepend			( ListNode *node );
 	void				Link				( ListNode *node);
-	void				Remove			( void );
-	ListNode*		Next				( void );
-	ListNode*		Prev				( void );
-	ListNode*		NextLoop		( void );
-	ListNode*		PrevLoop		( void );
-	void*				Item				( void );
+	void				Remove			();
+	ListNode*		Next				();
+	ListNode*		Prev				();
+	ListNode*		NextLoop		();
+	ListNode*		PrevLoop		();
+	void*				Item				();
 	void				SetItem			( void *item );
-	int					InList			( void );
-	int					IsHead			( void );
-	int					Priority		( void );
+	int					InList			();
+	int					IsHead			();
+	int					Priority		();
 	void				SetPriority ( int new_pri );
 
 
@@ -57,17 +57,17 @@ class List: public ListNode
 {
 
 	public:
-	List ( void );
+	List ();
 	void				AddToTail ( ListNode *node );
 	void				AddToHead ( ListNode *node );
 	void				Add				( ListNode *node );
 	void				Merge			( List *list );
-	int					NumItems  ( void );
+	int					NumItems  ();
 	void*				Item			( int list_index );
-	ListNode*		FirstNode ( void );
-	ListNode*		LastNode	( void );
-	int					IsEmpty		( void );
-	void				Empty			( void );
+	ListNode*		FirstNode ();
+	ListNode*		LastNode	();
+	int					IsEmpty		();
+	void				Empty			();
 	ListNode*		Find			( void *item );
 
 };
@@ -79,10 +79,10 @@ class ListSearch
 
 	public:
 
-	ListNode*		Next ( void ) { if (node) { node = node->Next ();} return node;};
-	ListNode*		Prev ( void ) { if (node) { node = node->Prev ();} return node;};
-	ListNode*		FirstNode ( void ) { node = head; return Next (); };
-	ListNode*		LastNode ( void ) { node = head; return Prev (); };
+	ListNode*		Next () { if (node) { node = node->Next ();} return node;};
+	ListNode*		Prev () { if (node) { node = node->Prev ();} return node;};
+	ListNode*		FirstNode () { node = head; return Next (); };
+	ListNode*		LastNode () { node = head; return Prev (); };
 	ListNode*		FirstNode ( List *new_head ) { node = head = new_head; return Next (); };
 	ListNode*		LastNode ( List *new_head) { node = head = new_head; return Prev (); };
 

--- a/Core/Tools/Babylon/loadsave.cpp
+++ b/Core/Tools/Babylon/loadsave.cpp
@@ -337,7 +337,7 @@ error:
 	return ok;
 }
 
-int LoadMainDB(TransDB *db, const char *filename, void (*cb) (void) )
+int LoadMainDB(TransDB *db, const char *filename, void (*cb) () )
 {
 	BabylonLabel	*label = nullptr;
 	BabylonText		*text = nullptr;

--- a/Core/Tools/Babylon/loadsave.h
+++ b/Core/Tools/Babylon/loadsave.h
@@ -23,5 +23,5 @@
 #pragma once
 
 int WriteMainDB(TransDB *db, const char *filename, CBabylonDlg *dlg );
-int LoadMainDB(TransDB *db, const char *filename, void (*cb) (void ) = nullptr );
+int LoadMainDB(TransDB *db, const char *filename, void (*cb) () = nullptr );
 int	GetLabelCountDB ( char *filename );

--- a/Core/Tools/Babylon/olestring.cpp
+++ b/Core/Tools/Babylon/olestring.cpp
@@ -60,7 +60,7 @@ template <typename text>int IsFormatTypeChar ( text ch )
 
 
 
-OLEString::OLEString ( void )
+OLEString::OLEString ()
 {
 	ole = nullptr;
 	sb = nullptr;
@@ -123,7 +123,7 @@ void OLEString::Set ( const char *new_sb )
 	}
 }
 
-void OLEString::StripSpaces ( void )
+void OLEString::StripSpaces ()
 {
 	if ( locked )
 	{
@@ -141,7 +141,7 @@ void OLEString::StripSpaces ( void )
 }
 
 
-void OLEString::FormatMetaString ( void )
+void OLEString::FormatMetaString ()
 {
 	char *str, *ptr;
 	char ch, last = -1;

--- a/Core/Tools/Babylon/olestring.h
+++ b/Core/Tools/Babylon/olestring.h
@@ -34,17 +34,17 @@ class OLEString
 
 	public:
 
-	OLEString ( void ) ;
+	OLEString () ;
 	~OLEString ();
 	void		Set ( OLECHAR *new_ole );
 	void		Set ( const char *new_sb );
-	OLECHAR*Get ( void ) { return ole; };
-	int			Len ( void ) { return len; };
-	char*		GetSB ( void ) { return sb; };
-	void		StripSpaces ( void );
-	void		FormatMetaString ( void );
-	void		Lock ( void )	{ locked = TRUE; };
-	void		Unlock ( void )	{ locked = FALSE; };
+	OLECHAR*Get () { return ole; };
+	int			Len () { return len; };
+	char*		GetSB () { return sb; };
+	void		StripSpaces ();
+	void		FormatMetaString ();
+	void		Lock ()	{ locked = TRUE; };
+	void		Unlock ()	{ locked = FALSE; };
 };
 
 template <typename text> void StripSpaces ( text *string );

--- a/Core/Tools/Babylon/transcs.cpp
+++ b/Core/Tools/Babylon/transcs.cpp
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <memory.h>
 
-void CreateTranslationTable ( void )
+void CreateTranslationTable ()
 {
 	int i;
 	FILE *out;

--- a/Core/Tools/Babylon/transcs.h
+++ b/Core/Tools/Babylon/transcs.h
@@ -22,4 +22,4 @@
 
 #pragma once
 
-void CreateTranslationTable ( void );
+void CreateTranslationTable ();

--- a/Core/Tools/CRCDiff/CRCDiff.cpp
+++ b/Core/Tools/CRCDiff/CRCDiff.cpp
@@ -32,7 +32,7 @@ std::string tableRow;
 
 //=============================================================================
 
-static void exitWait(void)
+static void exitWait()
 {
 	system("PAUSE");
 }
@@ -83,7 +83,7 @@ static std::string readInFile(const char *fname) {
 
 static FILE *ofp = nullptr;
 
-void dumpQueued(void);
+void dumpQueued();
 
 static void outputLine(const char *line)
 {
@@ -167,7 +167,7 @@ static void queueLine(int frame, int index, const char *line1)
 	//cout << buf << endl;
 }
 
-void dumpQueued(void)
+void dumpQueued()
 {
 	while (!queuedLines.empty())
 	{

--- a/Core/Tools/CRCDiff/KVPair.cpp
+++ b/Core/Tools/CRCDiff/KVPair.cpp
@@ -115,7 +115,7 @@ static KeyValueMap parseIntoKVPairs( std::string s, const std::string& delim )
 	return m;
 }
 
-KVPairClass::KVPairClass( void )
+KVPairClass::KVPairClass()
 {}
 
 KVPairClass::KVPairClass( const std::string& in, const std::string& delim )

--- a/Core/Tools/CRCDiff/KVPair.h
+++ b/Core/Tools/CRCDiff/KVPair.h
@@ -33,7 +33,7 @@ typedef std::map<std::string, std::string> KeyValueMap;
 class KVPairClass
 {
 public:
-	KVPairClass( void );
+	KVPairClass();
 	KVPairClass( const std::string& in, const std::string& delim );
 	void set( const std::string& in, const std::string& delim );
 	void readFromFile( const std::string& in, const std::string& delim );

--- a/Core/Tools/CRCDiff/expander.cpp
+++ b/Core/Tools/CRCDiff/expander.cpp
@@ -36,7 +36,7 @@ void Expander::addExpansion( const std::string& key, const std::string val )
 	m_expansions[key] = val;
 }
 
-void Expander::clear( void )
+void Expander::clear()
 {
 	m_expansions.clear();
 }

--- a/Core/Tools/CRCDiff/expander.h
+++ b/Core/Tools/CRCDiff/expander.h
@@ -37,7 +37,7 @@ class Expander
 		Expander( const std::string& leftMarker, const std::string& rightMarker );
 
 		void addExpansion( const std::string& key, const std::string val );
-		void clear( void );
+		void clear();
 
 		void expand( const std::string& input,
 				std::string& output,

--- a/Core/Tools/Launcher/BFISH.cpp
+++ b/Core/Tools/Launcher/BFISH.cpp
@@ -78,7 +78,7 @@ typedef union {
  * HISTORY:                                                                                    *
  *   07/08/1996 JLB : Created.                                                                 *
  *=============================================================================================*/
-BlowfishEngine::~BlowfishEngine(void)
+BlowfishEngine::~BlowfishEngine()
 {
 	if (IsKeyed) {
 		Submit_Key(nullptr, 0);

--- a/Core/Tools/Launcher/BFISH.h
+++ b/Core/Tools/Launcher/BFISH.h
@@ -53,8 +53,8 @@
 */
 class BlowfishEngine {
 	public:
-		BlowfishEngine(void) : IsKeyed(false) {}
-		~BlowfishEngine(void);
+		BlowfishEngine() : IsKeyed(false) {}
+		~BlowfishEngine();
 
 		void Submit_Key(void const * key, int length);
 
@@ -74,7 +74,7 @@ class BlowfishEngine {
 		void Sub_Key_Encrypt(unsigned long & left, unsigned long & right);
 
 		void Process_Block(void const * plaintext, void * cyphertext, unsigned long const * ptable);
-		void Initialize_Tables(void);
+		void Initialize_Tables();
 
 		enum {
 			ROUNDS = 16		// Feistal round count (16 is standard).

--- a/Core/Tools/Launcher/DatGen/DatGen.cpp
+++ b/Core/Tools/Launcher/DatGen/DatGen.cpp
@@ -26,9 +26,9 @@
 #include "BFISH.h"
 #include <Debug/DebugPrint.h>
 
-void __cdecl doIt(void);
+void __cdecl doIt();
 
-static void doIt(void)
+static void doIt()
 {
 	// Generate passkey
 	char passKey[128];

--- a/Core/Tools/Launcher/Toolkit/Storage/File.cpp
+++ b/Core/Tools/Launcher/Toolkit/Storage/File.cpp
@@ -153,7 +153,7 @@ File::~File()
 *
 ******************************************************************************/
 
-const UString& File::GetName(void) const
+const UString& File::GetName() const
 	{
 	return mName;
 	}
@@ -198,7 +198,7 @@ void File::SetName(const UString& name)
 *
 ******************************************************************************/
 
-ERights File::GetRights(void) const
+ERights File::GetRights() const
 	{
 	return mRights;
 	}
@@ -304,7 +304,7 @@ bool File::IsAvailable(bool force)
 *
 ******************************************************************************/
 
-bool File::IsOpen(void) const
+bool File::IsOpen() const
 	{
 	return ((mHandle != INVALID_HANDLE) ? true : false);
 	}
@@ -443,7 +443,7 @@ File::EFileError File::Open(const UString& name, ERights rights)
 *
 ******************************************************************************/
 
-void File::Close(void)
+void File::Close()
 	{
 	if (IsOpen())
 		{
@@ -470,7 +470,7 @@ void File::Close(void)
 *
 ******************************************************************************/
 
-File::EFileError File::Create(void)
+File::EFileError File::Create()
 	{
 	// Close any previous handle
 	Close();
@@ -504,7 +504,7 @@ File::EFileError File::Create(void)
 *
 ******************************************************************************/
 
-File::EFileError File::Delete(void)
+File::EFileError File::Delete()
 	{
 	// Make sure the file is closed.
 	Close();
@@ -764,7 +764,7 @@ bool File::OnFileError(EFileError error, bool)
 *
 ******************************************************************************/
 
-UInt32 File::GetLength(void)
+UInt32 File::GetLength()
 	{
 	// If the file is not open then it must be opened first.
 	bool openedHere = false;
@@ -843,7 +843,7 @@ void File::SetLength(UInt32 length)
 *
 ******************************************************************************/
 
-UInt32 File::GetMarker(void)
+UInt32 File::GetMarker()
 	{
 	return SetFilePointer(mHandle, 0, nullptr, FILE_CURRENT);
 	}
@@ -919,7 +919,7 @@ void File::SetMarker(Int32 offset, EStreamFrom from)
 *
 ******************************************************************************/
 
-bool File::AtEnd(void)
+bool File::AtEnd()
 	{
 	return (GetMarker() >= GetLength());
 	}
@@ -1103,6 +1103,6 @@ UInt32 File::PeekBytes(void* ptr, UInt32 bytes)
 *
 ******************************************************************************/
 
-void File::Flush(void)
+void File::Flush()
 	{
 	}

--- a/Core/Tools/Launcher/Toolkit/Storage/File.h
+++ b/Core/Tools/Launcher/Toolkit/Storage/File.h
@@ -70,13 +70,13 @@ class File : public Stream
 		virtual ~File();
 
 		//! Retrieve name of file
-		const UString& GetName(void) const;
+		const UString& GetName() const;
 
 		//! Associate a name to the file
 		virtual void SetName(const UString& name);
 
 		//! Retrieve file access rights
-		virtual ERights GetRights(void) const;
+		virtual ERights GetRights() const;
 
 		//! Set file access rights
 		virtual void SetRights(ERights rights);
@@ -85,7 +85,7 @@ class File : public Stream
 		virtual bool IsAvailable(bool force = false);
 
 		//! Check if te file is open
-		virtual bool IsOpen(void) const;
+		virtual bool IsOpen() const;
 
 		//! Open the file for access.
 		virtual EFileError Open(ERights rights);
@@ -94,13 +94,13 @@ class File : public Stream
 		virtual EFileError Open(const UString& name, ERights rights);
 
 		//! Close the file
-		virtual void Close(void);
+		virtual void Close();
 
 		//! Create a new file
-		virtual EFileError Create(void);
+		virtual EFileError Create();
 
 		//! Delete an existing file
-		virtual EFileError Delete(void);
+		virtual EFileError Delete();
 
 		//! Load the file into memory
 		virtual EFileError Load(void*& outBuffer, UInt32& outSize);
@@ -116,19 +116,19 @@ class File : public Stream
 		//-----------------------------------------------------------------------
 
 		//! Get the length of the file
-		virtual UInt32 GetLength(void);
+		virtual UInt32 GetLength();
 
 		//! Set the length of the file
 		virtual void SetLength(UInt32 length);
 
 		//! Get file position marker
-		virtual UInt32 GetMarker(void);
+		virtual UInt32 GetMarker();
 
 		//! Set file position marker
 		virtual void SetMarker(Int32 offset, EStreamFrom from);
 
 		//! End of file test
-		virtual bool AtEnd(void);
+		virtual bool AtEnd();
 
 		//! Read bytes from the file
 		virtual UInt32 GetBytes(void* ptr, UInt32 bytes);
@@ -140,7 +140,7 @@ class File : public Stream
 		virtual UInt32 PeekBytes(void* ptr, UInt32 bytes);
 
 		//! Flush the stream
-		virtual void Flush(void);
+		virtual void Flush();
 
 	private:
 		UString mName;

--- a/Core/Tools/Launcher/Toolkit/Storage/Stream.h
+++ b/Core/Tools/Launcher/Toolkit/Storage/Stream.h
@@ -50,19 +50,19 @@ class Stream
 			} EStreamFrom;
 
 		//! Get the length of the stream
-		virtual UInt32 GetLength(void) = 0;
+		virtual UInt32 GetLength() = 0;
 
 		//! Set the length of the stream
 		virtual void SetLength(UInt32 length) = 0;
 
 		//! Get current position of stream marker
-		virtual UInt32 GetMarker(void) = 0;
+		virtual UInt32 GetMarker() = 0;
 
 		//! Set position of stream marker
 		virtual void SetMarker(Int32 offset, EStreamFrom from) = 0;
 
 		//! End of stream test
-		virtual bool AtEnd(void) = 0;
+		virtual bool AtEnd() = 0;
 
 		//! Retrieve a sequence of bytes.
 		virtual UInt32 GetBytes(void* ptr, UInt32 bytes) = 0;
@@ -74,5 +74,5 @@ class Stream
 		virtual UInt32 PeekBytes(void* ptr, UInt32 bytes) = 0;
 
 		//! Flush the stream
-		virtual void Flush(void) = 0;
+		virtual void Flush() = 0;
 	};

--- a/Core/Tools/Launcher/Toolkit/Support/RefCounted.h
+++ b/Core/Tools/Launcher/Toolkit/Support/RefCounted.h
@@ -66,14 +66,14 @@ class RefCounted
 			{return false;}
 
 		// Add reference
-		inline void AddReference(void)
+		inline void AddReference()
 			{++mRefCount;}
 
 		// Release reference
-		inline virtual void Release(void)
+		inline virtual void Release()
 			{if (--mRefCount == 0) delete this;}
 
-		inline int ReferenceCount(void) const
+		inline int ReferenceCount() const
 			{return mRefCount;}
 
 	private:

--- a/Core/Tools/Launcher/Toolkit/Support/RefPtr.h
+++ b/Core/Tools/Launcher/Toolkit/Support/RefPtr.h
@@ -84,10 +84,10 @@ class RefPtrBase
 		inline bool operator!=(const RefPtrBase& rhs) const
 			{return !operator==(rhs);}
 
-		inline bool IsValid(void) const
+		inline bool IsValid() const
 			{return (mRefObject != nullptr);}
 
-		inline void Detach(void)
+		inline void Detach()
 			{
 			if (IsValid())
 				{
@@ -128,10 +128,10 @@ class RefPtrBase
 
 		const RefPtrBase& operator=(const RefPtrBase&);
 
-		inline RefCounted* const GetRefObject(void)
+		inline RefCounted* const GetRefObject()
 			{return mRefObject;}
 
-		inline const RefCounted* const GetRefObject(void) const
+		inline const RefCounted* const GetRefObject() const
 			{return mRefObject;}
 
 		inline void Attach(RefCounted* object)
@@ -214,10 +214,10 @@ template<typename Type> class RefPtr
 			}
 
 		// These are public mostly because I can't seem to declare rc_ptr<Other> as a friend
-		inline Type* const ReferencedObject(void)
+		inline Type* const ReferencedObject()
 			{return reinterpret_cast<Type*>(GetRefObject());}
 
-		inline const Type* const ReferencedObject(void) const
+		inline const Type* const ReferencedObject() const
 			{return reinterpret_cast<const Type*>(GetRefObject());}
 
 		RefPtr(Type* object)

--- a/Core/Tools/Launcher/Toolkit/Support/UString.cpp
+++ b/Core/Tools/Launcher/Toolkit/Support/UString.cpp
@@ -286,7 +286,7 @@ UString::~UString()
 *
 ******************************************************************************/
 
-UInt UString::Length(void) const
+UInt UString::Length() const
 	{
 	if (mData == nullptr)
 		{
@@ -988,7 +988,7 @@ UString UString::Right(UInt count)
 *
 ******************************************************************************/
 
-void UString::ToUpper(void)
+void UString::ToUpper()
 	{
 	if (mData != nullptr)
 		{
@@ -1013,7 +1013,7 @@ void UString::ToUpper(void)
 *
 ******************************************************************************/
 
-void UString::ToLower(void)
+void UString::ToLower()
 	{
 	if (mData != nullptr)
 		{
@@ -1038,7 +1038,7 @@ void UString::ToLower(void)
 *
 ******************************************************************************/
 
-void UString::Reverse(void)
+void UString::Reverse()
 	{
 	if (mData != nullptr)
 		{
@@ -1214,7 +1214,7 @@ void UString::ConvertToANSI(Char* buffer, UInt bufferLength) const
 *
 ******************************************************************************/
 
-UInt UString::Size(void) const
+UInt UString::Size() const
 	{
 	if (mData == nullptr)
 		{
@@ -1241,7 +1241,7 @@ UInt UString::Size(void) const
 *
 ******************************************************************************/
 
-UInt UString::Capacity(void) const
+UInt UString::Capacity() const
 	{
 	return mCapacity;
 	}

--- a/Core/Tools/Launcher/Toolkit/Support/UString.h
+++ b/Core/Tools/Launcher/Toolkit/Support/UString.h
@@ -52,7 +52,7 @@ class UString
 		virtual ~UString();
 
 		//! Get the length of the string
-		UInt Length(void) const;
+		UInt Length() const;
 
 		//! Copy string
 		void Copy(const Char* s);
@@ -97,13 +97,13 @@ class UString
 		UString Right(UInt count);
 
 		//! Convert string to uppercase
-		void ToUpper(void);
+		void ToUpper();
 
 		//! Convert string to lowercase
-		void ToLower(void);
+		void ToLower();
 
 		//! Reverse characters of string
-		void Reverse(void);
+		void Reverse();
 
 		//! Remove leading and trailing characters from string.
 		//  Returns true if any characters removed
@@ -127,15 +127,15 @@ class UString
 		void ConvertToANSI(Char* buffer, UInt bufferLength) const;
 
 		//! Get the size (in bytes) of the string.
-		UInt Size(void) const;
+		UInt Size() const;
 
 		//! Get the maximum number of characters this string can hold.
-		UInt Capacity(void) const;
+		UInt Capacity() const;
 
 		//! Resize the string
 		bool Resize(UInt size);
 
-		const WChar* Get(void) const
+		const WChar* Get() const
 			{return (mData != nullptr) ? mData : L"";}
 
 		//! Assignment operator

--- a/Core/Tools/Launcher/dialog.cpp
+++ b/Core/Tools/Launcher/dialog.cpp
@@ -27,7 +27,7 @@
 HWND PatchDialog;
 BOOL CALLBACK Patch_Window_Proc(HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam);
 
-HWND Create_Patch_Dialog(void)
+HWND Create_Patch_Dialog()
 {
   PatchDialog=CreateDialog(Global_instance, MAKEINTRESOURCE(IDD_PATCHPROGRESS),
     nullptr, (DLGPROC)Patch_Window_Proc);

--- a/Core/Tools/Launcher/dialog.h
+++ b/Core/Tools/Launcher/dialog.h
@@ -20,6 +20,6 @@
 
 #include"winblows.h"
 #include<commctrl.h>
-HWND Create_Patch_Dialog(void);
+HWND Create_Patch_Dialog();
 
 extern HWND PatchDialog;

--- a/Core/Tools/Launcher/dictionary.h
+++ b/Core/Tools/Launcher/dictionary.h
@@ -63,12 +63,12 @@ class Dictionary
                    Dictionary(uint32 (* hashFn)(K &key));
                   ~Dictionary();
 
-  void             clear(void);
+  void             clear();
   bit8             add(IN K &key,IN V &value);
   bit8             getValue(IN K &key, OUT V &value);
   void             print(IN FILE *out) const;
-  uint32           getSize(void) const;
-  uint32           getEntries(void) const;
+  uint32           getSize() const;
+  uint32           getEntries() const;
   bit8             contains(IN K &key);
   bit8             updateValue(IN K &key,IN V &value);
   bit8             remove(IN K &key,OUT V &value);
@@ -77,8 +77,8 @@ class Dictionary
   bit8             iterate(INOUT int &index,INOUT int &offset, OUT V &value) const;
 
  private:
-  void             shrink(void);  // halve the number of slots
-  void             expand(void);  // double the number of slots
+  void             shrink();  // halve the number of slots
+  void             expand();  // double the number of slots
 
 
   DNode<K,V>     **table;      // This stores the lists at each slot
@@ -242,13 +242,13 @@ bit8 Dictionary<K,V>::iterate(INOUT int &index,INOUT int &offset,
 
 // Return the current size of the hash table
 template <class K,class V>
-uint32 Dictionary<K,V>::getSize(void) const
+uint32 Dictionary<K,V>::getSize() const
 { return(size); }
 
 
 // Return the current number of entries in the table
 template <class K,class V>
-uint32 Dictionary<K,V>::getEntries(void) const
+uint32 Dictionary<K,V>::getEntries() const
 { return(entries); }
 
 
@@ -506,7 +506,7 @@ bit8 Dictionary<K,V>::getValue(IN K &key,OUT V &value)
 
 // Shrink the hash table by a factor of 2 (and relocate entries)
 template <class K,class V>
-void Dictionary<K,V>::shrink(void)
+void Dictionary<K,V>::shrink()
 {
   int    i;
   int    oldsize;
@@ -545,7 +545,7 @@ void Dictionary<K,V>::shrink(void)
 
 
 template <class K,class V>
-void Dictionary<K,V>::expand(void)
+void Dictionary<K,V>::expand()
 {
   int    i;
   int    oldsize;

--- a/Core/Tools/Launcher/loadbmp.cpp
+++ b/Core/Tools/Launcher/loadbmp.cpp
@@ -165,7 +165,7 @@ bit8 LoadBmp::init(const char *filename,HWND hwnd)
 }
 
 
-bit8 LoadBmp::drawBmp(void)
+bit8 LoadBmp::drawBmp()
 {
   // Paint the window (and draw the bitmap).
 

--- a/Core/Tools/Launcher/loadbmp.h
+++ b/Core/Tools/Launcher/loadbmp.h
@@ -33,7 +33,7 @@ class LoadBmp
                   LoadBmp();
                  ~LoadBmp();
    bit8           init(const char *filename,HWND hwnd);  // must call before the drawBmp
-   bit8           drawBmp(void);  // call this from your WM_PAINT message
+   bit8           drawBmp();  // call this from your WM_PAINT message
 
  private:
    HBITMAP        BitmapHandle_;

--- a/Core/Tools/Launcher/main.cpp
+++ b/Core/Tools/Launcher/main.cpp
@@ -339,7 +339,7 @@ void CreatePrimaryWin(const char *prefix)
 }
 
 
-//void DestroyPrimaryWin(void)
+//void DestroyPrimaryWin()
 //{
 //  DestroyWindow(PrimaryWin);
 //  UnregisterClass(classname);

--- a/Core/Tools/Launcher/monod.cpp
+++ b/Core/Tools/Launcher/monod.cpp
@@ -18,7 +18,7 @@
 
 #include "monod.h"
 
-MonoD::MonoD(void)
+MonoD::MonoD()
 {
 #ifdef _WIN32
   unsigned long retval;

--- a/Core/Tools/Launcher/patch.cpp
+++ b/Core/Tools/Launcher/patch.cpp
@@ -120,7 +120,7 @@ BOOL CALLBACK Update_Info_Proc(HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lPara
 
 
 // Restart the computer for certain types of patches
-void Shutdown_Computer_Now(void);
+void Shutdown_Computer_Now();
 
 
 __declspec(dllexport) LPVOID CALLBACK PatchCallBack(UINT ID, LPVOID Param);
@@ -349,7 +349,7 @@ void Apply_Patch(char *patchfile,ConfigFile &config,int skuIndex)
 
 
 
-void Shutdown_Computer_Now(void)
+void Shutdown_Computer_Now()
 {
   HANDLE hToken;
   TOKEN_PRIVILEGES tkp;

--- a/Core/Tools/Launcher/streamer.cpp
+++ b/Core/Tools/Launcher/streamer.cpp
@@ -94,7 +94,7 @@ int Streamer::overflow(int c)
 }
 
 // This is a write only stream, this should never happen
-int Streamer::underflow(void)
+int Streamer::underflow()
 {
   return(EOF);
 }

--- a/Core/Tools/Launcher/streamer.h
+++ b/Core/Tools/Launcher/streamer.h
@@ -47,7 +47,7 @@ class Streamer : public streambuf
     // Virtual methods from streambuf
     int       xsputn(const char* s, int n); // buffer some characters
     int       overflow(int = EOF);          // flush buffer and make more room
-    int       underflow(void);              // Does nothing
+    int       underflow();              // Does nothing
     int       sync();
 
     int       doallocate();                 // allocate a buffer

--- a/Core/Tools/Launcher/wdebug.cpp
+++ b/Core/Tools/Launcher/wdebug.cpp
@@ -122,22 +122,22 @@ int MsgManager::setErrorStream(OutputDevice *device)
 
 
 
-ostream *MsgManager::debugStream(void)
+ostream *MsgManager::debugStream()
 {
   return(debug_ostream);
 }
 
-ostream *MsgManager::infoStream(void)
+ostream *MsgManager::infoStream()
 {
   return(info_ostream);
 }
 
-ostream *MsgManager::warnStream(void)
+ostream *MsgManager::warnStream()
 {
   return(warn_ostream);
 }
 
-ostream *MsgManager::errorStream(void)
+ostream *MsgManager::errorStream()
 {
   return(error_ostream);
 }

--- a/Core/Tools/Launcher/wdebug.h
+++ b/Core/Tools/Launcher/wdebug.h
@@ -183,8 +183,8 @@ class MsgManager
    static void                enableWarn(int flag);
    static void                enableError(int flag);
 
-   static ostream            *debugStream(void);
-   static ostream            *infoStream(void);
-   static ostream            *warnStream(void);
-   static ostream            *errorStream(void);
+   static ostream            *debugStream();
+   static ostream            *infoStream();
+   static ostream            *warnStream();
+   static ostream            *errorStream();
 };

--- a/Core/Tools/Launcher/wstring.cpp
+++ b/Core/Tools/Launcher/wstring.cpp
@@ -297,13 +297,13 @@ bit8 Wstring::removeChar(char c)
   return(removed);
 }
 
-void Wstring::removeSpaces(void)
+void Wstring::removeSpaces()
 {
   removeChar(' ');
   removeChar('\t');
 }
 
-void Wstring::clear(void)
+void Wstring::clear()
 {
  delete[](str);
  str=nullptr;
@@ -328,7 +328,7 @@ void Wstring::cellCopy(char *dest, uint32 len)
   dest[len] = 0;
 }
 
-const char *Wstring::get(void) const
+const char *Wstring::get() const
 {
   if(!str)
     return "";
@@ -342,7 +342,7 @@ char Wstring::get(uint32 index) const
  return(0);
 }
 
-uint32 Wstring::length(void) const
+uint32 Wstring::length() const
 {
   if(str == nullptr)
     return(0);
@@ -503,7 +503,7 @@ char Wstring::set(uint32 size, const char *string)
 
 // This function converts all alphabetical characters in the string to lower
 // case.
-void Wstring::toLower(void)
+void Wstring::toLower()
 {
   uint32 i;
 
@@ -517,7 +517,7 @@ void Wstring::toLower(void)
 
 // This function converts all alphabetical characters in the string to upper
 // case.
-void Wstring::toUpper(void)
+void Wstring::toUpper()
 {
   uint32 i;
 

--- a/Core/Tools/Launcher/wstring.h
+++ b/Core/Tools/Launcher/wstring.h
@@ -40,7 +40,7 @@ class Wstring
            Wstring(const char *string);
           ~Wstring();
 
-   void    clear(void);
+   void    clear();
 
    bit8    cat(const char *string);
    bit8    cat(uint32 size,const char *string);
@@ -49,10 +49,10 @@ class Wstring
    void    cellCopy(OUT char *dest, uint32 len);
    char    remove(sint32 pos, sint32 count);
    bit8    removeChar(char c);
-   void    removeSpaces(void);
-   const char *get(void) const;
+   void    removeSpaces();
+   const char *get() const;
    char    get(uint32 index) const;
-   uint32  length(void) const;
+   uint32  length() const;
    bit8    insert(char c, uint32 pos);
    bit8    insert(const char *instring, uint32 pos);
    bit8    replace(const char *replaceThis,const char *withThis);
@@ -60,8 +60,8 @@ class Wstring
    char    set(uint32 size,const char *str);
    bit8    set(char c, uint32 index);
    void    setSize(sint32 bytes);  // create an empty string
-   void    toLower(void);
-   void    toUpper(void);
+   void    toLower();
+   void    toUpper();
    bit8    truncate(uint32 len);
    bit8    truncate(char c);  // trunc after char c
    sint32  getToken(int offset,const char *delim,Wstring &out);

--- a/Core/Tools/PATCHGET/CHATAPI.cpp
+++ b/Core/Tools/PATCHGET/CHATAPI.cpp
@@ -83,7 +83,7 @@ BOOL CALLBACK downloadDialogProc( HWND hwndDlg, UINT uMsg, WPARAM wParam,
 
 ///////////////////////////////////////////////////////////////////////////////////////
 
-static void startOnline( void );
+static void startOnline();
 
 ///////////////////////////////////////////////////////////////////////////////////////
 
@@ -170,7 +170,7 @@ BOOL CALLBACK simpleDialogProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
   return(FALSE);
 }
 
-static void startOnline( void )
+static void startOnline()
 {
 	checkingForPatch = false;
 
@@ -443,7 +443,7 @@ static GHTTPBool patchCheckCallback( GHTTPRequest request, GHTTPResult result, c
 
 ///////////////////////////////////////////////////////////////////////////////////////
 
-static void StartPatchCheck( void )
+static void StartPatchCheck()
 {
 	checkingForPatch = true;
 	std::string gameURL, mapURL;
@@ -598,7 +598,7 @@ BOOL CALLBACK Download_Dialog_Proc( HWND hwndDlg, UINT uMsg, WPARAM wParam,
 BOOL CALLBACK Simple_Dialog_Proc( HWND hwndDlg, UINT uMsg, WPARAM wParam,
     LPARAM lParam );
 
-HWND CreatePrimaryWin(void);
+HWND CreatePrimaryWin();
 
 char const * Fetch_String(int id);
 
@@ -606,7 +606,7 @@ char const * Fetch_String(int id);
 //
 // Create a primary window
 //
-HWND CreatePrimaryWin(void)
+HWND CreatePrimaryWin()
 {
   HWND                hwnd;
   WNDCLASS            wc;
@@ -663,7 +663,7 @@ HWND CreatePrimaryWin(void)
 //
 // Dispatch pending windows events
 //
-void DispatchEvents(void)
+void DispatchEvents()
 {
   MSG msg;
   int counter=0;
@@ -790,7 +790,7 @@ typedef struct SRecord {
 	int TimeStamp;				// 'Time' that this string was last requested.
 	char String[2048];			// Copy of string resource.
 
-	SRecord(void) : ID(-1), TimeStamp(-1) {}
+	SRecord() : ID(-1), TimeStamp(-1) {}
 } SRecord;
 
 
@@ -898,7 +898,7 @@ void LogMsg(const char *msg)
 
 
 
-void Startup_Chat(void)
+void Startup_Chat()
 {
 	/*
   //////CComObject<CChatEventSink>* g_pChatSink;
@@ -940,7 +940,7 @@ void Startup_Chat(void)
 	*/
 }
 
-void Shutdown_Chat(void)
+void Shutdown_Chat()
 {
 	/*
     /////AtlUnadvise(pChat, IID_IChatEvent, dwChatAdvise);
@@ -970,7 +970,7 @@ void Shutdown_Chat(void)
 // Download a patch for the registration client if required
 //   This uses the chat API for ver checking and FTP.
 //
-void Update_If_Required(void)
+void Update_If_Required()
 {
   int   retval;
   int   i;
@@ -1199,7 +1199,7 @@ CDownloadEventSink::Release()
 //// FTP Download stuff
 
 
-void SetupDownload( void )
+void SetupDownload()
 {
 	/*
   HRESULT              hRes;
@@ -1227,7 +1227,7 @@ void SetupDownload( void )
 
 
 
-void ClosedownDownload( void )
+void ClosedownDownload()
 {
 /*
   // AtlUnadvise(pDownload, IID_IDownloadEvent, dwDownloadAdvise);

--- a/Core/Tools/PATCHGET/CHATAPI.cpp
+++ b/Core/Tools/PATCHGET/CHATAPI.cpp
@@ -1388,7 +1388,7 @@ BOOL CALLBACK Simple_Dialog_Proc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lP
 
 /*
 
-STDMETHODIMP CDownloadEventSink::OnEnd(void)
+STDMETHODIMP CDownloadEventSink::OnEnd()
 {
   LogMsg("Finished!");
   g_Finished = 1;
@@ -1456,7 +1456,7 @@ STDMETHODIMP CDownloadEventSink::OnStatusUpdate(int status)
 //
 // Just tell the FTP module to go ahead and resume
 //
-STDMETHODIMP CDownloadEventSink::OnQueryResume(void)
+STDMETHODIMP CDownloadEventSink::OnQueryResume()
 {
   return(DOWNLOADEVENT_RESUME);
 }

--- a/Core/Tools/PATCHGET/CHATAPI.h
+++ b/Core/Tools/PATCHGET/CHATAPI.h
@@ -38,9 +38,9 @@ namespace patchget
 
 int main(int argc, char *argv[]);
 
-void Startup_Chat(void);
-void Shutdown_Chat(void);
-void Update_If_Required(void);
+void Startup_Chat();
+void Shutdown_Chat();
+void Update_If_Required();
 
 char const * Fetch_String(int id);
 

--- a/Core/Tools/PATCHGET/DownloadManager.cpp
+++ b/Core/Tools/PATCHGET/DownloadManager.cpp
@@ -67,15 +67,15 @@ DownloadManager::~DownloadManager()
 	}
 }
 
-void DownloadManager::init( void )
+void DownloadManager::init()
 {
 }
 
-void DownloadManager::reset( void )
+void DownloadManager::reset()
 {
 }
 
-HRESULT DownloadManager::update( void )
+HRESULT DownloadManager::update()
 {
 	return m_download->PumpMessages();
 }
@@ -99,7 +99,7 @@ void DownloadManager::queueFileForDownload( std::string server, std::string user
 	m_queuedDownloads.push_back(q);
 }
 
-HRESULT DownloadManager::downloadNextQueuedFile( void )
+HRESULT DownloadManager::downloadNextQueuedFile()
 {
 	QueuedDownload q;
 	std::list<QueuedDownload>::iterator it = m_queuedDownloads.begin();
@@ -117,7 +117,7 @@ HRESULT DownloadManager::downloadNextQueuedFile( void )
 	}
 }
 
-std::string DownloadManager::getLastLocalFile( void )
+std::string DownloadManager::getLastLocalFile()
 {
 	char buf[256] = "";
 	m_download->GetLastLocalFile(buf, 256);

--- a/Core/Tools/PATCHGET/DownloadManager.h
+++ b/Core/Tools/PATCHGET/DownloadManager.h
@@ -54,9 +54,9 @@ public:
 	virtual ~DownloadManager();
 
 public:
-	void init( void );
-	HRESULT update( void );
-	void reset( void );
+	void init();
+	HRESULT update();
+	void reset();
 
 	virtual HRESULT OnError( int error );
 	virtual HRESULT OnEnd();
@@ -65,18 +65,18 @@ public:
 	virtual HRESULT OnStatusUpdate( int status );
 
 	virtual HRESULT downloadFile( std::string server, std::string username, std::string password, std::string file, std::string localfile, std::string regkey, bool tryResume );
-	std::string getLastLocalFile( void );
+	std::string getLastLocalFile();
 
-	bool isDone( void ) { return m_sawEnd || m_wasError; }
-	bool isOk( void ) { return m_sawEnd; }
-	bool wasError( void ) { return m_wasError; }
+	bool isDone() { return m_sawEnd || m_wasError; }
+	bool isOk() { return m_sawEnd; }
+	bool wasError() { return m_wasError; }
 
-	std::string getStatusString( void ) { return m_statusString; }
-	std::string getErrorString( void ) { return m_errorString; }
+	std::string getStatusString() { return m_statusString; }
+	std::string getErrorString() { return m_errorString; }
 
 	void queueFileForDownload( std::string server, std::string username, std::string password, std::string file, std::string localfile, std::string regkey, bool tryResume );
-	bool isFileQueuedForDownload( void ) { return !m_queuedDownloads.empty(); }
-	HRESULT downloadNextQueuedFile( void );
+	bool isFileQueuedForDownload() { return !m_queuedDownloads.empty(); }
+	HRESULT downloadNextQueuedFile();
 
 private:
 	bool m_winsockInit;

--- a/Core/Tools/W3DView/SphereUtils.cpp
+++ b/Core/Tools/W3DView/SphereUtils.cpp
@@ -112,7 +112,7 @@ SphereKeysClass::Add_Key (W3dSphereKeyFrameStruct &keys)
 //
 /////////////////////////////////////////////////////////////
 void
-SphereKeysClass::Free_Keys (void)
+SphereKeysClass::Free_Keys ()
 {
 	SAFE_DELETE_ARRAY (m_Keys);
 	m_KeyCount	= 0;
@@ -126,7 +126,7 @@ SphereKeysClass::Free_Keys (void)
 //
 /////////////////////////////////////////////////////////////
 void
-SphereKeysClass::Detach (void)
+SphereKeysClass::Detach ()
 {
 	m_Keys		= nullptr;
 	m_KeyCount	= 0;
@@ -169,7 +169,7 @@ Key_Compare (const void *arg1, const void *arg2)
 //
 /////////////////////////////////////////////////////////////
 void
-SphereKeysClass::Sort (void)
+SphereKeysClass::Sort ()
 {
 	if (m_Keys != nullptr && m_KeyCount > 0) {
 		::qsort (m_Keys, m_KeyCount, sizeof (W3dSphereKeyFrameStruct), Key_Compare);

--- a/Core/Tools/W3DView/SphereUtils.h
+++ b/Core/Tools/W3DView/SphereUtils.h
@@ -50,25 +50,25 @@ public:
 	/////////////////////////////////////////////////////////////
 	//	Public constructors/destructors
 	/////////////////////////////////////////////////////////////
-	SphereKeysClass (void)
+	SphereKeysClass ()
 		:	m_Keys (nullptr),
 			m_KeyCount (0),
 			m_MaxKeys (0)		{ }
 
-	virtual ~SphereKeysClass (void)	{ Free_Keys (); }
+	virtual ~SphereKeysClass ()	{ Free_Keys (); }
 
 	/////////////////////////////////////////////////////////////
 	//	Public methods
 	/////////////////////////////////////////////////////////////
-	W3dSphereKeyFrameStruct *	Detach (void);
+	W3dSphereKeyFrameStruct *	Detach ();
 
-	int								Get_Key_Count (void) const { return m_KeyCount; }
-	W3dSphereKeyFrameStruct *	Get_Keys (void)				{ return m_Keys; }
+	int								Get_Key_Count () const { return m_KeyCount; }
+	W3dSphereKeyFrameStruct *	Get_Keys ()				{ return m_Keys; }
 
 	void								Add_Keys (W3dSphereKeyFrameStruct *keys, int key_count);
 	void								Add_Key (W3dSphereKeyFrameStruct &key);
 
-	void								Free_Keys (void);
+	void								Free_Keys ();
 
 protected:
 

--- a/Core/Tools/W3DView/TextureMgrDialog.cpp
+++ b/Core/Tools/W3DView/TextureMgrDialog.cpp
@@ -125,7 +125,7 @@ END_MESSAGE_MAP()
 // Fill_List_Ctrl_With_Meshes
 //
 void
-TextureMgrDialogClass::Fill_List_Ctrl_With_Meshes (void)
+TextureMgrDialogClass::Fill_List_Ctrl_With_Meshes ()
 {
 	m_ListCtrl.DeleteAllItems ();
 	m_ListCtrl.SetImageList (m_pImageList, LVSIL_NORMAL);
@@ -204,7 +204,7 @@ TextureMgrDialogClass::Fill_List_Ctrl_With_Textures (TextureListNodeClass &paren
 // OnInitDialog
 //
 BOOL
-TextureMgrDialogClass::OnInitDialog (void)
+TextureMgrDialogClass::OnInitDialog ()
 {
 	CWaitCursor wait_cursor;
 
@@ -362,7 +362,7 @@ TextureMgrDialogClass::Find_Texture_Thumbnail (LPCTSTR name)
 // OnOK
 //
 void
-TextureMgrDialogClass::OnOK (void)
+TextureMgrDialogClass::OnOK ()
 {
 	// Allow the base class to process this message
 	CDialog::OnOK ();
@@ -374,7 +374,7 @@ TextureMgrDialogClass::OnOK (void)
 // OnCancel
 //
 void
-TextureMgrDialogClass::OnCancel (void)
+TextureMgrDialogClass::OnCancel ()
 {
 	// Allow the base class to process this message
 	CDialog::OnCancel ();
@@ -491,7 +491,7 @@ TextureMgrDialogClass::OnKeydownMeshTextureListCtrl
 // OnDestroy
 //
 void
-TextureMgrDialogClass::OnDestroy (void)
+TextureMgrDialogClass::OnDestroy ()
 {
 	// Free the state image list we associated with the control
 	m_ListCtrl.SetImageList (nullptr, LVSIL_NORMAL);
@@ -521,7 +521,7 @@ TextureMgrDialogClass::OnDestroy (void)
 // OnBack
 //
 void
-TextureMgrDialogClass::OnBack (void)
+TextureMgrDialogClass::OnBack ()
 {
 	// Display the mesh list
 	if (m_bContainsMeshes == false) {
@@ -535,7 +535,7 @@ TextureMgrDialogClass::OnBack (void)
 // OnDetails
 //
 void
-TextureMgrDialogClass::OnDetails (void)
+TextureMgrDialogClass::OnDetails ()
 {
 	LONG style = ::GetWindowLong (m_ListCtrl, GWL_STYLE);
 	SetWindowLong (m_ListCtrl, GWL_STYLE, (style & (~LVS_TYPEMASK)) | LVS_REPORT);
@@ -547,7 +547,7 @@ TextureMgrDialogClass::OnDetails (void)
 // OnLarge
 //
 void
-TextureMgrDialogClass::OnLarge (void)
+TextureMgrDialogClass::OnLarge ()
 {
 	LONG style = ::GetWindowLong (m_ListCtrl, GWL_STYLE);
 	SetWindowLong (m_ListCtrl, GWL_STYLE, (style & (~LVS_TYPEMASK)) | LVS_ICON);
@@ -559,7 +559,7 @@ TextureMgrDialogClass::OnLarge (void)
 // OnList
 //
 void
-TextureMgrDialogClass::OnList (void)
+TextureMgrDialogClass::OnList ()
 {
 	LONG style = ::GetWindowLong (m_ListCtrl, GWL_STYLE);
 	SetWindowLong (m_ListCtrl, GWL_STYLE, (style & (~LVS_TYPEMASK)) | LVS_LIST);
@@ -571,7 +571,7 @@ TextureMgrDialogClass::OnList (void)
 // OnSmall
 //
 void
-TextureMgrDialogClass::OnSmall (void)
+TextureMgrDialogClass::OnSmall ()
 {
 	LONG style = ::GetWindowLong (m_ListCtrl, GWL_STYLE);
 	SetWindowLong (m_ListCtrl, GWL_STYLE, (style & (~LVS_TYPEMASK)) | LVS_SMALLICON);
@@ -692,7 +692,7 @@ TextureMgrDialogClass::Insert_Texture_Details
 //
 /////////////////////////////////////////////////////////////////////////////
 void
-TextureMgrDialogClass::OnPropagate (void)
+TextureMgrDialogClass::OnPropagate ()
 {
 	//
 	//	Determine the currently selected item

--- a/Core/Tools/W3DView/TextureMgrDialog.h
+++ b/Core/Tools/W3DView/TextureMgrDialog.h
@@ -93,7 +93,7 @@ class TextureListNodeClass
 			  m_TextureIndex (0),
 			  m_IconIndex (ICON_DEF_TEXTURE) { REF_PTR_SET (m_pTexture, ptexture); }
 
-		~TextureListNodeClass (void) { REF_PTR_RELEASE (m_pTexture); Free_Subobj_List (); }
+		~TextureListNodeClass () { REF_PTR_RELEASE (m_pTexture); Free_Subobj_List (); }
 
 
 		////////////////////////////////////////////////////////////
@@ -101,25 +101,25 @@ class TextureListNodeClass
 		//	Public methods
 		//
 		void									Set_Name (LPCTSTR name)		{ m_Name = name; }
-		LPCTSTR								Get_Name (void) const		{ return m_Name; }
+		LPCTSTR								Get_Name () const		{ return m_Name; }
 
-		NODE_TYPE							Get_Type (void) const		{ return m_Type; }
+		NODE_TYPE							Get_Type () const		{ return m_Type; }
 		void									Set_Type (NODE_TYPE type)	{ m_Type = type; }
 
-		TextureClass *						Peek_Texture (void) const	{ return m_pTexture; }
+		TextureClass *						Peek_Texture () const	{ return m_pTexture; }
 		void									Set_Texture (TextureClass *ptex) { REF_PTR_SET (m_pTexture, ptex); }
 
-		TEXTURE_NODE_LIST	&				Get_Subobj_List (void)		{ return m_SubObjectList; }
+		TEXTURE_NODE_LIST	&				Get_Subobj_List ()		{ return m_SubObjectList; }
 
 		void									Set_Parent (TextureListNodeClass *pparent)	{ m_pParent = pparent; }
-		TextureListNodeClass *			Get_Parent (void) const		{ return m_pParent; }
+		TextureListNodeClass *			Get_Parent () const		{ return m_pParent; }
 
 		void									Add_Subobj (TextureListNodeClass *pchild)	{ m_SubObjectList.Add (pchild); }
 
-		int									Get_Icon_Index (void) const	{ return m_IconIndex; }
+		int									Get_Icon_Index () const	{ return m_IconIndex; }
 		void									Set_Icon_Index (int index)		{ m_IconIndex = index; }
 
-		int									Get_Texture_Index (void) const	{ return m_TextureIndex; }
+		int									Get_Texture_Index () const	{ return m_TextureIndex; }
 		void									Set_Texture_Index (int index)		{ m_TextureIndex = index; }
 
 	protected:
@@ -128,7 +128,7 @@ class TextureListNodeClass
 		//
 		//	Protected methods
 		//
-		void									Free_Subobj_List (void);
+		void									Free_Subobj_List ();
 
 	private:
 
@@ -151,7 +151,7 @@ class TextureListNodeClass
 // Free_Subobj_List
 //
 __inline void
-TextureListNodeClass::Free_Subobj_List (void)
+TextureListNodeClass::Free_Subobj_List ()
 {
 	// Loop through all the subobject entries and free their pointers
 	for (int index = 0; index < m_SubObjectList.Count (); index ++) {
@@ -218,7 +218,7 @@ protected:
 		//
 		void						Add_Subobjs_To_List (RenderObjClass *prender_obj);
 		void						Add_Textures_To_Node (MeshClass *pmesh, TextureListNodeClass *pmesh_node);
-		void						Fill_List_Ctrl_With_Meshes (void);
+		void						Fill_List_Ctrl_With_Meshes ();
 		void						Fill_List_Ctrl_With_Textures (TextureListNodeClass &pparent);
 		int						Find_Texture_Thumbnail (LPCTSTR name);
 		int						Get_Thumbnail (TextureClass *ptexture);

--- a/Core/Tools/W3DView/TextureSettingsDialog.cpp
+++ b/Core/Tools/W3DView/TextureSettingsDialog.cpp
@@ -88,7 +88,7 @@ TextureSettingsDialogClass::TextureSettingsDialogClass
 //
 // ~TextureSettingsDialogClass
 //
-TextureSettingsDialogClass::~TextureSettingsDialogClass (void)
+TextureSettingsDialogClass::~TextureSettingsDialogClass ()
 {
 	SR_RELEASE (m_pTexture);
 	SR_RELEASE (m_pOriginalTexture);
@@ -128,7 +128,7 @@ END_MESSAGE_MAP()
 // OnInitDialog
 //
 BOOL
-TextureSettingsDialogClass::OnInitDialog (void)
+TextureSettingsDialogClass::OnInitDialog ()
 {
 	// Allow the base class to process this message
 	CDialog::OnInitDialog ();
@@ -164,7 +164,7 @@ TextureSettingsDialogClass::OnInitDialog (void)
 //  Load_Texture_Settings
 //
 void
-TextureSettingsDialogClass::Load_Texture_Settings (void)
+TextureSettingsDialogClass::Load_Texture_Settings ()
 {
 	// Free the old thumbnail (if there was one)
 	if (m_hThumbnail != nullptr) {
@@ -317,7 +317,7 @@ TextureSettingsDialogClass::Fill_Animation_Controls (TextureClass *ptexture)
 // OnOK
 //
 void
-TextureSettingsDialogClass::OnOK (void)
+TextureSettingsDialogClass::OnOK ()
 {
 	// Force the new settings to take effect
 	OnApply ();
@@ -332,7 +332,7 @@ TextureSettingsDialogClass::OnOK (void)
 // OnCancel
 //
 void
-TextureSettingsDialogClass::OnCancel (void)
+TextureSettingsDialogClass::OnCancel ()
 {
 	// Reuse the starting texture
 	m_pTexture->Set_Texture (m_pStartingTexture);
@@ -347,7 +347,7 @@ TextureSettingsDialogClass::OnCancel (void)
 // OnAnimationCheck
 //
 void
-TextureSettingsDialogClass::OnAnimationCheck (void)
+TextureSettingsDialogClass::OnAnimationCheck ()
 {
 	bool benable = (SendDlgItemMessage (IDC_ANIMATION_CHECK, BM_GETCHECK) == 1);
 
@@ -417,7 +417,7 @@ TextureSettingsDialogClass::WindowProc
 // OnDestroy
 //
 void
-TextureSettingsDialogClass::OnDestroy (void)
+TextureSettingsDialogClass::OnDestroy ()
 {
 	if (m_hThumbnail != nullptr) {
 		::DeleteObject (m_hThumbnail);
@@ -434,7 +434,7 @@ TextureSettingsDialogClass::OnDestroy (void)
 // OnBrowseButton
 //
 void
-TextureSettingsDialogClass::OnBrowseButton (void)
+TextureSettingsDialogClass::OnBrowseButton ()
 {
 	// Get the current filename to display
 	CString filename;
@@ -466,7 +466,7 @@ TextureSettingsDialogClass::OnBrowseButton (void)
 // Paint_Thumbnail
 //
 void
-TextureSettingsDialogClass::Paint_Thumbnail (void)
+TextureSettingsDialogClass::Paint_Thumbnail ()
 {
 	// Paint the thumbnail
 	if (m_hThumbnail != nullptr) {
@@ -505,7 +505,7 @@ TextureSettingsDialogClass::Paint_Thumbnail (void)
 // OnRestore
 //
 void
-TextureSettingsDialogClass::OnRestore (void)
+TextureSettingsDialogClass::OnRestore ()
 {
 	if (m_pOriginalTexture != nullptr) {
 
@@ -528,7 +528,7 @@ TextureSettingsDialogClass::OnRestore (void)
 // OnApply
 //
 void
-TextureSettingsDialogClass::OnApply (void)
+TextureSettingsDialogClass::OnApply ()
 {
 	// Get the current texture name from the edit control
 	CString texture_name;

--- a/Core/Tools/W3DView/TextureSettingsDialog.h
+++ b/Core/Tools/W3DView/TextureSettingsDialog.h
@@ -48,7 +48,7 @@ class TextureSettingsDialogClass : public CDialog
 // Construction
 public:
 	TextureSettingsDialogClass (IndirectTextureClass *ptexture, IndirectTextureClass *poriginal_texture, CWnd *pParent = nullptr);
-	virtual ~TextureSettingsDialogClass (void);
+	virtual ~TextureSettingsDialogClass ();
 
 // Dialog Data
 	//{{AFX_DATA(TextureSettingsDialogClass)
@@ -89,7 +89,7 @@ protected:
 		//
 		//	Private methods
 		//
-		bool					Were_Settings_Modified (void) const { return m_bWereSettingsModified; }
+		bool					Were_Settings_Modified () const { return m_bWereSettingsModified; }
 
 	protected:
 
@@ -99,9 +99,9 @@ protected:
 		//
 		void					Fill_Controls (TextureClass *ptexture);
 		void					Fill_Animation_Controls (TextureClass *ptexture);
-		void					Load_Textures_Into_Combo (void);
-		void					Load_Texture_Settings (void);
-		void					Paint_Thumbnail (void);
+		void					Load_Textures_Into_Combo ();
+		void					Load_Texture_Settings ();
+		void					Paint_Thumbnail ();
 
 	private:
 

--- a/Core/Tools/WW3D/max2w3d/ExportAllDlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/ExportAllDlg.cpp
@@ -65,7 +65,7 @@ ExportAllDlg::ExportAllDlg (Interface *max_interface)
 /////////////////////////////////////////////////////////////////////////////
 // ExportAllDlg Methods
 
-int ExportAllDlg::DoModal (void)
+int ExportAllDlg::DoModal ()
 {
 	// Put up the dialog box.
 	BOOL result = DialogBoxParam(AppInstance, MAKEINTRESOURCE(IDD_EXPORT_ALL),
@@ -151,7 +151,7 @@ BOOL CALLBACK ExportAllDlg::DialogProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPA
 /////////////////////////////////////////////////////////////////////////////
 // ExportAllDlg message handlers
 
-void ExportAllDlg::OnInitDialog (void)
+void ExportAllDlg::OnInitDialog ()
 {
 	CenterWindow(m_hWnd, m_MaxInterface->GetMAXHWnd());
 	SetCursor(LoadCursor(nullptr, IDC_ARROW));
@@ -192,7 +192,7 @@ void ExportAllDlg::OnBrowse()
 	}
 }
 
-BOOL ExportAllDlg::OnOK (void)
+BOOL ExportAllDlg::OnOK ()
 {
 	// Get the directory chosen by the user. If none is entered,
 	// freak on the user.

--- a/Core/Tools/WW3D/max2w3d/ExportAllDlg.h
+++ b/Core/Tools/WW3D/max2w3d/ExportAllDlg.h
@@ -53,7 +53,7 @@ public:
 	ExportAllDlg (Interface *max_interface);
 
 	// Methods
-	int DoModal (void);
+	int DoModal ();
 
 	// DialogProc
 	BOOL CALLBACK DialogProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
@@ -70,7 +70,7 @@ public:
 protected:
 
 	// Message Handlers
-	void OnInitDialog (void);
-	void OnBrowse (void);
-	BOOL OnOK (void);		// TRUE if ok to close dialog
+	void OnInitDialog ();
+	void OnBrowse ();
+	BOOL OnOK ();		// TRUE if ok to close dialog
 };

--- a/Core/Tools/WW3D/max2w3d/FormClass.h
+++ b/Core/Tools/WW3D/max2w3d/FormClass.h
@@ -42,15 +42,15 @@
 class FormClass : public ParamDlg
 {
 	public:
-		FormClass (void)
+		FormClass ()
 			: m_hWnd (nullptr) {}
-		~FormClass (void) {}
+		~FormClass () {}
 
 		HWND						Create_Form (HWND parent_wnd, UINT template_id);
 		void						Show (bool show_flag = true) { ::ShowWindow (m_hWnd, show_flag ? SW_SHOW : SW_HIDE); }
 		virtual BOOL			Dialog_Proc (HWND dlg_wnd, UINT message, WPARAM wparam, LPARAM lparam) = 0;
-		HWND						Get_Hwnd(void) { return m_hWnd; }
-		virtual void			Invalidate(void) { InvalidateRect(m_hWnd,nullptr,0); }
+		HWND						Get_Hwnd() { return m_hWnd; }
+		virtual void			Invalidate() { InvalidateRect(m_hWnd,nullptr,0); }
 
 	protected:
 

--- a/Core/Tools/WW3D/max2w3d/GameMtl.cpp
+++ b/Core/Tools/WW3D/max2w3d/GameMtl.cpp
@@ -784,7 +784,7 @@ GameMtl::GameMtl(BOOL loading)
  *                                                                                             *
  * HISTORY:                                                                                    *
  *=============================================================================================*/
-GameMtl::~GameMtl(void)
+GameMtl::~GameMtl()
 {
 	for (int pass=0; pass<W3dMaterialClass::MAX_PASSES; ++pass) {
 		for (int stage=0; stage<W3dMaterialClass::MAX_STAGES; ++stage) {
@@ -1136,7 +1136,7 @@ RefTargetHandle GameMtl::GetReference(int i)
  * HISTORY:                                                                                    *
  *   11/23/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-int GameMtl::NumSubTexmaps(void)
+int GameMtl::NumSubTexmaps()
 {
 	return (W3dMaterialClass::MAX_PASSES * W3dMaterialClass::MAX_STAGES) + 1;
 }
@@ -1154,7 +1154,7 @@ int GameMtl::NumSubTexmaps(void)
  * HISTORY:                                                                                    *
  *   7/01/99   PDS : Created.                                                                 *
  *=============================================================================================*/
-int GameMtl::Get_Displacement_Map_Index(void) const
+int GameMtl::Get_Displacement_Map_Index() const
 {
 	return DISPLACEMENT_INDEX;
 }
@@ -1246,7 +1246,7 @@ ParamDlg * GameMtl::CreateParamDlg(HWND hwnd_mtl_edit, IMtlParams *imp)
  * HISTORY:                                                                                    *
  *   11/23/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void GameMtl::Notify_Changed(void)
+void GameMtl::Notify_Changed()
 {
 	NotifyDependents(FOREVER, PART_ALL, REFMSG_CHANGE);
 	if (MaterialDialog != nullptr) {
@@ -2526,7 +2526,7 @@ void GameMtl::Set_Pass_Count(int passcount)
 	MainParameterBlock->SetValue(0, TimeValue(0), passcount);
 }
 
-int GameMtl::Get_Pass_Count(void)
+int GameMtl::Get_Pass_Count()
 {
 	assert(MainParameterBlock);
 	int pcount;

--- a/Core/Tools/WW3D/max2w3d/GameMtlDlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/GameMtlDlg.cpp
@@ -548,7 +548,7 @@ static BOOL CALLBACK PassCountPanelDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam
 	return res;
 }
 
-void GameMtlDlg::Set_Pass_Count_Dialog(void)
+void GameMtlDlg::Set_Pass_Count_Dialog()
 {
 	int res = DialogBoxParam(
 		AppInstance,

--- a/Core/Tools/WW3D/max2w3d/GameMtlDlg.h
+++ b/Core/Tools/WW3D/max2w3d/GameMtlDlg.h
@@ -61,25 +61,25 @@ public:
 	~GameMtlDlg();
 
 	// From ParamDlg:
-	Class_ID				ClassID(void);
+	Class_ID				ClassID();
 	void					SetThing(ReferenceTarget *m);
-	ReferenceTarget*	GetThing(void) { return (ReferenceTarget*)TheMtl; }
+	ReferenceTarget*	GetThing() { return (ReferenceTarget*)TheMtl; }
 	void					DeleteThis() { delete this;  }
 	void					SetTime(TimeValue t);
-	void					ReloadDialog(void);
+	void					ReloadDialog();
 	void					ActivateDlg(BOOL onOff);
 
-	void					Invalidate(void);
-	void					Update_Display(void)	{ IParams->MtlChanged(); }
+	void					Invalidate();
+	void					Update_Display()	{ IParams->MtlChanged(); }
 
 protected:
 
-	void					Build_Dialog(void);
+	void					Build_Dialog();
 
 	BOOL					DisplacementMapProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
 	BOOL					SurfaceTypeProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
 	BOOL					PassCountProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
-	void					Set_Pass_Count_Dialog(void);
+	void					Set_Pass_Count_Dialog();
 
 	enum { MAX_PASSES = 4 };
 

--- a/Core/Tools/WW3D/max2w3d/GameMtlForm.cpp
+++ b/Core/Tools/WW3D/max2w3d/GameMtlForm.cpp
@@ -103,7 +103,7 @@ void GameMtlFormClass::SetThing(ReferenceTarget * target)
  * HISTORY:                                                                                    *
  *   11/23/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-ReferenceTarget * GameMtlFormClass::GetThing(void)
+ReferenceTarget * GameMtlFormClass::GetThing()
 {
 	return (ReferenceTarget*)TheMtl;
 }
@@ -121,7 +121,7 @@ ReferenceTarget * GameMtlFormClass::GetThing(void)
  * HISTORY:                                                                                    *
  *   11/23/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void GameMtlFormClass::DeleteThis(void)
+void GameMtlFormClass::DeleteThis()
 {
 	delete this;
 }

--- a/Core/Tools/WW3D/max2w3d/GameMtlForm.h
+++ b/Core/Tools/WW3D/max2w3d/GameMtlForm.h
@@ -46,9 +46,9 @@ public:
 	GameMtlFormClass(IMtlParams * imtl_params,GameMtl * mtl,int pass);
 
 	void					SetThing(ReferenceTarget *m);
-	ReferenceTarget*	GetThing(void);
-	void					DeleteThis(void);
-	Class_ID				ClassID(void);
+	ReferenceTarget*	GetThing();
+	void					DeleteThis();
+	Class_ID				ClassID();
 	void					SetTime(TimeValue t);
 
 protected:

--- a/Core/Tools/WW3D/max2w3d/GameMtlShaderDlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/GameMtlShaderDlg.cpp
@@ -259,7 +259,7 @@ BOOL GameMtlShaderDlg::Dialog_Proc (HWND dlg_wnd, UINT message, WPARAM wparam, L
  * HISTORY:                                                                                    *
  *   11/23/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void GameMtlShaderDlg::ReloadDialog(void)
+void GameMtlShaderDlg::ReloadDialog()
 {
 	DebugPrint("GameMtlShaderDlg::ReloadDialog\n");
 	SendDlgItemMessage(m_hWnd, IDC_DESTBLEND_COMBO, CB_SETCURSEL, TheMtl->Get_Dest_Blend(PassIndex), 0 );
@@ -339,7 +339,7 @@ void GameMtlShaderDlg::Apply_Preset(int preset_index)
  * HISTORY:                                                                                    *
  *   02/26/99   NH : Created.                                                                  *
  *=============================================================================================*/
-void GameMtlShaderDlg::Set_Preset(void)
+void GameMtlShaderDlg::Set_Preset()
 {
 	for (int i = 0; i < NUM_SHADER_BLEND_PRESETS; i++) {
 		if (CompareShaderToBlendPreset(ShaderBlendSettingPresets[i])) break;
@@ -384,7 +384,7 @@ bool GameMtlShaderDlg::CompareShaderToBlendPreset(const ShaderBlendSettingPreset
  * HISTORY:                                                                                    *
  *   02/26/99   NH : Created.                                                                  *
  *=============================================================================================*/
-void GameMtlShaderDlg::Set_Advanced_Defaults(void)
+void GameMtlShaderDlg::Set_Advanced_Defaults()
 {
 	TheMtl->Set_Pri_Gradient(PassIndex, W3DSHADER_PRIGRADIENT_DEFAULT);
 	TheMtl->Set_Sec_Gradient(PassIndex, W3DSHADER_SECGRADIENT_DEFAULT);

--- a/Core/Tools/WW3D/max2w3d/GameMtlShaderDlg.h
+++ b/Core/Tools/WW3D/max2w3d/GameMtlShaderDlg.h
@@ -54,12 +54,12 @@ public:
 	virtual BOOL		Dialog_Proc (HWND dlg_wnd, UINT message, WPARAM wparam, LPARAM lparam);
 
 	void					ActivateDlg(BOOL onOff);
-	void					ReloadDialog(void);
+	void					ReloadDialog();
 
 private:
 
 	void					Apply_Preset(int preset_index);
-	void					Set_Preset(void);
+	void					Set_Preset();
 	bool					CompareShaderToBlendPreset(const ShaderBlendSettingPreset &blend_preset);
-	void					Set_Advanced_Defaults(void);
+	void					Set_Advanced_Defaults();
 };

--- a/Core/Tools/WW3D/max2w3d/GameMtlTextureDlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/GameMtlTextureDlg.cpp
@@ -497,7 +497,7 @@ BOOL GameMtlTextureDlg::Dialog_Proc (HWND dlg_wnd, UINT message, WPARAM wparam, 
  * HISTORY:                                                                                    *
  *   11/23/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void GameMtlTextureDlg::ReloadDialog(void)
+void GameMtlTextureDlg::ReloadDialog()
 {
 	DebugPrint("GameMtlTextureDlg::ReloadDialog\n");
 	assert(Stage0FramesSpin && Stage1FramesSpin && Stage0RateSpin && Stage1RateSpin);
@@ -644,7 +644,7 @@ void GameMtlTextureDlg::Enable_Stage(int stage,BOOL onoff)
  * HISTORY:                                                                                    *
  *   11/23/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void GameMtlTextureDlg::Update_Texture_Buttons(void)
+void GameMtlTextureDlg::Update_Texture_Buttons()
 {
 	Texmap * texmap;
 	texmap = TheMtl->Get_Texture(PassIndex,0);

--- a/Core/Tools/WW3D/max2w3d/GameMtlTextureDlg.h
+++ b/Core/Tools/WW3D/max2w3d/GameMtlTextureDlg.h
@@ -48,16 +48,16 @@ class GameMtlTextureDlg : public GameMtlFormClass
 public:
 
 	GameMtlTextureDlg(HWND parent, IMtlParams * imp, GameMtl * m, int pass);
-	~GameMtlTextureDlg(void);
+	~GameMtlTextureDlg();
 
 	virtual BOOL		Dialog_Proc (HWND dlg_wnd, UINT message, WPARAM wparam, LPARAM lparam);
 	void					ActivateDlg(BOOL onOff);
-	void					ReloadDialog(void);
+	void					ReloadDialog();
 
 private:
 
 	void					Enable_Stage(int stage,BOOL onoff);
-	void					Update_Texture_Buttons(void);
+	void					Update_Texture_Buttons();
 
 	ISpinnerControl * Stage0FramesSpin;
 	ISpinnerControl * Stage1FramesSpin;

--- a/Core/Tools/WW3D/max2w3d/GameMtlVertexMaterialDlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/GameMtlVertexMaterialDlg.cpp
@@ -296,7 +296,7 @@ BOOL GameMtlVertexMaterialDlg::Dialog_Proc(HWND dlg_wnd, UINT message, WPARAM wp
  * HISTORY:                                                                                    *
  *   11/23/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void GameMtlVertexMaterialDlg::ReloadDialog(void)
+void GameMtlVertexMaterialDlg::ReloadDialog()
 {
 	// Vertex Material Controls
 	DebugPrint("GameMtlVertexMaterialDlg::ReloadDialog\n");

--- a/Core/Tools/WW3D/max2w3d/GameMtlVertexMaterialDlg.h
+++ b/Core/Tools/WW3D/max2w3d/GameMtlVertexMaterialDlg.h
@@ -52,7 +52,7 @@ public:
 	virtual BOOL		Dialog_Proc (HWND dlg_wnd, UINT message, WPARAM wparam, LPARAM lparam);
 
 	void					ActivateDlg(BOOL onoff);
-	void					ReloadDialog(void);
+	void					ReloadDialog();
 
 private:
 

--- a/Core/Tools/WW3D/max2w3d/InputDlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/InputDlg.cpp
@@ -64,7 +64,7 @@ InputDlg::InputDlg (HWND hWndParent)
 /////////////////////////////////////////////////////////////////////////////
 // InputDlg Methods
 
-int InputDlg::DoModal (void)
+int InputDlg::DoModal ()
 {
 	// Put up the dialog box.
 	BOOL result = DialogBoxParam(AppInstance, MAKEINTRESOURCE(IDD),
@@ -200,7 +200,7 @@ LRESULT InputDlg::OnInitDialog (WPARAM wParam, LPARAM lParam)
 	return 0;
 }
 
-BOOL InputDlg::OnOK (void)
+BOOL InputDlg::OnOK ()
 {
 	// Update our copy of what the user typed.
 	HWND hEdit = GetDlgItem(m_hWnd, IDC_VALUE);

--- a/Core/Tools/WW3D/max2w3d/InputDlg.h
+++ b/Core/Tools/WW3D/max2w3d/InputDlg.h
@@ -53,7 +53,7 @@ public:
 	InputDlg (HWND hWndParent=nullptr);
 
 	// Methods
-	int DoModal (void);		// returns IDOK or IDCANCEL
+	int DoModal ();		// returns IDOK or IDCANCEL
 
 	void SetCaption (const char *caption);
 	void SetLabel (const char *label);
@@ -76,5 +76,5 @@ protected:
 
 	// Message Handlers
 	LRESULT OnInitDialog (WPARAM wParam, LPARAM lParam);
-	BOOL OnOK (void);
+	BOOL OnOK ();
 };

--- a/Core/Tools/WW3D/max2w3d/MeshDeform.cpp
+++ b/Core/Tools/WW3D/max2w3d/MeshDeform.cpp
@@ -64,7 +64,7 @@ Class_ID _MeshDeformClassID(0x51981f5b, 0x1db2bf3);
 class MeshDeformClassDesc : public ClassDesc
 {
 	public:
-	int 				IsPublic (void)			{ return 1; }
+	int 				IsPublic ()			{ return 1; }
 	void *			Create (BOOL loading)	{ return new MeshDeformClass (); }
 	const TCHAR *	ClassName ()				{ return _T("WWDeform"); }
 	SClass_ID		SuperClassID ()			{ return OSM_CLASS_ID; }
@@ -80,9 +80,9 @@ class MeshDeformClassDesc : public ClassDesc
 ///////////////////////////////////////////////////////////////////////////
 #if 0 // (gth) MeshDeform is obsolete! making sure nobody uses it...
 static MeshDeformClassDesc _MeshDeformCD;
-ClassDesc * Get_Mesh_Deform_Desc (void) { return &_MeshDeformCD; }
+ClassDesc * Get_Mesh_Deform_Desc () { return &_MeshDeformCD; }
 #else
-ClassDesc * Get_Mesh_Deform_Desc (void) { return nullptr; }
+ClassDesc * Get_Mesh_Deform_Desc () { return nullptr; }
 #endif
 
 
@@ -92,7 +92,7 @@ ClassDesc * Get_Mesh_Deform_Desc (void) { return nullptr; }
 //
 ///////////////////////////////////////////////////////////////////////////
 ChannelMask
-MeshDeformClass::ChannelsUsed (void)
+MeshDeformClass::ChannelsUsed ()
 {
 	return GEOM_CHANNEL | SELECT_CHANNEL | SUBSEL_TYPE_CHANNEL | VERTCOLOR_CHANNEL;
 }
@@ -104,7 +104,7 @@ MeshDeformClass::ChannelsUsed (void)
 //
 ///////////////////////////////////////////////////////////////////////////
 ChannelMask
-MeshDeformClass::ChannelsChanged (void)
+MeshDeformClass::ChannelsChanged ()
 {
 	return GEOM_CHANNEL | SELECT_CHANNEL | SUBSEL_TYPE_CHANNEL | VERTCOLOR_CHANNEL;
 }
@@ -161,7 +161,7 @@ MeshDeformClass::ModifyObject
 //
 ///////////////////////////////////////////////////////////////////////////
 Class_ID
-MeshDeformClass::InputType (void)
+MeshDeformClass::InputType ()
 {
 	return triObjectClassID;
 }
@@ -191,7 +191,7 @@ MeshDeformClass::NotifyRefChanged
 //
 ///////////////////////////////////////////////////////////////////////////
 CreateMouseCallBack *
-MeshDeformClass::GetCreateMouseCallBack (void)
+MeshDeformClass::GetCreateMouseCallBack ()
 {
 	return nullptr;
 }
@@ -1123,7 +1123,7 @@ MeshDeformClass::Set_Max_Deform_Sets (int max)
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformClass::Update_Set_Count (void)
+MeshDeformClass::Update_Set_Count ()
 {
 	m_MaxSets = 1;
 	if (m_MaxInterface != nullptr) {
@@ -1213,7 +1213,7 @@ MeshDeformClass::Set_Current_Set
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformClass::Update_Current_Set (void)
+MeshDeformClass::Update_Current_Set ()
 {
 	if (m_MaxInterface != nullptr) {
 

--- a/Core/Tools/WW3D/max2w3d/MeshDeform.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeform.h
@@ -50,7 +50,7 @@ class MeshDeformModData;
 //	Prototypes
 //
 ///////////////////////////////////////////////////////////////////////////
-ClassDesc *Get_Mesh_Deform_Desc (void);
+ClassDesc *Get_Mesh_Deform_Desc ();
 extern Class_ID _MeshDeformClassID;
 
 
@@ -66,7 +66,7 @@ class MeshDeformClass : public OSModifier
 		//////////////////////////////////////////////////////////////////////
 		//	Public constructors/destructors
 		//////////////////////////////////////////////////////////////////////
-		MeshDeformClass (void)
+		MeshDeformClass ()
 			:	m_MaxInterface (nullptr),
 				m_ModeMove (nullptr),
 				m_ModeSelect (nullptr),
@@ -82,7 +82,7 @@ class MeshDeformClass : public OSModifier
 				m_MaxSets (0),
 				m_hRollupWnd (nullptr)			{ SetName ("WW Mesh Deformer"); Set_Max_Deform_Sets (1); }
 
-		virtual ~MeshDeformClass (void)	{ }
+		virtual ~MeshDeformClass ()	{ }
 #if defined W3D_MAX4		//defined as in the project (.dsp)
 		NumSubObjTypes();
 		GetSubObjType();
@@ -91,13 +91,13 @@ class MeshDeformClass : public OSModifier
 		//	Public methods
 		//////////////////////////////////////////////////////////////////////
 		void							Set_Deform_State (float state = 1.0F);
-		float							Get_Deform_State (void) const					{ return m_DeformState; }
+		float							Get_Deform_State () const					{ return m_DeformState; }
 		void							Set_Vertex_Color (const Point3 &color, bool button_up);
 		void							Get_Vertex_Color (Point3 &color);
 		void							Set_Max_Deform_Sets (int max);
-		int							Get_Max_Deform_Sets (void) const				{ return m_MaxSets; }
+		int							Get_Max_Deform_Sets () const				{ return m_MaxSets; }
 		void							Set_Current_Set (int index, bool update_selection);
-		int							Get_Current_Set (void) const					{ return m_CurrentSet; }
+		int							Get_Current_Set () const					{ return m_CurrentSet; }
 		void							Update_UI (MeshDeformModData *mod_data);
 		void							Auto_Apply (bool auto_apply = true);
 
@@ -108,11 +108,11 @@ class MeshDeformClass : public OSModifier
 		//////////////////////////////////////////////////////////////////////
 		// From Animatable
 		//////////////////////////////////////////////////////////////////////
-		void							DeleteThis (void) { delete this; }
+		void							DeleteThis () { delete this; }
 		void							GetClassName (TSTR& s) { s = TSTR(_T("WWDeform")); }
-		TCHAR *						GetObjectName (void) { return _T("WWDamage"); }
-		SClass_ID					SuperClassID (void) { return OSM_CLASS_ID; }
-		Class_ID						ClassID (void) { return _MeshDeformClassID; }
+		TCHAR *						GetObjectName () { return _T("WWDamage"); }
+		SClass_ID					SuperClassID () { return OSM_CLASS_ID; }
+		Class_ID						ClassID () { return _MeshDeformClassID; }
 		//RefTargetHandle			Clone(RemapDir& remap = NoRemap());
 		void							BeginEditParams (IObjParam  *ip, ULONG flags,Animatable *prev);
 		void							EndEditParams (IObjParam *ip, ULONG flags,Animatable *next);
@@ -120,12 +120,12 @@ class MeshDeformClass : public OSModifier
 		//////////////////////////////////////////////////////////////////////
 		// From Modifier
 		//////////////////////////////////////////////////////////////////////
-		ChannelMask					ChannelsUsed (void);
-		ChannelMask					ChannelsChanged (void);
+		ChannelMask					ChannelsUsed ();
+		ChannelMask					ChannelsChanged ();
 		void							ModifyObject (TimeValue t, ModContext &mod_context, ObjectState* os, INode *node);
 		BOOL							DependOnTopology (ModContext &mod_context) { return TRUE; }
-		int							NeedUseSubselButton (void) { return TRUE; }
-		Class_ID						InputType (void);
+		int							NeedUseSubselButton () { return TRUE; }
+		Class_ID						InputType ();
 
 		//////////////////////////////////////////////////////////////////////
 		// From ReferenceMaker
@@ -137,7 +137,7 @@ class MeshDeformClass : public OSModifier
 		//////////////////////////////////////////////////////////////////////
 		// From BaseObject
 		//////////////////////////////////////////////////////////////////////
-		CreateMouseCallBack *	GetCreateMouseCallBack (void);
+		CreateMouseCallBack *	GetCreateMouseCallBack ();
 		void							ActivateSubobjSel (int level, XFormModes &modes);
 		int							HitTest (TimeValue time_value, INode * node, int type, int crossing, int flags, IPoint2 *point, ViewExp *viewport, ModContext *mod_context);
 		void							SelectSubComponent (HitRecord *hit_record, BOOL selected, BOOL all, BOOL invert);
@@ -164,8 +164,8 @@ class MeshDeformClass : public OSModifier
 		//////////////////////////////////////////////////////////////////////
 		//	Protected methods
 		//////////////////////////////////////////////////////////////////////
-		void							Update_Current_Set (void);
-		void							Update_Set_Count (void);
+		void							Update_Current_Set ();
+		void							Update_Set_Count ();
 
 	private:
 

--- a/Core/Tools/WW3D/max2w3d/MeshDeformData.cpp
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformData.cpp
@@ -45,7 +45,7 @@
 //	~MeshDeformModData
 //
 ///////////////////////////////////////////////////////////////////////////
-MeshDeformModData::~MeshDeformModData (void)
+MeshDeformModData::~MeshDeformModData ()
 {
 	Free_Sets_List ();
 }
@@ -85,7 +85,7 @@ MeshDeformModData::Record_Mesh_State (TriObject &tri_obj, float state, bool upda
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformModData::Free_Sets_List (void)
+MeshDeformModData::Free_Sets_List ()
 {
 	//
 	//	Delete all the object pointers in the set list

--- a/Core/Tools/WW3D/max2w3d/MeshDeformData.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformData.h
@@ -61,41 +61,41 @@ class MeshDeformModData : public LocalModData
 		//////////////////////////////////////////////////////////////////////
 		//	Public constructors/destructors
 		//////////////////////////////////////////////////////////////////////
-		MeshDeformModData (void)
+		MeshDeformModData ()
 			:	m_CurrentSet (0)		{ }
 
-		virtual ~MeshDeformModData (void);
+		virtual ~MeshDeformModData ();
 
 		//////////////////////////////////////////////////////////////////////
 		//	Public methods
 		//////////////////////////////////////////////////////////////////////
-		virtual LocalModData *	Clone (void)	{ return new MeshDeformModData; }
+		virtual LocalModData *	Clone ()	{ return new MeshDeformModData; }
 		void							Record_Mesh_State (TriObject &tri_obj, float state, bool update_all);
 
 		//	Inline accessors
-		Mesh *					Peek_Mesh (void) const						{ return m_SetsList[m_CurrentSet]->Peek_Mesh (); }
-		const Point3 *			Peek_Orig_Vertex_Array (void) const		{ return m_SetsList[m_CurrentSet]->Peek_Orig_Vertex_Array (); }
-		Point3 *					Peek_Vertex_OPStart_Array (void) const	{ return m_SetsList[m_CurrentSet]->Peek_Vertex_OPStart_Array (); }
-		VertColor *				Peek_Vertex_Colors (void) const			{ return m_SetsList[m_CurrentSet]->Peek_Vertex_Colors (); }
+		Mesh *					Peek_Mesh () const						{ return m_SetsList[m_CurrentSet]->Peek_Mesh (); }
+		const Point3 *			Peek_Orig_Vertex_Array () const		{ return m_SetsList[m_CurrentSet]->Peek_Orig_Vertex_Array (); }
+		Point3 *					Peek_Vertex_OPStart_Array () const	{ return m_SetsList[m_CurrentSet]->Peek_Vertex_OPStart_Array (); }
+		VertColor *				Peek_Vertex_Colors () const			{ return m_SetsList[m_CurrentSet]->Peek_Vertex_Colors (); }
 
 		// Auto apply
-		bool						Is_Auto_Apply (void) const					{ return m_SetsList[m_CurrentSet]->Does_Set_Auto_Apply (); }
+		bool						Is_Auto_Apply () const					{ return m_SetsList[m_CurrentSet]->Does_Set_Auto_Apply (); }
 		void						Auto_Apply (bool auto_apply = true)		{ m_SetsList[m_CurrentSet]->Auto_Apply (auto_apply); }
 
 		// Data modifiers
-		void						Update_Current_Data (void)					{ m_SetsList[m_CurrentSet]->Update_Current_Data (); }
+		void						Update_Current_Data ()					{ m_SetsList[m_CurrentSet]->Update_Current_Data (); }
 		void						Set_Vertex_Position (int index, const Point3 &value) { m_SetsList[m_CurrentSet]->Set_Vertex_Position (index, value); }
 		void						Set_Vertex_Color (int index, int color_index, const VertColor &value) { m_SetsList[m_CurrentSet]->Set_Vertex_Color (index, color_index, value); }
 
 		// Set management
 		void						Set_Max_Deform_Sets (int max);
 		void						Set_Current_Set (int set_index)			{ m_CurrentSet = set_index; }
-		int						Get_Current_Set (void) const				{ return m_CurrentSet; }
+		int						Get_Current_Set () const				{ return m_CurrentSet; }
 		void						Select_Set (int set_index)					{ m_SetsList[set_index]->Select_Members (); }
 		void						Update_Set (int set_index, DEFORM_CHANNELS flags)	{ m_SetsList[set_index]->Update_Members (flags); }
 		void						Restore_Set (int set_index = -1);
 		MeshDeformSetClass &	Peek_Set (int index)							{ return *(m_SetsList[index]); }
-		int						Get_Set_Count (void) const					{ return m_SetsList.Count (); }
+		int						Get_Set_Count () const					{ return m_SetsList.Count (); }
 
 		// Persistent storage
 		IOResult					Save (ISave *save_obj);
@@ -108,7 +108,7 @@ class MeshDeformModData : public LocalModData
 		//////////////////////////////////////////////////////////////////////
 		void						Resize_Vertex_Array (int count, int color_count);
 		void						Copy_Vertex_Array (Mesh &mesh);
-		void						Free_Sets_List (void);
+		void						Free_Sets_List ();
 		void						Util_Restore_Set (int set_index);
 
 	private:

--- a/Core/Tools/WW3D/max2w3d/MeshDeformDefs.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformDefs.h
@@ -67,7 +67,7 @@ typedef enum
 ///////////////////////////////////////////////////////////////////////////
 typedef struct _VERT_INFO
 {
-	_VERT_INFO (void)
+	_VERT_INFO ()
 		:	index (0),
 			color_index (0),
 			value (0,0,0)				{ }

--- a/Core/Tools/WW3D/max2w3d/MeshDeformPanel.cpp
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformPanel.cpp
@@ -279,7 +279,7 @@ MeshDeformPanelClass::Set_Deformer (MeshDeformClass *obj)
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformPanelClass::Update_Vertex_Color (void)
+MeshDeformPanelClass::Update_Vertex_Color ()
 {
 	if (m_pMeshDeformer != nullptr) {
 

--- a/Core/Tools/WW3D/max2w3d/MeshDeformPanel.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformPanel.h
@@ -61,28 +61,28 @@ class MeshDeformPanelClass
 				m_pMeshDeformer (nullptr),
 				m_pLockSetsButton (nullptr),
 				m_pMaxSetsEdit (nullptr)				{ }
-		virtual ~MeshDeformPanelClass (void)	{ }
+		virtual ~MeshDeformPanelClass ()	{ }
 
 		//////////////////////////////////////////////////////////////////////
 		// Public methods
 		//////////////////////////////////////////////////////////////////////
 
 		// Inline accessors
-		IColorSwatch *				Get_Color_Swatch (void) const			{ return m_pColorSwatch; }
-		COLORREF						Get_Vertex_Color (void) const			{ return m_pColorSwatch->GetColor (); }
+		IColorSwatch *				Get_Color_Swatch () const			{ return m_pColorSwatch; }
+		COLORREF						Get_Vertex_Color () const			{ return m_pColorSwatch->GetColor (); }
 		void							Set_Vertex_Color (COLORREF color)	{ m_pColorSwatch->SetColor (color); }
 		void							Set_Deformer (MeshDeformClass *obj);
-		BOOL							Is_Edit_Mode (void) const				{ return (::SendDlgItemMessage (m_hWnd, IDC_STATE_SLIDER, TBM_GETPOS, 0, 0L) > 0); }
-		BOOL							Are_Sets_Tied (void) const				{ return m_pLockSetsButton->IsChecked (); }
-		int							Get_Current_Set (void) const			{ return ::SendDlgItemMessage (m_hWnd, IDC_CURRENT_SET_SLIDER, TBM_GETPOS, 0, 0L); }
+		BOOL							Is_Edit_Mode () const				{ return (::SendDlgItemMessage (m_hWnd, IDC_STATE_SLIDER, TBM_GETPOS, 0, 0L) > 0); }
+		BOOL							Are_Sets_Tied () const				{ return m_pLockSetsButton->IsChecked (); }
+		int							Get_Current_Set () const			{ return ::SendDlgItemMessage (m_hWnd, IDC_CURRENT_SET_SLIDER, TBM_GETPOS, 0, 0L); }
 		void							Set_Current_Set (int set, bool notify = false);
 		void							Set_Max_Sets (int max, bool notify = false);
 		void							Set_Current_State (float state);
 		void							Set_Auto_Apply_Check (bool onoff)	{ ::SendDlgItemMessage (m_hWnd, IDC_MANUALAPPLY, BM_SETCHECK, (WPARAM)(!onoff), 0L); }
-		bool							Get_Auto_Apply_Check (void) const	{ return ::SendDlgItemMessage (m_hWnd, IDC_MANUALAPPLY, BM_GETCHECK, 0, 0L) == 0; }
+		bool							Get_Auto_Apply_Check () const	{ return ::SendDlgItemMessage (m_hWnd, IDC_MANUALAPPLY, BM_GETCHECK, 0, 0L) == 0; }
 
 		// Update methods
-		void							Update_Vertex_Color (void);
+		void							Update_Vertex_Color ();
 
 		//////////////////////////////////////////////////////////////////////
 		// Static methods

--- a/Core/Tools/WW3D/max2w3d/MeshDeformSave.cpp
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformSave.cpp
@@ -145,7 +145,7 @@ MeshDeformSaveClass::Initialize
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformSaveClass::Reset (void)
+MeshDeformSaveClass::Reset ()
 {
 	//
 	//	Delete all the damage sets
@@ -370,7 +370,7 @@ MeshDeformSaveClass::Re_Index (MeshBuilderClass &builder)
 //
 ///////////////////////////////////////////////////////////////////////////
 bool
-MeshDeformSaveClass::Does_Deformer_Modify_DCG (void)
+MeshDeformSaveClass::Does_Deformer_Modify_DCG ()
 {
 	bool retval = false;
 

--- a/Core/Tools/WW3D/max2w3d/MeshDeformSave.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformSave.h
@@ -68,9 +68,9 @@ class MeshDeformSaveClass
 		//////////////////////////////////////////////////////////////////////
 		//	Public constructors/destructors
 		//////////////////////////////////////////////////////////////////////
-		MeshDeformSaveClass (void)
+		MeshDeformSaveClass ()
 			:	m_AlphaPasses (0)			{ }
-		~MeshDeformSaveClass (void)	{ Reset (); }
+		~MeshDeformSaveClass ()	{ Reset (); }
 
 		//////////////////////////////////////////////////////////////////////
 		//	Public methods
@@ -81,12 +81,12 @@ class MeshDeformSaveClass
 		//void					Re_Index (MeshBuilderClass &builder);
 		bool					Export (ChunkSaveClass &chunk_save);
 
-		void					Reset (void);
-		bool					Is_Empty (void) const					{ return m_DeformSets.Count () == 0; }
+		void					Reset ();
+		bool					Is_Empty () const					{ return m_DeformSets.Count () == 0; }
 
-		bool					Does_Deformer_Modify_DCG (void);
+		bool					Does_Deformer_Modify_DCG ();
 
-		unsigned int		Get_Alpha_Passes (void) const					{ return m_AlphaPasses; }
+		unsigned int		Get_Alpha_Passes () const					{ return m_AlphaPasses; }
 		void					Set_Alpha_Passes (unsigned int pass_mask)	{ m_AlphaPasses = pass_mask; }
 
 	protected:

--- a/Core/Tools/WW3D/max2w3d/MeshDeformSaveSet.cpp
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformSaveSet.cpp
@@ -156,7 +156,7 @@ MeshDeformSaveSetClass::Replace_Deform_Data
 //
 ////////////////////////////////////////////////////////////////////////
 /*int
-MeshDeformSaveSetClass::Get_Deform_Count (void) const
+MeshDeformSaveSetClass::Get_Deform_Count () const
 {
 	//
 	//	Count up all the deform entries for all the keyframes

--- a/Core/Tools/WW3D/max2w3d/MeshDeformSaveSet.cpp
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformSaveSet.cpp
@@ -45,7 +45,7 @@
 //
 ////////////////////////////////////////////////////////////////////////
 void
-MeshDeformSaveSetClass::Reset (void)
+MeshDeformSaveSetClass::Reset ()
 {
 	//
 	//	Free all the keyframe pointers in our list
@@ -86,7 +86,7 @@ MeshDeformSaveSetClass::Begin_Keyframe (float state)
 //
 ////////////////////////////////////////////////////////////////////////
 void
-MeshDeformSaveSetClass::End_Keyframe (void)
+MeshDeformSaveSetClass::End_Keyframe ()
 {
 	m_CurrentKeyFrame = nullptr;
 }

--- a/Core/Tools/WW3D/max2w3d/MeshDeformSaveSet.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformSaveSet.h
@@ -92,10 +92,10 @@ public:
 		//////////////////////////////////////////////////////////////////////
 		//	Public constructors/destructors
 		//////////////////////////////////////////////////////////////////////
-		MeshDeformSaveSetClass (void)
+		MeshDeformSaveSetClass ()
 			:	m_Flags (0),
 				m_CurrentKeyFrame (nullptr)	{ }
-		~MeshDeformSaveSetClass (void)	{ Reset (); }
+		~MeshDeformSaveSetClass ()	{ Reset (); }
 
 		//////////////////////////////////////////////////////////////////////
 		//	Public methods
@@ -103,23 +103,23 @@ public:
 
 		// Keyframe management
 		void					Begin_Keyframe (float state);
-		void					End_Keyframe (void);
+		void					End_Keyframe ();
 
 		// Vertex management
 		void					Add_Vert (UINT vert_index, const Point3 &position, const VertColor &color);
 
 		// Misc
-		void					Reset (void);
-		bool					Is_Empty (void) const	{ return m_DeformData.Count () == 0; }
+		void					Reset ();
+		bool					Is_Empty () const	{ return m_DeformData.Count () == 0; }
 
 		// Flag support
 		bool					Get_Flag (unsigned int flag) const				{ return (m_Flags & flag) == flag; }
 		void					Set_Flag (unsigned int flag, bool value)		{ if (value) (m_Flags |= flag); else (m_Flags &= ~flag); }
-		unsigned int		Get_Flags (void) const								{ return m_Flags; }
+		unsigned int		Get_Flags () const								{ return m_Flags; }
 
 		// Enumeration
 		float					Get_Deform_State (int key_frame) const			{ return m_DeformData[key_frame]->state; }
-		int					Get_Keyframe_Count (void) const					{ return m_DeformData.Count (); }
+		int					Get_Keyframe_Count () const					{ return m_DeformData.Count (); }
 		int					Get_Deform_Data_Count (int key_frame) const	{ return m_DeformData[key_frame]->deform_list.Count (); }
 		DEFORM_DATA &		Get_Deform_Data (int key_frame, int index)	{ return m_DeformData[key_frame]->deform_list[index]; }
 		void					Replace_Deform_Data (int keyframe_index, DynamicVectorClass<DEFORM_DATA> &list);

--- a/Core/Tools/WW3D/max2w3d/MeshDeformSet.cpp
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformSet.cpp
@@ -55,7 +55,7 @@ const int MAX_DEFORM_KEY_FRAMES			= 10;
 //	~MeshDeformSetClass
 //
 ///////////////////////////////////////////////////////////////////////////
-MeshDeformSetClass::~MeshDeformSetClass (void)
+MeshDeformSetClass::~MeshDeformSetClass ()
 {
 	SAFE_DELETE (m_pMesh);
 	SAFE_DELETE (m_pVertexArray);
@@ -144,7 +144,7 @@ MeshDeformSetClass::Set_Vertex_Color
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformSetClass::Update_Set_Members (void)
+MeshDeformSetClass::Update_Set_Members ()
 {
 	//
 	//	Examine each keyframe
@@ -274,7 +274,7 @@ MeshDeformSetClass::Reset_Key_Frame_Colors (int keyframe)
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformSetClass::Update_Current_Data (void)
+MeshDeformSetClass::Update_Current_Data ()
 {
 	DEFORM_LIST &vertices		= m_KeyFrames[m_CurrentKeyFrame]->vertices;
 	DEFORM_LIST &colors			= m_KeyFrames[m_CurrentKeyFrame]->colors;
@@ -416,7 +416,7 @@ MeshDeformSetClass::Update_Key_Frame (int key_frame)
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformSetClass::Init_Key_Frames (void)
+MeshDeformSetClass::Init_Key_Frames ()
 {
 	//
 	// For now, add all the key frames upfront
@@ -434,7 +434,7 @@ MeshDeformSetClass::Init_Key_Frames (void)
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformSetClass::Free_Key_Frames (void)
+MeshDeformSetClass::Free_Key_Frames ()
 {
 	//
 	// Loop through and free all the key frames
@@ -1085,7 +1085,7 @@ MeshDeformSetClass::Update_Members (DEFORM_CHANNELS flags)
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformSetClass::Select_Members (void)
+MeshDeformSetClass::Select_Members ()
 {
 	//
 	// Loop through and select the necessary verts
@@ -1102,7 +1102,7 @@ MeshDeformSetClass::Select_Members (void)
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-MeshDeformSetClass::Restore_Members (void)
+MeshDeformSetClass::Restore_Members ()
 {
 /*
 	//
@@ -1163,7 +1163,7 @@ MeshDeformSetClass::Restore_Members (void)
 //
 ///////////////////////////////////////////////////////////////////////////
 bool
-MeshDeformSetClass::Is_Empty (void) const
+MeshDeformSetClass::Is_Empty () const
 {
 	bool is_empty = true;
 

--- a/Core/Tools/WW3D/max2w3d/MeshDeformSet.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformSet.h
@@ -79,7 +79,7 @@ class MeshDeformSetClass
 		//////////////////////////////////////////////////////////////////////
 		//	Public methods
 		//////////////////////////////////////////////////////////////////////
-		//virtual LocalModData *	Clone (void)	{ return new MeshDeformSetClass; }
+		//virtual LocalModData *	Clone ()	{ return new MeshDeformSetClass; }
 		void					Update_Mesh (TriObject &tri_obj);
 		void					Set_State (float state);
 

--- a/Core/Tools/WW3D/max2w3d/MeshDeformSet.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformSet.h
@@ -63,7 +63,7 @@ class MeshDeformSetClass
 		//////////////////////////////////////////////////////////////////////
 		//	Public constructors/destructors
 		//////////////////////////////////////////////////////////////////////
-		MeshDeformSetClass (void)
+		MeshDeformSetClass ()
 			:	m_pMesh (nullptr),
 				m_pVertexArray (nullptr),
 				m_pVertexOPStartArray (nullptr),
@@ -74,7 +74,7 @@ class MeshDeformSetClass
 				m_bAutoApply (true),
 				m_VertexCount (0)					{ Init_Key_Frames (); }
 
-		virtual ~MeshDeformSetClass (void);
+		virtual ~MeshDeformSetClass ();
 
 		//////////////////////////////////////////////////////////////////////
 		//	Public methods
@@ -84,17 +84,17 @@ class MeshDeformSetClass
 		void					Set_State (float state);
 
 		//	Inline accessors
-		Mesh *				Peek_Mesh (void) const						{ return m_pMesh; }
-		const Point3 *		Peek_Orig_Vertex_Array (void) const		{ return m_pVertexArray; }
-		Point3 *				Peek_Vertex_OPStart_Array (void) const	{ return m_pVertexOPStartArray; }
-		VertColor *			Peek_Vertex_Colors (void) const			{ return m_pVertexColors; }
+		Mesh *				Peek_Mesh () const						{ return m_pMesh; }
+		const Point3 *		Peek_Orig_Vertex_Array () const		{ return m_pVertexArray; }
+		Point3 *				Peek_Vertex_OPStart_Array () const	{ return m_pVertexOPStartArray; }
+		VertColor *			Peek_Vertex_Colors () const			{ return m_pVertexColors; }
 
 		// Keyframe managment
 		void					Set_Current_Key_Frame (int index);
-		int					Get_Current_Key_Frame (void) const		{ return m_CurrentKeyFrame; }
+		int					Get_Current_Key_Frame () const		{ return m_CurrentKeyFrame; }
 		void					Update_Key_Frame (int key_frame);
-		void					Update_Current_Data (void);
-		void					Update_Set_Members (void);
+		void					Update_Current_Data ();
+		void					Update_Set_Members ();
 		void					Collapse_Keyframe_Data (int keyframe);
 		void					Reset_Key_Frame_Verts (int keyframe);
 		void					Reset_Key_Frame_Colors (int keyframe);
@@ -104,16 +104,16 @@ class MeshDeformSetClass
 		void					Set_Vertex_Color (int index, int color_index, const VertColor &value);
 
 		// Set managment
-		void					Select_Members (void);
+		void					Select_Members ();
 		void					Update_Members (DEFORM_CHANNELS flags);
-		void					Restore_Members (void);
+		void					Restore_Members ();
 
 		//	Auto apply
-		bool					Does_Set_Auto_Apply (void) const			{ return m_bAutoApply; }
+		bool					Does_Set_Auto_Apply () const			{ return m_bAutoApply; }
 		void					Auto_Apply (bool auto_apply = true)		{ m_bAutoApply = auto_apply; }
 
 		// Information
-		bool					Is_Empty (void) const;
+		bool					Is_Empty () const;
 		int					Get_Vertex_Count (int keyframe) const				{ return m_KeyFrames[keyframe]->vertices.Count (); }
 		int					Get_Color_Count (int keyframe) const				{ return m_KeyFrames[keyframe]->colors.Count (); }
 		const VERT_INFO &	Get_Vertex_Data (int keyframe, int index) const	{ return m_KeyFrames[keyframe]->vertices[index]; }
@@ -134,8 +134,8 @@ class MeshDeformSetClass
 		void					Copy_Vertex_Array (Mesh &mesh);
 
 		// Keyframe methods
-		void					Init_Key_Frames (void);
-		void					Free_Key_Frames (void);
+		void					Init_Key_Frames ();
+		void					Free_Key_Frames ();
 		void					Determine_Interpolation_Indicies (int key_frame, bool position, int &from, int &to, float &state);
 
 		// Deformation application methods

--- a/Core/Tools/WW3D/max2w3d/MeshDeformUndo.cpp
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformUndo.cpp
@@ -74,7 +74,7 @@ VertexRestoreClass::VertexRestoreClass
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-VertexRestoreClass::Free_Vertex_Array (void)
+VertexRestoreClass::Free_Vertex_Array ()
 {
 	m_VertexList.Delete_All ();
 	m_RedoVertexList.Delete_All ();
@@ -123,7 +123,7 @@ VertexRestoreClass::Restore (int is_undo)
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-VertexRestoreClass::Redo (void)
+VertexRestoreClass::Redo ()
 {
 	assert (m_pMesh != nullptr);
 	assert (m_pModData != nullptr);
@@ -155,7 +155,7 @@ VertexRestoreClass::Redo (void)
 //
 ///////////////////////////////////////////////////////////////////////////
 void
-VertexRestoreClass::EndHold (void)
+VertexRestoreClass::EndHold ()
 {
 	//
 	//	Record the position of all the verts we are about to change

--- a/Core/Tools/WW3D/max2w3d/MeshDeformUndo.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformUndo.h
@@ -59,15 +59,15 @@ class VertexRestoreClass : public RestoreObj
 		//	Public constructors/destructor
 		//////////////////////////////////////////////////////////////////
 		VertexRestoreClass (Mesh *mesh, MeshDeformClass *modifier, MeshDeformModData *mod_data);
-		virtual ~VertexRestoreClass (void)	{ Free_Vertex_Array (); };
+		virtual ~VertexRestoreClass ()	{ Free_Vertex_Array (); };
 
 		//////////////////////////////////////////////////////////////////
 		//	RestoreObj overrides
 		//////////////////////////////////////////////////////////////////
 		virtual void			Restore (int is_undo);
-		virtual void			Redo (void);
-		virtual int				Size (void)				{ return (m_VertexList.Count () * sizeof (Point3) * 2) + sizeof (VertexRestoreClass); }
-		virtual void			EndHold (void);
+		virtual void			Redo ();
+		virtual int				Size ()				{ return (m_VertexList.Count () * sizeof (Point3) * 2) + sizeof (VertexRestoreClass); }
+		virtual void			EndHold ();
 
 	protected:
 
@@ -76,7 +76,7 @@ class VertexRestoreClass : public RestoreObj
 		//////////////////////////////////////////////////////////////////
 		virtual void			Copy_Vertex_State (DEFORM_LIST &list) = 0;
 		virtual void			Apply_Vertex_Data (DEFORM_LIST &list) = 0;
-		void						Free_Vertex_Array (void);
+		void						Free_Vertex_Array ();
 
 		//////////////////////////////////////////////////////////////////
 		//	Protected member data
@@ -104,12 +104,12 @@ class VertexPositionRestoreClass : public VertexRestoreClass
 		//	Public constructors/destructor
 		//////////////////////////////////////////////////////////////////
 		VertexPositionRestoreClass (Mesh *mesh, MeshDeformClass *modifier, MeshDeformModData *mod_data);
-		virtual ~VertexPositionRestoreClass (void)	{ };
+		virtual ~VertexPositionRestoreClass ()	{ };
 
 		//////////////////////////////////////////////////////////////////
 		//	RestoreObj overrides
 		//////////////////////////////////////////////////////////////////
-		TSTR				Description (void)	{ return TSTR(_T("Vertex Position")); }
+		TSTR				Description ()	{ return TSTR(_T("Vertex Position")); }
 
 	protected:
 
@@ -134,12 +134,12 @@ class VertexColorRestoreClass : public VertexRestoreClass
 		//	Public constructors/destructor
 		//////////////////////////////////////////////////////////////////
 		VertexColorRestoreClass (Mesh *mesh, MeshDeformClass *modifier, MeshDeformModData *mod_data);
-		virtual ~VertexColorRestoreClass (void)	{ };
+		virtual ~VertexColorRestoreClass ()	{ };
 
 		//////////////////////////////////////////////////////////////////
 		//	RestoreObj overrides
 		//////////////////////////////////////////////////////////////////
-		TSTR				Description (void)	{ return TSTR(_T("Vertex Color")); }
+		TSTR				Description ()	{ return TSTR(_T("Vertex Color")); }
 
 	protected:
 

--- a/Core/Tools/WW3D/max2w3d/PS2GameMtlShaderDlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/PS2GameMtlShaderDlg.cpp
@@ -244,7 +244,7 @@ BOOL PS2GameMtlShaderDlg::Dialog_Proc (HWND dlg_wnd, UINT message, WPARAM wparam
  * HISTORY:                                                                                    *
  *   10/12/1999MLL: Created.                                                                   *
  *=============================================================================================*/
-void PS2GameMtlShaderDlg::ReloadDialog(void)
+void PS2GameMtlShaderDlg::ReloadDialog()
 {
 	DebugPrint("GameMtlShaderDlg::ReloadDialog\n");
 	SendDlgItemMessage(m_hWnd, IDC_PRIGRADIENT_COMBO, CB_SETCURSEL, TheMtl->Get_Pri_Gradient(PassIndex), 0 );
@@ -309,7 +309,7 @@ void PS2GameMtlShaderDlg::Apply_Preset(int preset_index)
  * HISTORY:                                                                                    *
  *   10/12/1999MLL: Created.                                                                   *
  *=============================================================================================*/
-void PS2GameMtlShaderDlg::Set_Preset(void)
+void PS2GameMtlShaderDlg::Set_Preset()
 {
 	for (int i = 0; i < NUM_PS2_SHADER_BLEND_PRESETS; i++) {
 		if (CompareShaderToBlendPreset(PS2ShaderBlendSettingPresets[i])) break;
@@ -359,7 +359,7 @@ bool PS2GameMtlShaderDlg::CompareShaderToBlendPreset(const PS2ShaderBlendSetting
  * HISTORY:                                                                                    *
  *   02/26/99   NH : Created.                                                                  *
  *=============================================================================================*/
-void PS2GameMtlShaderDlg::Set_Advanced_Defaults(void)
+void PS2GameMtlShaderDlg::Set_Advanced_Defaults()
 {
 	TheMtl->Set_Pri_Gradient(PassIndex, PSS_PRIGRADIENT_MODULATE);
 	TheMtl->Set_Depth_Compare(PassIndex, PSS_DEPTHCOMPARE_PASS_LEQUAL);

--- a/Core/Tools/WW3D/max2w3d/PS2GameMtlShaderDlg.h
+++ b/Core/Tools/WW3D/max2w3d/PS2GameMtlShaderDlg.h
@@ -53,7 +53,7 @@ public:
 
 	virtual BOOL		Dialog_Proc (HWND dlg_wnd, UINT message, WPARAM wparam, LPARAM lparam);
 
-	void					ReloadDialog(void);
+	void					ReloadDialog();
 
 	// Pure virtual that must be defined.
 	void					ActivateDlg(BOOL onOff) {}
@@ -61,7 +61,7 @@ public:
 private:
 
 	void					Apply_Preset(int preset_index);
-	void					Set_Preset(void);
+	void					Set_Preset();
 	bool					CompareShaderToBlendPreset(const PS2ShaderBlendSettingPreset &blend_preset);
-	void					Set_Advanced_Defaults(void);
+	void					Set_Advanced_Defaults();
 };

--- a/Core/Tools/WW3D/max2w3d/SceneSetupDlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/SceneSetupDlg.cpp
@@ -123,7 +123,7 @@ bool SceneSetupDlg::ValidateEditFloat (int control_id)
 /////////////////////////////////////////////////////////////////////////////
 // SceneSetupDlg Public Methods
 
-int SceneSetupDlg::DoModal (void)
+int SceneSetupDlg::DoModal ()
 {
 	// Put up the dialog box.
 	BOOL result = DialogBoxParam(AppInstance, MAKEINTRESOURCE(IDD_SCENE_SETUP),

--- a/Core/Tools/WW3D/max2w3d/SceneSetupDlg.h
+++ b/Core/Tools/WW3D/max2w3d/SceneSetupDlg.h
@@ -56,7 +56,7 @@ public:
 	SceneSetupDlg(Interface *max_interface);
 
 	// Methods
-	int DoModal (void);
+	int DoModal ();
 
 	// DialogProc
 	BOOL CALLBACK DialogProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
@@ -76,8 +76,8 @@ public:
 protected:
 
 	// Message Handlers
-	void OnInitDialog (void);
-	BOOL OnOK (void);		// TRUE if ok to close dialog
+	void OnInitDialog ();
+	BOOL OnOK ();		// TRUE if ok to close dialog
 
 	// Protected Methods
 	void  SetEditInt   (int control_id, int value);

--- a/Core/Tools/WW3D/max2w3d/SnapPoints.cpp
+++ b/Core/Tools/WW3D/max2w3d/SnapPoints.cpp
@@ -49,7 +49,7 @@
 class PointFilterClass : public INodeFilterClass
 {
 public:
-	PointFilterClass(void) { }
+	PointFilterClass() { }
 
 	virtual BOOL Accept_Node(INode * node, TimeValue time)
 	{

--- a/Core/Tools/WW3D/max2w3d/TARGA.cpp
+++ b/Core/Tools/WW3D/max2w3d/TARGA.cpp
@@ -85,7 +85,7 @@
 * SYNOPSIS
 *     Targa()
 *
-*     void Targa(void);
+*     void Targa();
 *
 * FUNCTION
 *     Initialize the targa class instance.
@@ -118,7 +118,7 @@ Targa::Targa()
 * SYNOPSIS
 *     ~Targa()
 *
-*     void ~Targa(void);
+*     void ~Targa();
 *
 * FUNCTION
 *
@@ -295,7 +295,7 @@ long Targa::Open(const char* name, long mode)
 * SYNOPSIS
 *     Close()
 *
-*     void Close(void);
+*     void Close();
 *
 * FUNCTION
 *     Close the Targa image file and free its handle.
@@ -959,7 +959,7 @@ bool Targa::IsCompressed()
 * SYNOPSIS
 *     Ext = GetExtension()
 *
-*     TGA2Extension *GetExtension(void);
+*     TGA2Extension *GetExtension();
 *
 * FUNCTION
 *     Retrieve a pointer to the Targa 2.0 extension data area. If the file
@@ -1082,7 +1082,7 @@ long Targa::DecodeImage()
 * SYNOPSIS
 *     EncodeImage()
 *
-*     void EncodeImage(void);
+*     void EncodeImage();
 *
 * FUNCTION
 *     Encode the image data using the RLE algorithm outlined in the TARGA
@@ -1227,7 +1227,7 @@ long Targa::EncodeImage()
 * SYNOPSIS
 *     InvertImage()
 *
-*     void InvertImage(void);
+*     void InvertImage();
 *
 * FUNCTION
 *

--- a/Core/Tools/WW3D/max2w3d/TARGA.cpp
+++ b/Core/Tools/WW3D/max2w3d/TARGA.cpp
@@ -98,7 +98,7 @@
 *
 ****************************************************************************/
 
-Targa::Targa(void)
+Targa::Targa()
 	{
 	mImage = nullptr;
 	mPalette = nullptr;
@@ -130,7 +130,7 @@ Targa::Targa(void)
 *
 ****************************************************************************/
 
-Targa::~Targa(void)
+Targa::~Targa()
 {
 	/* Close the file if has been left open. */
 	Close();
@@ -308,7 +308,7 @@ long Targa::Open(const char* name, long mode)
 *
 ****************************************************************************/
 
-void Targa::Close(void)
+void Targa::Close()
 {
 #ifdef TGA_USES_WWLIB_FILE_CLASSES
 	if (TGAFile) {
@@ -771,7 +771,7 @@ long Targa::Save(const char* name, long flags, bool addextension)
 *
 ****************************************************************************/
 
-void Targa::XFlip(void)
+void Targa::XFlip()
 	{
 	char *ptr,*ptr1;
 	long  x,y,d;
@@ -824,7 +824,7 @@ void Targa::XFlip(void)
 *
 ****************************************************************************/
 
-void Targa::YFlip(void)
+void Targa::YFlip()
 	{
 	char *ptr,*ptr1;
 	long  x,y;
@@ -942,7 +942,7 @@ char *Targa::SetPalette(char *buffer)
 }
 
 
-bool Targa::IsCompressed(void)
+bool Targa::IsCompressed()
 	{
 	if (Header.ImageType > 8)
 		return true;
@@ -973,7 +973,7 @@ bool Targa::IsCompressed(void)
 *
 ****************************************************************************/
 
-TGA2Extension *Targa::GetExtension(void)
+TGA2Extension *Targa::GetExtension()
 	{
 	if (mFlags & TGAF_TGA2)
 		return (&mExtension);
@@ -1239,7 +1239,7 @@ long Targa::EncodeImage()
 *
 ****************************************************************************/
 
-void Targa::InvertImage(void)
+void Targa::InvertImage()
 	{
 	char *buffer;
 	long depth;
@@ -1279,7 +1279,7 @@ void Targa::InvertImage(void)
 /*
 ** These functions are just for ease of ifdef'ing between standard io calls and FileClass.
 */
-void Targa::Clear_File(void)
+void Targa::Clear_File()
 {
 #ifdef TGA_USES_WWLIB_FILE_CLASSES
 	TGAFile = nullptr;
@@ -1287,7 +1287,7 @@ void Targa::Clear_File(void)
 	mFH = -1;
 #endif
 }
-bool Targa::Is_File_Open(void)
+bool Targa::Is_File_Open()
 {
 #ifdef TGA_USES_WWLIB_FILE_CLASSES
 	return (TGAFile != nullptr);

--- a/Core/Tools/WW3D/max2w3d/TARGA.h
+++ b/Core/Tools/WW3D/max2w3d/TARGA.h
@@ -260,29 +260,29 @@ class Targa
 	{
 	public:
 		/* Constructor/destructor */
-		Targa(void);
+		Targa();
 		~Targa();
 
 		/* Function prototypes. */
 		long Open(const char* name, long mode);
-		void Close(void);
+		void Close();
 
 		long Load(const char* name, char* palette, char* image,bool invert_image=true);
 		long Load(const char* name, long flags, bool invert_image=true);
 		long Save(const char* name, long flags, bool addextension = false);
 
-		void XFlip(void);
-		void YFlip(void);
+		void XFlip();
+		void YFlip();
 
 		char* SetImage(char* buffer);
-		char* GetImage(void) const {return (mImage);}
+		char* GetImage() const {return (mImage);}
 
 		char* SetPalette(char* buffer);
-		char* GetPalette(void) const {return (mPalette);}
+		char* GetPalette() const {return (mPalette);}
 
-		bool IsCompressed(void);
+		bool IsCompressed();
 
-		TGA2Extension* GetExtension(void);
+		TGA2Extension* GetExtension();
 
 		TGAHeader Header;
 
@@ -300,14 +300,14 @@ class Targa
 
 	private:
 		// Utility functions
-		long DecodeImage(void);
-		long EncodeImage(void);
-		void InvertImage(void);
+		long DecodeImage();
+		long EncodeImage();
+		void InvertImage();
 
 		// These functions are for ease of ifdef'ing between standard io calls
 		// and FileClass.
-		void Clear_File(void);
-		bool Is_File_Open(void);
+		void Clear_File();
+		bool Is_File_Open();
 		bool File_Open_Read(const char* name);
 		bool File_Open_Write(const char* name);
 		bool File_Open_ReadWrite(const char* name);

--- a/Core/Tools/WW3D/max2w3d/aabtreebuilder.cpp
+++ b/Core/Tools/WW3D/max2w3d/aabtreebuilder.cpp
@@ -79,7 +79,7 @@ const float COINCIDENCE_EPSILON = 0.001f;
  *                                                                                             *
  * HISTORY:                                                                                    *
  *=============================================================================================*/
-AABTreeBuilderClass::AABTreeBuilderClass(void) :
+AABTreeBuilderClass::AABTreeBuilderClass() :
 	Root(nullptr),
 	CurPolyIndex(0),
 	PolyCount(0),
@@ -102,7 +102,7 @@ AABTreeBuilderClass::AABTreeBuilderClass(void) :
  * HISTORY:                                                                                    *
  *   5/19/2000  gth : Created.                                                                 *
  *=============================================================================================*/
-AABTreeBuilderClass::~AABTreeBuilderClass(void)
+AABTreeBuilderClass::~AABTreeBuilderClass()
 {
 	Reset();
 }
@@ -120,7 +120,7 @@ AABTreeBuilderClass::~AABTreeBuilderClass(void)
  * HISTORY:                                                                                    *
  *   5/19/2000  gth : Created.                                                                 *
  *=============================================================================================*/
-void AABTreeBuilderClass::Reset(void)
+void AABTreeBuilderClass::Reset()
 {
 	if (Root) {
 		delete Root; Root = nullptr;
@@ -664,7 +664,7 @@ int AABTreeBuilderClass::Assign_Index(CullNodeStruct * node,int index)
  * HISTORY:                                                                                    *
  *   6/19/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-int AABTreeBuilderClass::Node_Count(void)
+int AABTreeBuilderClass::Node_Count()
 {
 	if (Root) {
 		return Node_Count_Recursive(Root,0);
@@ -686,7 +686,7 @@ int AABTreeBuilderClass::Node_Count(void)
  * HISTORY:                                                                                    *
  *   10/23/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-int AABTreeBuilderClass::Poly_Count(void)
+int AABTreeBuilderClass::Poly_Count()
 {
 	return PolyCount;
 }

--- a/Core/Tools/WW3D/max2w3d/aabtreebuilder.h
+++ b/Core/Tools/WW3D/max2w3d/aabtreebuilder.h
@@ -59,14 +59,14 @@ class AABTreeBuilderClass
 {
 public:
 
-	AABTreeBuilderClass(void);
-	~AABTreeBuilderClass(void);
+	AABTreeBuilderClass();
+	~AABTreeBuilderClass();
 
 	void					Build_AABTree(int polycount,Vector3i * polys,int vertcount,Vector3 * verts);
 	void					Export(ChunkSaveClass & csave);
 
-	int					Node_Count(void);
-	int					Poly_Count(void);
+	int					Node_Count();
+	int					Poly_Count();
 
 	enum
 	{
@@ -84,8 +84,8 @@ private:
 	*/
 	struct CullNodeStruct
 	{
-		CullNodeStruct(void) : Index(0),Min(0,0,0),Max(0,0,0),Front(nullptr),Back(nullptr),PolyCount(0),PolyIndices(nullptr) {}
-		~CullNodeStruct(void)
+		CullNodeStruct() : Index(0),Min(0,0,0),Max(0,0,0),Front(nullptr),Back(nullptr),PolyCount(0),PolyIndices(nullptr) {}
+		~CullNodeStruct()
 		{
 			if (Front) { delete Front; }
 			if (Back) { delete Back; }
@@ -106,7 +106,7 @@ private:
 	*/
 	struct SplitChoiceStruct
 	{
-		SplitChoiceStruct(void) :
+		SplitChoiceStruct() :
 			Cost(FLT_MAX),
 			FrontCount(0),
 			BackCount(0),
@@ -130,7 +130,7 @@ private:
 
 	struct SplitArraysStruct
 	{
-		SplitArraysStruct(void) :
+		SplitArraysStruct() :
 			FrontCount(0),
 			BackCount(0),
 			FrontPolys(nullptr),

--- a/Core/Tools/WW3D/max2w3d/animationcompressionsettings.cpp
+++ b/Core/Tools/WW3D/max2w3d/animationcompressionsettings.cpp
@@ -62,7 +62,7 @@ AnimationCompressionSettingsDialogClass::AnimationCompressionSettingsDialogClass
 //	~AnimationCompressionSettingsDialogClass
 //
 ////////////////////////////////////////////////////////////////////////////////////////
-AnimationCompressionSettingsDialogClass::~AnimationCompressionSettingsDialogClass (void)
+AnimationCompressionSettingsDialogClass::~AnimationCompressionSettingsDialogClass ()
 {
 }
 
@@ -73,7 +73,7 @@ AnimationCompressionSettingsDialogClass::~AnimationCompressionSettingsDialogClas
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 int
-AnimationCompressionSettingsDialogClass::Do_Modal (void)
+AnimationCompressionSettingsDialogClass::Do_Modal ()
 {
 	int retval = ::DialogBoxParam (AppInstance, MAKEINTRESOURCE (IDD_ANIMATION_COMPRESSION),
 													ParentWnd, Real_Message_Proc, (LPARAM)this);
@@ -195,7 +195,7 @@ AnimationCompressionSettingsDialogClass::Message_Proc
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 void
-AnimationCompressionSettingsDialogClass::Initialize_Controls (void)
+AnimationCompressionSettingsDialogClass::Initialize_Controls ()
 {
 	SetCheckBox (Wnd, IDC_REDUCE_ANIMATION_CHECK, Options->ReduceAnimation);
 	char string[128] = { 0 };
@@ -251,7 +251,7 @@ AnimationCompressionSettingsDialogClass::Initialize_Controls (void)
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 void
-AnimationCompressionSettingsDialogClass::Save_Settings (void)
+AnimationCompressionSettingsDialogClass::Save_Settings ()
 {
 	//
 	//	Read the compression type setting

--- a/Core/Tools/WW3D/max2w3d/animationcompressionsettings.h
+++ b/Core/Tools/WW3D/max2w3d/animationcompressionsettings.h
@@ -56,7 +56,7 @@ public:
 	//	Public constructors/destructors
 	//////////////////////////////////////////////////////////////////
 	AnimationCompressionSettingsDialogClass (Interface *maxinterface, HWND parent_wnd = nullptr);
-	~AnimationCompressionSettingsDialogClass (void);
+	~AnimationCompressionSettingsDialogClass ();
 
 
 	//////////////////////////////////////////////////////////////////
@@ -64,7 +64,7 @@ public:
 	//////////////////////////////////////////////////////////////////
 
 	void			Set_Options (W3dExportOptionsStruct *options)	{ Options = options; }
-	int			Do_Modal (void);
+	int			Do_Modal ();
 
 private:
 
@@ -77,8 +77,8 @@ private:
 	//	Private methods
 	//////////////////////////////////////////////////////////////////
 	BOOL			Message_Proc (UINT message, WPARAM wparam, LPARAM lparam);
-	void			Initialize_Controls (void);
-	void			Save_Settings (void);
+	void			Initialize_Controls ();
+	void			Save_Settings ();
 
 	//////////////////////////////////////////////////////////////////
 	//	Private member data

--- a/Core/Tools/WW3D/max2w3d/bchannel.cpp
+++ b/Core/Tools/WW3D/max2w3d/bchannel.cpp
@@ -62,7 +62,7 @@ BitChannelClass::BitChannelClass
 	End = 0;
 }
 
-BitChannelClass::~BitChannelClass(void)
+BitChannelClass::~BitChannelClass()
 {
 }
 
@@ -222,7 +222,7 @@ bool BitChannelClass::is_default(bool bit)
 	return (bit == DefaultVal);
 }
 
-void BitChannelClass::compute_range(void)
+void BitChannelClass::compute_range()
 {
 	Begin = 0;
 	while ((Begin < MaxFrames) && (is_default(Get_Bit(Begin)))) {

--- a/Core/Tools/WW3D/max2w3d/bchannel.h
+++ b/Core/Tools/WW3D/max2w3d/bchannel.h
@@ -63,12 +63,12 @@ class BitChannelClass
 public:
 
 	BitChannelClass(uint32 id,int maxframes,uint32 chntype,bool def_val);
-	~BitChannelClass(void);
+	~BitChannelClass();
 
 	void		Set_Bit(int framenumber,bool bit);
 	void		Set_Bits(BooleanVectorClass & bits);
 	bool		Get_Bit(int frameidx);
-	bool		Is_Empty(void) { return IsEmpty; }
+	bool		Is_Empty() { return IsEmpty; }
 	bool		Save(ChunkSaveClass & csave, bool compress);
 
 private:
@@ -87,7 +87,7 @@ private:
 	bool is_default(bool bit);
 
 	// This function finds the start and end of the "non-default" data
-	void compute_range(void);
+	void compute_range();
 
   // compress functions
 	void remove_packet(W3dTimeCodedBitChannelStruct * c, uint32 packet_idx);

--- a/Core/Tools/WW3D/max2w3d/bpick.cpp
+++ b/Core/Tools/WW3D/max2w3d/bpick.cpp
@@ -144,12 +144,12 @@ void BonePickerClass::proc(INodeTab & nodetab)
 	BoneList = nullptr;
 }
 
-TCHAR * BonePickerClass::dialogTitle(void)
+TCHAR * BonePickerClass::dialogTitle()
 {
 	return Get_String(IDS_PICK_BONE_DIALOG_TITLE);
 }
 
-TCHAR * BonePickerClass::buttonText(void)
+TCHAR * BonePickerClass::buttonText()
 {
 	return Get_String(IDS_PICK_BONE_BUTTON_TEXT);
 }

--- a/Core/Tools/WW3D/max2w3d/bpick.h
+++ b/Core/Tools/WW3D/max2w3d/bpick.h
@@ -63,7 +63,7 @@ class BonePickerClass : public PickNodeCallback, public PickModeCallback, public
 {
 public:
 
-	BonePickerClass(void) : User(nullptr), BoneList(nullptr), SinglePick(FALSE) {}
+	BonePickerClass() : User(nullptr), BoneList(nullptr), SinglePick(FALSE) {}
 
 	/*
 	** Tell this class who is using it and optionally the list
@@ -92,12 +92,12 @@ public:
 	/*
 	** From HitByNameDlgCallback
 	*/
-	virtual TCHAR * dialogTitle(void);
-	virtual TCHAR * buttonText(void);
-	virtual BOOL singleSelect(void) { return SinglePick; }
-	virtual BOOL useFilter(void) { return TRUE; }
-	virtual BOOL useProc(void) { return TRUE; }
-	virtual BOOL doCustomHilite(void) { return FALSE; }
+	virtual TCHAR * dialogTitle();
+	virtual TCHAR * buttonText();
+	virtual BOOL singleSelect() { return SinglePick; }
+	virtual BOOL useFilter() { return TRUE; }
+	virtual BOOL useProc() { return TRUE; }
+	virtual BOOL doCustomHilite() { return FALSE; }
 	virtual BOOL filter(INode * inode);
 	virtual void proc(INodeTab & nodeTab);
 

--- a/Core/Tools/WW3D/max2w3d/floaterdialog.cpp
+++ b/Core/Tools/WW3D/max2w3d/floaterdialog.cpp
@@ -86,7 +86,7 @@ BOOL CALLBACK _floater_dialog_proc(HWND hwnd,UINT message,WPARAM wParam,LPARAM l
  *                                                                                             *
  * HISTORY:                                                                                    *
  *=============================================================================================*/
-FloaterDialogClass::FloaterDialogClass(void) :
+FloaterDialogClass::FloaterDialogClass() :
 	Hwnd(nullptr),
 	ChildDialogTemplateID(-1),
 	ChildDialogProc(nullptr)
@@ -105,7 +105,7 @@ FloaterDialogClass::FloaterDialogClass(void) :
  *                                                                                             *
  * HISTORY:                                                                                    *
  *=============================================================================================*/
-FloaterDialogClass::~FloaterDialogClass(void)
+FloaterDialogClass::~FloaterDialogClass()
 {
 	if (Hwnd != nullptr) {
 		::DestroyWindow(Hwnd);
@@ -125,7 +125,7 @@ FloaterDialogClass::~FloaterDialogClass(void)
  * HISTORY:                                                                                    *
  *   10/11/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-bool FloaterDialogClass::Is_Created(void)
+bool FloaterDialogClass::Is_Created()
 {
 	return (Hwnd != nullptr);
 }

--- a/Core/Tools/WW3D/max2w3d/floaterdialog.h
+++ b/Core/Tools/WW3D/max2w3d/floaterdialog.h
@@ -52,10 +52,10 @@ class FloaterDialogClass
 {
 public:
 
-	FloaterDialogClass(void);
+	FloaterDialogClass();
 	~FloaterDialogClass();
 
-	bool	Is_Created(void);
+	bool	Is_Created();
 	void	Create(Interface * ip, int child_dialog_id, DLGPROC child_dlg_proc);
 	bool	Dialog_Proc(HWND hWnd,UINT message,WPARAM wParam,LPARAM);
 

--- a/Core/Tools/WW3D/max2w3d/gamemtl.h
+++ b/Core/Tools/WW3D/max2w3d/gamemtl.h
@@ -136,7 +136,7 @@ public:
 		};
 
 		GameMtl(BOOL loading = FALSE);
-		~GameMtl(void);
+		~GameMtl();
 
 		Class_ID				ClassID();
 		SClass_ID			SuperClassID();
@@ -166,11 +166,11 @@ public:
 		float					GetXParency(int mtlNum=0, BOOL backFace=FALSE)		{ return 0.0f; }
 		float					GetShininess(int mtlNum=0, BOOL backFace=FALSE)		{ return Get_Shininess(0,0); }
 		float					GetShinStr(int mtlNum=0, BOOL backFace=FALSE)		{ return 1.0f; }
-		void					Reset(void);
+		void					Reset();
 		void					Update(TimeValue t, Interval& validr);
 		Interval				Validity(TimeValue t);
 
-		int					NumSubTexmaps(void);
+		int					NumSubTexmaps();
 		void					SetSubTexmap(int i, Texmap * m);
 		Texmap *				GetSubTexmap(int i);
 
@@ -195,13 +195,13 @@ public:
 		int					Get_Flag(ULONG f)		 										{ return ((Flags&f) ? 1 : 0); }
 
 		void					Set_Surface_Type(unsigned int type)						{ SurfaceType = type; }
-		unsigned int		Get_Surface_Type(void) const								{ return SurfaceType; }
+		unsigned int		Get_Surface_Type() const								{ return SurfaceType; }
 
 		void					Set_Sort_Level(int level)									{ SortLevel = level; }
-		int					Get_Sort_Level(void) const									{ return SortLevel; }
+		int					Get_Sort_Level() const									{ return SortLevel; }
 
 		void					Set_Pass_Count(int passcount);
-		int					Get_Pass_Count(void);
+		int					Get_Pass_Count();
 
 		IParamBlock *		Get_Parameter_Block(int pass);
 		int					Get_Current_Page(int pass)									{ return CurPage[pass]; }
@@ -245,9 +245,9 @@ public:
 		int					Get_Texture_Frame_Count(int pass,int stage);
 		int					Get_Texture_Anim_Type(int pass,int stage);
 		Texmap *				Get_Texture(int pass,int stage);
-		Texmap *				Get_Displacement_Map(void) const								{ return DisplacementMap; }
-		float					Get_Displacement_Amount(void) const							{ return DisplacementAmt; }
-		int					Get_Displacement_Map_Index(void) const;
+		Texmap *				Get_Displacement_Map() const								{ return DisplacementMap; }
+		float					Get_Displacement_Amount() const							{ return DisplacementAmt; }
+		int					Get_Displacement_Map_Index() const;
 		int					Get_Map_Channel(int pass,int stage);
 
 		void					Set_Current_Page(int pass,int page)							{ CurPage[pass] = page; }
@@ -295,7 +295,7 @@ public:
 
 		void					Set_Map_Channel(int pass,int stage,int channel);
 
-		void					Notify_Changed(void);
+		void					Notify_Changed();
 
 		// This returns the mapping args string buffer for that pass after
 		// assuring that it is at least of length 'len'.

--- a/Core/Tools/WW3D/max2w3d/genlodextensiondialog.cpp
+++ b/Core/Tools/WW3D/max2w3d/genlodextensiondialog.cpp
@@ -87,7 +87,7 @@ GenLodExtensionDialogClass::GenLodExtensionDialogClass(Interface * maxinterface)
  * HISTORY:                                                                                    *
  *   10/10/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-GenLodExtensionDialogClass::~GenLodExtensionDialogClass(void)
+GenLodExtensionDialogClass::~GenLodExtensionDialogClass()
 {
 	ReleaseISpinner(LodIndexSpin);
 }

--- a/Core/Tools/WW3D/max2w3d/genlodextensiondialog.h
+++ b/Core/Tools/WW3D/max2w3d/genlodextensiondialog.h
@@ -57,7 +57,7 @@ public:
 
 	struct OptionsStruct
 	{
-		OptionsStruct(void) : LodIndex(0)
+		OptionsStruct() : LodIndex(0)
 		{
 		}
 

--- a/Core/Tools/WW3D/max2w3d/genmtlnamesdialog.cpp
+++ b/Core/Tools/WW3D/max2w3d/genmtlnamesdialog.cpp
@@ -90,7 +90,7 @@ GenMtlNamesDialogClass::GenMtlNamesDialogClass(Interface * maxinterface) :
  * HISTORY:                                                                                    *
  *   10/10/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-GenMtlNamesDialogClass::~GenMtlNamesDialogClass(void)
+GenMtlNamesDialogClass::~GenMtlNamesDialogClass()
 {
 	ReleaseISpinner(NameIndexSpin);
 }
@@ -144,7 +144,7 @@ bool GenMtlNamesDialogClass::Get_Options(OptionsStruct * options)
  * HISTORY:                                                                                    *
  *   10/10/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-bool GenMtlNamesDialogClass::Ok_To_Exit(void)
+bool GenMtlNamesDialogClass::Ok_To_Exit()
 {
 	// just check that the user entered a name
 	char buf[W3D_NAME_LEN];

--- a/Core/Tools/WW3D/max2w3d/genmtlnamesdialog.h
+++ b/Core/Tools/WW3D/max2w3d/genmtlnamesdialog.h
@@ -66,7 +66,7 @@ public:
 
 	struct OptionsStruct
 	{
-		OptionsStruct(void) : OnlyAffectSelected(true), NameIndex(0)
+		OptionsStruct() : OnlyAffectSelected(true), NameIndex(0)
 		{
 			memset(RootName,0,sizeof(RootName));
 		}
@@ -81,7 +81,7 @@ public:
 
 	bool Get_Options(OptionsStruct * options);
 	bool Dialog_Proc(HWND hWnd,UINT message,WPARAM wParam,LPARAM);
-	bool Ok_To_Exit(void);
+	bool Ok_To_Exit();
 
 private:
 

--- a/Core/Tools/WW3D/max2w3d/gennamesdialog.cpp
+++ b/Core/Tools/WW3D/max2w3d/gennamesdialog.cpp
@@ -92,7 +92,7 @@ GenNamesDialogClass::GenNamesDialogClass(Interface * maxinterface) :
  * HISTORY:                                                                                    *
  *   10/10/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-GenNamesDialogClass::~GenNamesDialogClass(void)
+GenNamesDialogClass::~GenNamesDialogClass()
 {
 	ReleaseISpinner(NameIndexSpin);
 }
@@ -150,7 +150,7 @@ bool GenNamesDialogClass::Get_Options(OptionsStruct * options)
  * HISTORY:                                                                                    *
  *   10/10/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-bool GenNamesDialogClass::Ok_To_Exit(void)
+bool GenNamesDialogClass::Ok_To_Exit()
 {
 	if (IsDlgButtonChecked(Hwnd,IDC_ASSIGN_NAMES_CHECK) == BST_CHECKED) {
 
@@ -182,7 +182,7 @@ bool GenNamesDialogClass::Ok_To_Exit(void)
  * HISTORY:                                                                                    *
  *   10/10/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-void GenNamesDialogClass::Toggle_Name_Assignment(void)
+void GenNamesDialogClass::Toggle_Name_Assignment()
 {
 	bool onoff = (IsDlgButtonChecked(Hwnd,IDC_ASSIGN_NAMES_CHECK) == BST_CHECKED);
 	EnableWindow(GetDlgItem(Hwnd,IDC_BASE_NAME_EDIT),onoff);
@@ -205,7 +205,7 @@ void GenNamesDialogClass::Toggle_Name_Assignment(void)
  * HISTORY:                                                                                    *
  *   10/10/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-void GenNamesDialogClass::Toggle_Collision_Bits_Assignment(void)
+void GenNamesDialogClass::Toggle_Collision_Bits_Assignment()
 {
 	bool onoff = (IsDlgButtonChecked(Hwnd,IDC_ASSIGN_COLLISION_BITS_CHECK) == BST_CHECKED);
 	EnableWindow(GetDlgItem(Hwnd,IDC_COLLISION_PHYSICAL),onoff);

--- a/Core/Tools/WW3D/max2w3d/gennamesdialog.h
+++ b/Core/Tools/WW3D/max2w3d/gennamesdialog.h
@@ -55,7 +55,7 @@ public:
 
 	struct OptionsStruct
 	{
-		OptionsStruct(void) : OnlyAffectSelected(false), NameIndex(0), AssignCollisionBits(false)
+		OptionsStruct() : OnlyAffectSelected(false), NameIndex(0), AssignCollisionBits(false)
 		{
 			memset(RootName,0,sizeof(RootName));
 			memset(PrefixName,0,sizeof(PrefixName));
@@ -85,9 +85,9 @@ public:
 
 	bool Get_Options(OptionsStruct * options);
 	bool Dialog_Proc(HWND hWnd,UINT message,WPARAM wParam,LPARAM);
-	bool Ok_To_Exit(void);
-	void Toggle_Collision_Bits_Assignment(void);
-	void Toggle_Name_Assignment(void);
+	bool Ok_To_Exit();
+	void Toggle_Collision_Bits_Assignment();
+	void Toggle_Name_Assignment();
 
 private:
 

--- a/Core/Tools/WW3D/max2w3d/geometryexportcontext.h
+++ b/Core/Tools/WW3D/max2w3d/geometryexportcontext.h
@@ -85,7 +85,7 @@ public:
 		OriginTransform = Origin->GetNodeTM(CurTime);
 	}
 
-	~GeometryExportContextClass(void)
+	~GeometryExportContextClass()
 	{
 		delete[] ModelName;
 	}

--- a/Core/Tools/WW3D/max2w3d/geometryexporttask.cpp
+++ b/Core/Tools/WW3D/max2w3d/geometryexporttask.cpp
@@ -107,7 +107,7 @@ public:
 	{
 	}
 
-	virtual ~MeshGeometryExportTaskClass(void)
+	virtual ~MeshGeometryExportTaskClass()
 	{
 	}
 
@@ -148,7 +148,7 @@ public:
 	** new unique names.  These meshes are flagged and then new names are generated prior
 	** to exporting.
 	*/
-	bool	Is_Name_Dirty(void)				{ return NameDirty; }
+	bool	Is_Name_Dirty()				{ return NameDirty; }
 	void	Set_Name_Dirty(bool onoff)		{ NameDirty = onoff; }
 
 	/*
@@ -159,18 +159,18 @@ public:
 	/*
 	** Optimization functions
 	*/
-	bool	Is_Single_Material(void);
-	Mtl *	Get_Single_Material(void);
+	bool	Is_Single_Material();
+	Mtl *	Get_Single_Material();
 	void	Split(DynamicVectorClass<MeshGeometryExportTaskClass *> & simple_meshes);
 	void	Reduce_To_Single_Material(int mat_id);
-	bool	Can_Combine(void);
+	bool	Can_Combine();
 	bool	Can_Combine_With(MeshGeometryExportTaskClass * other_mesh);
 	void	Combine_Mesh(MeshGeometryExportTaskClass * other_mesh);
 
 protected:
 
-	virtual int			Get_Geometry_Type(void) { return MESH; }
-	void					Update_Cached_Data(void);
+	virtual int			Get_Geometry_Type() { return MESH; }
+	void					Update_Cached_Data();
 
 	Mesh					MeshData;			// Copy of the mesh data to be exported.
 	W3DAppData2Struct	ExportOptions;		// Copy of the export options in case we want to change them during optimization
@@ -221,7 +221,7 @@ public:
 
 protected:
 
-	virtual int	Get_Geometry_Type(void) { return COLLISIONBOX; }
+	virtual int	Get_Geometry_Type() { return COLLISIONBOX; }
 
 };
 
@@ -262,7 +262,7 @@ public:
 
 protected:
 
-	virtual int	Get_Geometry_Type(void) { return DAZZLE; }
+	virtual int	Get_Geometry_Type() { return DAZZLE; }
 
 };
 
@@ -293,7 +293,7 @@ public:
 
 protected:
 
-	virtual int	Get_Geometry_Type(void) { return NULLOBJ; }
+	virtual int	Get_Geometry_Type() { return NULLOBJ; }
 
 };
 
@@ -320,14 +320,14 @@ public:
 		context.ProgressMeter->Add_Increment();
 	};
 
-	virtual bool Is_Aggregate(void)
+	virtual bool Is_Aggregate()
 	{
 		return true;
 	}
 
 protected:
 
-	virtual int	Get_Geometry_Type(void) { return AGGREGATE; }
+	virtual int	Get_Geometry_Type() { return AGGREGATE; }
 
 };
 
@@ -365,11 +365,11 @@ public:
 		context.ProgressMeter->Add_Increment();
 	};
 
-	virtual bool Is_Proxy(void) { return true; }
+	virtual bool Is_Proxy() { return true; }
 
 protected:
 
-	virtual int	Get_Geometry_Type(void) { return PROXY; }
+	virtual int	Get_Geometry_Type() { return PROXY; }
 
 };
 
@@ -456,7 +456,7 @@ GeometryExportTaskClass::GeometryExportTaskClass(const GeometryExportTaskClass &
  *                                                                                             *
  * HISTORY:                                                                                    *
  *=============================================================================================*/
-GeometryExportTaskClass::~GeometryExportTaskClass(void)
+GeometryExportTaskClass::~GeometryExportTaskClass()
 {
 }
 
@@ -739,7 +739,7 @@ void GeometryExportTaskClass::Generate_Name(char * root,int index,GeometryExport
  * HISTORY:                                                                                    *
  *   10/23/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-void	MeshGeometryExportTaskClass::Update_Cached_Data(void)
+void	MeshGeometryExportTaskClass::Update_Cached_Data()
 {
 	SingleMtl = nullptr;
 	Mtl *	nodemtl = Node->GetMtl();
@@ -836,7 +836,7 @@ void	MeshGeometryExportTaskClass::Update_Cached_Data(void)
  * HISTORY:                                                                                    *
  *   10/20/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-bool MeshGeometryExportTaskClass::Is_Single_Material(void)
+bool MeshGeometryExportTaskClass::Is_Single_Material()
 {
 	return ((SingleMtl != nullptr) || (Node->GetMtl() == nullptr));
 }
@@ -854,7 +854,7 @@ bool MeshGeometryExportTaskClass::Is_Single_Material(void)
  * HISTORY:                                                                                    *
  *   10/23/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-Mtl* MeshGeometryExportTaskClass::Get_Single_Material(void)
+Mtl* MeshGeometryExportTaskClass::Get_Single_Material()
 {
 	return SingleMtl;
 }
@@ -970,7 +970,7 @@ void MeshGeometryExportTaskClass::Reduce_To_Single_Material(int mat_id)
  * HISTORY:                                                                                    *
  *   10/24/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-bool MeshGeometryExportTaskClass::Can_Combine(void)
+bool MeshGeometryExportTaskClass::Can_Combine()
 {
 	/*
 	** This mesh can't combine at all if:

--- a/Core/Tools/WW3D/max2w3d/geometryexporttask.h
+++ b/Core/Tools/WW3D/max2w3d/geometryexporttask.h
@@ -60,20 +60,20 @@ public:
 
 	GeometryExportTaskClass(INode * node,GeometryExportContextClass & context);
 	GeometryExportTaskClass(const GeometryExportTaskClass & that);
-	virtual ~GeometryExportTaskClass(void);
+	virtual ~GeometryExportTaskClass();
 
 	virtual void							Export_Geometry(GeometryExportContextClass & context) = 0;
 
 	/*
 	** Accessors
 	*/
-	char *									Get_Name(void)								{ return Name; }
-	char *									Get_Container_Name(void)				{ return ContainerName; }
+	char *									Get_Name()								{ return Name; }
+	char *									Get_Container_Name()				{ return ContainerName; }
 	void										Get_Full_Name(char * buffer,int size);
 
-	int										Get_Bone_Index(void)						{ return BoneIndex; }
-	INode *									Get_Object_Node(void)					{ return Node; }
-	Matrix3									Get_Export_Transform(void)				{ return ExportSpace; }
+	int										Get_Bone_Index()						{ return BoneIndex; }
+	INode *									Get_Object_Node()					{ return Node; }
+	Matrix3									Get_Export_Transform()				{ return ExportSpace; }
 
 	void										Set_Name(char * name)					{ strncpy(Name,name,sizeof(Name)); }
 	void										Set_Container_Name(char * name)		{ strncpy(ContainerName,name,sizeof(ContainerName)); }
@@ -99,14 +99,14 @@ public:
 	** as "additional models" rather than being placed in the normal LOD arrays).  This virtual
 	** can be used to detect "aggregate" models.
 	*/
-	virtual bool							Is_Aggregate(void)						{ return false; }
+	virtual bool							Is_Aggregate()						{ return false; }
 
 	/*
 	** Proxy Detection. A "proxy" is a reference (by name) to an external game object that should
 	** be instantiated at the specified transform.  Like the aggregates, these had to unfortunately
 	** be handled with special cases and therefore have this virtual function devoted solely to them.
 	*/
-	virtual bool							Is_Proxy(void)								{ return false; }
+	virtual bool							Is_Proxy()								{ return false; }
 
 	/*
 	** Virtual Constructor
@@ -135,7 +135,7 @@ protected:
 		AGGREGATE,
 		PROXY,
 	};
-	virtual int	Get_Geometry_Type(void) = 0;
+	virtual int	Get_Geometry_Type() = 0;
 
 protected:
 

--- a/Core/Tools/WW3D/max2w3d/gridsnapmodifier.cpp
+++ b/Core/Tools/WW3D/max2w3d/gridsnapmodifier.cpp
@@ -107,10 +107,10 @@ public:
 class GridSnapDeformerClass : public Deformer
 {
 public:
-	GridSnapDeformerClass(void) : GridDimension(0.001f) {}
+	GridSnapDeformerClass() : GridDimension(0.001f) {}
 
 	void		Set_Grid_Dimension(float grid_dim)		{ GridDimension = grid_dim; }
-	float		Get_Grid_Dimension(void)					{ return GridDimension; }
+	float		Get_Grid_Dimension()					{ return GridDimension; }
 
 	void		Set_Matrices(const Matrix3 & tm,const Matrix3 & invtm)	{ Transform = tm; InvTransform = invtm; }
 
@@ -152,7 +152,7 @@ public:
 
 static GridSnapModifierClassDesc _GridSnapModifierDesc;
 
-ClassDesc* Get_Grid_Snap_Modifier_Desc(void)
+ClassDesc* Get_Grid_Snap_Modifier_Desc()
 {
 	return &_GridSnapModifierDesc;
 }

--- a/Core/Tools/WW3D/max2w3d/gridsnapmodifier.h
+++ b/Core/Tools/WW3D/max2w3d/gridsnapmodifier.h
@@ -40,4 +40,4 @@
 
 class ClassDesc;
 
-ClassDesc * Get_Grid_Snap_Modifier_Desc(void);
+ClassDesc * Get_Grid_Snap_Modifier_Desc();

--- a/Core/Tools/WW3D/max2w3d/hiersave.cpp
+++ b/Core/Tools/WW3D/max2w3d/hiersave.cpp
@@ -217,7 +217,7 @@ HierarchySaveClass::HierarchySaveClass():
  * HISTORY:                                                                                    *
  *   10/26/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-HierarchySaveClass::~HierarchySaveClass(void)
+HierarchySaveClass::~HierarchySaveClass()
 {
 	Free();
 }
@@ -234,7 +234,7 @@ HierarchySaveClass::~HierarchySaveClass(void)
  * HISTORY:                                                                                    *
  *   10/26/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-void HierarchySaveClass::Free(void)
+void HierarchySaveClass::Free()
 {
 	Node.Clear();
 }
@@ -321,7 +321,7 @@ Matrix3 HierarchySaveClass::get_relative_transform(int nodeidx) const
  * HISTORY:                                                                                    *
  *   10/26/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-const char * HierarchySaveClass::Get_Name(void) const
+const char * HierarchySaveClass::Get_Name() const
 {
 	return HierarchyHeader.Name;
 }

--- a/Core/Tools/WW3D/max2w3d/hiersave.h
+++ b/Core/Tools/WW3D/max2w3d/hiersave.h
@@ -109,8 +109,8 @@ public:
 
 	bool				Save(ChunkSaveClass & csave);
 	bool				Load(ChunkLoadClass & cload);
-	int				Num_Nodes(void) const { return CurNode; }
-	const char *	Get_Name(void) const;
+	int				Num_Nodes() const { return CurNode; }
+	const char *	Get_Name() const;
 	const char *	Get_Node_Name(int node) const;
 
 	// get ahold of the max inode
@@ -163,5 +163,5 @@ private:
 
 	Matrix3	get_relative_transform(int nodeidx) const;
 	Matrix3	fixup_matrix(const Matrix3 & src) const;
-	void	 	Free(void);
+	void	 	Free();
 };

--- a/Core/Tools/WW3D/max2w3d/hlodsave.cpp
+++ b/Core/Tools/WW3D/max2w3d/hlodsave.cpp
@@ -220,7 +220,7 @@ HLodSaveClass::HLodSaveClass (MeshConnectionsClass **connections, int lod_count,
  * HISTORY:                                                                                    *
  *   9/14/1999  AJA : Created.                                                                 *
  *=============================================================================================*/
-HLodSaveClass::~HLodSaveClass (void)
+HLodSaveClass::~HLodSaveClass ()
 {
 	if (lod_array)
 	{

--- a/Core/Tools/WW3D/max2w3d/hlodsave.h
+++ b/Core/Tools/WW3D/max2w3d/hlodsave.h
@@ -62,7 +62,7 @@ public:
 	HLodSaveClass (MeshConnectionsClass **connections, int lod_count, TimeValue CurTime,
 						char *name, const char *htree_name, Progress_Meter_Class &meter,
 						INodeListClass *origin_list);
-	~HLodSaveClass (void);
+	~HLodSaveClass ();
 
 	bool Save (ChunkSaveClass &csave);
 
@@ -86,7 +86,7 @@ protected:
 			Allocate_Sub_Objects(num_sub_objs);
 		}
 
-		~HLodArrayEntry (void)
+		~HLodArrayEntry ()
 		{
 			if (sub_obj)
 			{

--- a/Core/Tools/WW3D/max2w3d/logdlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/logdlg.cpp
@@ -79,7 +79,7 @@ LogDataDialogClass::LogDataDialogClass(HWND parent):
 	}
 }
 
-LogDataDialogClass::~LogDataDialogClass(void)
+LogDataDialogClass::~LogDataDialogClass()
 {
 	status = 3;
 	if (::IsWindow(Hwnd)) {

--- a/Core/Tools/WW3D/max2w3d/maxworldinfo.h
+++ b/Core/Tools/WW3D/max2w3d/maxworldinfo.h
@@ -60,22 +60,22 @@ class MaxWorldInfoClass : public WorldInfoClass
 				SmoothBetweenMeshes (true),
 				CurrentTask(nullptr),
 				CurrentTime(0)					{ }
-		virtual ~MaxWorldInfoClass(void)	{ }
+		virtual ~MaxWorldInfoClass()	{ }
 
 		// Public methods
 		virtual Vector3	Get_Shared_Vertex_Normal(Vector3 pos, int smgroup);
 
-		virtual GeometryExportTaskClass *	Get_Current_Task(void) const								{ return CurrentTask; }
+		virtual GeometryExportTaskClass *	Get_Current_Task() const								{ return CurrentTask; }
 		virtual void								Set_Current_Task(GeometryExportTaskClass * task)	{ CurrentTask = task; }
 
-		virtual TimeValue	Get_Current_Time(void) const	{ return CurrentTime; }
+		virtual TimeValue	Get_Current_Time() const	{ return CurrentTime; }
 		virtual void		Set_Current_Time(TimeValue &time) { CurrentTime = time; }
 
-		virtual Matrix3	Get_Export_Transform(void) const	{ return ExportTrans; }
+		virtual Matrix3	Get_Export_Transform() const	{ return ExportTrans; }
 		virtual void		Set_Export_Transform(const Matrix3 &matrix) { ExportTrans = matrix; }
 
 		virtual void		Allow_Mesh_Smoothing (bool onoff)	{ SmoothBetweenMeshes = onoff; }
-		virtual bool		Are_Meshes_Smoothed (void) const		{ return SmoothBetweenMeshes; }
+		virtual bool		Are_Meshes_Smoothed () const		{ return SmoothBetweenMeshes; }
 
 	private:
 

--- a/Core/Tools/WW3D/max2w3d/meshbuild.cpp
+++ b/Core/Tools/WW3D/max2w3d/meshbuild.cpp
@@ -121,12 +121,12 @@ public:
 		HashVal = (int)(item.VertIdx[0]*12345.6f + item.VertIdx[1]*1714.38484f + item.VertIdx[2]*27561.3f)&1023;
 	}
 
-	virtual int		Num_Hash_Bits(void)
+	virtual int		Num_Hash_Bits()
 	{
 		return 10;
 	}
 
-	virtual int		Num_Hash_Values(void)
+	virtual int		Num_Hash_Values()
 	{
 		return 1;
 	}
@@ -178,7 +178,7 @@ public:
 		Extent.Set(1.0f,1.0f,1.0f);
 	}
 
-	~VertexArrayClass(void)
+	~VertexArrayClass()
 	{
 		delete[] Verts;
 		delete[] HashTable;
@@ -341,7 +341,7 @@ public:
 		return 0;
 	}
 
-	void Propogate_Shared_Smooth_Groups(void)
+	void Propogate_Shared_Smooth_Groups()
 	{
 		for (int i=0; i<VertCount; i++) {
 			if (Verts[i].ShadeIndex != i) {
@@ -387,7 +387,7 @@ private:
  * HISTORY:                                                                                    *
  *   10/19/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::VertClass::Reset(void)
+void MeshBuilderClass::VertClass::Reset()
 {
 	Position.Set(0,0,0);
 	Normal.Set(0,0,0);
@@ -430,7 +430,7 @@ void MeshBuilderClass::VertClass::Reset(void)
  * HISTORY:                                                                                    *
  *   10/19/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::FaceClass::Reset(void)
+void MeshBuilderClass::FaceClass::Reset()
 {
 	for (int i=0; i<3; i++) {
 		Verts[i].Reset();
@@ -467,7 +467,7 @@ void MeshBuilderClass::FaceClass::Reset(void)
  * HISTORY:                                                                                    *
  *   5/15/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::FaceClass::Compute_Plane(void)
+void MeshBuilderClass::FaceClass::Compute_Plane()
 {
 	Normal = Vector3::Cross_Product((Verts[1].Position - Verts[0].Position),(Verts[2].Position - Verts[0].Position));
 	Normal.Normalize();
@@ -488,7 +488,7 @@ void MeshBuilderClass::FaceClass::Compute_Plane(void)
  * HISTORY:                                                                                    *
  *   7/7/98     GTH : Created.                                                                 *
  *=============================================================================================*/
-bool MeshBuilderClass::FaceClass::Is_Degenerate(void)
+bool MeshBuilderClass::FaceClass::Is_Degenerate()
 {
 	for (int v0 = 0; v0 < 3; v0++) {
 		for (int v1 = v0+1; v1 < 3; v1++) {
@@ -521,7 +521,7 @@ bool MeshBuilderClass::FaceClass::Is_Degenerate(void)
  * HISTORY:                                                                                    *
  *   10/20/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::MeshStatsStruct::Reset(void)
+void MeshBuilderClass::MeshStatsStruct::Reset()
 {
 	for (int pass = 0; pass < MeshBuilderClass::MAX_PASSES; pass++) {
 		HasPerPolyShader[pass] = false;
@@ -586,7 +586,7 @@ MeshBuilderClass::MeshBuilderClass(int pass_count,int face_count_guess,int face_
  * HISTORY:                                                                                    *
  *   5/15/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-MeshBuilderClass::~MeshBuilderClass(void)
+MeshBuilderClass::~MeshBuilderClass()
 {
 	Free();
 	Set_World_Info(nullptr);
@@ -605,7 +605,7 @@ MeshBuilderClass::~MeshBuilderClass(void)
  * HISTORY:                                                                                    *
  *   5/15/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::Free(void)
+void MeshBuilderClass::Free()
 {
 	if (Faces != nullptr) {
 		delete[] Faces;
@@ -741,7 +741,7 @@ void MeshBuilderClass::Build_Mesh(bool compute_normals)
  *   7/10/98    GTH : Created.                                                                 *
  *   10/19/98   GTH : Modified to use the FaceClass::Compute_Plane function                    *
  *=============================================================================================*/
-void MeshBuilderClass::Compute_Face_Normals(void)
+void MeshBuilderClass::Compute_Face_Normals()
 {
 	for (int faceidx = 0; faceidx < FaceCount; faceidx++) {
 		Faces[faceidx].Compute_Plane();
@@ -760,7 +760,7 @@ void MeshBuilderClass::Compute_Face_Normals(void)
  * HISTORY:                                                                                    *
  *   7/10/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-bool MeshBuilderClass::Verify_Face_Normals(void)
+bool MeshBuilderClass::Verify_Face_Normals()
 {
 	int faceidx;
 	bool ok = true;
@@ -797,7 +797,7 @@ bool MeshBuilderClass::Verify_Face_Normals(void)
  * HISTORY:                                                                                    *
  *   5/15/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::Compute_Vertex_Normals(void)
+void MeshBuilderClass::Compute_Vertex_Normals()
 {
 	int vertidx;
 	int faceidx;
@@ -855,7 +855,7 @@ void MeshBuilderClass::Compute_Vertex_Normals(void)
  * HISTORY:                                                                                    *
  *   7/10/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::Remove_Degenerate_Faces(void)
+void MeshBuilderClass::Remove_Degenerate_Faces()
 {
 	int faceidx;
 	FaceHasherClass facehasher;
@@ -893,7 +893,7 @@ void MeshBuilderClass::Remove_Degenerate_Faces(void)
  * HISTORY:                                                                                    *
  *   10/19/98   GTH : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::Compute_Mesh_Stats(void)
+void MeshBuilderClass::Compute_Mesh_Stats()
 {
 	int	pass;
 	int	stage;
@@ -1323,7 +1323,7 @@ void MeshBuilderClass::Optimize_Mesh(bool compute_normals)
  *   10/20/98   GTH : Modified to strip based on the desired texture channel                   *
  *   2/11/99    GTH : Added strip stats tracking                                               *
  *=============================================================================================*/
-void MeshBuilderClass::Strip_Optimize_Mesh(void)
+void MeshBuilderClass::Strip_Optimize_Mesh()
 {
 	WingedEdgeStruct *		edgehash[512];
 	WingedEdgeStruct *		edgetab			= new WingedEdgeStruct[FaceCount*3];
@@ -1679,7 +1679,7 @@ void MeshBuilderClass::Strip_Optimize_Mesh(void)
  * HISTORY:                                                                                    *
  *   5/15/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::Grow_Face_Array(void)
+void MeshBuilderClass::Grow_Face_Array()
 {
 	int oldcount = AllocFaceCount;
 	FaceClass * oldfaces = Faces;
@@ -1708,7 +1708,7 @@ void MeshBuilderClass::Grow_Face_Array(void)
  * HISTORY:                                                                                    *
  *   5/1/2000   gth : Created.                                                                 *
  *=============================================================================================*/
-void MeshBuilderClass::Sort_Vertices(void)
+void MeshBuilderClass::Sort_Vertices()
 {
 	/*
 	** Sort the vertices

--- a/Core/Tools/WW3D/max2w3d/meshbuild.h
+++ b/Core/Tools/WW3D/max2w3d/meshbuild.h
@@ -52,12 +52,12 @@
 class WorldInfoClass
 {
 	public:
-		WorldInfoClass(void)				{ }
-		virtual ~WorldInfoClass(void)	{ }
+		WorldInfoClass()				{ }
+		virtual ~WorldInfoClass()	{ }
 
 		// Public methods
 		virtual Vector3	Get_Shared_Vertex_Normal (Vector3 pos, int smgroup) = 0;
-		virtual bool		Are_Meshes_Smoothed (void) const { return true; }
+		virtual bool		Are_Meshes_Smoothed () const { return true; }
 };
 
 /*
@@ -98,7 +98,7 @@ public:
 	** Constructor, Destructor
 	*/
 	MeshBuilderClass(int pass_count=1,int face_count_guess=255,int face_count_growth_rate=64);
-	~MeshBuilderClass(void);
+	~MeshBuilderClass();
 
 	/*
 	** VertClass.  The MeshBuilder deals with vertices in this format.
@@ -106,8 +106,8 @@ public:
 	class VertClass
 	{
 	public:
-		VertClass(void)		{ Reset(); }
-		void						Reset(void);
+		VertClass()		{ Reset(); }
+		void						Reset();
 
 	public:
 
@@ -146,8 +146,8 @@ public:
 	class FaceClass
 	{
 	public:
-		FaceClass(void)		{ Reset(); }
-		void						Reset(void);									// reset this face
+		FaceClass()		{ Reset(); }
+		void						Reset();									// reset this face
 
 	public:
 		VertClass				Verts[3];										// array of 3 verts
@@ -163,10 +163,10 @@ public:
 		Vector3					Normal;		 		// set by builder: Face normal
 		float32					Dist;			 		// set by builder: Plane distance
 
-		void						Compute_Plane(void);
+		void						Compute_Plane();
 		bool						operator != (const FaceClass & that)		{ return !(*this == that); }
 		bool						operator == (const FaceClass & /*that*/)	{ return false; }
-		bool						Is_Degenerate(void);
+		bool						Is_Degenerate();
 
 		friend class MeshBuilderClass;
 	};
@@ -197,9 +197,9 @@ public:
 	** 2. Loop through the verts, looking at each one using Get_Vertex
 	** 3. Loop through the faces, looking at each one using Get_Face
 	*/
-	int							Get_Pass_Count(void) const;
-	int							Get_Vertex_Count(void) const;
-	int							Get_Face_Count(void) const;
+	int							Get_Pass_Count() const;
+	int							Get_Vertex_Count() const;
+	int							Get_Face_Count() const;
 	const VertClass &			Get_Vertex(int index) const;
 	const FaceClass &			Get_Face(int index) const;
 
@@ -223,7 +223,7 @@ public:
 	** World information management.  Used to give the mesh builder information
 	** about the world outside of its mesh.
 	*/
-	WorldInfoClass *			Peek_World_Info(void) const						{ return WorldInfo; }
+	WorldInfoClass *			Peek_World_Info() const						{ return WorldInfo; }
 	void							Set_World_Info(WorldInfoClass *world_info)	{ WorldInfo = world_info; }
 
 	/*
@@ -232,7 +232,7 @@ public:
 	*/
 	struct MeshStatsStruct
 	{
-		void		Reset(void);
+		void		Reset();
 
 		bool		HasTexture[MAX_PASSES][MAX_STAGES];				// has at least one texture in given pass/stage
 		bool		HasShader[MAX_PASSES];								// has at least one shader in given pass
@@ -254,20 +254,20 @@ public:
 		float		AvgStripLength;										// average strip length
 	};
 
-	const MeshStatsStruct & Get_Mesh_Stats(void) const;
+	const MeshStatsStruct & Get_Mesh_Stats() const;
 
 private:
 
-	void							Free(void);
-	void							Compute_Mesh_Stats(void);
+	void							Free();
+	void							Compute_Mesh_Stats();
 	void							Optimize_Mesh(bool compute_normals);
-	void							Strip_Optimize_Mesh(void);
-	void							Remove_Degenerate_Faces(void);
-	void							Compute_Face_Normals(void);
-	bool							Verify_Face_Normals(void);
-	void							Compute_Vertex_Normals(void);
-	void							Grow_Face_Array(void);
-	void							Sort_Vertices(void);
+	void							Strip_Optimize_Mesh();
+	void							Remove_Degenerate_Faces();
+	void							Compute_Face_Normals();
+	bool							Verify_Face_Normals();
+	void							Compute_Vertex_Normals();
+	void							Grow_Face_Array();
+	void							Sort_Vertices();
 
 	/*
 	** Winged edge stuff is used by the strip optimize function
@@ -316,18 +316,18 @@ inline void	MeshBuilderClass::Set_Polygon_Ordering_Channel(int pass,int texstage
 	PolyOrderStage = texstage;
 }
 
-inline int MeshBuilderClass::Get_Pass_Count(void) const
+inline int MeshBuilderClass::Get_Pass_Count() const
 {
 	return PassCount;
 }
 
-inline int MeshBuilderClass::Get_Vertex_Count(void) const
+inline int MeshBuilderClass::Get_Vertex_Count() const
 {
 	assert(State == STATE_MESH_PROCESSED);
 	return VertCount;
 }
 
-inline int MeshBuilderClass::Get_Face_Count(void) const
+inline int MeshBuilderClass::Get_Face_Count() const
 {
 	assert(State == STATE_MESH_PROCESSED);
 	return FaceCount;
@@ -365,7 +365,7 @@ inline MeshBuilderClass::FaceClass & MeshBuilderClass::Get_Face(int index)
 	return Faces[index];
 }
 
-inline const MeshBuilderClass::MeshStatsStruct & MeshBuilderClass::Get_Mesh_Stats(void) const
+inline const MeshBuilderClass::MeshStatsStruct & MeshBuilderClass::Get_Mesh_Stats() const
 {
 	assert(State == STATE_MESH_PROCESSED);
 	return Stats;

--- a/Core/Tools/WW3D/max2w3d/meshcon.cpp
+++ b/Core/Tools/WW3D/max2w3d/meshcon.cpp
@@ -110,7 +110,7 @@ MeshConnectionsClass::MeshConnectionsClass
  * HISTORY:                                                                                    *
  *   07/24/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-MeshConnectionsClass::~MeshConnectionsClass(void)
+MeshConnectionsClass::~MeshConnectionsClass()
 {
 }
 

--- a/Core/Tools/WW3D/max2w3d/meshcon.h
+++ b/Core/Tools/WW3D/max2w3d/meshcon.h
@@ -68,7 +68,7 @@ class GeometryExportContextClass;
 
 struct ConnectionStruct
 {
-	ConnectionStruct(void) : BoneIndex(0),MeshINode(nullptr)
+	ConnectionStruct() : BoneIndex(0),MeshINode(nullptr)
 	{
 		memset(ObjectName,0,sizeof(ObjectName));
 	}
@@ -95,21 +95,21 @@ public:
 	MeshConnectionsClass(	DynamicVectorClass<GeometryExportTaskClass *> sub_objects,
 									GeometryExportContextClass & context );
 
-	~MeshConnectionsClass(void);
+	~MeshConnectionsClass();
 
 	/*
 	** Get the name of the mesh connections object (will be
 	** the name of the runtime HierarchyModel that this
 	** object is describing.
 	*/
-	const char * Get_Name(void) const			{ return Name; }
+	const char * Get_Name() const			{ return Name; }
 
 	/*
 	** Get the total number of meshes (of all types).
 	*/
-	int Get_Sub_Object_Count (void) const		{ return SubObjects.Count(); }
-	int Get_Aggregate_Count(void) const			{ return Aggregates.Count(); }
-	int Get_Proxy_Count(void) const				{ return ProxyObjects.Count(); }
+	int Get_Sub_Object_Count () const		{ return SubObjects.Count(); }
+	int Get_Aggregate_Count() const			{ return Aggregates.Count(); }
+	int Get_Proxy_Count() const				{ return ProxyObjects.Count(); }
 
 	/*
 	** Retrieve data about the mesh of the given index.
@@ -125,7 +125,7 @@ public:
 	/*
 	** Returns the origin node used by this model.
 	*/
-	INode * Get_Origin (void) const				{ return Origin; }
+	INode * Get_Origin () const				{ return Origin; }
 
 private:
 

--- a/Core/Tools/WW3D/max2w3d/meshsave.cpp
+++ b/Core/Tools/WW3D/max2w3d/meshsave.cpp
@@ -430,7 +430,7 @@ MeshSaveClass::MeshSaveClass
  * HISTORY:                                                                                    *
  *   06/10/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-MeshSaveClass::~MeshSaveClass(void)
+MeshSaveClass::~MeshSaveClass()
 {
 	if (UserText) {
 		delete[] UserText;
@@ -2103,7 +2103,7 @@ void MeshSaveClass::create_materials(Mtl * nodemtl,DWORD wirecolor, char *materi
  * HISTORY:                                                                                    *
  *   08/01/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-void MeshSaveClass::compute_bounding_volumes(void)
+void MeshSaveClass::compute_bounding_volumes()
 {
 	Vector3 min,max,center;
 	float radius;

--- a/Core/Tools/WW3D/max2w3d/meshsave.h
+++ b/Core/Tools/WW3D/max2w3d/meshsave.h
@@ -120,7 +120,7 @@ public:
 			WorldInfoClass *			world_info = nullptr
 			);
 
-	~MeshSaveClass(void);
+	~MeshSaveClass();
 
 	int Write_To_File(ChunkSaveClass & csave,bool export_aabtrees = false);
 
@@ -153,7 +153,7 @@ private:
 	void Build_Mesh(Mesh & mesh, Mtl *node_mtl, unsigned int *materialColors, int &numMaterialColors, int &numHouseColors);
 
 	// compute properties for the mesh
-	void compute_bounding_volumes(void);
+	void compute_bounding_volumes();
 	void compute_physical_constants(INode * inode,Progress_Meter_Class & meter,bool voxelize);
 
 	// create the materials
@@ -200,10 +200,10 @@ private:
 	// inverse deform the mesh so that its ready to be used as a skin!
 	void get_skin_modifier_objects(SkinDataClass ** skin_data_ptr,SkinWSMObjectClass ** skin_obj_ptr);
 	int  get_htree_bone_index_for_inode(INode * node);
-	void inv_deform_mesh(void);
+	void inv_deform_mesh();
 
 	// get rendering settings for the materials
-	void customize_materials(void);
+	void customize_materials();
 
 	// Write the ps2 shaders and approximate them as close as possible in the W3D shaders.
 	int write_ps2_shaders(ChunkSaveClass & csave);

--- a/Core/Tools/WW3D/max2w3d/motion.cpp
+++ b/Core/Tools/WW3D/max2w3d/motion.cpp
@@ -169,7 +169,7 @@ MotionClass::MotionClass
  * HISTORY:                                                                                    *
  *   10/26/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-void MotionClass::init(void)
+void MotionClass::init()
 {
 	int i,j;
 
@@ -292,7 +292,7 @@ void MotionClass::init(void)
  * HISTORY:                                                                                    *
  *   10/26/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-MotionClass::~MotionClass(void)
+MotionClass::~MotionClass()
 {
 	int i;
 

--- a/Core/Tools/WW3D/max2w3d/motion.h
+++ b/Core/Tools/WW3D/max2w3d/motion.h
@@ -96,7 +96,7 @@ public:
 																	// base object space (for damage animations)
 					);
 
-	~MotionClass(void);
+	~MotionClass();
 
 	bool Save(ChunkSaveClass & csave);
 
@@ -153,6 +153,6 @@ private:
 	bool			save_header(ChunkSaveClass & csave);
 	bool			save_channels(ChunkSaveClass & csave);
 
-	void			init(void);
+	void			init();
 
 };

--- a/Core/Tools/WW3D/max2w3d/namedsel.cpp
+++ b/Core/Tools/WW3D/max2w3d/namedsel.cpp
@@ -77,7 +77,7 @@ void NamedSelSetList::Delete_Set(TSTR & setname)
 	if (i >= 0) Delete_Set(i);
 }
 
-void NamedSelSetList::Reset(void)
+void NamedSelSetList::Reset()
 {
 	while (Sets.Count() > 0) {
 		Delete_Set(0);

--- a/Core/Tools/WW3D/max2w3d/namedsel.h
+++ b/Core/Tools/WW3D/max2w3d/namedsel.h
@@ -60,7 +60,7 @@ public:
 	int  Find_Set(TSTR & setname);
 	void Delete_Set(int i);
 	void Delete_Set(TSTR & setname);
-	void Reset(void);
+	void Reset();
 	void Append_Set(BitArray & nset,TSTR & setname);
 
 	IOResult Load(ILoad * iload);

--- a/Core/Tools/WW3D/max2w3d/presetexportoptionsdialog.cpp
+++ b/Core/Tools/WW3D/max2w3d/presetexportoptionsdialog.cpp
@@ -72,7 +72,7 @@ PresetExportOptionsDialogClass::PresetExportOptionsDialogClass (Interface *maxin
 //	~PresetExportOptionsDialogClass
 //
 ////////////////////////////////////////////////////////////////////////////////////////
-PresetExportOptionsDialogClass::~PresetExportOptionsDialogClass (void)
+PresetExportOptionsDialogClass::~PresetExportOptionsDialogClass ()
 {
 }
 
@@ -83,7 +83,7 @@ PresetExportOptionsDialogClass::~PresetExportOptionsDialogClass (void)
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 int
-PresetExportOptionsDialogClass::Do_Modal (void)
+PresetExportOptionsDialogClass::Do_Modal ()
 {
 	int retval = ::DialogBoxParam (AppInstance, MAKEINTRESOURCE (IDD_W3D_PRESET_EXPORT_OPTIONS),
 													ParentWnd, Real_Message_Proc, (LPARAM)this);
@@ -508,7 +508,7 @@ PresetExportOptionsDialogClass::Show_Settings_Pane (int pane_id)
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 void
-PresetExportOptionsDialogClass::Create_Settings_Panes (void)
+PresetExportOptionsDialogClass::Create_Settings_Panes ()
 {
 	PaneWnds[PANE_HLOD] = ::CreateDialogParam (AppInstance, MAKEINTRESOURCE (IDD_EXPORT_PANE_HLOD),
 										Wnd, Settings_Pane_Message_Proc, (LPARAM)this);
@@ -569,7 +569,7 @@ PresetExportOptionsDialogClass::Create_Settings_Panes (void)
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 void
-PresetExportOptionsDialogClass::Destroy_Settings_Panes (void)
+PresetExportOptionsDialogClass::Destroy_Settings_Panes ()
 {
 	//
 	//	Loop over all the panes and destroy them
@@ -587,7 +587,7 @@ PresetExportOptionsDialogClass::Destroy_Settings_Panes (void)
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 void
-PresetExportOptionsDialogClass::Determine_Preset_Type (void)
+PresetExportOptionsDialogClass::Determine_Preset_Type ()
 {
 	//
 	//	Examine the current options and try to determine which
@@ -653,7 +653,7 @@ PresetExportOptionsDialogClass::Determine_Preset_Type (void)
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 void
-PresetExportOptionsDialogClass::Initialize_Controls (void)
+PresetExportOptionsDialogClass::Initialize_Controls ()
 {
 	//
 	//	Check the review log file button if necessary
@@ -710,7 +710,7 @@ PresetExportOptionsDialogClass::Initialize_Controls (void)
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 void
-PresetExportOptionsDialogClass::Update_Controls (void)
+PresetExportOptionsDialogClass::Update_Controls ()
 {
 	//
 	//	Loop over all the panes and update any of the controls therein
@@ -797,7 +797,7 @@ PresetExportOptionsDialogClass::Update_Controls (void)
 //
 ////////////////////////////////////////////////////////////////////////////////////////
 void
-PresetExportOptionsDialogClass::Save_Settings (void)
+PresetExportOptionsDialogClass::Save_Settings ()
 {
 	//
 	//	Force settings that certain preset types need

--- a/Core/Tools/WW3D/max2w3d/presetexportoptionsdialog.h
+++ b/Core/Tools/WW3D/max2w3d/presetexportoptionsdialog.h
@@ -56,7 +56,7 @@ public:
 	//	Public constructors/destructors
 	//////////////////////////////////////////////////////////////////
 	PresetExportOptionsDialogClass (Interface *maxinterface, HWND parent_wnd = nullptr);
-	~PresetExportOptionsDialogClass (void);
+	~PresetExportOptionsDialogClass ();
 
 
 	//////////////////////////////////////////////////////////////////
@@ -64,7 +64,7 @@ public:
 	//////////////////////////////////////////////////////////////////
 
 	void			Set_Options (W3dExportOptionsStruct *options)	{ Options = options; ::memcpy (&OrigOptions, Options, sizeof (OrigOptions)); }
-	int			Do_Modal (void);
+	int			Do_Modal ();
 
 private:
 
@@ -98,12 +98,12 @@ private:
 	BOOL			Settings_Message_Proc (UINT message, WPARAM wparam, LPARAM lparam);
 	BOOL			On_Command (WPARAM wparam, LPARAM lparam);
 	void			Show_Settings_Pane (int pane_id);
-	void			Create_Settings_Panes (void);
-	void			Destroy_Settings_Panes (void);
-	void			Determine_Preset_Type (void);
-	void			Initialize_Controls (void);
-	void			Update_Controls (void);
-	void			Save_Settings (void);
+	void			Create_Settings_Panes ();
+	void			Destroy_Settings_Panes ();
+	void			Determine_Preset_Type ();
+	void			Initialize_Controls ();
+	void			Update_Controls ();
+	void			Save_Settings ();
 
 	//////////////////////////////////////////////////////////////////
 	//	Private member data

--- a/Core/Tools/WW3D/max2w3d/simpdib.cpp
+++ b/Core/Tools/WW3D/max2w3d/simpdib.cpp
@@ -106,7 +106,7 @@ SimpleDIBClass::SimpleDIBClass(HWND hwnd,int width,int height,PaletteClass & pal
     }
 }
 
-SimpleDIBClass::~SimpleDIBClass(void)
+SimpleDIBClass::~SimpleDIBClass()
 {
 	if (Info) delete [] Info;
 	if (Handle) DeleteObject(Handle);

--- a/Core/Tools/WW3D/max2w3d/simpdib.h
+++ b/Core/Tools/WW3D/max2w3d/simpdib.h
@@ -55,11 +55,11 @@ class SimpleDIBClass
 public:
 
 	SimpleDIBClass(HWND hwnd,int width, int height,PaletteClass & pal);
-	~SimpleDIBClass(void);
+	~SimpleDIBClass();
 
 	HBITMAP		Get_Handle()		{ return Handle; }
-	int			Get_Width(void)		{ return Width; }
-	int			Get_Height(void)	{ return Height; }
+	int			Get_Width()		{ return Width; }
+	int			Get_Height()	{ return Height; }
 
 	void			Clear(unsigned char color);
 	void			Set_Pixel(int i,int j,unsigned char color);

--- a/Core/Tools/WW3D/max2w3d/skin.cpp
+++ b/Core/Tools/WW3D/max2w3d/skin.cpp
@@ -157,7 +157,7 @@ SkinWSMObjectClass::SkinWSMObjectClass()
 	pblock = nullptr;
 }
 
-SkinWSMObjectClass::~SkinWSMObjectClass(void)
+SkinWSMObjectClass::~SkinWSMObjectClass()
 {
 	assert(!((InterfacePtr == nullptr) && (SotHWND != nullptr)));
 	if (SotHWND != nullptr) {
@@ -307,7 +307,7 @@ RefResult SkinWSMObjectClass::NotifyRefChanged(Interval changeInt,RefTargetHandl
 	return(REF_SUCCEED);
 }
 
-CreateMouseCallBack * SkinWSMObjectClass::GetCreateMouseCallBack(void)
+CreateMouseCallBack * SkinWSMObjectClass::GetCreateMouseCallBack()
 {
 	/*
 	** The "CreateMouseCallback" is used when creating the
@@ -491,7 +491,7 @@ void SkinWSMObjectClass::Remove_Bones(INodeTab & nodetab)
 	}
 }
 
-void SkinWSMObjectClass::Update_Bone_List(void)
+void SkinWSMObjectClass::Update_Bone_List()
 {
 	assert(BoneListHWND != nullptr);
 
@@ -596,7 +596,7 @@ int SkinWSMObjectClass::Find_Closest_Bone(const Point3 & vertex)
 **
 *******************************************************************************/
 
-SkinModifierClass::SkinModifierClass(void)
+SkinModifierClass::SkinModifierClass()
 {
 	Default_Init();
 }
@@ -617,7 +617,7 @@ SkinModifierClass::SkinModifierClass(INode * node,SkinWSMObjectClass * skin_obj)
 
 }
 
-void SkinModifierClass::Default_Init(void)
+void SkinModifierClass::Default_Init()
 {
 	SubObjSelLevel = VERTEX_SEL_LEVEL;
 	WSMObjectRef = nullptr;
@@ -1392,7 +1392,7 @@ void SkinModifierClass::RemoveSubSelSet(TSTR &setname)
 	Install_Named_Selection_Sets();
 }
 
-void SkinModifierClass::Create_Named_Selection_Sets(void)
+void SkinModifierClass::Create_Named_Selection_Sets()
 {
 	/*
 	** This function creates a named selection set of vertices
@@ -1439,7 +1439,7 @@ void SkinModifierClass::Create_Named_Selection_Sets(void)
 	nodes.DisposeTemporary();
 }
 
-void SkinModifierClass::Install_Named_Selection_Sets(void)
+void SkinModifierClass::Install_Named_Selection_Sets()
 {
 	/*
 	** If we are in sub-object selection mode add the sets
@@ -1525,7 +1525,7 @@ void SkinModifierClass::Auto_Attach_Verts(BOOL all)
 	}
 }
 
-void SkinModifierClass::Unlink_Verts(void)
+void SkinModifierClass::Unlink_Verts()
 {
 	assert(InterfacePtr);
 
@@ -1571,7 +1571,7 @@ void SkinModifierClass::Unlink_Verts(void)
 **
 ****************************************************************************/
 
-void SkinModifierClass::Install_Bone_Influence_Dialog(void)
+void SkinModifierClass::Install_Bone_Influence_Dialog()
 {
 	if (BoneInfluenceHWND != nullptr) return;
 
@@ -1598,7 +1598,7 @@ void SkinModifierClass::Install_Bone_Influence_Dialog(void)
 				0);
 }
 
-void SkinModifierClass::Remove_Bone_Influence_Dialog(void)
+void SkinModifierClass::Remove_Bone_Influence_Dialog()
 {
 	/*
 	** If it is currently up, remove the bone influences dialog

--- a/Core/Tools/WW3D/max2w3d/skin.h
+++ b/Core/Tools/WW3D/max2w3d/skin.h
@@ -132,7 +132,7 @@ public:
 	void Add_Bones(INodeTab & nodetab);
 	void Remove_Bone(INode * node);
 	void Remove_Bones(INodeTab & nodetab);
-	void Update_Bone_List(void);
+	void Update_Bone_List();
 
 	/*
 	** Converting between bone indexes and reference indexes
@@ -145,12 +145,12 @@ public:
 	/*
 	** External access to the bones
 	*/
-	int Num_Bones(void) { return BoneTab.Count(); }
+	int Num_Bones() { return BoneTab.Count(); }
 	INode * Get_Bone(int idx) { return BoneTab[idx]; }
-	INodeTab & Get_Bone_List(void) { return BoneTab; }
+	INodeTab & Get_Bone_List() { return BoneTab; }
 	int Find_Bone(INode * node);
-	int Get_Base_Pose_Frame(void) { return BasePoseFrame; }
-	int Get_Base_Pose_Time(void) { return BasePoseFrame * GetTicksPerFrame(); }
+	int Get_Base_Pose_Frame() { return BasePoseFrame; }
+	int Get_Base_Pose_Time() { return BasePoseFrame * GetTicksPerFrame(); }
 	int Find_Closest_Bone(const Point3 & vertex);
 
 	/*
@@ -217,13 +217,13 @@ class SkinModifierClass : public Modifier, BonePickerUserClass
 
 public:
 
-	SkinModifierClass(void);
+	SkinModifierClass();
 	SkinModifierClass(INode * node,SkinWSMObjectClass * skin_obj);
 #if defined W3D_MAX4		//defined as in the project (.dsp)
 	ISubObjType *GetSubObjType(int i);
 	int NumSubObjTypes();
 #endif
-	void								Default_Init(void);
+	void								Default_Init();
 
 	/*
 	** From Animatable
@@ -312,10 +312,10 @@ public:
 	virtual void ActivateSubSelSet(TSTR &setName);
 	virtual void NewSetFromCurSel(TSTR &setName);
 	virtual void RemoveSubSelSet(TSTR &setName);
-	void Create_Named_Selection_Sets(void);
-	void Install_Named_Selection_Sets(void);
+	void Create_Named_Selection_Sets();
+	void Install_Named_Selection_Sets();
 
-	WSMObject * Get_WSMObject(void) { return (WSMObject*)GetReference(OBJ_REF); }
+	WSMObject * Get_WSMObject() { return (WSMObject*)GetReference(OBJ_REF); }
 	Interval Get_Validity(TimeValue t);
 
 	/*
@@ -332,15 +332,15 @@ public:
 	/*
 	** Unlink selected verts (links them to the root or origin)
 	*/
-	void Unlink_Verts(void);
+	void Unlink_Verts();
 
 private:
 
 	/*
 	** Windows dialog management and communication functions
 	*/
-	void Install_Bone_Influence_Dialog(void);
-	void Remove_Bone_Influence_Dialog(void);
+	void Install_Bone_Influence_Dialog();
+	void Remove_Bone_Influence_Dialog();
 
 	BOOL Bone_Influence_Dialog_Proc(HWND hWnd,UINT message,WPARAM wParam,LPARAM lParam);
 

--- a/Core/Tools/WW3D/max2w3d/skindata.h
+++ b/Core/Tools/WW3D/max2w3d/skindata.h
@@ -52,7 +52,7 @@ struct InfluenceStruct
 	int		BoneIdx[2];
 	float		BoneWeight[2];
 
-	InfluenceStruct(void) { BoneIdx[0] = -1; BoneIdx[1] = -1; BoneWeight[0] = 1.0f; BoneWeight[1] = 0.0f; }
+	InfluenceStruct() { BoneIdx[0] = -1; BoneIdx[1] = -1; BoneWeight[0] = 1.0f; BoneWeight[1] = 0.0f; }
 
 	void Set_Influence(int boneidx) {
 		// TODO: make this actually let you set two bones with
@@ -72,7 +72,7 @@ class SkinDataClass : public LocalModData
 
 public:
 
-	SkinDataClass(void) { Held = FALSE; Valid = FALSE; }
+	SkinDataClass() { Held = FALSE; Valid = FALSE; }
 
 	SkinDataClass(Mesh *mesh)
 	{
@@ -101,7 +101,7 @@ public:
 		}
 	}
 
-	virtual LocalModData * Clone(void)
+	virtual LocalModData * Clone()
 	{
 		SkinDataClass * newdata = new SkinDataClass();
 		newdata->VertSel = VertSel;

--- a/Core/Tools/WW3D/max2w3d/vchannel.cpp
+++ b/Core/Tools/WW3D/max2w3d/vchannel.cpp
@@ -131,7 +131,7 @@ VectorChannelClass::VectorChannelClass
 
 }
 
-VectorChannelClass::~VectorChannelClass(void)
+VectorChannelClass::~VectorChannelClass()
 {
 	if (Data) {
 		delete[] Data;
@@ -746,7 +746,7 @@ bool VectorChannelClass::is_identity(float32 * vec)
 	}
 }
 
-void VectorChannelClass::compute_range(void)
+void VectorChannelClass::compute_range()
 {
 	Begin = 0;
 	while ((Begin < MaxFrames) && (is_identity(Get_Vector(Begin)))) {

--- a/Core/Tools/WW3D/max2w3d/vchannel.h
+++ b/Core/Tools/WW3D/max2w3d/vchannel.h
@@ -78,11 +78,11 @@ class VectorChannelClass
 public:
 
 	VectorChannelClass(uint32 id,int maxframes,uint32 flags,int vectorlength,float32 * identvec);
-	~VectorChannelClass(void);
+	~VectorChannelClass();
 
 	void		Set_Vector(int framenumber,float32 * vector);
 	float *	Get_Vector(int frameidx);
-	bool		Is_Empty(void) { return IsEmpty; }
+	bool		Is_Empty() { return IsEmpty; }
 	void		SetSaveOptions(bool compress, int flavor, float Terr, float Rerr, bool reduce, int reduce_percent);
 	bool		Save(ChunkSaveClass & csave, BitChannelClass *binmov);
 	void		ClearInvisibleData(BitChannelClass *vis);
@@ -119,7 +119,7 @@ private:
 	bool is_identity(float32 * vec);
 
 	// This function finds the start and end of the "non-identity" data
-	void compute_range(void);
+	void compute_range();
 
 	// compress functions
 	void		compress(W3dTimeCodedAnimChannelStruct * c);

--- a/Core/Tools/WW3D/max2w3d/vxl.h
+++ b/Core/Tools/WW3D/max2w3d/vxl.h
@@ -79,7 +79,7 @@ public:
 		Progress_Meter_Class &		meter
 	);
 
-	~VoxelClass(void);
+	~VoxelClass();
 
 	int		Get_Width() { return XDim; }
 	int		Get_Height() { return YDim; }
@@ -113,7 +113,7 @@ private:
 	uint8  raw_read_vis(int i,int j,int k);
 
 	int    voxel_touches_space(int i,int j,int k);
-	void   purge_interior(void);
+	void   purge_interior();
 
 	void Quantize_Meshes
 	(

--- a/Core/Tools/WW3D/max2w3d/vxldbg.cpp
+++ b/Core/Tools/WW3D/max2w3d/vxldbg.cpp
@@ -59,12 +59,12 @@ VoxelDebugWindowClass::VoxelDebugWindowClass(VoxelClass * vxl) :
 	_VoxelPalette[1] = RGBClass(128,255,128);
 }
 
-VoxelDebugWindowClass::~VoxelDebugWindowClass(void)
+VoxelDebugWindowClass::~VoxelDebugWindowClass()
 {
 	ReleaseISpinner(LayerSpin);
 }
 
-void VoxelDebugWindowClass::Display_Window(void)
+void VoxelDebugWindowClass::Display_Window()
 {
 	DialogBoxParam
 						(
@@ -180,7 +180,7 @@ bool VoxelDebugWindowClass::Dialog_Proc
 }
 
 
-void VoxelDebugWindowClass::update_display(void)
+void VoxelDebugWindowClass::update_display()
 {
 	int i,j;
 

--- a/Core/Tools/WW3D/max2w3d/vxldbg.h
+++ b/Core/Tools/WW3D/max2w3d/vxldbg.h
@@ -57,9 +57,9 @@ class VoxelDebugWindowClass
 public:
 
 	VoxelDebugWindowClass(VoxelClass * vxl);
-	~VoxelDebugWindowClass(void);
+	~VoxelDebugWindowClass();
 
-	void	Display_Window(void);
+	void	Display_Window();
 	bool	Dialog_Proc(HWND hWnd,UINT message,WPARAM wParam,LPARAM);
 
 private:
@@ -72,5 +72,5 @@ private:
 	HWND						ViewportHWND;
 	ISpinnerControl *		LayerSpin;
 
-	void update_display(void);
+	void update_display();
 };

--- a/Core/Tools/WW3D/max2w3d/vxllayer.cpp
+++ b/Core/Tools/WW3D/max2w3d/vxllayer.cpp
@@ -111,7 +111,7 @@ static vertexstruct intersect(
 						const vertexstruct &	p1,
 						const PlaneClass &	plane);
 
-static void clear_scan_table(void);
+static void clear_scan_table();
 
 static void fixup_scan_table(
 						int						y0,
@@ -650,7 +650,7 @@ static vertexstruct intersect
  * HISTORY:                                                                                    *
  *   06/10/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-static void clear_scan_table(void)
+static void clear_scan_table()
 {
 	memset(_scantab,0,sizeof(_scantab));
 	for (int i=0; i<256; i++) {

--- a/Core/Tools/WW3D/max2w3d/vxllayer.h
+++ b/Core/Tools/WW3D/max2w3d/vxllayer.h
@@ -102,8 +102,8 @@ public:
 		}
 	}
 
-	unsigned int Get_Width(void) { return bitmap_width; }
-	unsigned int Get_Height(void) { return bitmap_height; }
+	unsigned int Get_Width() { return bitmap_width; }
+	unsigned int Get_Height() { return bitmap_height; }
 
 protected:
 

--- a/Core/Tools/WW3D/max2w3d/w3d_file.h
+++ b/Core/Tools/WW3D/max2w3d/w3d_file.h
@@ -668,7 +668,7 @@ struct W3dMaterialInfoStruct
 
 struct W3dVertexMaterialStruct
 {
-	W3dVertexMaterialStruct(void) {}
+	W3dVertexMaterialStruct() {}
 
 	bool operator == (W3dVertexMaterialStruct vm)
 	{
@@ -820,7 +820,7 @@ enum PS2_SHADER_SETTINGS {
 
 struct W3dShaderStruct
 {
-	W3dShaderStruct(void) {}
+	W3dShaderStruct() {}
 	uint8						DepthCompare;
 	uint8						DepthMask;
 	uint8						ColorMask;		// now obsolete and ignored
@@ -965,7 +965,7 @@ inline int W3d_Shader_Get_Post_Detail_Alpha_Func(const W3dShaderStruct * s)	 { r
 
 struct W3dTextureInfoStruct
 {
-	W3dTextureInfoStruct(void)	{}
+	W3dTextureInfoStruct()	{}
 	uint16					Attributes;					// flags for this texture
 	uint16					AnimType;					// animation logic
 	uint32					FrameCount;					// Number of frames (1 if not animated)

--- a/Core/Tools/WW3D/max2w3d/w3dappdata.cpp
+++ b/Core/Tools/WW3D/max2w3d/w3dappdata.cpp
@@ -79,7 +79,7 @@ const int W3DAPPDATA2_CURRENT_VERSION = 1;
 
 
 
-W3DAppData2Struct::W3DAppData2Struct(void) :
+W3DAppData2Struct::W3DAppData2Struct() :
 	ExportFlags(0),
 	GeometryType(0),
 	GeometryFlags(0),
@@ -99,7 +99,7 @@ W3DAppData2Struct::W3DAppData2Struct(W3DAppData0Struct & olddata)	:
 	Init_From_AppData0(olddata);
 }
 
-void W3DAppData2Struct::Init_With_Mesh_Defaults(void)
+void W3DAppData2Struct::Init_With_Mesh_Defaults()
 {
 	ExportFlags = (EXPORT_TRANSFORM|EXPORT_GEOMETRY);
 	GeometryType = GEO_TYPE_NORMAL_MESH;
@@ -110,7 +110,7 @@ void W3DAppData2Struct::Init_With_Mesh_Defaults(void)
 	Set_Version(W3DAPPDATA2_CURRENT_VERSION);
 }
 
-void	W3DAppData2Struct::Init_With_Other_Defaults(void)
+void	W3DAppData2Struct::Init_With_Other_Defaults()
 {
 	ExportFlags = 0;
 	GeometryType = 0;
@@ -160,7 +160,7 @@ void	W3DAppData2Struct::Init_From_AppData0(W3DAppData0Struct & olddata)
 	Set_Version(W3DAPPDATA2_CURRENT_VERSION);
 }
 
-void W3DAppData2Struct::Update_Version(void)
+void W3DAppData2Struct::Update_Version()
 {
 	/*
 	** If this is a version 0 struct, We need to initialize the camera collision
@@ -278,7 +278,7 @@ W3DAppData2Struct * W3DAppData2Struct::Get_App_Data
 ** W3DDazzleAppDataStruct Implementation
 **
 ***********************************************************************************************/
-W3DDazzleAppDataStruct::W3DDazzleAppDataStruct(void)
+W3DDazzleAppDataStruct::W3DDazzleAppDataStruct()
 {
 	UnUsed[0] = 0;
 	UnUsed[1] = 0;

--- a/Core/Tools/WW3D/max2w3d/w3dappdata.h
+++ b/Core/Tools/WW3D/max2w3d/w3dappdata.h
@@ -185,27 +185,27 @@ inline bool Is_Proxy(INode &node)
 */
 struct W3DAppData0Struct
 {
-	W3DAppData0Struct(void) : ExportFlags(DEFAULT_EXPORT_FLAGS) {}
+	W3DAppData0Struct() : ExportFlags(DEFAULT_EXPORT_FLAGS) {}
 
-	bool	Is_Bone(void)							{ return (ExportFlags & EXPORT_BONE_FLAG) == EXPORT_BONE_FLAG; }
-	bool	Is_Geometry(void)						{ return (ExportFlags & EXPORT_GEOMETRY_FLAG) == EXPORT_GEOMETRY_FLAG; }
+	bool	Is_Bone()							{ return (ExportFlags & EXPORT_BONE_FLAG) == EXPORT_BONE_FLAG; }
+	bool	Is_Geometry()						{ return (ExportFlags & EXPORT_GEOMETRY_FLAG) == EXPORT_GEOMETRY_FLAG; }
 
-	bool	Is_Normal_Mesh(void)					{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_NORMAL_MESH; }
-	bool	Is_Camera_Aligned_Mesh(void)		{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_CAMERA_ALIGNED; }
-	bool	Is_Camera_Oriented_Mesh(void)		{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_CAMERA_ORIENTED; }
-	bool	Is_Collision_AABox(void)			{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_AABOX; }
-	bool	Is_Collision_OBBox(void)			{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_OBBOX; }
-	bool	Is_Null(void)							{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_NULL; }
+	bool	Is_Normal_Mesh()					{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_NORMAL_MESH; }
+	bool	Is_Camera_Aligned_Mesh()		{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_CAMERA_ALIGNED; }
+	bool	Is_Camera_Oriented_Mesh()		{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_CAMERA_ORIENTED; }
+	bool	Is_Collision_AABox()			{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_AABOX; }
+	bool	Is_Collision_OBBox()			{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_OBBOX; }
+	bool	Is_Null()							{ return (ExportFlags & GEOMETRY_TYPE_MASK) == GEOMETRY_TYPE_NULL; }
 
-	bool	Is_Physical_Collision(void)		{ return (ExportFlags & COLLISION_TYPE_PHYSICAL) == COLLISION_TYPE_PHYSICAL; }
-	bool	Is_Projectile_Collision(void)		{ return (ExportFlags & COLLISION_TYPE_PROJECTILE) == COLLISION_TYPE_PROJECTILE; }
-	bool	Is_Vis_Collision(void)				{ return (ExportFlags & COLLISION_TYPE_VIS) == COLLISION_TYPE_VIS; }
+	bool	Is_Physical_Collision()		{ return (ExportFlags & COLLISION_TYPE_PHYSICAL) == COLLISION_TYPE_PHYSICAL; }
+	bool	Is_Projectile_Collision()		{ return (ExportFlags & COLLISION_TYPE_PROJECTILE) == COLLISION_TYPE_PROJECTILE; }
+	bool	Is_Vis_Collision()				{ return (ExportFlags & COLLISION_TYPE_VIS) == COLLISION_TYPE_VIS; }
 
-	bool	Is_Hidden(void)						{ return (ExportFlags & EXPORT_HIDDEN_FLAG) == EXPORT_HIDDEN_FLAG; }
-	bool	Is_Two_Sided(void)					{ return (ExportFlags & EXPORT_TWO_SIDED_FLAG) == EXPORT_TWO_SIDED_FLAG; }
-	bool	Is_Vertex_Alpha(void)				{ return (ExportFlags & EXPORT_VERTEX_ALPHA_FLAG) == EXPORT_VERTEX_ALPHA_FLAG; }
-	bool	Is_ZNormals(void)						{ return (ExportFlags & EXPORT_ZNORMALS_FLAG) == EXPORT_ZNORMALS_FLAG; }
-	bool	Is_Shadow(void)						{ return (ExportFlags & EXPORT_CAST_SHADOW_FLAG) == EXPORT_CAST_SHADOW_FLAG; }
+	bool	Is_Hidden()						{ return (ExportFlags & EXPORT_HIDDEN_FLAG) == EXPORT_HIDDEN_FLAG; }
+	bool	Is_Two_Sided()					{ return (ExportFlags & EXPORT_TWO_SIDED_FLAG) == EXPORT_TWO_SIDED_FLAG; }
+	bool	Is_Vertex_Alpha()				{ return (ExportFlags & EXPORT_VERTEX_ALPHA_FLAG) == EXPORT_VERTEX_ALPHA_FLAG; }
+	bool	Is_ZNormals()						{ return (ExportFlags & EXPORT_ZNORMALS_FLAG) == EXPORT_ZNORMALS_FLAG; }
+	bool	Is_Shadow()						{ return (ExportFlags & EXPORT_CAST_SHADOW_FLAG) == EXPORT_CAST_SHADOW_FLAG; }
 
 	unsigned short ExportFlags;	// what was I thinking??? (gth)
 };
@@ -226,7 +226,7 @@ struct W3DAppData0Struct
 
 struct W3DAppData1Struct
 {
-	W3DAppData1Struct(void) : DamageRegion(NO_DAMAGE_REGION) { }
+	W3DAppData1Struct() : DamageRegion(NO_DAMAGE_REGION) { }
 
 	/*
 	** NO_DAMAGE_REGION means the object isn't part of
@@ -251,13 +251,13 @@ struct W3DAppData1Struct
 
 struct W3DAppData2Struct
 {
-	W3DAppData2Struct(void);
+	W3DAppData2Struct();
 	W3DAppData2Struct(W3DAppData0Struct & olddata);
 
-	void	Init_With_Mesh_Defaults(void);
-	void	Init_With_Other_Defaults(void);
+	void	Init_With_Mesh_Defaults();
+	void	Init_With_Other_Defaults();
 	void	Init_From_AppData0(W3DAppData0Struct & olddata);
-	void	Update_Version(void);
+	void	Update_Version();
 
 	enum GeometryTypeEnum
 	{
@@ -274,31 +274,31 @@ struct W3DAppData2Struct
 	/*
 	** Read Access
 	*/
-	bool	Is_Bone(void) const							{ return (ExportFlags & EXPORT_TRANSFORM) == EXPORT_TRANSFORM; }
-	bool	Is_Geometry(void)	const						{ return (ExportFlags & EXPORT_GEOMETRY) == EXPORT_GEOMETRY; }
+	bool	Is_Bone() const							{ return (ExportFlags & EXPORT_TRANSFORM) == EXPORT_TRANSFORM; }
+	bool	Is_Geometry()	const						{ return (ExportFlags & EXPORT_GEOMETRY) == EXPORT_GEOMETRY; }
 
-	int	Get_Geometry_Type(void)	const				{ return GeometryType; }
-	bool	Is_Normal_Mesh(void)	const					{ return GeometryType == GEO_TYPE_NORMAL_MESH; }
-	bool	Is_Camera_Aligned_Mesh(void) const		{ return GeometryType == GEO_TYPE_CAMERA_ALIGNED; }
-	bool	Is_Camera_Oriented_Mesh(void) const		{ return GeometryType == GEO_TYPE_CAMERA_ORIENTED; }
-	bool	Is_Collision_AABox(void) const			{ return GeometryType == GEO_TYPE_AABOX; }
-	bool	Is_Collision_OBBox(void) const			{ return GeometryType == GEO_TYPE_OBBOX; }
-	bool	Is_Null(void) const							{ return GeometryType == GEO_TYPE_NULL; }
-	bool	Is_Dazzle(void) const 						{ return GeometryType == GEO_TYPE_DAZZLE; }
+	int	Get_Geometry_Type()	const				{ return GeometryType; }
+	bool	Is_Normal_Mesh()	const					{ return GeometryType == GEO_TYPE_NORMAL_MESH; }
+	bool	Is_Camera_Aligned_Mesh() const		{ return GeometryType == GEO_TYPE_CAMERA_ALIGNED; }
+	bool	Is_Camera_Oriented_Mesh() const		{ return GeometryType == GEO_TYPE_CAMERA_ORIENTED; }
+	bool	Is_Collision_AABox() const			{ return GeometryType == GEO_TYPE_AABOX; }
+	bool	Is_Collision_OBBox() const			{ return GeometryType == GEO_TYPE_OBBOX; }
+	bool	Is_Null() const							{ return GeometryType == GEO_TYPE_NULL; }
+	bool	Is_Dazzle() const 						{ return GeometryType == GEO_TYPE_DAZZLE; }
 
-	bool	Is_Hidden_Enabled(void) const				{ return (GeometryFlags & GEOMETRY_FLAG_HIDDEN) == GEOMETRY_FLAG_HIDDEN; }
-	bool	Is_Two_Sided_Enabled(void) const			{ return (GeometryFlags & GEOMETRY_FLAG_TWO_SIDED) == GEOMETRY_FLAG_TWO_SIDED; }
-	bool	Is_Vertex_Alpha_Enabled(void) const		{ return (GeometryFlags & GEOMETRY_FLAG_VERTEX_ALPHA) == GEOMETRY_FLAG_VERTEX_ALPHA; }
-	bool	Is_ZNormals_Enabled(void) const			{ return (GeometryFlags & GEOMETRY_FLAG_ZNORMALS) == GEOMETRY_FLAG_ZNORMALS; }
-	bool	Is_Shadow_Enabled(void) const				{ return (GeometryFlags & GEOMETRY_FLAG_CAST_SHADOW) == GEOMETRY_FLAG_CAST_SHADOW; }
-	bool	Is_Shatterable_Enabled(void) const		{ return (GeometryFlags & GEOMETRY_FLAG_SHATTERABLE) == GEOMETRY_FLAG_SHATTERABLE; }
-	bool	Is_NPatchable_Enabled(void) const		{ return (GeometryFlags & GEOMETRY_FLAG_NPATCHABLE) == GEOMETRY_FLAG_NPATCHABLE; }
+	bool	Is_Hidden_Enabled() const				{ return (GeometryFlags & GEOMETRY_FLAG_HIDDEN) == GEOMETRY_FLAG_HIDDEN; }
+	bool	Is_Two_Sided_Enabled() const			{ return (GeometryFlags & GEOMETRY_FLAG_TWO_SIDED) == GEOMETRY_FLAG_TWO_SIDED; }
+	bool	Is_Vertex_Alpha_Enabled() const		{ return (GeometryFlags & GEOMETRY_FLAG_VERTEX_ALPHA) == GEOMETRY_FLAG_VERTEX_ALPHA; }
+	bool	Is_ZNormals_Enabled() const			{ return (GeometryFlags & GEOMETRY_FLAG_ZNORMALS) == GEOMETRY_FLAG_ZNORMALS; }
+	bool	Is_Shadow_Enabled() const				{ return (GeometryFlags & GEOMETRY_FLAG_CAST_SHADOW) == GEOMETRY_FLAG_CAST_SHADOW; }
+	bool	Is_Shatterable_Enabled() const		{ return (GeometryFlags & GEOMETRY_FLAG_SHATTERABLE) == GEOMETRY_FLAG_SHATTERABLE; }
+	bool	Is_NPatchable_Enabled() const		{ return (GeometryFlags & GEOMETRY_FLAG_NPATCHABLE) == GEOMETRY_FLAG_NPATCHABLE; }
 
-	bool	Is_Physical_Collision_Enabled(void) const		{ return (CollisionFlags & COLLISION_FLAG_PHYSICAL) == COLLISION_FLAG_PHYSICAL; }
-	bool	Is_Projectile_Collision_Enabled(void) const	{ return (CollisionFlags & COLLISION_FLAG_PROJECTILE) == COLLISION_FLAG_PROJECTILE; }
-	bool	Is_Vis_Collision_Enabled(void) const			{ return (CollisionFlags & COLLISION_FLAG_VIS) == COLLISION_FLAG_VIS; }
-	bool	Is_Camera_Collision_Enabled(void) const		{ return (CollisionFlags & COLLISION_FLAG_CAMERA) == COLLISION_FLAG_CAMERA; }
-	bool	Is_Vehicle_Collision_Enabled(void) const		{ return (CollisionFlags & COLLISION_FLAG_VEHICLE) == COLLISION_FLAG_VEHICLE; }
+	bool	Is_Physical_Collision_Enabled() const		{ return (CollisionFlags & COLLISION_FLAG_PHYSICAL) == COLLISION_FLAG_PHYSICAL; }
+	bool	Is_Projectile_Collision_Enabled() const	{ return (CollisionFlags & COLLISION_FLAG_PROJECTILE) == COLLISION_FLAG_PROJECTILE; }
+	bool	Is_Vis_Collision_Enabled() const			{ return (CollisionFlags & COLLISION_FLAG_VIS) == COLLISION_FLAG_VIS; }
+	bool	Is_Camera_Collision_Enabled() const		{ return (CollisionFlags & COLLISION_FLAG_CAMERA) == COLLISION_FLAG_CAMERA; }
+	bool	Is_Vehicle_Collision_Enabled() const		{ return (CollisionFlags & COLLISION_FLAG_VEHICLE) == COLLISION_FLAG_VEHICLE; }
 
 	/*
 	** Write Access
@@ -338,7 +338,7 @@ struct W3DAppData2Struct
 protected:
 
 	void	Set_Version(int ver)								{ ExportFlags &= ~VERSION_MASK; ExportFlags |= (ver<<VERSION_SHIFT); }
-	int	Get_Version(void)									{ return (ExportFlags & VERSION_MASK)>>VERSION_SHIFT; }
+	int	Get_Version()									{ return (ExportFlags & VERSION_MASK)>>VERSION_SHIFT; }
 
 	enum ExportFlagsEnum
 	{
@@ -394,7 +394,7 @@ struct W3DDazzleAppDataStruct
 	/*
 	** Constructor, zeros everything, then initializes DazzleType to "DEFAULT"
 	*/
-	W3DDazzleAppDataStruct(void);
+	W3DDazzleAppDataStruct();
 
 	/*
 	** Get the W3DAppData2Struct for a given INode and create one if

--- a/Core/Tools/WW3D/max2w3d/w3ddlg.cpp
+++ b/Core/Tools/WW3D/max2w3d/w3ddlg.cpp
@@ -52,7 +52,7 @@
 ** Static functions
 */
 static BOOL CALLBACK		_options_dialog_proc(HWND Hwnd,UINT message,WPARAM wParam,LPARAM lParam);
-static void					_init_ofn(void);
+static void					_init_ofn();
 
 /*
 ** Static data
@@ -86,7 +86,7 @@ W3dOptionsDialogClass::W3dOptionsDialogClass(Interface * maxinterface,ExpInterfa
 	GetMasterUnitInfo(&UnitsType, &UnitsScale);
 }
 
-W3dOptionsDialogClass::~W3dOptionsDialogClass(void)
+W3dOptionsDialogClass::~W3dOptionsDialogClass()
 {
 	ReleaseISpinner(RangeLowSpin);
 	ReleaseISpinner(RangeHighSpin);
@@ -558,7 +558,7 @@ BOOL W3dOptionsDialogClass::Dialog_Ok()
 	return TRUE;
 }
 
-void W3dOptionsDialogClass::Enable_WHT_Export(void)
+void W3dOptionsDialogClass::Enable_WHT_Export()
 {
 	EnableWindow(GetDlgItem(Hwnd,IDC_TRANSLATION_ONLY_CHECK),TRUE);
 	EnableWindow(GetDlgItem(Hwnd,IDC_TERRAIN_MODE_CHECK),TRUE);
@@ -566,7 +566,7 @@ void W3dOptionsDialogClass::Enable_WHT_Export(void)
 	EnableWindow(GetDlgItem(Hwnd,IDC_WHA_EXPORT_RADIO),TRUE);
 }
 
-void W3dOptionsDialogClass::Enable_WHT_Load(void)
+void W3dOptionsDialogClass::Enable_WHT_Load()
 {
 	EnableWindow(GetDlgItem(Hwnd,IDC_TRANSLATION_ONLY_CHECK),FALSE);
 	EnableWindow(GetDlgItem(Hwnd,IDC_TERRAIN_MODE_CHECK),FALSE);
@@ -574,7 +574,7 @@ void W3dOptionsDialogClass::Enable_WHT_Load(void)
 	EnableWindow(GetDlgItem(Hwnd,IDC_WHA_EXPORT_RADIO),TRUE);
 }
 
-void W3dOptionsDialogClass::Disable_WHT_Export(void)
+void W3dOptionsDialogClass::Disable_WHT_Export()
 {
 	// since there will be no hierarchy tree, disable animation
 	CheckDlgButton(Hwnd,IDC_WHA_EXPORT_RADIO,BST_UNCHECKED);
@@ -587,7 +587,7 @@ void W3dOptionsDialogClass::Disable_WHT_Export(void)
 	EnableWindow(GetDlgItem(Hwnd,IDC_WHA_EXPORT_RADIO),FALSE);
 }
 
-void W3dOptionsDialogClass::Enable_WHA_Export(void)
+void W3dOptionsDialogClass::Enable_WHA_Export()
 {
 	EnableWindow(GetDlgItem(Hwnd,IDC_RANGE_LOW_EDIT),TRUE);
 	EnableWindow(GetDlgItem(Hwnd,IDC_RANGE_LOW_SPIN),TRUE);
@@ -602,7 +602,7 @@ void W3dOptionsDialogClass::Enable_WHA_Export(void)
 	}
 }
 
-void W3dOptionsDialogClass::Disable_WHA_Export(void)
+void W3dOptionsDialogClass::Disable_WHA_Export()
 {
 	EnableWindow(GetDlgItem(Hwnd,IDC_RANGE_LOW_EDIT),FALSE);
 	EnableWindow(GetDlgItem(Hwnd,IDC_RANGE_LOW_SPIN),FALSE);
@@ -614,17 +614,17 @@ void W3dOptionsDialogClass::Disable_WHA_Export(void)
 	Disable_CompressAnimationOptions_Export();
 }
 
-void W3dOptionsDialogClass::Enable_ReduceAnimationOptions_Export(void)
+void W3dOptionsDialogClass::Enable_ReduceAnimationOptions_Export()
 {
 	EnableWindow(GetDlgItem(Hwnd,IDC_REDUCE_ANIMATION_COMBO), TRUE);
 }
 
-void W3dOptionsDialogClass::Disable_ReduceAnimationOptions_Export(void)
+void W3dOptionsDialogClass::Disable_ReduceAnimationOptions_Export()
 {
 	EnableWindow(GetDlgItem(Hwnd,IDC_REDUCE_ANIMATION_COMBO), FALSE);
 }
 
-void W3dOptionsDialogClass::Enable_CompressAnimationOptions_Export(void)
+void W3dOptionsDialogClass::Enable_CompressAnimationOptions_Export()
 {
 	EnableWindow(GetDlgItem(Hwnd,IDC_COMPRESS_ANIMATION_FLAVOR_COMBO), TRUE);
 	EnableWindow(GetDlgItem(Hwnd,IDC_MAX_TRANS_ERROR_EDIT), TRUE);
@@ -634,7 +634,7 @@ void W3dOptionsDialogClass::Enable_CompressAnimationOptions_Export(void)
 	WHA_Compression_Flavor_Changed();
 }
 
-void W3dOptionsDialogClass::Disable_CompressAnimationOptions_Export(void)
+void W3dOptionsDialogClass::Disable_CompressAnimationOptions_Export()
 {
 	EnableWindow(GetDlgItem(Hwnd,IDC_COMPRESS_ANIMATION_FLAVOR_COMBO), FALSE);
 	EnableWindow(GetDlgItem(Hwnd,IDC_MAX_TRANS_ERROR_EDIT), FALSE);
@@ -643,7 +643,7 @@ void W3dOptionsDialogClass::Disable_CompressAnimationOptions_Export(void)
 	EnableWindow(GetDlgItem(Hwnd,IDC_REDUCE_ANIMATION_COMBO), FALSE);
 }
 
-void W3dOptionsDialogClass::Enable_WTM_Export(void)
+void W3dOptionsDialogClass::Enable_WTM_Export()
 {
 	::EnableWindow(::GetDlgItem(Hwnd,IDC_EXPORT_MESH_SMOOTH_CHECK),TRUE);
 	::EnableWindow(::GetDlgItem(Hwnd,IDC_EXPORT_MESH_AABTREES),TRUE);
@@ -652,7 +652,7 @@ void W3dOptionsDialogClass::Enable_WTM_Export(void)
 #endif
 }
 
-void W3dOptionsDialogClass::Disable_WTM_Export(void)
+void W3dOptionsDialogClass::Disable_WTM_Export()
 {
 	::EnableWindow(::GetDlgItem(Hwnd,IDC_EXPORT_MESH_SMOOTH_CHECK),FALSE);
 	::EnableWindow(::GetDlgItem(Hwnd,IDC_EXPORT_MESH_AABTREES),FALSE);
@@ -661,7 +661,7 @@ void W3dOptionsDialogClass::Disable_WTM_Export(void)
 #endif
 }
 
-void W3dOptionsDialogClass::WHT_Export_Radio_Changed(void)
+void W3dOptionsDialogClass::WHT_Export_Radio_Changed()
 {
 	if (IsDlgButtonChecked(Hwnd, IDC_WHT_EXPORT_RADIO) == BST_CHECKED) {
 		Enable_WHT_Export();
@@ -672,7 +672,7 @@ void W3dOptionsDialogClass::WHT_Export_Radio_Changed(void)
 	}
 }
 
-void W3dOptionsDialogClass::WHA_Export_Radio_Changed(void)
+void W3dOptionsDialogClass::WHA_Export_Radio_Changed()
 {
 	if (IsDlgButtonChecked(Hwnd, IDC_WHA_EXPORT_RADIO) == BST_CHECKED) {
 		Enable_WHA_Export();
@@ -681,7 +681,7 @@ void W3dOptionsDialogClass::WHA_Export_Radio_Changed(void)
 	}
 }
 
-void W3dOptionsDialogClass::WTM_Export_Radio_Changed(void)
+void W3dOptionsDialogClass::WTM_Export_Radio_Changed()
 {
 	if (IsDlgButtonChecked(Hwnd, IDC_WTM_EXPORT_RADIO) == BST_CHECKED) {
 		Enable_WTM_Export();
@@ -691,7 +691,7 @@ void W3dOptionsDialogClass::WTM_Export_Radio_Changed(void)
 }
 
 
-void W3dOptionsDialogClass::WHA_Compress_Animation_Check_Changed(void)
+void W3dOptionsDialogClass::WHA_Compress_Animation_Check_Changed()
 {
 	if (IsDlgButtonChecked(Hwnd, IDC_COMPRESS_ANIMATION_CHECK) == BST_CHECKED) {
 		Enable_CompressAnimationOptions_Export();
@@ -700,7 +700,7 @@ void W3dOptionsDialogClass::WHA_Compress_Animation_Check_Changed(void)
 	}
 }
 
-void W3dOptionsDialogClass::WHA_Reduce_Animation_Check_Changed(void)
+void W3dOptionsDialogClass::WHA_Reduce_Animation_Check_Changed()
 {
 	if (IsDlgButtonChecked(Hwnd, IDC_REDUCE_ANIMATION_CHECK) == BST_CHECKED) {
 		Enable_ReduceAnimationOptions_Export();
@@ -793,7 +793,7 @@ BOOL CALLBACK _options_dialog_proc
  * HISTORY:                                                                                    *
  *   07/24/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-void _init_ofn(void)
+void _init_ofn()
 {
 	static char _szhierarchyfilter[] = "W3D Files (*.W3D)\0*.W3D\0WHT Files (*.WHT)\0*.WHT\0\0";
 

--- a/Core/Tools/WW3D/max2w3d/w3dexp.cpp
+++ b/Core/Tools/WW3D/max2w3d/w3dexp.cpp
@@ -936,7 +936,7 @@ bool W3dExportClass::Export_HLod( char *name, const char *htree_name, ChunkSaveC
  * HISTORY:                                                                                    *
  *   10/16/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-HierarchySaveClass * W3dExportClass::get_hierarchy_tree(void)
+HierarchySaveClass * W3dExportClass::get_hierarchy_tree()
 {
 	/*
 	** If the hierarchy tree pointer has been initialized, just return it
@@ -981,7 +981,7 @@ HierarchySaveClass * W3dExportClass::get_hierarchy_tree(void)
  * HISTORY:                                                                                    *
  *   10/17/2000 gth : Created.                                                                 *
  *=============================================================================================*/
-INodeListClass * W3dExportClass::get_damage_root_list(void)
+INodeListClass * W3dExportClass::get_damage_root_list()
 {
 	if (DamageRootList != nullptr) return DamageRootList;
 
@@ -1006,7 +1006,7 @@ INodeListClass * W3dExportClass::get_damage_root_list(void)
  * HISTORY:                                                                                    *
  *   9/13/1999  AJA : Created.                                                                 *
  *=============================================================================================*/
-INodeListClass * W3dExportClass::get_origin_list(void)
+INodeListClass * W3dExportClass::get_origin_list()
 {
 	if (OriginList != nullptr) return OriginList;
 
@@ -1153,7 +1153,7 @@ bool W3dExportClass::get_export_options(BOOL suppress_prompts)
  * HISTORY:                                                                                    *
  *   10/16/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-void W3dExportClass::Start_Progress_Bar(void)
+void W3dExportClass::Start_Progress_Bar()
 {
 	MaxInterface->ProgressStart(
 		"Processing Triangle Mesh",
@@ -1174,7 +1174,7 @@ void W3dExportClass::Start_Progress_Bar(void)
  * HISTORY:                                                                                    *
  *   10/16/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-void W3dExportClass::End_Progress_Bar(void)
+void W3dExportClass::End_Progress_Bar()
 {
 	MaxInterface->ProgressUpdate( 100);
 	MaxInterface->ProgressEnd();

--- a/Core/Tools/WW3D/max2w3d/w3dexp.h
+++ b/Core/Tools/WW3D/max2w3d/w3dexp.h
@@ -99,9 +99,9 @@ private:
 	HierarchySaveClass *	HierarchyTree;
 
 	bool get_export_options(BOOL suppress_prompts = FALSE);
-	INodeListClass * get_origin_list(void);
-	INodeListClass * get_damage_root_list(void);
-	HierarchySaveClass * get_hierarchy_tree(void);
+	INodeListClass * get_origin_list();
+	INodeListClass * get_damage_root_list();
+	HierarchySaveClass * get_hierarchy_tree();
 
 	bool get_base_object_tm(Matrix3 &tm);
 
@@ -112,7 +112,7 @@ private:
 	bool Export_HLod (char *name, const char *htree_name, ChunkSaveClass &csave, Progress_Meter_Class &meter, MeshConnectionsClass **connections, int lod_count);
 	bool Export_Collection(const char * name,ChunkSaveClass & csave,DynamicVectorClass<GeometryExportTaskClass *> & objlist,INodeListClass & placeholder_list,INodeListClass & transform_node_list);
 
-	void Start_Progress_Bar(void);
-	void End_Progress_Bar(void);
+	void Start_Progress_Bar();
+	void End_Progress_Bar();
 
 };

--- a/Core/Tools/WW3D/max2w3d/w3dmtl.cpp
+++ b/Core/Tools/WW3D/max2w3d/w3dmtl.cpp
@@ -77,13 +77,13 @@ W3dMapClass & W3dMapClass::operator = (const W3dMapClass & that)
 	return *this;
 }
 
-W3dMapClass::~W3dMapClass(void)
+W3dMapClass::~W3dMapClass()
 {
 	if (Filename) free(Filename);
 	if (AnimInfo) delete AnimInfo;
 }
 
-void W3dMapClass::Reset(void)
+void W3dMapClass::Reset()
 {
 	if (Filename) free(Filename);
 	if (AnimInfo) delete AnimInfo;
@@ -147,7 +147,7 @@ void W3dMapClass::Set_Anim_Info(int framecount,float framerate)
 */
 
 
-W3dMaterialClass::W3dMaterialClass(void)
+W3dMaterialClass::W3dMaterialClass()
 {
 	PassCount = 0;
 	SortLevel = SORT_LEVEL_NONE;
@@ -162,12 +162,12 @@ W3dMaterialClass::W3dMaterialClass(void)
 	}
 }
 
-W3dMaterialClass::~W3dMaterialClass(void)
+W3dMaterialClass::~W3dMaterialClass()
 {
 	Free();
 }
 
-void W3dMaterialClass::Free(void)
+void W3dMaterialClass::Free()
 {
 	for (int pass = 0; pass < MAX_PASSES; pass++) {
 
@@ -190,7 +190,7 @@ void W3dMaterialClass::Free(void)
 	}
 }
 
-void W3dMaterialClass::Reset(void)
+void W3dMaterialClass::Reset()
 {
 	Free();
 	SortLevel = SORT_LEVEL_NONE;
@@ -276,17 +276,17 @@ void W3dMaterialClass::Set_Map_Channel(int pass,int stage,int channel)
 	MapChannel[pass][stage] = channel;
 }
 
-unsigned int W3dMaterialClass::Get_Surface_Type(void) const
+unsigned int W3dMaterialClass::Get_Surface_Type() const
 {
 	return SurfaceType;
 }
 
-int W3dMaterialClass::Get_Sort_Level(void) const
+int W3dMaterialClass::Get_Sort_Level() const
 {
 	return SortLevel;
 }
 
-int W3dMaterialClass::Get_Pass_Count(void) const
+int W3dMaterialClass::Get_Pass_Count() const
 {
 	return PassCount;
 }
@@ -663,7 +663,7 @@ void W3dMaterialClass::Init(GameMtl * gamemtl, char *materialColorTexture)
 }
 
 
-bool W3dMaterialClass::Is_Multi_Pass_Transparent(void) const
+bool W3dMaterialClass::Is_Multi_Pass_Transparent() const
 {
 	return ((PassCount >= 2) && (Get_Shader(0).DestBlend != W3DSHADER_DESTBLENDFUNC_ZERO));
 }
@@ -676,7 +676,7 @@ bool W3dMaterialClass::Is_Multi_Pass_Transparent(void) const
 
 
 */
-W3dMaterialDescClass::VertMatClass::VertMatClass(void) :
+W3dMaterialDescClass::VertMatClass::VertMatClass() :
 	PassIndex(-1),
 	Crc(0),
 	Name(nullptr)
@@ -686,7 +686,7 @@ W3dMaterialDescClass::VertMatClass::VertMatClass(void) :
 	}
 }
 
-W3dMaterialDescClass::VertMatClass::~VertMatClass(void)
+W3dMaterialDescClass::VertMatClass::~VertMatClass()
 {
 	if (Name) free(Name);
 
@@ -758,7 +758,7 @@ void W3dMaterialDescClass::VertMatClass::Set_Mapper_Args(const char * args, int 
 
 
 */
-W3dMaterialDescClass::MaterialRemapClass::MaterialRemapClass(void)
+W3dMaterialDescClass::MaterialRemapClass::MaterialRemapClass()
 {
 	PassCount = -1;
 	for (int pass=0; pass<W3dMaterialClass::MAX_PASSES; pass++) {
@@ -792,16 +792,16 @@ bool W3dMaterialDescClass::MaterialRemapClass::operator == (const MaterialRemapC
 
 
 
-W3dMaterialDescClass::W3dMaterialDescClass(void)
+W3dMaterialDescClass::W3dMaterialDescClass()
 {
 	Reset();
 }
 
-W3dMaterialDescClass::~W3dMaterialDescClass(void)
+W3dMaterialDescClass::~W3dMaterialDescClass()
 {
 }
 
-void W3dMaterialDescClass::Reset(void)
+void W3dMaterialDescClass::Reset()
 {
 	PassCount = -1;
 	SortLevel = -1;
@@ -877,32 +877,32 @@ W3dMaterialDescClass::ErrorType W3dMaterialDescClass::Add_Material(const W3dMate
 }
 
 
-int W3dMaterialDescClass::Material_Count(void)
+int W3dMaterialDescClass::Material_Count()
 {
 	return MaterialRemaps.Count();
 }
 
-int W3dMaterialDescClass::Pass_Count(void)
+int W3dMaterialDescClass::Pass_Count()
 {
 	return PassCount;
 }
 
-int W3dMaterialDescClass::Vertex_Material_Count(void)
+int W3dMaterialDescClass::Vertex_Material_Count()
 {
 	return VertexMaterials.Count();
 }
 
-int W3dMaterialDescClass::Shader_Count(void)
+int W3dMaterialDescClass::Shader_Count()
 {
 	return Shaders.Count();
 }
 
-int W3dMaterialDescClass::Texture_Count(void)
+int W3dMaterialDescClass::Texture_Count()
 {
 	return Textures.Count();
 }
 
-int W3dMaterialDescClass::Get_Sort_Level(void)
+int W3dMaterialDescClass::Get_Sort_Level()
 {
 	return SortLevel;
 }

--- a/Core/Tools/WW3D/max2w3d/w3dmtl.h
+++ b/Core/Tools/WW3D/max2w3d/w3dmtl.h
@@ -52,13 +52,13 @@ class ChunkSaveClass;
 class W3dMapClass
 {
 public:
-	W3dMapClass(void) : Filename(nullptr), AnimInfo(nullptr) {};
+	W3dMapClass() : Filename(nullptr), AnimInfo(nullptr) {};
 	W3dMapClass(const W3dMapClass & that);
-	~W3dMapClass(void);
+	~W3dMapClass();
 
 	W3dMapClass & operator = (const W3dMapClass & that);
 
-	void Reset(void);
+	void Reset();
 	void Set_Filename(const char * name);
 	void Set_Anim_Info(const W3dTextureInfoStruct * info);
 	void Set_Anim_Info(int framecount,float framerate);
@@ -78,12 +78,12 @@ class W3dMaterialClass
 {
 public:
 
-	W3dMaterialClass(void);
-	~W3dMaterialClass(void);
+	W3dMaterialClass();
+	~W3dMaterialClass();
 
 	enum { MAX_PASSES = 4, MAX_STAGES = 2 };
 
-	void								Reset(void);
+	void								Reset();
 
 	/*
 	** Construction from Max materials
@@ -106,20 +106,20 @@ public:
 	/*
 	** Inspection
 	*/
-	unsigned int					Get_Surface_Type(void) const;
-	int								Get_Sort_Level(void) const;
-	int								Get_Pass_Count(void) const;
+	unsigned int					Get_Surface_Type() const;
+	int								Get_Sort_Level() const;
+	int								Get_Pass_Count() const;
 	W3dVertexMaterialStruct *	Get_Vertex_Material(int pass = 0) const;
 	const char *					Get_Mapper_Args(int pass /*= 0*/, int stage /*= 0*/) const;
 	W3dShaderStruct				Get_Shader(int pass = 0) const;
 	W3dMapClass *					Get_Texture(int pass = 0,int stage = 0) const;
 	int								Get_Map_Channel(int pass = 0,int stage = 0) const;
 
-	bool								Is_Multi_Pass_Transparent(void) const;
+	bool								Is_Multi_Pass_Transparent() const;
 
 protected:
 
-	void								Free(void);
+	void								Free();
 
 	unsigned int					SurfaceType;
 	int								SortLevel;
@@ -152,10 +152,10 @@ public:
 		INCONSISTENT_SORT_LEVEL,	// material doesn't have the same sort level!
 	};
 
-	W3dMaterialDescClass(void);
-	~W3dMaterialDescClass(void);
+	W3dMaterialDescClass();
+	~W3dMaterialDescClass();
 
-	void								Reset(void);
+	void								Reset();
 
 	/*
 	** Interface for adding a material description.  The material will be assigned
@@ -169,12 +169,12 @@ public:
 	** Global Information.  These methods give access to all of the unique vertex materials,
 	** shaders, and textures being used.
 	*/
-	int								Material_Count(void);
-	int								Pass_Count(void);
-	int								Vertex_Material_Count(void);
-	int								Shader_Count(void);
-	int								Texture_Count(void);
-	int								Get_Sort_Level(void);
+	int								Material_Count();
+	int								Pass_Count();
+	int								Vertex_Material_Count();
+	int								Shader_Count();
+	int								Texture_Count();
+	int								Get_Sort_Level();
 
 	W3dVertexMaterialStruct *	Get_Vertex_Material(int vmat_index);
 	const char *					Get_Mapper_Args(int vmat_index, int stage);
@@ -224,7 +224,7 @@ private:
 	class MaterialRemapClass
 	{
 	public:
-		MaterialRemapClass(void);
+		MaterialRemapClass();
 
 		bool operator != (const MaterialRemapClass & that);
 		bool operator == (const MaterialRemapClass & that);
@@ -246,8 +246,8 @@ private:
 	class VertMatClass
 	{
 	public:
-		VertMatClass(void);
-		~VertMatClass(void);
+		VertMatClass();
+		~VertMatClass();
 
 		VertMatClass & operator = (const VertMatClass & that);
 		bool operator != (const VertMatClass & that);

--- a/Core/Tools/WW3D/max2w3d/w3dutil.cpp
+++ b/Core/Tools/WW3D/max2w3d/w3dutil.cpp
@@ -118,18 +118,18 @@ class SettingsFormClass
 public:
 
 	SettingsFormClass(HWND hwnd);
-	~SettingsFormClass(void);
+	~SettingsFormClass();
 
 	bool		Dialog_Proc(HWND hWnd,UINT message,WPARAM wParam,LPARAM);
-	void		Selection_Changed(void);
+	void		Selection_Changed();
 
-	static void	Update_All_Instances(void);
+	static void	Update_All_Instances();
 
 private:
 
-	void		Init(void);
-	void		Destroy(void);
-	void		Disable_Controls(void);
+	void		Init();
+	void		Destroy();
+	void		Disable_Controls();
 	void		Update_Controls(INodeListClass * nodelist = nullptr);
 
 	HWND						Hwnd;
@@ -159,12 +159,12 @@ public:
 	void SelectionSetChanged(Interface *ip,IUtil *iu);
 	void DeleteThis() {}
 
-	void Select_Hierarchy(void);
-	void Select_Geometry(void);
-	void Select_Alpha(void);
-	void Select_Physical(void);
-	void Select_Projectile(void);
-	void Select_Vis(void);
+	void Select_Hierarchy();
+	void Select_Geometry();
+	void Select_Alpha();
+	void Select_Physical();
+	void Select_Projectile();
+	void Select_Vis();
 
 public:
 
@@ -278,15 +278,15 @@ public:
 	bool		is_alpha_material(Mtl * nodemtl);
 	bool		is_alpha_mesh(INode * node,Mtl * nodemtl);
 
-	void		generate_names(void);
+	void		generate_names();
 	void		generate_node_name(INode * node);
-	void		generate_material_names(void);
+	void		generate_material_names();
 	void		generate_material_names_for_node(INode * node);
 	void		generate_material_names(Mtl * mtl);
-	void		generate_lod_extensions(void);
+	void		generate_lod_extensions();
 	void		generate_lod_ext(INode * node);
 
-	void		create_floater(void);
+	void		create_floater();
 
 	void		export_with_standard_materials();
 	int		convert_materials (MaterialConversionEnum conversion, MaterialReferenceMaker *gamenodematerials);
@@ -320,7 +320,7 @@ public:
 
 static W3DUtilityClassDesc W3DUtilityDesc;
 
-ClassDesc * Get_W3D_Utility_Desc(void)
+ClassDesc * Get_W3D_Utility_Desc()
 {
 	return &W3DUtilityDesc;
 }
@@ -330,7 +330,7 @@ ClassDesc * Get_W3D_Utility_Desc(void)
 ** W3DUtilityClass Implementation
 **
 **********************************************************************************************/
-W3DUtilityClass::W3DUtilityClass(void)
+W3DUtilityClass::W3DUtilityClass()
 {
 	InterfacePtr = nullptr;
 	SettingsPanelHWND = nullptr;
@@ -338,7 +338,7 @@ W3DUtilityClass::W3DUtilityClass(void)
 	UpdateSpinnerValue = true;
 }
 
-W3DUtilityClass::~W3DUtilityClass(void)
+W3DUtilityClass::~W3DUtilityClass()
 {
 }
 
@@ -690,7 +690,7 @@ void W3DUtilityClass::set_region_in_all_selected(INodeListClass * list,char regi
 	update_settings_controls(list);
 }
 
-void W3DUtilityClass::generate_names(void)
+void W3DUtilityClass::generate_names()
 {
 	GenNamesDialogClass dialog(InterfacePtr);
 	bool retval = dialog.Get_Options(&NameOptions);
@@ -701,7 +701,7 @@ void W3DUtilityClass::generate_names(void)
 	}
 }
 
-void W3DUtilityClass::generate_material_names(void)
+void W3DUtilityClass::generate_material_names()
 {
 	GenMtlNamesDialogClass dialog(InterfacePtr);
 	bool retval = dialog.Get_Options(&MtlNameOptions);
@@ -712,7 +712,7 @@ void W3DUtilityClass::generate_material_names(void)
 	}
 }
 
-void W3DUtilityClass::generate_lod_extensions(void)
+void W3DUtilityClass::generate_lod_extensions()
 {
 	GenLodExtensionDialogClass dialog(InterfacePtr);
 	bool retval = dialog.Get_Options(&LodExtensionOptions);
@@ -794,7 +794,7 @@ void W3DUtilityClass::generate_lod_ext(INode * node)
 	}
 }
 
-void W3DUtilityClass::create_floater(void)
+void W3DUtilityClass::create_floater()
 {
 	SettingsFloater.Create(InterfacePtr,IDD_W3DUTILITY_SETTINGS_DIALOG,_settings_form_dlg_proc);
 	SettingsFormClass::Update_All_Instances();
@@ -973,7 +973,7 @@ StdMat *W3DUtilityClass::new_standard_material (GameMtl *gamemtl)
 	return (stdmtl);
 }
 
-void W3DUtilityClass::Select_Hierarchy(void)
+void W3DUtilityClass::Select_Hierarchy()
 {
 	InterfacePtr->SelectNode(nullptr);
 	INode * root = InterfacePtr->GetRootNode();
@@ -981,7 +981,7 @@ void W3DUtilityClass::Select_Hierarchy(void)
 	InterfacePtr->ForceCompleteRedraw();
 }
 
-void W3DUtilityClass::Select_Geometry(void)
+void W3DUtilityClass::Select_Geometry()
 {
 	InterfacePtr->SelectNode(nullptr);
 	INode * root = InterfacePtr->GetRootNode();
@@ -989,7 +989,7 @@ void W3DUtilityClass::Select_Geometry(void)
 	InterfacePtr->ForceCompleteRedraw();
 }
 
-void W3DUtilityClass::Select_Alpha(void)
+void W3DUtilityClass::Select_Alpha()
 {
 	InterfacePtr->SelectNode(nullptr);
 	INode * root = InterfacePtr->GetRootNode();
@@ -997,7 +997,7 @@ void W3DUtilityClass::Select_Alpha(void)
 	InterfacePtr->ForceCompleteRedraw();
 }
 
-void W3DUtilityClass::Select_Physical(void)
+void W3DUtilityClass::Select_Physical()
 {
 	InterfacePtr->SelectNode(nullptr);
 	INode * root = InterfacePtr->GetRootNode();
@@ -1005,7 +1005,7 @@ void W3DUtilityClass::Select_Physical(void)
 	InterfacePtr->ForceCompleteRedraw();
 }
 
-void W3DUtilityClass::Select_Projectile(void)
+void W3DUtilityClass::Select_Projectile()
 {
 	InterfacePtr->SelectNode(nullptr);
 	INode * root = InterfacePtr->GetRootNode();
@@ -1013,7 +1013,7 @@ void W3DUtilityClass::Select_Projectile(void)
 	InterfacePtr->ForceCompleteRedraw();
 }
 
-void W3DUtilityClass::Select_Vis(void)
+void W3DUtilityClass::Select_Vis()
 {
 	InterfacePtr->SelectNode(nullptr);
 	INode * root = InterfacePtr->GetRootNode();
@@ -1459,7 +1459,7 @@ SettingsFormClass::SettingsFormClass(HWND hwnd) :
 	::RegisterNotification(_settings_form_selection_changed_callback, this, NOTIFY_SELECTIONSET_CHANGED);
 }
 
-SettingsFormClass::~SettingsFormClass(void)
+SettingsFormClass::~SettingsFormClass()
 {
 	/*
 	** Unregister from MAX
@@ -1491,7 +1491,7 @@ SettingsFormClass::~SettingsFormClass(void)
 }
 
 
-void SettingsFormClass::Update_All_Instances(void)
+void SettingsFormClass::Update_All_Instances()
 {
 	if (ActiveList == nullptr) {
 		return;
@@ -1515,7 +1515,7 @@ void SettingsFormClass::Update_All_Instances(void)
 }
 
 
-void SettingsFormClass::Init(void)
+void SettingsFormClass::Init()
 {
 	// Initialize the contents of the dazzle combo
 	// Reset the dazzle combo
@@ -1570,7 +1570,7 @@ void SettingsFormClass::Init(void)
 
 }
 
-void SettingsFormClass::Destroy(void)
+void SettingsFormClass::Destroy()
 {
 	ReleaseISpinner(RegionSpin);
 	RegionSpin = nullptr;
@@ -1785,7 +1785,7 @@ bool SettingsFormClass::Dialog_Proc(HWND hWnd,UINT message,WPARAM wParam,LPARAM 
 	return TRUE;
 }
 
-void SettingsFormClass::Selection_Changed(void)
+void SettingsFormClass::Selection_Changed()
 {
 	INodeListClass node_list(		::GetCOREInterface()->GetRootNode(),
 											::GetCOREInterface()->GetTime(),
@@ -1961,7 +1961,7 @@ void SettingsFormClass::Update_Controls(INodeListClass * node_list)
 }
 
 
-void SettingsFormClass::Disable_Controls(void)
+void SettingsFormClass::Disable_Controls()
 {
 	EnableWindow(GetDlgItem(Hwnd,IDC_OBJ_NAME),FALSE);
 

--- a/Core/Tools/WW3D/max2w3d/w3dutil.h
+++ b/Core/Tools/WW3D/max2w3d/w3dutil.h
@@ -46,7 +46,7 @@
 
 #define W3DUtilityClassID Class_ID(0x3c362c97, 0x5fc73ab0)
 
-ClassDesc * Get_W3D_Utility_Desc(void);
+ClassDesc * Get_W3D_Utility_Desc();
 
 
 

--- a/Core/Tools/WW3D/pluglib/EULER.h
+++ b/Core/Tools/WW3D/pluglib/EULER.h
@@ -99,7 +99,7 @@ class EulerAnglesClass
 
 public:
 
-	EulerAnglesClass(void) : Order(0) { Angle[0] = 0.0; Angle[1] = 0.0; Angle[2] = 0.0; };
+	EulerAnglesClass() : Order(0) { Angle[0] = 0.0; Angle[1] = 0.0; Angle[2] = 0.0; };
 	EulerAnglesClass(const Matrix3 & from,int order);
 	void		From_Matrix(const Matrix3 & from,int order);
 	void		To_Matrix(Matrix3 & M);

--- a/Core/Tools/WW3D/pluglib/Vector.cpp
+++ b/Core/Tools/WW3D/pluglib/Vector.cpp
@@ -238,7 +238,7 @@ int BooleanVectorClass::Resize(unsigned size)
  * HISTORY:                                                                                    *
  *   07/18/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
-void BooleanVectorClass::Clear(void)
+void BooleanVectorClass::Clear()
 {
 	Fixup();
 	BitCount = 0;
@@ -260,7 +260,7 @@ void BooleanVectorClass::Clear(void)
  * HISTORY:                                                                                    *
  *   07/18/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
-void BooleanVectorClass::Reset(void)
+void BooleanVectorClass::Reset()
 {
 	LastIndex = -1;
 	if (BitArray.Length() > 0) {
@@ -283,7 +283,7 @@ void BooleanVectorClass::Reset(void)
  * HISTORY:                                                                                    *
  *   07/18/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
-void BooleanVectorClass::Set(void)
+void BooleanVectorClass::Set()
 {
 	LastIndex = -1;
 	if (BitArray.Length() > 0) {

--- a/Core/Tools/WW3D/pluglib/Vector.h
+++ b/Core/Tools/WW3D/pluglib/Vector.h
@@ -83,7 +83,7 @@ class VectorClass
 		VectorClass(NoInitClass const &) {};
 		VectorClass(int size=0, T const * array=0);
 		VectorClass(VectorClass<T> const &);		// Copy constructor.
-		virtual ~VectorClass(void);
+		virtual ~VectorClass();
 
 		T & operator[](int index) {assert(unsigned(index) < unsigned(VectorMax));return(Vector[index]);};
 		T const & operator[](int index) const {assert(unsigned(index) < unsigned(VectorMax));return(Vector[index]);};
@@ -92,8 +92,8 @@ class VectorClass
 		virtual bool operator == (VectorClass<T> const &) const;	// Equality operator.
 
 		virtual bool Resize(int newsize, T const * array=0);
-		virtual void Clear(void);
-		int Length(void) const {return VectorMax;};
+		virtual void Clear();
+		int Length() const {return VectorMax;};
 		virtual int ID(T const * ptr);	// Pointer based identification.
 		virtual int ID(T const & ptr);	// Value based identification.
 
@@ -180,7 +180,7 @@ VectorClass<T>::VectorClass(int size, T const * array) :
  *   03/10/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
 template<class T>
-VectorClass<T>::~VectorClass(void)
+VectorClass<T>::~VectorClass()
 {
 	VectorClass<T>::Clear();
 }
@@ -354,7 +354,7 @@ int VectorClass<T>::ID(T const & object)
  *   03/10/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
 template<class T>
-void VectorClass<T>::Clear(void)
+void VectorClass<T>::Clear()
 {
 	if (Vector && IsAllocated) {
 		delete[] Vector;
@@ -486,10 +486,10 @@ protected:
 		virtual bool Resize(int newsize, T const * array=0);
 
 		// Resets and frees the vector array.
-		virtual void Clear(void) {ActiveCount = 0;VectorClass<T>::Clear();};
+		virtual void Clear() {ActiveCount = 0;VectorClass<T>::Clear();};
 
 		// Fetch number of "allocated" vector objects.
-		int Count(void) const {return(ActiveCount);};
+		int Count() const {return(ActiveCount);};
 
 		// Add object to vector (growing as necessary).
 		bool Add(T const & object);
@@ -502,13 +502,13 @@ protected:
 		bool Delete(int index);
 
 		// Deletes all objects in the vector.
-		void Delete_All(void) {ActiveCount = 0;};
+		void Delete_All() {ActiveCount = 0;};
 
 		// Set amount that vector grows by.
 		int Set_Growth_Step(int step) {return(GrowthStep = step);};
 
 		// Fetch current growth step rate.
-		int Growth_Step(void) {return GrowthStep;};
+		int Growth_Step() {return GrowthStep;};
 
 		virtual int ID(T const * ptr) {return(VectorClass<T>::ID(ptr));};
 		virtual int ID(T const & ptr);
@@ -525,7 +525,7 @@ protected:
       // the 'new' spot. (null if the Add failed). NOTE - you must then fill
       // this memory area with a valid object (e.g. by using placement new),
       // or chaos will result!
-      T * Uninitialized_Add(void);
+      T * Uninitialized_Add();
 
 	protected:
 
@@ -817,7 +817,7 @@ bool DynamicVectorClass<T>::Delete(int index)
  *   03/04/1998 NH : Created.                                                                  *
  *=============================================================================================*/
 template<class T>
-T * DynamicVectorClass<T>::Uninitialized_Add(void)
+T * DynamicVectorClass<T>::Uninitialized_Add()
 {
 	if (ActiveCount >= Length()) {
 		if ((IsAllocated || !VectorMax) && GrowthStep > 0) {
@@ -876,16 +876,16 @@ class BooleanVectorClass
 		bool operator == (BooleanVectorClass const & vector);
 
 		// Fetch number of boolean objects in vector.
-		int Length(void) {return BitCount;};
+		int Length() {return BitCount;};
 
 		// Set all boolean values to false;
-		void Reset(void);
+		void Reset();
 
 		// Set all boolean values to true.
-		void Set(void);
+		void Set();
 
 		// Resets vector to zero length (frees memory).
-		void Clear(void);
+		void Clear();
 
 		// Change size of this boolean vector.
 		int Resize(unsigned size);
@@ -907,7 +907,7 @@ class BooleanVectorClass
 		};
 
 		// Find first index that is false.
-		int First_False(void) const {
+		int First_False() const {
 			if (LastIndex != -1) Fixup(-1);
 
 			int retval = First_False_Bit(&BitArray[0]);
@@ -921,7 +921,7 @@ class BooleanVectorClass
 		}
 
 		// Find first index that is true.
-		int First_True(void) const {
+		int First_True() const {
 			if (LastIndex != -1) Fixup(-1);
 
 			int retval = First_True_Bit(&BitArray[0]);

--- a/Core/Tools/WW3D/pluglib/WWmatrix3.cpp
+++ b/Core/Tools/WW3D/pluglib/WWmatrix3.cpp
@@ -260,7 +260,7 @@ void Matrix3::Compute_Jacobi_Rotation(int i,int j,Matrix3 * r,Matrix3 * rinv)
 
 }
 
-void Matrix3::Symmetric_Eigen_Solve(void)
+void Matrix3::Symmetric_Eigen_Solve()
 {
 	Matrix3 eigen_vals = *this;
 	Matrix3 eigen_vecs(1);
@@ -325,7 +325,7 @@ void Matrix3::Multiply(const Matrix3 & A,const Matrix3 & B,Matrix3 * set_res)
 	(*set_res)[2][2] = (float)((*Aptr)[2][0]*tmp1 + (*Aptr)[2][1]*tmp2 + (*Aptr)[2][2]*tmp3);
 }
 
-int Matrix3::Is_Orthogonal(void) const
+int Matrix3::Is_Orthogonal() const
 {
 	Vector3 x(Row[0].X,Row[0].Y,Row[0].Z);
 	Vector3 y(Row[1].X,Row[1].Y,Row[1].Z);
@@ -342,7 +342,7 @@ int Matrix3::Is_Orthogonal(void) const
 	return 1;
 }
 
-void Matrix3::Re_Orthogonalize(void)
+void Matrix3::Re_Orthogonalize()
 {
 	Vector3 x(Row[0][0],Row[0][1],Row[0][2]);
 	Vector3 y(Row[1][0],Row[1][1],Row[1][2]);

--- a/Core/Tools/WW3D/pluglib/WWmatrix3.h
+++ b/Core/Tools/WW3D/pluglib/WWmatrix3.h
@@ -71,7 +71,7 @@ public:
 	/*
 	** Constructors
 	*/
-	Matrix3(void) {};
+	Matrix3() {};
 	Matrix3(const Matrix3 & m);
 
 	explicit Matrix3(bool identity);
@@ -111,9 +111,9 @@ public:
 	/*
 	** Transpose and Inverse
 	*/
-	Matrix3	Transpose	(void) const;
-	Matrix3	Inverse		(void) const;
-	float		Determinant	(void) const;
+	Matrix3	Transpose	() const;
+	Matrix3	Inverse		() const;
+	float		Determinant	() const;
 
 	/*
 	** Assignment operators
@@ -127,7 +127,7 @@ public:
 	Matrix3 & operator *= (float d);
 	Matrix3 & operator /= (float d);
 
-	void	Make_Identity(void);
+	void	Make_Identity();
 
 	/*
 	** Automatically concatenate a rotation onto the current matrix
@@ -147,17 +147,17 @@ public:
 	** cannot be used to re-build a matrx.  Use the EulerAnglesClass
 	** to convert a matrix into a set of three Euler angles.
 	*/
-	float Get_X_Rotation(void) const;
-	float Get_Y_Rotation(void) const;
-	float Get_Z_Rotation(void) const;
+	float Get_X_Rotation() const;
+	float Get_Y_Rotation() const;
+	float Get_Z_Rotation() const;
 
 	/*
 	** These functions return a vector representing the direction an
    ** axis is pointing.
    */
-	Vector3 Get_X_Vector(void) const;
-	Vector3 Get_Y_Vector(void) const;
-	Vector3 Get_Z_Vector(void) const;
+	Vector3 Get_X_Vector() const;
+	Vector3 Get_Y_Vector() const;
+	Vector3 Get_Z_Vector() const;
 	void Get_X_Vector(Vector3 * set_x) const;
 	void Get_Y_Vector(Vector3 * set_y) const;
 	void Get_Z_Vector(Vector3 * set_z) const;
@@ -218,8 +218,8 @@ public:
 	/*
 	** Check whether a matrix is orthogonal, make it orthogonal
 	*/
-	int	Is_Orthogonal(void) const;
-	void	Re_Orthogonalize(void);
+	int	Is_Orthogonal() const;
+	void	Re_Orthogonalize();
 
 	/*
 	** Miscellaneous
@@ -311,7 +311,7 @@ inline void Matrix3::Set(const Vector3 & r0, const Vector3 & r1, const Vector3 &
 	Row[2] = r2;
 }
 
-inline void Matrix3::Make_Identity(void)
+inline void Matrix3::Make_Identity()
 {
 	Row[0].Set(1.0f,0.0f,0.0f);
 	Row[1].Set(0.0f,1.0f,0.0f);
@@ -471,7 +471,7 @@ inline Matrix3 Matrix3::Inverse() const    // Gauss-Jordan elimination with part
  * HISTORY:                                                                                    *
  *   1/7/20     DRM : Created.                                                                 *
  *=============================================================================================*/
-inline float Matrix3::Determinant(void) const
+inline float Matrix3::Determinant() const
 {
 	return   Row[0][0] * (Row[1][1] * Row[2][2] - Row[1][2] * Row[2][1])
 		    - Row[0][1] * (Row[1][0] * Row[2][2] - Row[1][2] * Row[2][0])
@@ -580,7 +580,7 @@ inline Matrix3& Matrix3::operator /= (float d)
  * HISTORY:                                                                                    *
  *   08/11/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-inline float Matrix3::Get_X_Rotation(void) const
+inline float Matrix3::Get_X_Rotation() const
 {
 	Vector3 v = (*this) * Vector3(0.0,1.0,0.0);
 	return atan2(v[2], v[1]);
@@ -598,7 +598,7 @@ inline float Matrix3::Get_X_Rotation(void) const
  * HISTORY:                                                                                    *
  *   08/11/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-inline float Matrix3::Get_Y_Rotation(void) const
+inline float Matrix3::Get_Y_Rotation() const
 {
 	Vector3 v = (*this) * Vector3(0.0,0.0,1.0);
 	return atan2(v[0],v[2]);
@@ -616,23 +616,23 @@ inline float Matrix3::Get_Y_Rotation(void) const
  * HISTORY:                                                                                    *
  *   08/11/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-inline float Matrix3::Get_Z_Rotation(void) const
+inline float Matrix3::Get_Z_Rotation() const
 {
 	Vector3 v = (*this) * Vector3(1.0,0.0,0.0);
 	return atan2(v[1],v[0]);
 }
 
-inline Vector3 Matrix3::Get_X_Vector(void) const
+inline Vector3 Matrix3::Get_X_Vector() const
 {
    return Vector3(Row[0][0], Row[1][0], Row[2][0]);
 }
 
-inline Vector3 Matrix3::Get_Y_Vector(void) const
+inline Vector3 Matrix3::Get_Y_Vector() const
 {
    return Vector3(Row[0][1], Row[1][1], Row[2][1]);
 }
 
-inline Vector3 Matrix3::Get_Z_Vector(void) const
+inline Vector3 Matrix3::Get_Z_Vector() const
 {
    return Vector3(Row[0][2], Row[1][2], Row[2][2]);
 }

--- a/Core/Tools/WW3D/pluglib/aaplane.h
+++ b/Core/Tools/WW3D/pluglib/aaplane.h
@@ -50,7 +50,7 @@ public:
 
 	enum AxisEnum { XNORMAL = 0, YNORMAL = 1, ZNORMAL = 2 };
 
-	AAPlaneClass(void)																		{ }
+	AAPlaneClass()																		{ }
 	AAPlaneClass(AxisEnum normal,float dist) : Normal(normal),Dist(dist)		{ }
 
 	void Set(AxisEnum normal,float dist);

--- a/Core/Tools/WW3D/pluglib/chunkio.cpp
+++ b/Core/Tools/WW3D/pluglib/chunkio.cpp
@@ -145,7 +145,7 @@ bool ChunkSaveClass::Begin_Chunk(uint32 id)
  * HISTORY:                                                                                    *
  *   07/17/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-bool ChunkSaveClass::End_Chunk(void)
+bool ChunkSaveClass::End_Chunk()
 {
 	// If the user didn't close his micro chunks bad things are gonna happen
 	assert(!InMicroChunk);
@@ -230,7 +230,7 @@ bool ChunkSaveClass::Begin_Micro_Chunk(uint32 id)
  * HISTORY:                                                                                    *
  *   9/3/99     GTH : Created.                                                                 *
  *=============================================================================================*/
-bool ChunkSaveClass::End_Micro_Chunk(void)
+bool ChunkSaveClass::End_Micro_Chunk()
 {
 	assert(InMicroChunk);
 
@@ -367,7 +367,7 @@ uint32 ChunkSaveClass::Write(const IOQuaternionStruct & q)
  * HISTORY:                                                                                    *
  *   07/17/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-int ChunkSaveClass::Cur_Chunk_Depth(void)
+int ChunkSaveClass::Cur_Chunk_Depth()
 {
 	return StackIndex;
 }

--- a/Core/Tools/WW3D/pluglib/chunkio.h
+++ b/Core/Tools/WW3D/pluglib/chunkio.h
@@ -92,12 +92,12 @@ struct ChunkHeader
 
 	// Use these accessors to ensure you correctly deal with the data in the chunk header
 	void		Set_Type(uint32 type)					{ ChunkType = type; }
-	uint32	Get_Type(void)								{ return ChunkType; }
+	uint32	Get_Type()								{ return ChunkType; }
 	void		Set_Size(uint32 size)					{ ChunkSize &= 0x80000000; ChunkSize |= (size & 0x7FFFFFFF); }
 	void		Add_Size(uint32 add)						{ Set_Size(Get_Size() + add); }
-	uint32	Get_Size(void)								{ return (ChunkSize & 0x7FFFFFFF); }
+	uint32	Get_Size()								{ return (ChunkSize & 0x7FFFFFFF); }
 	void		Set_Sub_Chunk_Flag(bool onoff)		{ if (onoff) { ChunkSize |= 0x80000000; } else { ChunkSize &= 0x7FFFFFFF; } }
-	int		Get_Sub_Chunk_Flag(void)				{ return (ChunkSize & 0x80000000); }
+	int		Get_Sub_Chunk_Flag()				{ return (ChunkSize & 0x80000000); }
 
 	// Chunk type and size.
 	// Note: MSB of ChunkSize is used to indicate whether this chunk
@@ -112,10 +112,10 @@ struct MicroChunkHeader
 	MicroChunkHeader(uint8 type, uint8 size) { ChunkType = type, ChunkSize = size; }
 
 	void		Set_Type(uint8 type)						{ ChunkType = type; }
-	uint8		Get_Type(void)								{ return ChunkType; }
+	uint8		Get_Type()								{ return ChunkType; }
 	void		Set_Size(uint8 size)						{ ChunkSize = size; }
 	void		Add_Size(uint8 add)						{ Set_Size(Get_Size() + add); }
-	uint8		Get_Size(void)								{ return ChunkSize; }
+	uint8		Get_Size()								{ return ChunkSize; }
 
 	uint8	ChunkType;
 	uint8	ChunkSize;

--- a/Core/Tools/WW3D/pluglib/errclass.h
+++ b/Core/Tools/WW3D/pluglib/errclass.h
@@ -45,7 +45,7 @@ class ErrorClass
 public:
 	ErrorClass(char * format,...);
 	ErrorClass(const ErrorClass & that);
-	~ErrorClass(void) { if (error_message != nullptr) free(error_message); }
+	~ErrorClass() { if (error_message != nullptr) free(error_message); }
 
 	ErrorClass & operator = (const ErrorClass & that);
 

--- a/Core/Tools/WW3D/pluglib/hashcalc.h
+++ b/Core/Tools/WW3D/pluglib/hashcalc.h
@@ -58,7 +58,7 @@ template <class T> class HashCalculatorClass
 public:
 	virtual bool	Items_Match(const T & a, const T & b) = 0;
 	virtual void	Compute_Hash(const T & item) = 0;
-	virtual int		Num_Hash_Bits(void) = 0;
-	virtual int		Num_Hash_Values(void) = 0;
+	virtual int		Num_Hash_Bits() = 0;
+	virtual int		Num_Hash_Values() = 0;
 	virtual int		Get_Hash_Value(int index = 0) = 0;
 };

--- a/Core/Tools/WW3D/pluglib/hsv.cpp
+++ b/Core/Tools/WW3D/pluglib/hsv.cpp
@@ -134,7 +134,7 @@ int HSVClass::Difference(HSVClass const & hsv) const
  * HISTORY:                                                                                    *
  *   02/20/1996 JLB : Created.                                                                 *
  *=============================================================================================*/
-HSVClass::operator RGBClass (void) const
+HSVClass::operator RGBClass () const
 {
 	unsigned int i;				// Integer part.
 	unsigned int f;				// Fractional or remainder part.  f/HSV_BASE gives fraction.

--- a/Core/Tools/WW3D/pluglib/hsv.h
+++ b/Core/Tools/WW3D/pluglib/hsv.h
@@ -50,13 +50,13 @@ class HSVClass
 		static HSVClass const BlackColor;
 
 	public:
-		HSVClass(void) : Hue(0), Saturation(0), Value(0) {};
+		HSVClass() : Hue(0), Saturation(0), Value(0) {};
 		HSVClass(unsigned char hue, unsigned char saturation, unsigned char value) :
 				Hue(hue),
 				Saturation(saturation),
 				Value(value)
 			{};
-		operator RGBClass (void) const;
+		operator RGBClass () const;
 
 		enum {
 			MAX_VALUE=255
@@ -64,9 +64,9 @@ class HSVClass
 
 		void Adjust(int ratio, HSVClass const & hsv);
 		int Difference(HSVClass const & hsv) const;
-		int Get_Hue(void) const {return(Hue);};
-		int Get_Saturation(void) const {return(Saturation);};
-		int Get_Value(void) const {return(Value);};
+		int Get_Hue() const {return(Hue);};
+		int Get_Saturation() const {return(Saturation);};
+		int Get_Value() const {return(Value);};
 		void Set_Hue(unsigned char value) {Hue = value;}
 		void Set_Saturation(unsigned char value) {Saturation = value;}
 		void Set_Value(unsigned char value) {Value = value;}

--- a/Core/Tools/WW3D/pluglib/matrix3d.cpp
+++ b/Core/Tools/WW3D/pluglib/matrix3d.cpp
@@ -239,7 +239,7 @@ void Matrix3D::Set_Rotation(const Quaternion & q)
  * HISTORY:                                                                                    *
  *   08/11/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-float Matrix3D::Get_X_Rotation(void) const
+float Matrix3D::Get_X_Rotation() const
 {
 	return atan2(Row[2][1], Row[1][1]);
 }
@@ -257,7 +257,7 @@ float Matrix3D::Get_X_Rotation(void) const
  * HISTORY:                                                                                    *
  *   08/11/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-float Matrix3D::Get_Y_Rotation(void) const
+float Matrix3D::Get_Y_Rotation() const
 {
 	return atan2(Row[0][2], Row[2][2]);
 }
@@ -275,7 +275,7 @@ float Matrix3D::Get_Y_Rotation(void) const
  * HISTORY:                                                                                    *
  *   08/11/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-float Matrix3D::Get_Z_Rotation(void) const
+float Matrix3D::Get_Z_Rotation() const
 {
 	return atan2(Row[1][0], Row[0][0]);
 }
@@ -738,7 +738,7 @@ void Matrix3D::Transform_Center_Extent_AABox
  * HISTORY:                                                                                    *
  *   9/16/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-int Matrix3D::Is_Orthogonal(void) const
+int Matrix3D::Is_Orthogonal() const
 {
 	Vector3 x(Row[0].X,Row[0].Y,Row[0].Z);
 	Vector3 y(Row[1].X,Row[1].Y,Row[1].Z);
@@ -769,7 +769,7 @@ int Matrix3D::Is_Orthogonal(void) const
  * HISTORY:                                                                                    *
  *   9/16/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-void Matrix3D::Re_Orthogonalize(void)
+void Matrix3D::Re_Orthogonalize()
 {
 	Vector3 x(Row[0][0],Row[0][1],Row[0][2]);
 	Vector3 y(Row[1][0],Row[1][1],Row[1][2]);

--- a/Core/Tools/WW3D/pluglib/matrix3d.h
+++ b/Core/Tools/WW3D/pluglib/matrix3d.h
@@ -117,7 +117,7 @@ class	Matrix3D
 public:
 
 	// Constructors
-	Matrix3D(void) {}
+	Matrix3D() {}
 
 	explicit Matrix3D(bool init) { if (init) Make_Identity(); }
 
@@ -197,16 +197,16 @@ public:
  	Vector4 & operator [] (int i) { return Row[i]; }
 	const Vector4 & operator [] (int i) const { return Row[i]; }
 
-	Vector3 Get_Translation(void) const { return Vector3(Row[0][3],Row[1][3],Row[2][3]); }
+	Vector3 Get_Translation() const { return Vector3(Row[0][3],Row[1][3],Row[2][3]); }
 	void Get_Translation(Vector3 * set) const { set->X = Row[0][3]; set->Y = Row[1][3]; set->Z = Row[2][3]; }
 	void Set_Translation(const Vector3 & t)  { Row[0][3] = t[0]; Row[1][3] = t[1];Row[2][3] = t[2]; }
 
 	void Set_Rotation(const Matrix3 & m);
 	void Set_Rotation(const Quaternion & q);
 
-	float Get_X_Translation(void) const { return Row[0][3]; };
-	float Get_Y_Translation(void) const { return Row[1][3]; };
-	float Get_Z_Translation(void) const { return Row[2][3]; };
+	float Get_X_Translation() const { return Row[0][3]; };
+	float Get_Y_Translation() const { return Row[1][3]; };
+	float Get_Z_Translation() const { return Row[2][3]; };
 
 	void Set_X_Translation(float x) { Row[0][3] = x; };
 	void Set_Y_Translation(float y) { Row[1][3] = y; };
@@ -221,14 +221,14 @@ public:
 	// matrix has been rotated about a given axis.  These functions
 	// cannot be used to re-build a matrx.  Use the EulerAnglesClass
 	// to convert a matrix into a set of three Euler angles.
-	float Get_X_Rotation(void) const;
-	float Get_Y_Rotation(void) const;
-	float Get_Z_Rotation(void) const;
+	float Get_X_Rotation() const;
+	float Get_Y_Rotation() const;
+	float Get_Z_Rotation() const;
 
 	// Each of the transformation methods performs an
 	// "optimized" post-multiplication with the current matrix.
 	// All angles are assumed to be radians.
-	void	Make_Identity(void);
+	void	Make_Identity();
 	void	Translate(float x,float y,float z);
 	void	Translate(const Vector3 &t);
    void  Translate_X(float x);
@@ -308,8 +308,8 @@ public:
 	static void	Inverse_Rotate_Vector(const Matrix3D & tm,const Vector3 & in,Vector3 * out);
 
 	// Check whether a matrix is orthogonal or FORCE it to be :-)
-	int	Is_Orthogonal(void) const;
-	void	Re_Orthogonalize(void);
+	int	Is_Orthogonal() const;
+	void	Re_Orthogonalize();
 
 	// some static matrices which are sometimes useful
 	static const Matrix3D		Identity;
@@ -591,7 +591,7 @@ inline void Matrix3D::Set(const Vector3 & position)
  * HISTORY:                                                                                    *
  *   02/24/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-inline void Matrix3D::Make_Identity(void)
+inline void Matrix3D::Make_Identity()
 {
 	Row[0].Set(1.0f,0.0f,0.0f,0.0f);
 	Row[1].Set(0.0f,1.0f,0.0f,0.0f);

--- a/Core/Tools/WW3D/pluglib/matrix4.h
+++ b/Core/Tools/WW3D/pluglib/matrix4.h
@@ -67,7 +67,7 @@ public:
 	/*
 	** Constructors
 	*/
-	Matrix4(void) {};
+	Matrix4() {};
 	Matrix4(const Matrix4 & m);
 
 	explicit Matrix4(bool identity);
@@ -75,7 +75,7 @@ public:
 	explicit Matrix4(const Matrix3 & m);
 	explicit Matrix4(const Vector4 & v0, const Vector4 & v1, const Vector4 & v2, const Vector4 & v3);
 
-	void		Make_Identity(void);
+	void		Make_Identity();
 	void		Init(const Matrix3D & m);
 	void		Init(const Matrix3 & m);
 	void		Init(const Vector4 & v0, const Vector4 & v1, const Vector4 & v2, const Vector4 & v3);
@@ -93,8 +93,8 @@ public:
 	/*
 	** Transpose and Inverse
 	*/
-	Matrix4 Transpose(void) const;
-	Matrix4 Inverse(void) const;
+	Matrix4 Transpose() const;
+	Matrix4 Inverse() const;
 
 	/*
 	** Assignment operators
@@ -251,7 +251,7 @@ inline Matrix4::Matrix4(const Vector4 & r0, const Vector4 & r1, const Vector4 & 
  * HISTORY:                                                                                    *
  *   11/5/99    gth : Created.                                                                 *
  *=============================================================================================*/
-inline void Matrix4::Make_Identity(void)
+inline void Matrix4::Make_Identity()
 {
 	Row[0].Set(1.0,0.0,0.0,0.0);
 	Row[1].Set(0.0,1.0,0.0,0.0);

--- a/Core/Tools/WW3D/pluglib/nodelist.cpp
+++ b/Core/Tools/WW3D/pluglib/nodelist.cpp
@@ -63,7 +63,7 @@ class INodeListEntryClass
 public:
 
 	INodeListEntryClass(INode * n,TimeValue /*time*/) { Node = n; }
-	~INodeListEntryClass(void) {}
+	~INodeListEntryClass() {}
 
 	INode							* Node;
 	INodeListEntryClass		* Next;
@@ -183,7 +183,7 @@ INodeListClass::INodeListClass(INodeListClass & copyfrom,TimeValue time,INodeFil
  * HISTORY:                                                                                    *
  *   06/09/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-INodeListClass::~INodeListClass(void)
+INodeListClass::~INodeListClass()
 {
 	while (ListHead)
 	{

--- a/Core/Tools/WW3D/pluglib/nodelist.h
+++ b/Core/Tools/WW3D/pluglib/nodelist.h
@@ -70,7 +70,7 @@ public:
 	void			Insert(INodeListClass & insertlist);
 	void			Insert(INode * node);
 	void			Remove(int i);
-	unsigned		Num_Nodes(void) const { return NumNodes; }
+	unsigned		Num_Nodes() const { return NumNodes; }
 	INode *		operator[] (int index) const;
 	void			Sort(const INodeCompareClass & node_compare);
 	void			Add_Tree(INode * root);

--- a/Core/Tools/WW3D/pluglib/noinit.h
+++ b/Core/Tools/WW3D/pluglib/noinit.h
@@ -48,6 +48,6 @@
 #ifndef NoInitClass
 class NoInitClass {
 	public:
-		void operator () (void) const {};
+		void operator () () const {};
 };
 #endif

--- a/Core/Tools/WW3D/pluglib/palette.h
+++ b/Core/Tools/WW3D/pluglib/palette.h
@@ -49,7 +49,7 @@ class PaletteClass
 			COLOR_COUNT=256			// Number of color indices on the palette.
 		};
 
-		PaletteClass(void) {};
+		PaletteClass() {};
 		PaletteClass(RGBClass const & rgb);
 		PaletteClass(unsigned char *binary_palette);
 
@@ -60,8 +60,8 @@ class PaletteClass
 		int operator == (PaletteClass const & palette) const;
 		int operator != (PaletteClass const & palette) const {return(!(operator ==(palette)));};
 		PaletteClass & operator = (PaletteClass const & palette);
-		operator const unsigned char * (void) const {return((const unsigned char *)&Palette[0]);};
-		operator unsigned char * (void) {return((unsigned char *)&Palette[0]);};
+		operator const unsigned char * () const {return((const unsigned char *)&Palette[0]);};
+		operator unsigned char * () {return((unsigned char *)&Palette[0]);};
 
 		void Adjust(int ratio);
 		void Adjust(int ratio, PaletteClass const & palette);

--- a/Core/Tools/WW3D/pluglib/plane.h
+++ b/Core/Tools/WW3D/pluglib/plane.h
@@ -54,7 +54,7 @@ public:
 	Vector3	N;
 	float		D;
 
-	PlaneClass(void) : N(0.0f,0.0f,1.0f), D(0.0f) { }
+	PlaneClass() : N(0.0f,0.0f,1.0f), D(0.0f) { }
 	PlaneClass(float a,float b,float c,float d) : N(a,b,c),D(d) { }
 	PlaneClass(const Vector3 & normal,float dist) : N(normal), D(dist) { }
 

--- a/Core/Tools/WW3D/pluglib/rawfile.cpp
+++ b/Core/Tools/WW3D/pluglib/rawfile.cpp
@@ -145,7 +145,7 @@
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-RawFileClass::RawFileClass(void) :
+RawFileClass::RawFileClass() :
 	Rights(READ),
 	BiasStart(0),
 	BiasLength(-1),
@@ -174,7 +174,7 @@ RawFileClass::RawFileClass(void) :
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-bool RawFileClass::Is_Open(void) const
+bool RawFileClass::Is_Open() const
 {
 	return(Handle != NULL_HANDLE);
 }
@@ -222,7 +222,7 @@ void RawFileClass::Error(int, int, char const * )
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-int RawFileClass::Transfer_Block_Size(void)
+int RawFileClass::Transfer_Block_Size()
 {
 	return (int)((unsigned)UINT_MAX)-16L;
 }
@@ -272,7 +272,7 @@ RawFileClass::RawFileClass(char const * filename) :
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-RawFileClass::~RawFileClass(void)
+RawFileClass::~RawFileClass()
 {
 	Reset ();
 }
@@ -289,7 +289,7 @@ RawFileClass::~RawFileClass(void)
  * HISTORY:                                                                                    *
  *   06/10/1999 PDS : Created.                                                                 *
  *=============================================================================================*/
-void RawFileClass::Reset(void)
+void RawFileClass::Reset()
 {
 	Close();
 	if (Allocated && Filename) {
@@ -581,7 +581,7 @@ bool RawFileClass::Is_Available(int forced)
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void RawFileClass::Close(void)
+void RawFileClass::Close()
 {
 	/*
 	**	If the file is open, then close it. If the file is already closed, then just return. This
@@ -862,7 +862,7 @@ int RawFileClass::Seek(int pos, int dir)
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-int RawFileClass::Size(void)
+int RawFileClass::Size()
 {
 	int size = 0;
 
@@ -939,7 +939,7 @@ int RawFileClass::Size(void)
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-int RawFileClass::Create(void)
+int RawFileClass::Create()
 {
 	Close();
 	if (Open(WRITE)) {
@@ -977,7 +977,7 @@ int RawFileClass::Create(void)
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-int RawFileClass::Delete(void)
+int RawFileClass::Delete()
 {
 	/*
 	**	If the file was open, then it must be closed first.
@@ -1045,7 +1045,7 @@ int RawFileClass::Delete(void)
  *   11/14/1995 DRD : Created.                                                                 *
  *   07/13/1996 JLB : Handles win32 method.                                                    *
  *=============================================================================================*/
-unsigned long RawFileClass::Get_Date_Time(void)
+unsigned long RawFileClass::Get_Date_Time()
 {
 #ifdef _UNIX
 	struct stat statbuf;
@@ -1249,7 +1249,7 @@ void RawFileClass::Attach (void *handle, int rights)
  * HISTORY:                                                                                    *
  *   06/10/1999 PDS : Created.                                                                 *
  *=============================================================================================*/
-void RawFileClass::Detach (void)
+void RawFileClass::Detach ()
 {
 	Rights = 0;
 	BiasStart = 0;

--- a/Core/Tools/WW3D/pluglib/rawfile.h
+++ b/Core/Tools/WW3D/pluglib/rawfile.h
@@ -85,34 +85,34 @@ class RawFileClass : public FileClass
 		int Rights;
 
 		RawFileClass(char const *filename);
-		RawFileClass(void);
+		RawFileClass();
 		RawFileClass (RawFileClass const & f);
 		RawFileClass & operator = (RawFileClass const & f);
-		virtual ~RawFileClass(void);
+		virtual ~RawFileClass();
 
-		virtual char const * File_Name(void) const;
+		virtual char const * File_Name() const;
 		virtual char const * Set_Name(char const *filename);
-		virtual int Create(void);
-		virtual int Delete(void);
+		virtual int Create();
+		virtual int Delete();
 		virtual bool Is_Available(int forced=false);
-		virtual bool Is_Open(void) const;
+		virtual bool Is_Open() const;
 		virtual int Open(char const *filename, int rights=READ);
 		virtual int Open(int rights=READ);
 		virtual int Read(void *buffer, int size);
 		virtual int Seek(int pos, int dir=SEEK_CUR);
-		virtual int Size(void);
+		virtual int Size();
 		virtual int Write(void const *buffer, int size);
-		virtual void Close(void);
-		virtual unsigned long Get_Date_Time(void);
+		virtual void Close();
+		virtual unsigned long Get_Date_Time();
 		virtual bool Set_Date_Time(unsigned long datetime);
 		virtual void Error(int error, int canretry = false, char const * filename=nullptr);
 
 		void Bias(int start, int length=-1);
 
-		virtual void * Get_File_Handle(void) { return Handle; }
+		virtual void * Get_File_Handle() { return Handle; }
 
 		virtual void	Attach (void *handle, int rights=READ);
-		virtual void	Detach (void);
+		virtual void	Detach ();
 
 		/*
 		**	These bias values enable a sub-portion of a file to appear as if it
@@ -128,10 +128,10 @@ class RawFileClass : public FileClass
 		**	This function returns the largest size a low level DOS read or write may
 		**	perform. Larger file transfers are performed in chunks of this size or less.
 		*/
-		int Transfer_Block_Size(void);
+		int Transfer_Block_Size();
 
 		int Raw_Seek(int pos, int dir=SEEK_CUR);
-		void Reset(void);
+		void Reset();
 
 	private:
 
@@ -191,7 +191,7 @@ class RawFileClass : public FileClass
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-inline char const * RawFileClass::File_Name(void) const
+inline char const * RawFileClass::File_Name() const
 {
 	return(Filename);
 }

--- a/Core/Tools/WW3D/pluglib/rgb.cpp
+++ b/Core/Tools/WW3D/pluglib/rgb.cpp
@@ -144,7 +144,7 @@ int RGBClass::Difference(RGBClass const & rgb) const
  * HISTORY:                                                                                    *
  *   02/20/1996 JLB : Created.                                                                 *
  *=============================================================================================*/
-RGBClass::operator HSVClass (void) const
+RGBClass::operator HSVClass () const
 {
 	int hue;
 	int saturation;

--- a/Core/Tools/WW3D/pluglib/rgb.h
+++ b/Core/Tools/WW3D/pluglib/rgb.h
@@ -48,9 +48,9 @@ class HSVClass;
 class RGBClass
 {
 	public:
-		RGBClass(void) : Red(0), Green(0), Blue(0) {}
+		RGBClass() : Red(0), Green(0), Blue(0) {}
 		RGBClass(unsigned char red, unsigned char green, unsigned char blue) : Red(red), Green(green), Blue(blue) {}
-		operator HSVClass (void) const;
+		operator HSVClass () const;
 		RGBClass & operator = (RGBClass const & rgb) {
 			if (this == &rgb) return(*this);
 
@@ -66,9 +66,9 @@ class RGBClass
 
 		void Adjust(int ratio, RGBClass const & rgb);
 		int Difference(RGBClass const & rgb) const;
-		int Get_Red(void) const {return (Red);}
-		int Get_Green(void) const {return(Green);}
-		int Get_Blue(void) const {return(Blue);}
+		int Get_Red() const {return (Red);}
+		int Get_Green() const {return(Green);}
+		int Get_Blue() const {return(Blue);}
 		void Set_Red(unsigned char value) {Red = value;}
 		void Set_Green(unsigned char value) {Green = value;}
 		void Set_Blue(unsigned char value) {Blue = value;}

--- a/Core/Tools/WW3D/pluglib/uarray.h
+++ b/Core/Tools/WW3D/pluglib/uarray.h
@@ -64,12 +64,12 @@ template <class T> class UniqueArrayClass
 public:
 
 	UniqueArrayClass(int initialsize,int growthrate,HashCalculatorClass<T> * hasher);
-	~UniqueArrayClass(void);
+	~UniqueArrayClass();
 
 	int				Add(const T & new_item);
 
-	int				Count(void) const								{ return Get_Unique_Count(); }
-	int				Get_Unique_Count(void) const				{ return UniqueItems.Count(); }
+	int				Count() const								{ return Get_Unique_Count(); }
+	int				Get_Unique_Count() const				{ return UniqueItems.Count(); }
 	const T &		Get(int index) const							{ return UniqueItems[index].Item; }
 	const T &		operator [] (int index) const				{ return Get(index); }
 
@@ -149,7 +149,7 @@ UniqueArrayClass<T>::UniqueArrayClass(int initial_size,int growth_rate,HashCalcu
  *   5/29/98    GTH : Created.                                                                 *
  *=============================================================================================*/
 template <class T>
-UniqueArrayClass<T>::~UniqueArrayClass(void)
+UniqueArrayClass<T>::~UniqueArrayClass()
 {
 	if (HashTable != nullptr) {
 		delete[] HashTable;

--- a/Core/Tools/WW3D/pluglib/vector2.h
+++ b/Core/Tools/WW3D/pluglib/vector2.h
@@ -76,7 +76,7 @@ public:
 	};
 
 	// Constructors
-	Vector2(void) {};
+	Vector2() {};
 	Vector2(const Vector2 & v) { X = v.X; Y = v.Y; }
 	Vector2(float x, float y) { X = x; Y = y; }
 	Vector2(const float vector[2]) { X = vector[0]; Y = vector[1]; }
@@ -92,9 +92,9 @@ public:
 	const float &  operator [](int i) const { return (&X)[i]; }
 
 	// normalize, compute length
-	void	Normalize(void);
-	float	Length(void) const;
-	float	Length2(void) const;
+	void	Normalize();
+	float	Length() const;
+	float	Length2() const;
 
 	// unary operators
 	Vector2 operator-() const { return Vector2(-X,-Y); }
@@ -133,7 +133,7 @@ public:
 	bool Rotate_Towards_Vector(Vector2 &target, float max_s, float max_c, bool & positive_turn);
 
 	// verify that none of the members of this vector are invalid floats
-	bool Is_Valid(void) const;
+	bool Is_Valid() const;
 
 	// make this vector the min or max of itself and the passed vector
 	void Update_Min (const Vector2 & a);
@@ -488,7 +488,7 @@ inline void Swap(Vector2 & a,Vector2 & b)
  * HISTORY:                                                                                    *
  *   10/18/99   gth : Created.                                                                 *
  *=============================================================================================*/
-inline bool Vector2::Is_Valid(void) const
+inline bool Vector2::Is_Valid() const
 {
 	return (WWMath::Is_Valid_Float(X) && WWMath::Is_Valid_Float(Y));
 }

--- a/Core/Tools/WW3D/pluglib/vector3.h
+++ b/Core/Tools/WW3D/pluglib/vector3.h
@@ -88,7 +88,7 @@ public:
 
 
 	// Constructors
-	WWINLINE Vector3(void) {};
+	WWINLINE Vector3() {};
 	WWINLINE Vector3(const Vector3 & v) { X = v.X; Y = v.Y; Z = v.Z; }
 	WWINLINE Vector3(float x, float y, float z) { X = x; Y = y; Z = z; }
 	WWINLINE Vector3(const float vector[3]) { X = vector[0]; Y = vector[1]; Z = vector[2]; }
@@ -103,10 +103,10 @@ public:
 	WWINLINE const float &  operator [](int i) const { return (&X)[i]; }
 
 	// normalize, compute length
-	void	Normalize(void);
-	WWINLINE float	Length(void) const;
-	WWINLINE float	Length2(void) const;
-	float Quick_Length(void) const;
+	void	Normalize();
+	WWINLINE float	Length() const;
+	WWINLINE float	Length2() const;
+	float Quick_Length() const;
 	void  Scale(const Vector3 & scale);
 
 	// rotation, (warning, modifies this vector!)
@@ -169,7 +169,7 @@ public:
 	WWINLINE void Cap_Absolute_To(const Vector3 & a);
 
 	// verify that none of the members of this vector are invalid floats
-	WWINLINE bool Is_Valid(void) const;
+	WWINLINE bool Is_Valid() const;
 
 	static WWINLINE float Quick_Distance(const Vector3 &p1, const Vector3 &p2);
 	static WWINLINE float Distance(const Vector3 &p1, const Vector3 &p2);
@@ -178,8 +178,8 @@ public:
 	static void Lerp(const Vector3 & a, const Vector3 & b, float alpha,Vector3 * set_result);
 
 	// Color Conversion
-	WWINLINE unsigned	long	Convert_To_ABGR( void ) const;
-	WWINLINE unsigned	long	Convert_To_ARGB( void ) const;
+	WWINLINE unsigned	long	Convert_To_ABGR() const;
+	WWINLINE unsigned	long	Convert_To_ARGB() const;
 };
 
 
@@ -463,7 +463,7 @@ WWINLINE float Vector3::Length2() const
  * HISTORY:                                                                                    *
  *   7/15/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-WWINLINE float Vector3::Quick_Length(void) const
+WWINLINE float Vector3::Quick_Length() const
 {
 	// this method of approximating the length comes from Graphics Gems 1 and
 	// supposedly gives an error of +/- 8%
@@ -825,7 +825,7 @@ WWINLINE void Vector3::Rotate_Z(float s_angle,float c_angle)
  * HISTORY:                                                                                    *
  *   10/18/99   gth : Created.                                                                 *
  *=============================================================================================*/
-WWINLINE bool Vector3::Is_Valid(void) const
+WWINLINE bool Vector3::Is_Valid() const
 {
 	return (WWMath::Is_Valid_Float(X) && WWMath::Is_Valid_Float(Y) && WWMath::Is_Valid_Float(Z));
 }
@@ -896,7 +896,7 @@ WWINLINE float Vector3::Quick_Distance(const Vector3 &p1, const Vector3 &p2)
  * HISTORY:                                                                                    *
  *   11/29/1999MLL: Created.                                                                   *
  *=============================================================================================*/
-WWINLINE unsigned long	Vector3::Convert_To_ABGR( void ) const
+WWINLINE unsigned long	Vector3::Convert_To_ABGR() const
 {
 	return (unsigned(255)<<24) |
 			 (unsigned(Z*255.0f)<<16) |
@@ -913,7 +913,7 @@ WWINLINE unsigned long	Vector3::Convert_To_ABGR( void ) const
  * HISTORY:                                                                                    *
  *   11/29/1999MLL: Created.                                                                   *
  *=============================================================================================*/
-WWINLINE unsigned long	Vector3::Convert_To_ARGB( void ) const
+WWINLINE unsigned long	Vector3::Convert_To_ARGB() const
 {
 	return (unsigned(255)<<24) |
 			 (unsigned(X*255.0f)<<16) |

--- a/Core/Tools/WW3D/pluglib/vector3i.h
+++ b/Core/Tools/WW3D/pluglib/vector3i.h
@@ -46,7 +46,7 @@ public:
 	int		J;
 	int		K;
 
-	WWINLINE Vector3i(void);
+	WWINLINE Vector3i();
 	WWINLINE Vector3i(int i,int j,int k);
 
 	WWINLINE bool			operator== (const Vector3i & v) const;
@@ -56,7 +56,7 @@ public:
 };
 
 
-WWINLINE Vector3i::Vector3i(void)
+WWINLINE Vector3i::Vector3i()
 {
 }
 

--- a/Core/Tools/WW3D/pluglib/vector4.h
+++ b/Core/Tools/WW3D/pluglib/vector4.h
@@ -65,7 +65,7 @@ public:
 
 
 	// Constructors
-	Vector4(void) {};
+	Vector4() {};
 	Vector4(const Vector4 & v) { X = v.X; Y = v.Y; Z = v.Z; W = v.W; }
 	Vector4(float x, float y, float z, float w) { X = x; Y = y; Z = z; W = w; }
 	Vector4(const float vector[4]) { X = vector[0]; Y = vector[1]; Z = vector[2]; W = vector[3]; }
@@ -79,9 +79,9 @@ public:
 	const float &  operator [](int i) const { return (&X)[i]; }
 
 	// normalize, compute length
-	void	Normalize(void);
-	float	Length(void) const;
-	float Length2(void) const;
+	void	Normalize();
+	float	Length() const;
+	float Length2() const;
 
 	// unary operators
 	Vector4 operator-() const { return(Vector4(-X,-Y,-Z,-W)); }
@@ -110,7 +110,7 @@ public:
 	friend bool operator != (const Vector4 &a,const Vector4 &b);
 
 	// verify that none of the members of this vector are invalid floats
-	bool Is_Valid(void) const;
+	bool Is_Valid() const;
 };
 
 /**************************************************************************
@@ -375,7 +375,7 @@ inline Vector4 Lerp(const Vector4 & a, const Vector4 & b, float alpha)
  * HISTORY:                                                                                    *
  *   10/18/99   gth : Created.                                                                 *
  *=============================================================================================*/
-inline bool Vector4::Is_Valid(void) const
+inline bool Vector4::Is_Valid() const
 {
 	return (WWMath::Is_Valid_Float(X) && WWMath::Is_Valid_Float(Y) && WWMath::Is_Valid_Float(Z) && WWMath::Is_Valid_Float(W));
 }

--- a/Core/Tools/WW3D/pluglib/w3dquat.cpp
+++ b/Core/Tools/WW3D/pluglib/w3dquat.cpp
@@ -696,7 +696,7 @@ float project_to_sphere(float r, float x, float y)
 }
 
 
-void Quaternion::Randomize(void)
+void Quaternion::Randomize()
 {
 	X = ((float) (rand() & 0xFFFF)) / 65536.0f;
 	Y = ((float) (rand() & 0xFFFF)) / 65536.0f;

--- a/Core/Tools/WW3D/pluglib/w3dquat.h
+++ b/Core/Tools/WW3D/pluglib/w3dquat.h
@@ -58,14 +58,14 @@ public:
 
 public:
 
-	Quaternion(void) {};
+	Quaternion() {};
 	explicit Quaternion(bool init) { if (init) { X = 0.0f; Y = 0.0f; Z = 0.0f; W = 1.0f; } }
 	explicit Quaternion(float a, float b, float c, float d) { X=a; Y=b; Z=c; W=d; }
 	explicit Quaternion(const Vector3 & axis,float angle);
 	Quaternion & operator=(const Quaternion & source);
 
 	void		Set(float a = 0.0, float b = 0.0, float c = 0.0, float d = 1.0) { X = a; Y = b; Z = c; W = d; }
-	void		Make_Identity(void) { Set(); };
+	void		Make_Identity() { Set(); };
 	void		Scale(float s) { X = (float)(s*X); Y = (float)(s*Y); Z = (float)(s*Z); W = (float)(s*W); }
 
 	// Array access
@@ -83,13 +83,13 @@ public:
 	Quaternion & Make_Closest(const Quaternion & qto);
 
 	// Square of the magnitude of the quaternion
-	float Length2(void) const { return (X*X + Y*Y + Z*Z + W*W); }
+	float Length2() const { return (X*X + Y*Y + Z*Z + W*W); }
 
 	// Magnitude of the quaternion
-	float Length(void) const { return WWMath::Sqrt(Length2()); }
+	float Length() const { return WWMath::Sqrt(Length2()); }
 
 	// Make the quaternion unit length
-	void Normalize(void);
+	void Normalize();
 
 	// post-concatenate rotations about the coordinate axes
 	void	Rotate_X(float theta);
@@ -97,14 +97,14 @@ public:
 	void 	Rotate_Z(float theta);
 
 	// initialize this quaternion randomly (creates a random *unit* quaternion)
-	void	Randomize(void);
+	void	Randomize();
 
 	// transform (rotate) a vector with this quaternion
 	Vector3	Rotate_Vector(const Vector3 & v) const;
 	void		Rotate_Vector(const Vector3 & v,Vector3 * set_result) const;
 
 	// verify that none of the members of this quaternion are invalid floats
-	bool		Is_Valid(void) const;
+	bool		Is_Valid() const;
 };
 
 // Inverse of the quaternion (1/q)
@@ -243,7 +243,7 @@ inline void Quaternion::Rotate_Vector(const Vector3 & v,Vector3 * result) const
 	result->Z = w*(-Z) + W*z + (x*(-Y) - (-X)*y);
 }
 
-inline bool Quaternion::Is_Valid(void) const
+inline bool Quaternion::Is_Valid() const
 {
 	return (	WWMath::Is_Valid_Float(X) &&
 				WWMath::Is_Valid_Float(Y) &&

--- a/Core/Tools/WW3D/pluglib/wwfile.h
+++ b/Core/Tools/WW3D/pluglib/wwfile.h
@@ -65,25 +65,25 @@ class FileClass
 			PRINTF_BUFFER_SIZE = 1024
 		};
 
-		virtual ~FileClass(void) {};
-		virtual char const * File_Name(void) const = 0;
+		virtual ~FileClass() {};
+		virtual char const * File_Name() const = 0;
 		virtual char const * Set_Name(char const *filename) = 0;
-		virtual int Create(void) = 0;
-		virtual int Delete(void) = 0;
+		virtual int Create() = 0;
+		virtual int Delete() = 0;
 		virtual bool Is_Available(int forced=false) = 0;
-		virtual bool Is_Open(void) const = 0;
+		virtual bool Is_Open() const = 0;
 		virtual int Open(char const *filename, int rights=READ) = 0;
 		virtual int Open(int rights=READ) = 0;
 		virtual int Read(void *buffer, int size) = 0;
 		virtual int Seek(int pos, int dir=SEEK_CUR) = 0;
-		virtual int Tell(void) { return Seek(0); }
-		virtual int Size(void) = 0;
+		virtual int Tell() { return Seek(0); }
+		virtual int Size() = 0;
 		virtual int Write(void const *buffer, int size) = 0;
-		virtual void Close(void) = 0;
-		virtual unsigned long Get_Date_Time(void) {return(0);}
+		virtual void Close() = 0;
+		virtual unsigned long Get_Date_Time() {return(0);}
 		virtual bool Set_Date_Time(unsigned long ) {return(false);}
 		virtual void Error(int error, int canretry = false, char const * filename=nullptr) = 0;
-		virtual void * Get_File_Handle(void) { return reinterpret_cast<void *>(-1); }
+		virtual void * Get_File_Handle() { return reinterpret_cast<void *>(-1); }
 
 		operator char const * ()
 		{

--- a/Core/Tools/WW3D/pluglib/wwmath.cpp
+++ b/Core/Tools/WW3D/pluglib/wwmath.cpp
@@ -41,7 +41,7 @@
 /*
 **
 */
-float		WWMath::Random_Float(void)
+float		WWMath::Random_Float()
 {
 	return ((float)(rand() & 0xFFF)) / (float)(0xFFF);
 }

--- a/Core/Tools/WW3D/pluglib/wwmath.h
+++ b/Core/Tools/WW3D/pluglib/wwmath.h
@@ -90,7 +90,7 @@ static float		Sign(float val);
 static float		Floor(float val) { return (float)floor(val); }
 static bool			Fast_Is_Float_Positive(const float & val);
 
-static float		Random_Float(void);
+static float		Random_Float();
 static float		Random_Float(float min,float max);
 static float		Clamp(float val, float min = 0.0f, float max = 1.0f);
 static double		Clamp(double val, double min = 0.0f, double max = 1.0f);

--- a/Core/Tools/mangler/wlib/arraylist.h
+++ b/Core/Tools/mangler/wlib/arraylist.h
@@ -67,7 +67,7 @@ class ArrayList
                   ~ArrayList();
 
   // Remove all entries from the lsit
-  void             clear(void);
+  void             clear();
 
   // Add a node after the zero based 'pos'
   bit8             add(IN T &node,sint32 pos);
@@ -97,7 +97,7 @@ class ArrayList
   bit8             getPointer(OUT T **node,sint32 pos) RO;
 
   // Get the number of entries in the list
-  sint32           length(void) RO;
+  sint32           length() RO;
 
   // UNSAFE! for classes, see note below!
   bit8             setSize(sint32 newsize, IN T &filler);
@@ -120,8 +120,8 @@ class ArrayList
     INITIAL_SIZE = 10
   };
 
-  bit8             growVector(void);   // Expand the number of slots
-  bit8             shrinkVector(void); // Reduce the number of slots
+  bit8             growVector();   // Expand the number of slots
+  bit8             shrinkVector(); // Reduce the number of slots
 };
 
 
@@ -627,14 +627,14 @@ void ArrayList<T>::print(FILE *out)
 
 // Return the current length of the list
 template <class T>
-sint32 ArrayList<T>::length(void) RO
+sint32 ArrayList<T>::length() RO
 {
   return(Entries_);
 }
 
 // Grow the vector by a factor of 2X
 template <class T>
-bit8 ArrayList<T>::growVector(void)
+bit8 ArrayList<T>::growVector()
 {
   if (Entries_ < Slots_)   // Don't grow until we're at 100% usage
     return(FALSE);
@@ -668,7 +668,7 @@ bit8 ArrayList<T>::growVector(void)
 
 // Shrink the vector by a factor of 2X
 template <class T>
-bit8 ArrayList<T>::shrinkVector(void)
+bit8 ArrayList<T>::shrinkVector()
 {
   //fprintf(stderr,"Shrink called\n");
 

--- a/Core/Tools/mangler/wlib/critsec.cpp
+++ b/Core/Tools/mangler/wlib/critsec.cpp
@@ -93,7 +93,7 @@ sint32 CritSec::lock(int *refcount) RO
 }
 
 // The "unlock" function release the critical section.
-sint32 CritSec::unlock(void) RO
+sint32 CritSec::unlock() RO
 {
  #ifdef _UNIX
     sint32	status = 0;

--- a/Core/Tools/mangler/wlib/critsec.h
+++ b/Core/Tools/mangler/wlib/critsec.h
@@ -46,7 +46,7 @@ class CritSec
                ~CritSec();
 
   sint32		lock(int *refcount=nullptr) RO;
-  sint32		unlock(void) RO;
+  sint32		unlock() RO;
 
  protected:
   #ifdef _WIN32

--- a/Core/Tools/mangler/wlib/dictionary.h
+++ b/Core/Tools/mangler/wlib/dictionary.h
@@ -92,13 +92,13 @@ Dictionary(uint32 (*hashFn)(const K &key)) :
 
                   ~Dictionary();
 
-  void             clear(void);
+  void             clear();
   bit8             add(IN K &key,IN V &value);
   bool             getValue(IN K &key, OUT V &value) RO;
   bool             getPointer(IN K &key, OUT V **value) RO;  // ptr to internal storage (Careful!)
   void             print(FILE *out) RO;
-  uint32           getSize(void) RO;
-  uint32           getEntries(void) RO;
+  uint32           getSize() RO;
+  uint32           getEntries() RO;
   bit8             contains(IN K &key) RO;
   bit8             updateValue(IN K &key,IN V &value);
   bit8             remove(IN K &key,OUT V &value);
@@ -109,8 +109,8 @@ Dictionary(uint32 (*hashFn)(const K &key)) :
   Dictionary<K,V>  &operator=(Dictionary<K,V> &other);
 
  private:
-  void             shrink(void);  // halve the number of slots
-  void             expand(void);  // double the number of slots
+  void             shrink();  // halve the number of slots
+  void             expand();  // double the number of slots
 
 
   DNode<K,V>     **table;      // This stores the lists at each slot
@@ -309,13 +309,13 @@ bit8 Dictionary<K,V>::iterate(INOUT int &index,INOUT int &offset,
 
 // Return the current size of the hash table
 template <class K,class V>
-uint32 Dictionary<K,V>::getSize(void) RO
+uint32 Dictionary<K,V>::getSize() RO
 { return(size); }
 
 
 // Return the current number of entries in the table
 template <class K,class V>
-uint32 Dictionary<K,V>::getEntries(void) RO
+uint32 Dictionary<K,V>::getEntries() RO
 { return(entries); }
 
 
@@ -597,7 +597,7 @@ bool Dictionary<K,V>::getPointer(IN K &key,OUT V **valptr) RO
 
 // Shrink the hash table by a factor of 2 (and relocate entries)
 template <class K,class V>
-void Dictionary<K,V>::shrink(void)
+void Dictionary<K,V>::shrink()
 {
   int    i;
   int    oldsize;
@@ -636,7 +636,7 @@ void Dictionary<K,V>::shrink(void)
 
 
 template <class K,class V>
-void Dictionary<K,V>::expand(void)
+void Dictionary<K,V>::expand()
 {
   int    i;
   int    oldsize;

--- a/Core/Tools/mangler/wlib/linkedlist.h
+++ b/Core/Tools/mangler/wlib/linkedlist.h
@@ -60,7 +60,7 @@ class LinkedList
                   ~LinkedList();
 
   // Remove all entries from the lsit
-  void             clear(void);
+  void             clear();
 
   // Add a node after the zero based 'pos'
   bit8             add(IN T &node,sint32 pos, OUT T **newnodeptr=nullptr);
@@ -83,7 +83,7 @@ class LinkedList
   bit8             getPointer(OUT T **node, sint32 pos);
 
   // Get the number of entries in the list
-  sint32           length(void);
+  sint32           length();
 
   // Print information on the list
   void             print(IN FILE *out);
@@ -487,6 +487,6 @@ void LinkedList<T>::print(IN FILE *out)
 
 // Return the current length of the list
 template <class T>
-sint32 LinkedList<T>::length(void) {
+sint32 LinkedList<T>::length() {
   return(Entries);
 }

--- a/Core/Tools/mangler/wlib/monod.cpp
+++ b/Core/Tools/mangler/wlib/monod.cpp
@@ -18,7 +18,7 @@
 
 #include "monod.h"
 
-MonoD::MonoD(void)
+MonoD::MonoD()
 {
 #ifdef _WIN32
   unsigned long retval;

--- a/Core/Tools/mangler/wlib/sem4.cpp
+++ b/Core/Tools/mangler/wlib/sem4.cpp
@@ -56,7 +56,7 @@ Sem4::~Sem4()
 #endif
 }
 
-sint32  Sem4::Wait(void) const
+sint32  Sem4::Wait() const
 {
 #ifndef _WIN32
 	return(sem_wait((sem_t *)&sem));
@@ -77,7 +77,7 @@ sint32  Sem4::Wait(void) const
 #endif
 }
 
-sint32 Sem4::Post(void) const
+sint32 Sem4::Post() const
 {
 #ifndef _WIN32
   return(sem_post((sem_t *)&sem));
@@ -90,7 +90,7 @@ sint32 Sem4::Post(void) const
 #endif
 }
 
-sint32 Sem4::TryWait(void) const
+sint32 Sem4::TryWait() const
 {
 #ifndef _WIN32
   return(sem_trywait((sem_t *)&sem));
@@ -126,7 +126,7 @@ sint32 Sem4::GetValue(int *sval) const
 #endif
 }
 
-sint32 Sem4::Destroy(void)
+sint32 Sem4::Destroy()
 {
 #ifndef _WIN32
   return(sem_destroy(&sem));
@@ -153,17 +153,17 @@ Sem4::~Sem4()
 {
 }
 
-sint32  Sem4::Wait(void) const
+sint32  Sem4::Wait() const
 {
   return(0);
 }
 
-sint32 Sem4::Post(void) const
+sint32 Sem4::Post() const
 {
   return(0);
 }
 
-sint32 Sem4::TryWait(void) const
+sint32 Sem4::TryWait() const
 {
   return(0);
 }
@@ -173,7 +173,7 @@ sint32 Sem4::GetValue(int *) const
   return(0);
 }
 
-sint32 Sem4::Destroy(void)
+sint32 Sem4::Destroy()
 {
   return(0);
 }

--- a/Core/Tools/mangler/wlib/sem4.h
+++ b/Core/Tools/mangler/wlib/sem4.h
@@ -53,9 +53,9 @@ class Sem4
                Sem4(uint32 value);
               ~Sem4();
 
-  sint32       Wait(void) const;
-  sint32       TryWait(void) const;
-  sint32       Post(void) const;
+  sint32       Wait() const;
+  sint32       TryWait() const;
+  sint32       Post() const;
   sint32       GetValue(int *sval) const;
-  sint32       Destroy(void);
+  sint32       Destroy();
 };

--- a/Core/Tools/mangler/wlib/streamer.cpp
+++ b/Core/Tools/mangler/wlib/streamer.cpp
@@ -94,7 +94,7 @@ int Streamer::overflow(int c)
 }
 
 // This is a write only stream, this should never happen
-int Streamer::underflow(void)
+int Streamer::underflow()
 {
   return(EOF);
 }

--- a/Core/Tools/mangler/wlib/streamer.h
+++ b/Core/Tools/mangler/wlib/streamer.h
@@ -53,7 +53,7 @@ class Streamer : public streambuf
     // Virtual methods from streambuf
     int       xsputn(const char* s, int n); // buffer some characters
     int       overflow(int = EOF);          // flush buffer and make more room
-    int       underflow(void);              // Does nothing
+    int       underflow();              // Does nothing
     int       sync();
 
     int       doallocate();                 // allocate a buffer

--- a/Core/Tools/mangler/wlib/threadfac.cpp
+++ b/Core/Tools/mangler/wlib/threadfac.cpp
@@ -203,7 +203,7 @@ Runnable::~Runnable()
 { }
 
 // Is there a thread running in this class
-bit8 Runnable::isRunning(void)
+bit8 Runnable::isRunning()
 {
   // Don't need to lock a simple assignment
   int temp=ThreadCount_;
@@ -211,7 +211,7 @@ bit8 Runnable::isRunning(void)
 }
 
 // How many threads are running in this class
-int Runnable::getThreadCount(void)
+int Runnable::getThreadCount()
 {
   // Don't need to lock a simple assignment
   int temp=ThreadCount_;

--- a/Core/Tools/mangler/wlib/threadfac.h
+++ b/Core/Tools/mangler/wlib/threadfac.h
@@ -109,7 +109,7 @@ class Runnable
            };
 
            // Is there a thread running in this class?
-           static bit8 isRunning(void);
+           static bit8 isRunning();
 
            // Get the count of threads running inside this class
            static int    getThreadCount();

--- a/Core/Tools/mangler/wlib/timezone.cpp
+++ b/Core/Tools/mangler/wlib/timezone.cpp
@@ -56,14 +56,14 @@ void GetTimezoneInfo(const char * &timezone_str, int &timezone_offset) {
 #endif
 }
 
-const char * TimezoneString(void) {
+const char * TimezoneString() {
 	const char *timezone_str;
 	int timezone_offset;
 	GetTimezoneInfo(timezone_str, timezone_offset);
 	return timezone_str;
 }
 
-int TimezoneOffset(void) {
+int TimezoneOffset() {
 	const char *timezone_str;
 	int timezone_offset;
 	GetTimezoneInfo(timezone_str, timezone_offset);

--- a/Core/Tools/mangler/wlib/timezone.h
+++ b/Core/Tools/mangler/wlib/timezone.h
@@ -31,7 +31,7 @@ from now, not 2 hours ago.  Oh well.
 void GetTimezoneInfo(const char * &timezone_str, int &timezone_offset);
 
 // Returns the description of the current timezone (daylight savings included)
-const char * TimezoneString(void);
+const char * TimezoneString();
 
 // Returns the offset from GMT of the current timezone
-int TimezoneOffset(void);
+int TimezoneOffset();

--- a/Core/Tools/mangler/wlib/ustring.h
+++ b/Core/Tools/mangler/wlib/ustring.h
@@ -41,7 +41,7 @@ class UstringT : public basic_string<charT, string_char_traits<charT> >
 
 		UstringT() { max_bytelength=4000; }
 
-      size_t   get_max_bytelength(void) { return(max_bytelength); }
+      size_t   get_max_bytelength() { return(max_bytelength); }
       void     set_max_bytelength(size_t max) { max_bytelength=max; }
 
       bool     operator==(const UstringT<charT> &other)

--- a/Core/Tools/mangler/wlib/wdebug.cpp
+++ b/Core/Tools/mangler/wlib/wdebug.cpp
@@ -169,22 +169,22 @@ int MsgManager::setErrorStream(OutputDevice *device)
 
 
 
-ostream *MsgManager::debugStream(void)
+ostream *MsgManager::debugStream()
 {
   return(debug_ostream);
 }
 
-ostream *MsgManager::infoStream(void)
+ostream *MsgManager::infoStream()
 {
   return(info_ostream);
 }
 
-ostream *MsgManager::warnStream(void)
+ostream *MsgManager::warnStream()
 {
   return(warn_ostream);
 }
 
-ostream *MsgManager::errorStream(void)
+ostream *MsgManager::errorStream()
 {
   return(error_ostream);
 }

--- a/Core/Tools/mangler/wlib/wdebug.h
+++ b/Core/Tools/mangler/wlib/wdebug.h
@@ -304,8 +304,8 @@ class MsgManager
    static void                enableWarn(int flag);
    static void                enableError(int flag);
 
-   static ostream            *debugStream(void);
-   static ostream            *infoStream(void);
-   static ostream            *warnStream(void);
-   static ostream            *errorStream(void);
+   static ostream            *debugStream();
+   static ostream            *infoStream();
+   static ostream            *warnStream();
+   static ostream            *errorStream();
 };

--- a/Core/Tools/mangler/wlib/wstring.cpp
+++ b/Core/Tools/mangler/wlib/wstring.cpp
@@ -257,13 +257,13 @@ bit8 Wstring::removeChar(char c)
   return(removed);
 }
 
-void Wstring::removeSpaces(void)
+void Wstring::removeSpaces()
 {
   removeChar(' ');
   removeChar('\t');
 }
 
-void Wstring::clear(void)
+void Wstring::clear()
 {
  delete[](str);
  strsize=0;
@@ -292,7 +292,7 @@ void Wstring::cellCopy(char *dest, uint32 len)
   dest[len] = 0;
 }
 
-const char *Wstring::get(void) const
+const char *Wstring::get() const
 {
   if(!str)
     return "";
@@ -306,7 +306,7 @@ char Wstring::get(uint32 index) const
  return(0);
 }
 
-uint32 Wstring::length(void) const
+uint32 Wstring::length() const
 {
   if(str == nullptr)
     return(0);
@@ -463,7 +463,7 @@ char Wstring::setFormatted(const char *msg, ...)
 
 // This function converts all alphabetical characters in the string to lower
 // case.
-void Wstring::toLower(void)
+void Wstring::toLower()
 {
   uint32 i;
   int    strlength=length();
@@ -478,7 +478,7 @@ void Wstring::toLower(void)
 
 // This function converts all alphabetical characters in the string to upper
 // case.
-void Wstring::toUpper(void)
+void Wstring::toUpper()
 {
   uint32 i;
   int    strlength=length();

--- a/Core/Tools/mangler/wlib/wstring.h
+++ b/Core/Tools/mangler/wlib/wstring.h
@@ -40,7 +40,7 @@ class Wstring
            Wstring(const char *string);
           ~Wstring();
 
-   void    clear(void);
+   void    clear();
 
    bit8    cat(const char *string);
    bit8    cat(uint32 size,const char *string);
@@ -49,10 +49,10 @@ class Wstring
    void    cellCopy(OUT char *dest, uint32 len);
    char    remove(sint32 pos, sint32 count);
    bit8    removeChar(char c);
-   void    removeSpaces(void);
-   const char *get(void) const;
+   void    removeSpaces();
+   const char *get() const;
    char    get(uint32 index) const;
-   uint32  length(void) const;
+   uint32  length() const;
    bit8    insert(char c, uint32 pos);
    bit8    insert(const char *instring, uint32 pos);
    bit8    beautifyNumber();
@@ -62,8 +62,8 @@ class Wstring
    bit8    set(char c, uint32 index);
    char    setFormatted(const char *str, ...);		// Added by Joe Howes
    void    setSize(sint32 bytes);  // create an empty string
-   void    toLower(void);
-   void    toUpper(void);
+   void    toLower();
+   void    toUpper();
    bit8    truncate(uint32 len);
    bit8    truncate(char c);  // trunc after char c
    sint32  getToken(int offset,const char *delim,Wstring &out) const;

--- a/Core/Tools/mangler/wlib/wtime.cpp
+++ b/Core/Tools/mangler/wlib/wtime.cpp
@@ -56,7 +56,7 @@ static struct tm *localtime_r(const time_t *clockval, struct tm *res) {
 }
 #endif // _WIN32
 
-Wtime::Wtime(void)
+Wtime::Wtime()
 {
   Update();
 }
@@ -79,7 +79,7 @@ Wtime::~Wtime()
 {
 }
 
-void Wtime::Update(void)
+void Wtime::Update()
 {
  sign=POSITIVE;
  #ifdef _WIN32
@@ -411,12 +411,12 @@ void Wtime::PrintDate(char *out) const
     GetYear());
 }
 
-uint32 Wtime::GetSec(void) const
+uint32 Wtime::GetSec() const
 {
   return(sec);
 }
 
-uint32 Wtime::GetUsec(void) const
+uint32 Wtime::GetUsec() const
 {
   return(usec);
 }
@@ -438,7 +438,7 @@ void Wtime::Set(uint32 newsec, uint32 newusec)
 }
 
 // Get a timeval ptr from a Wtime class
-struct timeval *Wtime::GetTimeval(void)
+struct timeval *Wtime::GetTimeval()
 {
   static struct timeval tv;
   tv.tv_sec=sec;
@@ -454,49 +454,49 @@ void Wtime::GetTimevalMT(struct timeval &tv)
 }
 
 
-uint32 Wtime::GetSecond(void) const
+uint32 Wtime::GetSecond() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_sec);
 }
-uint32 Wtime::GetMinute(void) const
+uint32 Wtime::GetMinute() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_min);
 }
-uint32 Wtime::GetHour(void) const
+uint32 Wtime::GetHour() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_hour);
 }
-uint32 Wtime::GetMDay(void) const
+uint32 Wtime::GetMDay() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_mday);
 }
-uint32 Wtime::GetWDay(void) const
+uint32 Wtime::GetWDay() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_wday+1);
 }
-uint32 Wtime::GetYDay(void) const
+uint32 Wtime::GetYDay() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_yday+1);
 }
-uint32 Wtime::GetYWeek(void) const
+uint32 Wtime::GetYWeek() const
 {
   uint32 yweek;
   uint32 yday=GetYDay();
@@ -507,7 +507,7 @@ uint32 Wtime::GetYWeek(void) const
   yweek=((yday+phase-1)/7)+1;
   return(yweek);
 }
-uint32 Wtime::GetMonth(void) const
+uint32 Wtime::GetMonth() const
 {
   struct tm  t;
   struct tm *tptr;
@@ -515,7 +515,7 @@ uint32 Wtime::GetMonth(void) const
   return(tptr->tm_mon+1);
 }
 
-uint32 Wtime::GetYear(void) const
+uint32 Wtime::GetYear() const
 {
   struct tm  t;
   struct tm *tptr;
@@ -527,7 +527,7 @@ uint32 Wtime::GetYear(void) const
 }
 
 
-bit8 Wtime::GetSign(void) const
+bit8 Wtime::GetSign() const
 {
   return(sign);
 }

--- a/Core/Tools/mangler/wlib/wtime.h
+++ b/Core/Tools/mangler/wlib/wtime.h
@@ -65,28 +65,28 @@ class Wtime
     void      PrintDate(FILE *out) const;
     void      PrintDate(char *out) const;
 
-    uint32    GetSec(void) const;    // Get member variable 'sec'
-    uint32    GetUsec(void) const;   // Get member variable 'usec'
+    uint32    GetSec() const;    // Get member variable 'sec'
+    uint32    GetUsec() const;   // Get member variable 'usec'
     void      SetSec(uint32 newsec);
     void      SetUsec(uint32 newusec);
     void      Set(uint32 newsec,uint32 newusec);
     bit8      ParseDate(char *in);
     bit8      FormatTime(char *out, const char *format);
 
-    struct timeval   *GetTimeval(void);
+    struct timeval   *GetTimeval();
     void              GetTimevalMT(struct timeval &tv);
 
-    uint32    GetSecond(void) const; // Second (0- 60) (60 is for a leap second)
-    uint32    GetMinute(void) const; // Minute (0 - 59)
-    uint32    GetHour(void) const;   // Hour (0-23)
-    uint32    GetMDay(void) const;   // Day of Month (1-31)
-    uint32    GetWDay(void) const;   // Day of Week  (1-7)
-    uint32    GetYDay(void) const;   // Day of Year  (1-366)
-    uint32    GetMonth(void) const;  // Month (1-12)
-    uint32    GetYWeek(void) const;  // Week of Year (1-53)
-    uint32    GetYear(void) const;   // Year (e.g. 1997)
+    uint32    GetSecond() const; // Second (0- 60) (60 is for a leap second)
+    uint32    GetMinute() const; // Minute (0 - 59)
+    uint32    GetHour() const;   // Hour (0-23)
+    uint32    GetMDay() const;   // Day of Month (1-31)
+    uint32    GetWDay() const;   // Day of Week  (1-7)
+    uint32    GetYDay() const;   // Day of Year  (1-366)
+    uint32    GetMonth() const;  // Month (1-12)
+    uint32    GetYWeek() const;  // Week of Year (1-53)
+    uint32    GetYear() const;   // Year (e.g. 1997)
 
-    bit8      GetSign(void) const;  // 0 = pos   1 = neg
+    bit8      GetSign() const;  // 0 = pos   1 = neg
 
     int       Compare(const Wtime &other) const;
 

--- a/Core/Tools/mangler/wlib/xtime.cpp
+++ b/Core/Tools/mangler/wlib/xtime.cpp
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
 //
 // Construct with current clock time
 //
-Xtime::Xtime(void)
+Xtime::Xtime()
 {
   update();
 }
@@ -265,7 +265,7 @@ void Xtime::addSeconds(sint32 seconds)
 // If msec is > 1 days worth, adjust the day count
 //   & decrement the msec counter until OK.
 //
-void Xtime::normalize(void)
+void Xtime::normalize()
 {
   day_+=(msec_/86400000);
   msec_%=86400000;
@@ -281,7 +281,7 @@ void Xtime::normalize(void)
 // Update time to hold the current clock time
 // (breaks in 2038 :-)
 //
-void Xtime::update(void)
+void Xtime::update()
 {
   day_=719528;  // day_s from year 0 to Jan1, 1970
   msec_=0;
@@ -623,13 +623,13 @@ void Xtime::PrintDate(char *out) const
 ********************************************/
 
 // Get day_s since year 0
-sint32 Xtime::getDay(void) const
+sint32 Xtime::getDay() const
 {
   return(day_);
 }
 
 // Get msecs since start of day
-sint32 Xtime::getMsec(void) const
+sint32 Xtime::getMsec() const
 {
   return(msec_);
 }
@@ -686,7 +686,7 @@ bit8 Xtime::setTime(int month, int mday, int year, int hour, int minute, int sec
 
 
 
-int Xtime::getYDay(void) const   // Day of Year  (1-366)  (366 = leap yr)
+int Xtime::getYDay() const   // Day of Year  (1-366)  (366 = leap yr)
 {
 	int year;
 	sint32 dayofyear;
@@ -738,32 +738,32 @@ bit8 Xtime::getTime(int &month, int &mday, int &year, int &hour, int &minute, in
 // These are for getting components of the time in the
 //   standard ranges.  Like Day 1-31, Second 0-59, etc...
 //
-int Xtime::getSecond(void) const
+int Xtime::getSecond() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
   return(second);
 }
-int Xtime::getMinute(void) const
+int Xtime::getMinute() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
   return(minute);
 }
-int Xtime::getHour(void) const
+int Xtime::getHour() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
   return(hour);
 }
-int Xtime::getMDay(void) const
+int Xtime::getMDay() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
   return(mday);
 }
 
-int Xtime::getMonth(void) const
+int Xtime::getMonth() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
@@ -771,7 +771,7 @@ int Xtime::getMonth(void) const
 }
 
 // based at year 0 (real 0, not 1970)
-int Xtime::getYear(void) const
+int Xtime::getYear() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);

--- a/Core/Tools/mangler/wlib/xtime.h
+++ b/Core/Tools/mangler/wlib/xtime.h
@@ -77,8 +77,8 @@ class Xtime
     void      PrintDate(char *out) const;
 **********/
 
-    sint32    getDay(void) const;    // Get days since year 0
-    sint32    getMsec(void) const;   // Get milliseconds into the day
+    sint32    getDay() const;    // Get days since year 0
+    sint32    getMsec() const;   // Get milliseconds into the day
 
     void      setDay(sint32 day);
     void      setMsec(sint32 msec);
@@ -90,15 +90,15 @@ class Xtime
     bit8      getTimeval(struct timeval &tv);
 
     // All of these may return -1 if the time is invalid
-    int    getSecond(void) const; // Second (0-60) (60 is for a leap second)
-    int    getMinute(void) const; // Minute (0-59)
-    int    getHour(void) const;   // Hour (0-23)
-    int    getMDay(void) const;   // Day of Month (1-31)
-    int    getWDay(void) const;   // Day of Week  (1-7)
-    int    getYDay(void) const;   // Day of Year  (1-366)  (366 = leap yr)
-    int    getMonth(void) const;  // Month (1-12)
-    int    getYWeek(void) const;  // Week of Year (1-53)
-    int    getYear(void) const;   // Year (e.g. 1997)
+    int    getSecond() const; // Second (0-60) (60 is for a leap second)
+    int    getMinute() const; // Minute (0-59)
+    int    getHour() const;   // Hour (0-23)
+    int    getMDay() const;   // Day of Month (1-31)
+    int    getWDay() const;   // Day of Week  (1-7)
+    int    getYDay() const;   // Day of Year  (1-366)  (366 = leap yr)
+    int    getMonth() const;  // Month (1-12)
+    int    getYWeek() const;  // Week of Year (1-53)
+    int    getYear() const;   // Year (e.g. 1997)
 
     // Modify the time components.  Return FALSE if fail
     bit8      setSecond(sint32 sec);
@@ -108,7 +108,7 @@ class Xtime
     bit8      setMonth(sint32 month);
     bit8      setMDay(sint32 mday);
 
-    void      normalize(void);  // move msec overflows to the day
+    void      normalize();  // move msec overflows to the day
 
     // Compare two times
     int       compare(const Xtime &other) const;

--- a/Core/Tools/mangler/wnet/field.cpp
+++ b/Core/Tools/mangler/wnet/field.cpp
@@ -44,7 +44,7 @@
 
 
 // private member func
-void FieldClass::Clear(void)
+void FieldClass::Clear()
 {
   delete[](Data);
 
@@ -209,17 +209,17 @@ FieldClass::~FieldClass()
 }
 
 // Fetch the datatype
-int FieldClass::Get_Type(void)
+int FieldClass::Get_Type()
 {
   return(DataType);
 }
 
-void *FieldClass::Get_Data(void)
+void *FieldClass::Get_Data()
 {
 return(Data);
 }
 
-char *FieldClass::Get_ID(void)
+char *FieldClass::Get_ID()
 {
 return(ID);
 }
@@ -234,7 +234,7 @@ return(ID);
  * HISTORY:                                                               *
  *   04/22/1996 PWG : Created.                                            *
  *========================================================================*/
-void FieldClass::Host_To_Net(void)
+void FieldClass::Host_To_Net()
 {
   //
   // Before we convert the data type, we should convert the actual data
@@ -280,7 +280,7 @@ void FieldClass::Host_To_Net(void)
  * HISTORY:                                                               *
  *   04/22/1996 PWG : Created.                                            *
  *========================================================================*/
-void FieldClass::Net_To_Host(void)
+void FieldClass::Net_To_Host()
 {
   //
   // Finally convert over the data type and the size of the packet.

--- a/Core/Tools/mangler/wnet/field.h
+++ b/Core/Tools/mangler/wnet/field.h
@@ -58,7 +58,7 @@ class FieldClass
    // Define constructors to be able to create all the different kinds
    // of fields.
    //
-   FieldClass(void) {};
+   FieldClass() {};
    FieldClass(char *id, char data);
    FieldClass(char *id, unsigned char data);
    FieldClass(char *id, short data);
@@ -80,17 +80,17 @@ class FieldClass
    void Set(char *id, char *data);
    void Set(char *id, void *data, int length);
 
-   int             Get_Type(void);    // get the datatype of this field
-   unsigned short  Get_Size(void)  { return Size; }
-   void *             Get_Data(void);    // get the datatype of this field
-   char *             Get_ID(void);    // get the datatype of this field
+   int             Get_Type();    // get the datatype of this field
+   unsigned short  Get_Size()  { return Size; }
+   void *             Get_Data();    // get the datatype of this field
+   char *             Get_ID();    // get the datatype of this field
 
-   void            Host_To_Net(void);
-   void            Net_To_Host(void);
+   void            Host_To_Net();
+   void            Net_To_Host();
 
  private:
 
-   void            Clear(void);        // dealloc mem & zero safely
+   void            Clear();        // dealloc mem & zero safely
 
    char            ID[4];              // id value of this field
    unsigned short  DataType;           // id of the data type we are using

--- a/Core/Tools/mangler/wnet/tcp.cpp
+++ b/Core/Tools/mangler/wnet/tcp.cpp
@@ -196,7 +196,7 @@ sint32 TCP::SetBlocking(bit8 block,sint32 whichFD)
 }
 
 
-sint32 TCP::GetMaxFD(void)
+sint32 TCP::GetMaxFD()
 {
   if (mode==CLIENT)
     return(fd);
@@ -657,7 +657,7 @@ sint32 TCP::EncapsulatedRead(uint8 *msg,uint32 len,sint32 whichFD)
 }
 
 
-sint32 TCP::CloseAll(void)
+sint32 TCP::CloseAll()
 {
   int i;
 
@@ -676,7 +676,7 @@ sint32 TCP::CloseAll(void)
 // For clients this is used to give up ownership of a socket.
 //  Often used so the destructor won't call close on a socket.
 //
-void TCP::DisownSocket(void)
+void TCP::DisownSocket()
 {
   if (mode==CLIENT)
   {
@@ -1157,14 +1157,14 @@ bit8 TCP::ConnectAsync(uint32 IP,uint16 Port)
 
 
 
-void TCP::ClearStatus(void)
+void TCP::ClearStatus()
 {
   #ifndef _WIN32
   errno=0;
   #endif
 }
 
-int TCP::GetStatus(void)
+int TCP::GetStatus()
 {
   #ifdef _WIN32
   int status=WSAGetLastError();
@@ -1201,7 +1201,7 @@ int TCP::GetStatus(void)
 
 // this is only for servers
 
-sint32 TCP::GetConnection(void)
+sint32 TCP::GetConnection()
 {
   if (mode!=SERVER)
     return(-1);

--- a/Core/Tools/mangler/wnet/tcp.h
+++ b/Core/Tools/mangler/wnet/tcp.h
@@ -136,7 +136,7 @@ public:
   bit8    Bind(uint32 IP,uint16 port,bit8 reuseAddr=FALSE);
   bit8    Bind(char *Host,uint16 port,bit8 reuseAddr=FALSE);
 
-  sint32  GetMaxFD(void);
+  sint32  GetMaxFD();
 
   bit8    Connect(uint32 IP,uint16 port);
   bit8    Connect(char *Host,uint16 port);
@@ -145,14 +145,14 @@ public:
 
   bit8    IsConnected(sint32 whichFD=0);
 
-  sint32  GetFD(void);
-  sint32  GetClientCount(void) { return(clientCount); }
+  sint32  GetFD();
+  sint32  GetClientCount() { return(clientCount); }
 
   // Get IP or Port of a connected endpoint
   uint32  GetRemoteIP(sint32 whichFD=0);
   uint16  GetRemotePort(sint32 whichFD=0);
 
-  sint32  GetConnection(void);
+  sint32  GetConnection();
   sint32  GetConnection(struct sockaddr *clientAddr);
   void    WaitWrite(sint32 whichFD=0);
   bit8    CanWrite(sint32 whichFD=0);
@@ -173,16 +173,16 @@ public:
   int     Wait(sint32 sec,sint32 usec,fd_set &returnSet,sint32 whichFD=0);
   int     Wait(sint32 sec,sint32 usec,fd_set &inputSet,fd_set &returnSet);
 
-  int     GetStatus(void);
-  void    ClearStatus(void);
+  int     GetStatus();
+  void    ClearStatus();
 
   //sint32  GetSockStatus(sint32 whichFD=0);
 
   // give up ownership of the socket without closing it
-  void    DisownSocket(void);
+  void    DisownSocket();
 
   sint32  Close(sint32 whichFD=0);
-  sint32  CloseAll(void);   // close all sockets (same as close for client)
+  sint32  CloseAll();   // close all sockets (same as close for client)
 
   sint32  SetBlocking(bit8 block,sint32 whichFD=0);
 

--- a/Core/Tools/mangler/wnet/udp.cpp
+++ b/Core/Tools/mangler/wnet/udp.cpp
@@ -178,14 +178,14 @@ sint32 UDP::Read(uint8 *msg,uint32 len,sockaddr_in *from)
 }
 
 
-void UDP::ClearStatus(void)
+void UDP::ClearStatus()
 {
   #ifndef _WIN32
   errno=0;
   #endif
 }
 
-UDP::sockStat UDP::GetStatus(void)
+UDP::sockStat UDP::GetStatus()
 {
  #ifdef _WIN32
   int status=WSAGetLastError();
@@ -344,7 +344,7 @@ bit8 UDP::SetOutputBuffer(uint32 bytes)
 
 // Get the system buffer sizes
 
-int UDP::GetInputBuffer(void)
+int UDP::GetInputBuffer()
 {
   #ifndef _WIN32
    int retval,arg=0,len=sizeof(int);
@@ -358,7 +358,7 @@ int UDP::GetInputBuffer(void)
 }
 
 
-int UDP::GetOutputBuffer(void)
+int UDP::GetOutputBuffer()
 {
   #ifndef _WIN32
    int retval,arg=0,len=sizeof(int);

--- a/Core/Tools/mangler/wnet/udp.h
+++ b/Core/Tools/mangler/wnet/udp.h
@@ -96,16 +96,16 @@ class UDP
   sint32           Bind(char *Host,uint16 port);
   sint32           Write(uint8 *msg,uint32 len,uint32 IP,uint16 port);
   sint32           Read(uint8 *msg,uint32 len,sockaddr_in *from);
-  sockStat         GetStatus(void);
-  void             ClearStatus(void);
+  sockStat         GetStatus();
+  void             ClearStatus();
   int              Wait(sint32 sec,sint32 usec,fd_set &returnSet);
   int              Wait(sint32 sec,sint32 usec,fd_set &givenSet,fd_set &returnSet);
 
   bit8             getLocalAddr(uint32 &ip, uint16 &port);
-  sint32           getFD(void) { return(fd); }
+  sint32           getFD() { return(fd); }
 
   bit8             SetInputBuffer(uint32 bytes);
   bit8             SetOutputBuffer(uint32 bytes);
-  int              GetInputBuffer(void);
-  int              GetOutputBuffer(void);
+  int              GetInputBuffer();
+  int              GetOutputBuffer();
 };

--- a/Core/Tools/matchbot/encrypt.cpp
+++ b/Core/Tools/matchbot/encrypt.cpp
@@ -76,7 +76,7 @@ char *do_encrypt(char *String)
 
 
 #ifdef UNIT_TEST
-void main(void)
+void main()
 {
 	char Input_String[9];
 	char *new_string;

--- a/Core/Tools/matchbot/generals.cpp
+++ b/Core/Tools/matchbot/generals.cpp
@@ -128,7 +128,7 @@ int MapSetCount(const MapBitSet& a)
 // Users
 // =====================================================================
 
-GeneralsUser::GeneralsUser(void)
+GeneralsUser::GeneralsUser()
 {
 	status = STATUS_INCHANNEL;
 	points = 1;
@@ -197,12 +197,12 @@ GeneralsMatcher::GeneralsMatcher()
 	m_nextPoolSizeAnnouncement = time(nullptr);
 }
 
-void GeneralsMatcher::init(void)
+void GeneralsMatcher::init()
 {}
 
 
 #define W(x) setw(x) <<
-void GeneralsMatcher::dumpUsers(void)
+void GeneralsMatcher::dumpUsers()
 {}
 
 
@@ -431,7 +431,7 @@ void GeneralsMatcher::sendMatchInfo(std::string name1, std::string name2, std::s
 	peerMessagePlayer(m_peer, n.c_str(), s.c_str(), NormalMessage);
 }
 
-void GeneralsMatcher::checkMatches(void)
+void GeneralsMatcher::checkMatches()
 {
 	bool showPoolSize = false;
 	time_t now = time(nullptr);
@@ -1290,13 +1290,13 @@ GeneralsClientMatcher::GeneralsClientMatcher()
 		quiet = false;
 }
 
-void GeneralsClientMatcher::init(void)
+void GeneralsClientMatcher::init()
 {
 	m_baseNick.setFormatted("qmBot%d", time(nullptr));
 	m_profileID = 0;
 }
 
-void GeneralsClientMatcher::checkMatches(void)
+void GeneralsClientMatcher::checkMatches()
 {}
 
 void GeneralsClientMatcher::handleDisconnect( const char *reason )

--- a/Core/Tools/matchbot/generals.h
+++ b/Core/Tools/matchbot/generals.h
@@ -51,7 +51,7 @@ typedef enum
 class GeneralsUser
 {
 public:
-	GeneralsUser(void);
+	GeneralsUser();
 	UserStatus status;
 
 	int points, minPoints, maxPoints;
@@ -96,8 +96,8 @@ public:
 	virtual ~GeneralsMatcher()
 	{}
 
-	virtual void init(void);
-	virtual void checkMatches(void);
+	virtual void init();
+	virtual void checkMatches();
 
 	virtual void handleDisconnect( const char *reason );
 	virtual void handleRoomMessage( const char *nick, const char *message, MessageType messageType );
@@ -137,7 +137,7 @@ private:
 
 	void checkMatchesInUserMap(UserMap& userMap, int ladderID, int numPlayers, bool showPoolSize);
 
-	void dumpUsers(void);
+	void dumpUsers();
 
 	void sendMatchInfo(std::string name1, std::string name2, std::string name3, std::string name4,
 	                   std::string name5, std::string name6, std::string name7, std::string name8,
@@ -174,8 +174,8 @@ public:
 	virtual ~GeneralsClientMatcher()
 	{}
 
-	virtual void init(void);
-	virtual void checkMatches(void);
+	virtual void init();
+	virtual void checkMatches();
 
 	virtual void handleDisconnect( const char *reason );
 	virtual void handleRoomMessage( const char *nick, const char *message, MessageType messageType );

--- a/Core/Tools/matchbot/global.cpp
+++ b/Core/Tools/matchbot/global.cpp
@@ -21,7 +21,7 @@
 
 GlobalClass Global;
 
-GlobalClass::GlobalClass(void)
+GlobalClass::GlobalClass()
 {}
 
 bool GlobalClass::ReadFile(const char *fname)

--- a/Core/Tools/matchbot/global.h
+++ b/Core/Tools/matchbot/global.h
@@ -49,5 +49,5 @@ public:
 extern GlobalClass Global;
 
 // Log rotation functions
-void rotateOutput(void);
-void rotateParanoid(void);
+void rotateOutput();
+void rotateParanoid();

--- a/Core/Tools/matchbot/main.cpp
+++ b/Core/Tools/matchbot/main.cpp
@@ -66,7 +66,7 @@ void Signal_Quit(int)
 	exit(2);
 }
 
-void Setup_Signals(void)
+void Setup_Signals()
 {
 #ifdef _UNIX
 	struct sigaction act, oact;
@@ -298,7 +298,7 @@ void logMonitor(void *)
 #endif
 }
 
-void rotateOutput(void)
+void rotateOutput()
 {
 	Xtime xtime;
 	char filenamebuf[128];
@@ -374,7 +374,7 @@ void paranoidLogMonitor(void *)
 #endif
 }
 
-void rotateParanoid(void)
+void rotateParanoid()
 {
 	Xtime xtime;
 	char filenamebuf[128];

--- a/Core/Tools/matchbot/matcher.cpp
+++ b/Core/Tools/matchbot/matcher.cpp
@@ -26,7 +26,7 @@
 #define usleep(x) Sleep((x)/100000)
 #endif
 
-MatcherClass::MatcherClass(void)
+MatcherClass::MatcherClass()
 {
 	m_lastRotation = 0;
 	m_baseNick = "matcher";
@@ -52,7 +52,7 @@ void logIt(const char *Txt)
 	fclose(fp);
 }
 
-void MatcherClass::readLoop(void)
+void MatcherClass::readLoop()
 {
 	int delay = -1;
 	Global.config.getInt("ROTATEDELAY", delay);
@@ -310,7 +310,7 @@ static void AuthenticateCDKeyCallback
 	}
 }
 
-void MatcherClass::connectAndLoop(void)
+void MatcherClass::connectAndLoop()
 {
 	// Game-specific initializations, if necessary
 	init();

--- a/Core/Tools/matchbot/matcher.h
+++ b/Core/Tools/matchbot/matcher.h
@@ -39,10 +39,10 @@ public:
 	virtual ~MatcherClass()
 	{}
 
-	virtual void init(void)
+	virtual void init()
 	{}
 
-	virtual void checkMatches(void)
+	virtual void checkMatches()
 	{}
 
 	virtual void handleDisconnect( const char *reason )
@@ -65,7 +65,7 @@ public:
 	void handleJoin( bool success );
 	void handleNickError( const char *badNick );
 
-	void connectAndLoop( void );
+	void connectAndLoop();
 
 protected:
 
@@ -77,7 +77,7 @@ protected:
 	PEER m_peer;
 	bool m_connectSuccess;
 	bool m_joinSuccess;
-	void readLoop( void );
+	void readLoop();
 
 	int done;  // 0=no, neg=quit;error, pos=quit;success
 	bool quiet;

--- a/Core/Tools/matchbot/mydebug.cpp
+++ b/Core/Tools/matchbot/mydebug.cpp
@@ -69,7 +69,7 @@ int MyMsgManager::setParanoidStream(OutputDevice *device)
 
 
 
-ostream *MyMsgManager::paranoidStream(void)
+ostream *MyMsgManager::paranoidStream()
 {
 	return(paranoid_ostream);
 }

--- a/Core/Tools/matchbot/mydebug.h
+++ b/Core/Tools/matchbot/mydebug.h
@@ -127,5 +127,5 @@ public:
 
 	static void                enableParanoid(int flag);
 
-	static ostream            *paranoidStream(void);
+	static ostream            *paranoidStream();
 };

--- a/Core/Tools/matchbot/rand.cpp
+++ b/Core/Tools/matchbot/rand.cpp
@@ -50,7 +50,7 @@ RandClass::RandClass(int start)
 // Add with carry. SUM is replaced with A + B + C, C is replaced with 1  if there was a carry, 0 if there wasn't. A carry occurred if the sum is  less than one of the inputs. This is addition, so carry can never be  more than one.
 #define ADC(SUM, A, B, C)   SUM = (A) + (B) + (C); C = ((SUM < (A)) || (SUM < (B)))
 
-unsigned int RandClass::randomValue( void )
+unsigned int RandClass::randomValue()
 {
 	unsigned int ax;
 	unsigned int c = 0;
@@ -94,7 +94,7 @@ unsigned int RandClass::randomValue( void )
 }
 
 
-int RandClass::Int(void)
+int RandClass::Int()
 {
 	return (int)randomValue();
 }
@@ -112,7 +112,7 @@ int RandClass::Int(int low, int high)
 	return rval;
 }
 
-double RandClass::Double(void)
+double RandClass::Double()
 {
 	return Double(0.0, 1.0);
 }

--- a/Core/Tools/matchbot/rand.h
+++ b/Core/Tools/matchbot/rand.h
@@ -28,14 +28,14 @@ public:
 	{}
 
 
-	int Int(void);
-	double Double(void);
+	int Int();
+	double Double();
 	int Int(int low, int high);
 	double Double(double low, double high);
 
 private:
 
-	unsigned int randomValue( void );
+	unsigned int randomValue();
 	unsigned int seed[6];
 
 };

--- a/Core/Tools/matchbot/wlib/arraylist.h
+++ b/Core/Tools/matchbot/wlib/arraylist.h
@@ -67,7 +67,7 @@ class ArrayList
                   ~ArrayList();
 
   // Remove all entries from the lsit
-  void             clear(void);
+  void             clear();
 
   // Add a node after the zero based 'pos'
   bit8             add(IN T &node,sint32 pos);
@@ -97,7 +97,7 @@ class ArrayList
   bit8             getPointer(OUT T **node,sint32 pos) RO;
 
   // Get the number of entries in the list
-  sint32           length(void) RO;
+  sint32           length() RO;
 
   // UNSAFE! for classes, see note below!
   bit8             setSize(sint32 newsize, IN T &filler);
@@ -120,8 +120,8 @@ class ArrayList
     INITIAL_SIZE = 10
   };
 
-  bit8             growVector(void);   // Expand the number of slots
-  bit8             shrinkVector(void); // Reduce the number of slots
+  bit8             growVector();   // Expand the number of slots
+  bit8             shrinkVector(); // Reduce the number of slots
 };
 
 
@@ -627,14 +627,14 @@ void ArrayList<T>::print(FILE *out)
 
 // Return the current length of the list
 template <class T>
-sint32 ArrayList<T>::length(void) RO
+sint32 ArrayList<T>::length() RO
 {
   return(Entries_);
 }
 
 // Grow the vector by a factor of 2X
 template <class T>
-bit8 ArrayList<T>::growVector(void)
+bit8 ArrayList<T>::growVector()
 {
   if (Entries_ < Slots_)   // Don't grow until we're at 100% usage
     return(FALSE);
@@ -668,7 +668,7 @@ bit8 ArrayList<T>::growVector(void)
 
 // Shrink the vector by a factor of 2X
 template <class T>
-bit8 ArrayList<T>::shrinkVector(void)
+bit8 ArrayList<T>::shrinkVector()
 {
   //fprintf(stderr,"Shrink called\n");
 

--- a/Core/Tools/matchbot/wlib/critsec.cpp
+++ b/Core/Tools/matchbot/wlib/critsec.cpp
@@ -93,7 +93,7 @@ sint32 CritSec::lock(int *refcount) RO
 }
 
 // The "unlock" function release the critical section.
-sint32 CritSec::unlock(void) RO
+sint32 CritSec::unlock() RO
 {
  #ifdef _UNIX
     sint32	status = 0;

--- a/Core/Tools/matchbot/wlib/critsec.h
+++ b/Core/Tools/matchbot/wlib/critsec.h
@@ -46,7 +46,7 @@ class CritSec
                ~CritSec();
 
   sint32		lock(int *refcount=nullptr) RO;
-  sint32		unlock(void) RO;
+  sint32		unlock() RO;
 
  protected:
   #ifdef _WIN32

--- a/Core/Tools/matchbot/wlib/dictionary.h
+++ b/Core/Tools/matchbot/wlib/dictionary.h
@@ -92,13 +92,13 @@ Dictionary(uint32 (*hashFn)(const K &key)) :
 
                   ~Dictionary();
 
-  void             clear(void);
+  void             clear();
   bit8             add(IN K &key,IN V &value);
   bool             getValue(IN K &key, OUT V &value) RO;
   bool             getPointer(IN K &key, OUT V **value) RO;  // ptr to internal storage (Careful!)
   void             print(FILE *out) RO;
-  uint32           getSize(void) RO;
-  uint32           getEntries(void) RO;
+  uint32           getSize() RO;
+  uint32           getEntries() RO;
   bit8             contains(IN K &key) RO;
   bit8             updateValue(IN K &key,IN V &value);
   bit8             remove(IN K &key,OUT V &value);
@@ -109,8 +109,8 @@ Dictionary(uint32 (*hashFn)(const K &key)) :
   Dictionary<K,V>  &operator=(Dictionary<K,V> &other);
 
  private:
-  void             shrink(void);  // halve the number of slots
-  void             expand(void);  // double the number of slots
+  void             shrink();  // halve the number of slots
+  void             expand();  // double the number of slots
 
 
   DNode<K,V>     **table;      // This stores the lists at each slot
@@ -309,13 +309,13 @@ bit8 Dictionary<K,V>::iterate(INOUT int &index,INOUT int &offset,
 
 // Return the current size of the hash table
 template <class K,class V>
-uint32 Dictionary<K,V>::getSize(void) RO
+uint32 Dictionary<K,V>::getSize() RO
 { return(size); }
 
 
 // Return the current number of entries in the table
 template <class K,class V>
-uint32 Dictionary<K,V>::getEntries(void) RO
+uint32 Dictionary<K,V>::getEntries() RO
 { return(entries); }
 
 
@@ -597,7 +597,7 @@ bool Dictionary<K,V>::getPointer(IN K &key,OUT V **valptr) RO
 
 // Shrink the hash table by a factor of 2 (and relocate entries)
 template <class K,class V>
-void Dictionary<K,V>::shrink(void)
+void Dictionary<K,V>::shrink()
 {
   int    i;
   int    oldsize;
@@ -636,7 +636,7 @@ void Dictionary<K,V>::shrink(void)
 
 
 template <class K,class V>
-void Dictionary<K,V>::expand(void)
+void Dictionary<K,V>::expand()
 {
   int    i;
   int    oldsize;

--- a/Core/Tools/matchbot/wlib/linkedlist.h
+++ b/Core/Tools/matchbot/wlib/linkedlist.h
@@ -60,7 +60,7 @@ class LinkedList
                   ~LinkedList();
 
   // Remove all entries from the lsit
-  void             clear(void);
+  void             clear();
 
   // Add a node after the zero based 'pos'
   bit8             add(IN T &node,sint32 pos, OUT T **newnodeptr=nullptr);
@@ -83,7 +83,7 @@ class LinkedList
   bit8             getPointer(OUT T **node, sint32 pos);
 
   // Get the number of entries in the list
-  sint32           length(void);
+  sint32           length();
 
   // Print information on the list
   void             print(IN FILE *out);
@@ -487,6 +487,6 @@ void LinkedList<T>::print(IN FILE *out)
 
 // Return the current length of the list
 template <class T>
-sint32 LinkedList<T>::length(void) {
+sint32 LinkedList<T>::length() {
   return(Entries);
 }

--- a/Core/Tools/matchbot/wlib/monod.cpp
+++ b/Core/Tools/matchbot/wlib/monod.cpp
@@ -18,7 +18,7 @@
 
 #include "monod.h"
 
-MonoD::MonoD(void)
+MonoD::MonoD()
 {
 #ifdef _WIN32
   unsigned long retval;

--- a/Core/Tools/matchbot/wlib/sem4.cpp
+++ b/Core/Tools/matchbot/wlib/sem4.cpp
@@ -56,7 +56,7 @@ Sem4::~Sem4()
 #endif
 }
 
-sint32  Sem4::Wait(void) const
+sint32  Sem4::Wait() const
 {
 #ifndef _WIN32
 	return(sem_wait((sem_t *)&sem));
@@ -77,7 +77,7 @@ sint32  Sem4::Wait(void) const
 #endif
 }
 
-sint32 Sem4::Post(void) const
+sint32 Sem4::Post() const
 {
 #ifndef _WIN32
   return(sem_post((sem_t *)&sem));
@@ -90,7 +90,7 @@ sint32 Sem4::Post(void) const
 #endif
 }
 
-sint32 Sem4::TryWait(void) const
+sint32 Sem4::TryWait() const
 {
 #ifndef _WIN32
   return(sem_trywait((sem_t *)&sem));
@@ -126,7 +126,7 @@ sint32 Sem4::GetValue(int *sval) const
 #endif
 }
 
-sint32 Sem4::Destroy(void)
+sint32 Sem4::Destroy()
 {
 #ifndef _WIN32
   return(sem_destroy(&sem));
@@ -153,17 +153,17 @@ Sem4::~Sem4()
 {
 }
 
-sint32  Sem4::Wait(void) const
+sint32  Sem4::Wait() const
 {
   return(0);
 }
 
-sint32 Sem4::Post(void) const
+sint32 Sem4::Post() const
 {
   return(0);
 }
 
-sint32 Sem4::TryWait(void) const
+sint32 Sem4::TryWait() const
 {
   return(0);
 }
@@ -173,7 +173,7 @@ sint32 Sem4::GetValue(int *) const
   return(0);
 }
 
-sint32 Sem4::Destroy(void)
+sint32 Sem4::Destroy()
 {
   return(0);
 }

--- a/Core/Tools/matchbot/wlib/sem4.h
+++ b/Core/Tools/matchbot/wlib/sem4.h
@@ -53,9 +53,9 @@ class Sem4
                Sem4(uint32 value);
               ~Sem4();
 
-  sint32       Wait(void) const;
-  sint32       TryWait(void) const;
-  sint32       Post(void) const;
+  sint32       Wait() const;
+  sint32       TryWait() const;
+  sint32       Post() const;
   sint32       GetValue(int *sval) const;
-  sint32       Destroy(void);
+  sint32       Destroy();
 };

--- a/Core/Tools/matchbot/wlib/streamer.cpp
+++ b/Core/Tools/matchbot/wlib/streamer.cpp
@@ -94,7 +94,7 @@ int Streamer::overflow(int c)
 }
 
 // This is a write only stream, this should never happen
-int Streamer::underflow(void)
+int Streamer::underflow()
 {
   return(EOF);
 }

--- a/Core/Tools/matchbot/wlib/streamer.h
+++ b/Core/Tools/matchbot/wlib/streamer.h
@@ -53,7 +53,7 @@ class Streamer : public streambuf
     // Virtual methods from streambuf
     int       xsputn(const char* s, int n); // buffer some characters
     int       overflow(int = EOF);          // flush buffer and make more room
-    int       underflow(void);              // Does nothing
+    int       underflow();              // Does nothing
     int       sync();
 
     int       doallocate();                 // allocate a buffer

--- a/Core/Tools/matchbot/wlib/threadfac.cpp
+++ b/Core/Tools/matchbot/wlib/threadfac.cpp
@@ -203,7 +203,7 @@ Runnable::~Runnable()
 { }
 
 // Is there a thread running in this class
-bit8 Runnable::isRunning(void)
+bit8 Runnable::isRunning()
 {
   // Don't need to lock a simple assignment
   int temp=ThreadCount_;
@@ -211,7 +211,7 @@ bit8 Runnable::isRunning(void)
 }
 
 // How many threads are running in this class
-int Runnable::getThreadCount(void)
+int Runnable::getThreadCount()
 {
   // Don't need to lock a simple assignment
   int temp=ThreadCount_;

--- a/Core/Tools/matchbot/wlib/threadfac.h
+++ b/Core/Tools/matchbot/wlib/threadfac.h
@@ -109,7 +109,7 @@ class Runnable
            };
 
            // Is there a thread running in this class?
-           static bit8 isRunning(void);
+           static bit8 isRunning();
 
            // Get the count of threads running inside this class
            static int    getThreadCount();

--- a/Core/Tools/matchbot/wlib/timezone.cpp
+++ b/Core/Tools/matchbot/wlib/timezone.cpp
@@ -56,14 +56,14 @@ void GetTimezoneInfo(const char * &timezone_str, int &timezone_offset) {
 #endif
 }
 
-const char * TimezoneString(void) {
+const char * TimezoneString() {
 	const char *timezone_str;
 	int timezone_offset;
 	GetTimezoneInfo(timezone_str, timezone_offset);
 	return timezone_str;
 }
 
-int TimezoneOffset(void) {
+int TimezoneOffset() {
 	const char *timezone_str;
 	int timezone_offset;
 	GetTimezoneInfo(timezone_str, timezone_offset);

--- a/Core/Tools/matchbot/wlib/timezone.h
+++ b/Core/Tools/matchbot/wlib/timezone.h
@@ -31,7 +31,7 @@ from now, not 2 hours ago.  Oh well.
 void GetTimezoneInfo(const char * &timezone_str, int &timezone_offset);
 
 // Returns the description of the current timezone (daylight savings included)
-const char * TimezoneString(void);
+const char * TimezoneString();
 
 // Returns the offset from GMT of the current timezone
-int TimezoneOffset(void);
+int TimezoneOffset();

--- a/Core/Tools/matchbot/wlib/ustring.h
+++ b/Core/Tools/matchbot/wlib/ustring.h
@@ -41,7 +41,7 @@ class UstringT : public basic_string<charT, string_char_traits<charT>/**/>
 
 		UstringT() { max_bytelength=4000; }
 
-      size_t   get_max_bytelength(void) { return(max_bytelength); }
+      size_t   get_max_bytelength() { return(max_bytelength); }
       void     set_max_bytelength(size_t max) { max_bytelength=max; }
 
       bool     operator==(const UstringT<charT> &other)

--- a/Core/Tools/matchbot/wlib/wdebug.cpp
+++ b/Core/Tools/matchbot/wlib/wdebug.cpp
@@ -164,22 +164,22 @@ int MsgManager::setErrorStream(OutputDevice *device)
 
 
 
-ostream *MsgManager::debugStream(void)
+ostream *MsgManager::debugStream()
 {
   return(debug_ostream);
 }
 
-ostream *MsgManager::infoStream(void)
+ostream *MsgManager::infoStream()
 {
   return(info_ostream);
 }
 
-ostream *MsgManager::warnStream(void)
+ostream *MsgManager::warnStream()
 {
   return(warn_ostream);
 }
 
-ostream *MsgManager::errorStream(void)
+ostream *MsgManager::errorStream()
 {
   return(error_ostream);
 }

--- a/Core/Tools/matchbot/wlib/wdebug.h
+++ b/Core/Tools/matchbot/wlib/wdebug.h
@@ -308,8 +308,8 @@ class MsgManager
    static void                enableWarn(int flag);
    static void                enableError(int flag);
 
-   static ostream            *debugStream(void);
-   static ostream            *infoStream(void);
-   static ostream            *warnStream(void);
-   static ostream            *errorStream(void);
+   static ostream            *debugStream();
+   static ostream            *infoStream();
+   static ostream            *warnStream();
+   static ostream            *errorStream();
 };

--- a/Core/Tools/matchbot/wlib/wstring.cpp
+++ b/Core/Tools/matchbot/wlib/wstring.cpp
@@ -257,13 +257,13 @@ bit8 Wstring::removeChar(char c)
   return(removed);
 }
 
-void Wstring::removeSpaces(void)
+void Wstring::removeSpaces()
 {
   removeChar(' ');
   removeChar('\t');
 }
 
-void Wstring::clear(void)
+void Wstring::clear()
 {
  delete[](str);
  strsize=0;
@@ -292,7 +292,7 @@ void Wstring::cellCopy(char *dest, uint32 len)
   dest[len] = 0;
 }
 
-const char *Wstring::get(void) const
+const char *Wstring::get() const
 {
   if(!str)
     return "";
@@ -306,7 +306,7 @@ char Wstring::get(uint32 index) const
  return(0);
 }
 
-uint32 Wstring::length(void) const
+uint32 Wstring::length() const
 {
   if(str == nullptr)
     return(0);
@@ -463,7 +463,7 @@ char Wstring::setFormatted(const char *msg, ...)
 
 // This function converts all alphabetical characters in the string to lower
 // case.
-void Wstring::toLower(void)
+void Wstring::toLower()
 {
   uint32 i;
   int    strlength=length();
@@ -478,7 +478,7 @@ void Wstring::toLower(void)
 
 // This function converts all alphabetical characters in the string to upper
 // case.
-void Wstring::toUpper(void)
+void Wstring::toUpper()
 {
   uint32 i;
   int    strlength=length();

--- a/Core/Tools/matchbot/wlib/wstring.h
+++ b/Core/Tools/matchbot/wlib/wstring.h
@@ -40,7 +40,7 @@ class Wstring
            Wstring(const char *string);
           ~Wstring();
 
-   void    clear(void);
+   void    clear();
 
    bit8    cat(const char *string);
    bit8    cat(uint32 size,const char *string);
@@ -49,10 +49,10 @@ class Wstring
    void    cellCopy(OUT char *dest, uint32 len);
    char    remove(sint32 pos, sint32 count);
    bit8    removeChar(char c);
-   void    removeSpaces(void);
-   const char *get(void) const;
+   void    removeSpaces();
+   const char *get() const;
    char    get(uint32 index) const;
-   uint32  length(void) const;
+   uint32  length() const;
    bit8    insert(char c, uint32 pos);
    bit8    insert(const char *instring, uint32 pos);
    bit8    beautifyNumber();
@@ -62,8 +62,8 @@ class Wstring
    bit8    set(char c, uint32 index);
    char    setFormatted(const char *str, ...);		// Added by Joe Howes
    void    setSize(sint32 bytes);  // create an empty string
-   void    toLower(void);
-   void    toUpper(void);
+   void    toLower();
+   void    toUpper();
    bit8    truncate(uint32 len);
    bit8    truncate(char c);  // trunc after char c
    sint32  getToken(int offset,const char *delim,Wstring &out) const;

--- a/Core/Tools/matchbot/wlib/wtime.cpp
+++ b/Core/Tools/matchbot/wlib/wtime.cpp
@@ -56,7 +56,7 @@ static struct tm *localtime_r(const time_t *clockval, struct tm *res) {
 }
 #endif // _WIN32
 
-Wtime::Wtime(void)
+Wtime::Wtime()
 {
   Update();
 }
@@ -79,7 +79,7 @@ Wtime::~Wtime()
 {
 }
 
-void Wtime::Update(void)
+void Wtime::Update()
 {
  sign=POSITIVE;
  #ifdef _WIN32
@@ -411,12 +411,12 @@ void Wtime::PrintDate(char *out) const
     GetYear());
 }
 
-uint32 Wtime::GetSec(void) const
+uint32 Wtime::GetSec() const
 {
   return(sec);
 }
 
-uint32 Wtime::GetUsec(void) const
+uint32 Wtime::GetUsec() const
 {
   return(usec);
 }
@@ -438,7 +438,7 @@ void Wtime::Set(uint32 newsec, uint32 newusec)
 }
 
 // Get a timeval ptr from a Wtime class
-struct timeval *Wtime::GetTimeval(void)
+struct timeval *Wtime::GetTimeval()
 {
   static struct timeval tv;
   tv.tv_sec=sec;
@@ -454,49 +454,49 @@ void Wtime::GetTimevalMT(struct timeval &tv)
 }
 
 
-uint32 Wtime::GetSecond(void) const
+uint32 Wtime::GetSecond() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_sec);
 }
-uint32 Wtime::GetMinute(void) const
+uint32 Wtime::GetMinute() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_min);
 }
-uint32 Wtime::GetHour(void) const
+uint32 Wtime::GetHour() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_hour);
 }
-uint32 Wtime::GetMDay(void) const
+uint32 Wtime::GetMDay() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_mday);
 }
-uint32 Wtime::GetWDay(void) const
+uint32 Wtime::GetWDay() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_wday+1);
 }
-uint32 Wtime::GetYDay(void) const
+uint32 Wtime::GetYDay() const
 {
   struct tm  t;
   struct tm *tptr;
   tptr=localtime_r((time_t *)&sec,&t);
   return(tptr->tm_yday+1);
 }
-uint32 Wtime::GetYWeek(void) const
+uint32 Wtime::GetYWeek() const
 {
   uint32 yweek;
   uint32 yday=GetYDay();
@@ -507,7 +507,7 @@ uint32 Wtime::GetYWeek(void) const
   yweek=((yday+phase-1)/7)+1;
   return(yweek);
 }
-uint32 Wtime::GetMonth(void) const
+uint32 Wtime::GetMonth() const
 {
   struct tm  t;
   struct tm *tptr;
@@ -515,7 +515,7 @@ uint32 Wtime::GetMonth(void) const
   return(tptr->tm_mon+1);
 }
 
-uint32 Wtime::GetYear(void) const
+uint32 Wtime::GetYear() const
 {
   struct tm  t;
   struct tm *tptr;
@@ -527,7 +527,7 @@ uint32 Wtime::GetYear(void) const
 }
 
 
-bit8 Wtime::GetSign(void) const
+bit8 Wtime::GetSign() const
 {
   return(sign);
 }

--- a/Core/Tools/matchbot/wlib/wtime.h
+++ b/Core/Tools/matchbot/wlib/wtime.h
@@ -65,28 +65,28 @@ class Wtime
     void      PrintDate(FILE *out) const;
     void      PrintDate(char *out) const;
 
-    uint32    GetSec(void) const;    // Get member variable 'sec'
-    uint32    GetUsec(void) const;   // Get member variable 'usec'
+    uint32    GetSec() const;    // Get member variable 'sec'
+    uint32    GetUsec() const;   // Get member variable 'usec'
     void      SetSec(uint32 newsec);
     void      SetUsec(uint32 newusec);
     void      Set(uint32 newsec,uint32 newusec);
     bit8      ParseDate(char *in);
     bit8      FormatTime(char *out, const char *format);
 
-    struct timeval   *GetTimeval(void);
+    struct timeval   *GetTimeval();
     void              GetTimevalMT(struct timeval &tv);
 
-    uint32    GetSecond(void) const; // Second (0- 60) (60 is for a leap second)
-    uint32    GetMinute(void) const; // Minute (0 - 59)
-    uint32    GetHour(void) const;   // Hour (0-23)
-    uint32    GetMDay(void) const;   // Day of Month (1-31)
-    uint32    GetWDay(void) const;   // Day of Week  (1-7)
-    uint32    GetYDay(void) const;   // Day of Year  (1-366)
-    uint32    GetMonth(void) const;  // Month (1-12)
-    uint32    GetYWeek(void) const;  // Week of Year (1-53)
-    uint32    GetYear(void) const;   // Year (e.g. 1997)
+    uint32    GetSecond() const; // Second (0- 60) (60 is for a leap second)
+    uint32    GetMinute() const; // Minute (0 - 59)
+    uint32    GetHour() const;   // Hour (0-23)
+    uint32    GetMDay() const;   // Day of Month (1-31)
+    uint32    GetWDay() const;   // Day of Week  (1-7)
+    uint32    GetYDay() const;   // Day of Year  (1-366)
+    uint32    GetMonth() const;  // Month (1-12)
+    uint32    GetYWeek() const;  // Week of Year (1-53)
+    uint32    GetYear() const;   // Year (e.g. 1997)
 
-    bit8      GetSign(void) const;  // 0 = pos   1 = neg
+    bit8      GetSign() const;  // 0 = pos   1 = neg
 
     int       Compare(const Wtime &other) const;
 

--- a/Core/Tools/matchbot/wlib/xtime.cpp
+++ b/Core/Tools/matchbot/wlib/xtime.cpp
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
 //
 // Construct with current clock time
 //
-Xtime::Xtime(void)
+Xtime::Xtime()
 {
   update();
 }
@@ -265,7 +265,7 @@ void Xtime::addSeconds(sint32 seconds)
 // If msec is > 1 days worth, adjust the day count
 //   & decrement the msec counter until OK.
 //
-void Xtime::normalize(void)
+void Xtime::normalize()
 {
   day_+=(msec_/86400000);
   msec_%=86400000;
@@ -281,7 +281,7 @@ void Xtime::normalize(void)
 // Update time to hold the current clock time
 // (breaks in 2038 :-)
 //
-void Xtime::update(void)
+void Xtime::update()
 {
   day_=719528;  // day_s from year 0 to Jan1, 1970
   msec_=0;
@@ -623,13 +623,13 @@ void Xtime::PrintDate(char *out) const
 ********************************************/
 
 // Get day_s since year 0
-sint32 Xtime::getDay(void) const
+sint32 Xtime::getDay() const
 {
   return(day_);
 }
 
 // Get msecs since start of day
-sint32 Xtime::getMsec(void) const
+sint32 Xtime::getMsec() const
 {
   return(msec_);
 }
@@ -686,7 +686,7 @@ bit8 Xtime::setTime(int month, int mday, int year, int hour, int minute, int sec
 
 
 
-int Xtime::getYDay(void) const   // Day of Year  (1-366)  (366 = leap yr)
+int Xtime::getYDay() const   // Day of Year  (1-366)  (366 = leap yr)
 {
 	int year;
 	sint32 dayofyear;
@@ -738,32 +738,32 @@ bit8 Xtime::getTime(int &month, int &mday, int &year, int &hour, int &minute, in
 // These are for getting components of the time in the
 //   standard ranges.  Like Day 1-31, Second 0-59, etc...
 //
-int Xtime::getSecond(void) const
+int Xtime::getSecond() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
   return(second);
 }
-int Xtime::getMinute(void) const
+int Xtime::getMinute() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
   return(minute);
 }
-int Xtime::getHour(void) const
+int Xtime::getHour() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
   return(hour);
 }
-int Xtime::getMDay(void) const
+int Xtime::getMDay() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
   return(mday);
 }
 
-int Xtime::getMonth(void) const
+int Xtime::getMonth() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);
@@ -771,7 +771,7 @@ int Xtime::getMonth(void) const
 }
 
 // based at year 0 (real 0, not 1970)
-int Xtime::getYear(void) const
+int Xtime::getYear() const
 {
   int month,mday,year,hour,minute,second;
   getTime(month, mday, year, hour, minute, second);

--- a/Core/Tools/matchbot/wlib/xtime.h
+++ b/Core/Tools/matchbot/wlib/xtime.h
@@ -77,8 +77,8 @@ class Xtime
     void      PrintDate(char *out) const;
 **********/
 
-    sint32    getDay(void) const;    // Get days since year 0
-    sint32    getMsec(void) const;   // Get milliseconds into the day
+    sint32    getDay() const;    // Get days since year 0
+    sint32    getMsec() const;   // Get milliseconds into the day
 
     void      setDay(sint32 day);
     void      setMsec(sint32 msec);
@@ -90,15 +90,15 @@ class Xtime
     bit8      getTimeval(struct timeval &tv);
 
     // All of these may return -1 if the time is invalid
-    int    getSecond(void) const; // Second (0-60) (60 is for a leap second)
-    int    getMinute(void) const; // Minute (0-59)
-    int    getHour(void) const;   // Hour (0-23)
-    int    getMDay(void) const;   // Day of Month (1-31)
-    int    getWDay(void) const;   // Day of Week  (1-7)
-    int    getYDay(void) const;   // Day of Year  (1-366)  (366 = leap yr)
-    int    getMonth(void) const;  // Month (1-12)
-    int    getYWeek(void) const;  // Week of Year (1-53)
-    int    getYear(void) const;   // Year (e.g. 1997)
+    int    getSecond() const; // Second (0-60) (60 is for a leap second)
+    int    getMinute() const; // Minute (0-59)
+    int    getHour() const;   // Hour (0-23)
+    int    getMDay() const;   // Day of Month (1-31)
+    int    getWDay() const;   // Day of Week  (1-7)
+    int    getYDay() const;   // Day of Year  (1-366)  (366 = leap yr)
+    int    getMonth() const;  // Month (1-12)
+    int    getYWeek() const;  // Week of Year (1-53)
+    int    getYear() const;   // Year (e.g. 1997)
 
     // Modify the time components.  Return FALSE if fail
     bit8      setSecond(sint32 sec);
@@ -108,7 +108,7 @@ class Xtime
     bit8      setMonth(sint32 month);
     bit8      setMDay(sint32 mday);
 
-    void      normalize(void);  // move msec overflows to the day
+    void      normalize();  // move msec overflows to the day
 
     // Compare two times
     int       compare(const Xtime &other) const;

--- a/Core/Tools/matchbot/wnet/field.cpp
+++ b/Core/Tools/matchbot/wnet/field.cpp
@@ -44,7 +44,7 @@
 
 
 // private member func
-void FieldClass::Clear(void)
+void FieldClass::Clear()
 {
   delete[](Data);
 
@@ -209,17 +209,17 @@ FieldClass::~FieldClass()
 }
 
 // Fetch the datatype
-int FieldClass::Get_Type(void)
+int FieldClass::Get_Type()
 {
   return(DataType);
 }
 
-void *FieldClass::Get_Data(void)
+void *FieldClass::Get_Data()
 {
 return(Data);
 }
 
-char *FieldClass::Get_ID(void)
+char *FieldClass::Get_ID()
 {
 return(ID);
 }
@@ -234,7 +234,7 @@ return(ID);
  * HISTORY:                                                               *
  *   04/22/1996 PWG : Created.                                            *
  *========================================================================*/
-void FieldClass::Host_To_Net(void)
+void FieldClass::Host_To_Net()
 {
   //
   // Before we convert the data type, we should convert the actual data
@@ -280,7 +280,7 @@ void FieldClass::Host_To_Net(void)
  * HISTORY:                                                               *
  *   04/22/1996 PWG : Created.                                            *
  *========================================================================*/
-void FieldClass::Net_To_Host(void)
+void FieldClass::Net_To_Host()
 {
   //
   // Finally convert over the data type and the size of the packet.

--- a/Core/Tools/matchbot/wnet/field.h
+++ b/Core/Tools/matchbot/wnet/field.h
@@ -58,7 +58,7 @@ class FieldClass
    // Define constructors to be able to create all the different kinds
    // of fields.
    //
-   FieldClass(void) {};
+   FieldClass() {};
    FieldClass(char *id, char data);
    FieldClass(char *id, unsigned char data);
    FieldClass(char *id, short data);
@@ -80,17 +80,17 @@ class FieldClass
    void Set(char *id, char *data);
    void Set(char *id, void *data, int length);
 
-   int             Get_Type(void);    // get the datatype of this field
-   unsigned short  Get_Size(void)  { return Size; }
-   void *             Get_Data(void);    // get the datatype of this field
-   char *             Get_ID(void);    // get the datatype of this field
+   int             Get_Type();    // get the datatype of this field
+   unsigned short  Get_Size()  { return Size; }
+   void *             Get_Data();    // get the datatype of this field
+   char *             Get_ID();    // get the datatype of this field
 
-   void            Host_To_Net(void);
-   void            Net_To_Host(void);
+   void            Host_To_Net();
+   void            Net_To_Host();
 
  private:
 
-   void            Clear(void);        // dealloc mem & zero safely
+   void            Clear();        // dealloc mem & zero safely
 
    char            ID[4];              // id value of this field
    unsigned short  DataType;           // id of the data type we are using

--- a/Core/Tools/matchbot/wnet/tcp.cpp
+++ b/Core/Tools/matchbot/wnet/tcp.cpp
@@ -196,7 +196,7 @@ sint32 TCP::SetBlocking(bit8 block,sint32 whichFD)
 }
 
 
-sint32 TCP::GetMaxFD(void)
+sint32 TCP::GetMaxFD()
 {
   if (mode==CLIENT)
     return(fd);
@@ -657,7 +657,7 @@ sint32 TCP::EncapsulatedRead(uint8 *msg,uint32 len,sint32 whichFD)
 }
 
 
-sint32 TCP::CloseAll(void)
+sint32 TCP::CloseAll()
 {
   int i;
 
@@ -676,7 +676,7 @@ sint32 TCP::CloseAll(void)
 // For clients this is used to give up ownership of a socket.
 //  Often used so the destructor won't call close on a socket.
 //
-void TCP::DisownSocket(void)
+void TCP::DisownSocket()
 {
   if (mode==CLIENT)
   {
@@ -1157,14 +1157,14 @@ bit8 TCP::ConnectAsync(uint32 IP,uint16 Port)
 
 
 
-void TCP::ClearStatus(void)
+void TCP::ClearStatus()
 {
   #ifndef _WIN32
   errno=0;
   #endif
 }
 
-int TCP::GetStatus(void)
+int TCP::GetStatus()
 {
   #ifdef _WIN32
   int status=WSAGetLastError();
@@ -1201,7 +1201,7 @@ int TCP::GetStatus(void)
 
 // this is only for servers
 
-sint32 TCP::GetConnection(void)
+sint32 TCP::GetConnection()
 {
   if (mode!=SERVER)
     return(-1);

--- a/Core/Tools/matchbot/wnet/tcp.h
+++ b/Core/Tools/matchbot/wnet/tcp.h
@@ -136,7 +136,7 @@ public:
   bit8    Bind(uint32 IP,uint16 port,bit8 reuseAddr=FALSE);
   bit8    Bind(char *Host,uint16 port,bit8 reuseAddr=FALSE);
 
-  sint32  GetMaxFD(void);
+  sint32  GetMaxFD();
 
   bit8    Connect(uint32 IP,uint16 port);
   bit8    Connect(char *Host,uint16 port);
@@ -145,14 +145,14 @@ public:
 
   bit8    IsConnected(sint32 whichFD=0);
 
-  sint32  GetFD(void);
-  sint32  GetClientCount(void) { return(clientCount); }
+  sint32  GetFD();
+  sint32  GetClientCount() { return(clientCount); }
 
   // Get IP or Port of a connected endpoint
   uint32  GetRemoteIP(sint32 whichFD=0);
   uint16  GetRemotePort(sint32 whichFD=0);
 
-  sint32  GetConnection(void);
+  sint32  GetConnection();
   sint32  GetConnection(struct sockaddr *clientAddr);
   void    WaitWrite(sint32 whichFD=0);
   bit8    CanWrite(sint32 whichFD=0);
@@ -173,16 +173,16 @@ public:
   int     Wait(sint32 sec,sint32 usec,fd_set &returnSet,sint32 whichFD=0);
   int     Wait(sint32 sec,sint32 usec,fd_set &inputSet,fd_set &returnSet);
 
-  int     GetStatus(void);
-  void    ClearStatus(void);
+  int     GetStatus();
+  void    ClearStatus();
 
   //sint32  GetSockStatus(sint32 whichFD=0);
 
   // give up ownership of the socket without closing it
-  void    DisownSocket(void);
+  void    DisownSocket();
 
   sint32  Close(sint32 whichFD=0);
-  sint32  CloseAll(void);   // close all sockets (same as close for client)
+  sint32  CloseAll();   // close all sockets (same as close for client)
 
   sint32  SetBlocking(bit8 block,sint32 whichFD=0);
 

--- a/Core/Tools/matchbot/wnet/udp.cpp
+++ b/Core/Tools/matchbot/wnet/udp.cpp
@@ -178,14 +178,14 @@ sint32 UDP::Read(uint8 *msg,uint32 len,sockaddr_in *from)
 }
 
 
-void UDP::ClearStatus(void)
+void UDP::ClearStatus()
 {
   #ifndef _WIN32
   errno=0;
   #endif
 }
 
-UDP::sockStat UDP::GetStatus(void)
+UDP::sockStat UDP::GetStatus()
 {
  #ifdef _WIN32
   int status=WSAGetLastError();
@@ -344,7 +344,7 @@ bit8 UDP::SetOutputBuffer(uint32 bytes)
 
 // Get the system buffer sizes
 
-int UDP::GetInputBuffer(void)
+int UDP::GetInputBuffer()
 {
   #ifndef _WIN32
    int retval,arg=0,len=sizeof(int);
@@ -358,7 +358,7 @@ int UDP::GetInputBuffer(void)
 }
 
 
-int UDP::GetOutputBuffer(void)
+int UDP::GetOutputBuffer()
 {
   #ifndef _WIN32
    int retval,arg=0,len=sizeof(int);

--- a/Core/Tools/matchbot/wnet/udp.h
+++ b/Core/Tools/matchbot/wnet/udp.h
@@ -96,16 +96,16 @@ class UDP
   sint32           Bind(char *Host,uint16 port);
   sint32           Write(uint8 *msg,uint32 len,uint32 IP,uint16 port);
   sint32           Read(uint8 *msg,uint32 len,sockaddr_in *from);
-  sockStat         GetStatus(void);
-  void             ClearStatus(void);
+  sockStat         GetStatus();
+  void             ClearStatus();
   int              Wait(sint32 sec,sint32 usec,fd_set &returnSet);
   int              Wait(sint32 sec,sint32 usec,fd_set &givenSet,fd_set &returnSet);
 
   bit8             getLocalAddr(uint32 &ip, uint16 &port);
-  sint32           getFD(void) { return(fd); }
+  sint32           getFD() { return(fd); }
 
   bit8             SetInputBuffer(uint32 bytes);
   bit8             SetOutputBuffer(uint32 bytes);
-  int              GetInputBuffer(void);
-  int              GetOutputBuffer(void);
+  int              GetInputBuffer();
+  int              GetOutputBuffer();
 };

--- a/Core/Tools/textureCompress/textureCompress.cpp
+++ b/Core/Tools/textureCompress/textureCompress.cpp
@@ -144,8 +144,8 @@ public:
 	Directory(const std::string& dirPath);
 	~Directory() {}
 
-	FileInfoSet* getFiles( void );
-	FileInfoSet* getSubdirs( void );
+	FileInfoSet* getFiles();
+	FileInfoSet* getSubdirs();
 
 protected:
 	std::string m_dirPath;
@@ -256,12 +256,12 @@ Directory::Directory( const std::string& dirPath ) : m_dirPath(dirPath)
 	SetCurrentDirectory( currDir );
 }
 
-FileInfoSet* Directory::getFiles( void )
+FileInfoSet* Directory::getFiles()
 {
 	return &m_files;
 }
 
-FileInfoSet* Directory::getSubdirs( void )
+FileInfoSet* Directory::getSubdirs()
 {
 	return &m_subdirs;
 }

--- a/Core/Tools/wolSetup/WOLAPI/wolapi.h
+++ b/Core/Tools/wolSetup/WOLAPI/wolapi.h
@@ -219,7 +219,7 @@ EXTERN_C const IID IID_IRTPatcher;
             /* [string][in] */ LPCSTR destpath,
             /* [string][in] */ LPCSTR filename) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE PumpMessages( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE PumpMessages() = 0;
 
     };
 
@@ -633,7 +633,7 @@ EXTERN_C const IID IID_IChat;
     IChat : public IUnknown
     {
     public:
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE PumpMessages( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE PumpMessages() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestServerList(
             /* [in] */ unsigned long SKU,
@@ -657,9 +657,9 @@ EXTERN_C const IID IID_IChat;
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestChannelJoin(
             /* [in] */ Channel __RPC_FAR *channel) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestChannelLeave( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestChannelLeave() = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestUserList( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestUserList() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestPublicMessage(
             /* [in] */ LPCSTR message) = 0;
@@ -668,7 +668,7 @@ EXTERN_C const IID IID_IChat;
             /* [in] */ User __RPC_FAR *users,
             /* [in] */ LPCSTR message) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestLogout( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestLogout() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestPrivateGameOptions(
             /* [in] */ User __RPC_FAR *users,
@@ -728,7 +728,7 @@ EXTERN_C const IID IID_IChat;
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE SetChannelFilter(
             int channelType) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestGameEnd( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestGameEnd() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE SetLangFilter(
             int onoff) = 0;
@@ -774,7 +774,7 @@ EXTERN_C const IID IID_IChat;
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE SetChannelExInfo(
             LPCSTR info) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE StopAutoping( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE StopAutoping() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestSquadInfo(
             unsigned long id) = 0;
@@ -812,7 +812,7 @@ EXTERN_C const IID IID_IChat;
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE SetCodepageFilter(
             int filter) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestBuddyList( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestBuddyList() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestBuddyAdd(
             User __RPC_FAR *newbuddy) = 0;
@@ -842,12 +842,12 @@ EXTERN_C const IID IID_IChat;
             unsigned int currentPlayers,
             unsigned int maxPlayers) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestServerTime( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestServerTime() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestInsiderStatus(
             User __RPC_FAR *users) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestSetLocalIP( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestSetLocalIP() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestSquadByName(
             LPCSTR name) = 0;
@@ -3554,9 +3554,9 @@ EXTERN_C const IID IID_IDownload;
             LPCSTR localfile,
             LPCSTR regkey) = 0;
 
-        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Abort( void) = 0;
+        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Abort() = 0;
 
-        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE PumpMessages( void) = 0;
+        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE PumpMessages() = 0;
 
     };
 
@@ -3689,7 +3689,7 @@ EXTERN_C const IID IID_IDownloadEvent;
     IDownloadEvent : public IUnknown
     {
     public:
-        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE OnEnd( void) = 0;
+        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE OnEnd() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE OnError(
             int error) = 0;
@@ -3700,7 +3700,7 @@ EXTERN_C const IID IID_IDownloadEvent;
             int timetaken,
             int timeleft) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE OnQueryResume( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE OnQueryResume() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE OnStatusUpdate(
             int status) = 0;
@@ -3901,7 +3901,7 @@ EXTERN_C const IID IID_INetUtil;
             int timeout,
             int __RPC_FAR *handle) = 0;
 
-        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE PumpMessages( void) = 0;
+        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE PumpMessages() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE GetAvgPing(
             unsigned long ip,
@@ -4662,7 +4662,7 @@ EXTERN_C const IID IID_IChat2;
     IChat2 : public IUnknown
     {
     public:
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE PumpMessages( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE PumpMessages() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestConnection(
             Server __RPC_FAR *server,
@@ -4676,7 +4676,7 @@ EXTERN_C const IID IID_IChat2;
             GID id,
             GTYPE __RPC_FAR *type) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestChannelList( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestChannelList() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestChannelJoin(
             LPCSTR name) = 0;
@@ -4687,7 +4687,7 @@ EXTERN_C const IID IID_IChat2;
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestUserList(
             Channel __RPC_FAR *chan) = 0;
 
-        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestLogout( void) = 0;
+        virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestLogout() = 0;
 
         virtual /* [helpstring] */ HRESULT STDMETHODCALLTYPE RequestChannelCreate(
             Channel __RPC_FAR *chan) = 0;
@@ -5271,13 +5271,13 @@ EXTERN_C const IID IID_IIGROptions;
     IIGROptions : public IUnknown
     {
     public:
-        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Init( void) = 0;
+        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Init() = 0;
 
-        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Is_Auto_Login_Allowed( void) = 0;
+        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Is_Auto_Login_Allowed() = 0;
 
-        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Is_Storing_Nicks_Allowed( void) = 0;
+        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Is_Storing_Nicks_Allowed() = 0;
 
-        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Is_Running_Reg_App_Allowed( void) = 0;
+        virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Is_Running_Reg_App_Allowed() = 0;
 
         virtual /* [helpstring][id] */ HRESULT STDMETHODCALLTYPE Set_Options(
             unsigned int options) = 0;

--- a/Core/Tools/wolSetup/wolInit.cpp
+++ b/Core/Tools/wolSetup/wolInit.cpp
@@ -63,7 +63,7 @@ char g_generalsSerial[1024];
 #define DLL_REG_KEY_BOTTOM DLL_REG_KEY_PATH "\\"											///< WOLAPI registry key with trailing backslashes
 #define DLL_REG_KEY_LOCATION ""																		///< Version registry key
 
-void getPathsFromRegistry( void )
+void getPathsFromRegistry()
 {
 	HKEY handle;
 	unsigned long type;
@@ -186,7 +186,7 @@ IChat *g_pChat = nullptr;
 	* checkInstalledWolapiVersion inits WOLAPI if possible and gets its version
 	* number.  It also saves off its install path from the registry.
 	*/
-void checkInstalledWolapiVersion( void )
+void checkInstalledWolapiVersion()
 {
 	// Initialize this instance
 	_Module.Init(nullptr, g_hInst);

--- a/Core/Tools/wolSetup/wolSetup.h
+++ b/Core/Tools/wolSetup/wolSetup.h
@@ -26,7 +26,7 @@
 #endif
 #include <windows.h>
 
-void checkInstalledWolapiVersion( void );
+void checkInstalledWolapiVersion();
 void setupGenerals( const char *genPath, const char *genSerial );
 
 extern HINSTANCE g_hInst;

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/TeamObjectProperties.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/TeamObjectProperties.h
@@ -57,48 +57,48 @@ protected:
 	Dict* m_dictToEdit;
 
 #if 0 // Keys not implemented yet.  jba. [3/26/2003]//
-	void updateTheUI(void);
+	void updateTheUI();
 
 	// Generated message map functions
 	//{{AFX_MSG(TeamObjectProperties)
 	virtual BOOL OnInitDialog();
 	virtual void OnOK();
-	afx_msg void _HealthToDict(void);
-	afx_msg void _EnabledToDict(void);
-	afx_msg void _IndestructibleToDict(void);
-	afx_msg void _UnsellableToDict(void);
-	afx_msg void _PoweredToDict(void);
-	afx_msg void _AggressivenessToDict(void);
-	afx_msg void _VisibilityToDict(void);
-	afx_msg void _VeterancyToDict(void);
-	afx_msg void _ShroudClearingDistanceToDict(void);
-	afx_msg void _RecruitableAIToDict(void);
-	afx_msg void _SelectableToDict(void);
-	afx_msg void _WeatherToDict(void);
-	afx_msg void _TimeToDict(void);
+	afx_msg void _HealthToDict();
+	afx_msg void _EnabledToDict();
+	afx_msg void _IndestructibleToDict();
+	afx_msg void _UnsellableToDict();
+	afx_msg void _PoweredToDict();
+	afx_msg void _AggressivenessToDict();
+	afx_msg void _VisibilityToDict();
+	afx_msg void _VeterancyToDict();
+	afx_msg void _ShroudClearingDistanceToDict();
+	afx_msg void _RecruitableAIToDict();
+	afx_msg void _SelectableToDict();
+	afx_msg void _WeatherToDict();
+	afx_msg void _TimeToDict();
 	afx_msg void _HPsToDict();
-	afx_msg void _StoppingDistanceToDict(void);
-	afx_msg void _UpdateTeamMembers(void);
+	afx_msg void _StoppingDistanceToDict();
+	afx_msg void _UpdateTeamMembers();
 	//}}AFX_MSG
 
 	DECLARE_MESSAGE_MAP()
 
-	void _DictToHealth(void);
-	void _DictToHPs(void);
-	void _DictToEnabled(void);
-	void _DictToDestructible(void);
-	void _DictToUnsellable(void);
-	void _DictToPowered(void);
-	void _DictToAggressiveness(void);
-	void _DictToVisibilityRange(void);
-	void _DictToVeterancy(void);
-	void _DictToShroudClearingDistance(void);
+	void _DictToHealth();
+	void _DictToHPs();
+	void _DictToEnabled();
+	void _DictToDestructible();
+	void _DictToUnsellable();
+	void _DictToPowered();
+	void _DictToAggressiveness();
+	void _DictToVisibilityRange();
+	void _DictToVeterancy();
+	void _DictToShroudClearingDistance();
 	void _DictToRecruitableAI();
-	void _DictToSelectable(void);
-	void _DictToWeather(void);
-	void _DictToTime(void);
-	void _DictToStoppingDistance(void);
-	void _PropertiesToDict(void);
+	void _DictToSelectable();
+	void _DictToWeather();
+	void _DictToTime();
+	void _DictToStoppingDistance();
+	void _PropertiesToDict();
 #endif
 };
 

--- a/GeneralsMD/Code/Tools/wdump/rawfilem.h
+++ b/GeneralsMD/Code/Tools/wdump/rawfilem.h
@@ -140,31 +140,31 @@ class RawFileMClass : public FileClass
 		int Error_Number; // added by ehc to allow multithread library usage
 
 		RawFileMClass(char const *filename);
-		RawFileMClass(void);
+		RawFileMClass();
 		RawFileMClass (RawFileMClass const & f);
 		RawFileMClass & operator = (RawFileMClass const & f);
-		virtual ~RawFileMClass(void);
+		virtual ~RawFileMClass();
 
-		virtual char const * File_Name(void) const;
+		virtual char const * File_Name() const;
 		virtual char const * Set_Name(char const *filename);
-		virtual int Create(void);
-		virtual int Delete(void);
+		virtual int Create();
+		virtual int Delete();
 		virtual bool Is_Available(int forced=false);
-		virtual bool Is_Open(void) const;
+		virtual bool Is_Open() const;
 		virtual int Open(char const *filename, int rights=READ);
 		virtual int Open(int rights=READ);
 		virtual int Read(void *buffer, int size);
 		virtual int Seek(int pos, int dir=SEEK_CUR);
-		virtual int Size(void);
+		virtual int Size();
 		virtual int Write(void const *buffer, int size);
-		virtual void Close(void);
-		virtual unsigned long Get_Date_Time(void);
+		virtual void Close();
+		virtual unsigned long Get_Date_Time();
 		virtual bool Set_Date_Time(unsigned long datetime);
 		virtual void Error(int error, int canretry = false, char const * filename=nullptr);
 
 		void Bias(int start, int length=-1);
 
-		HANDLE_TYPE Get_File_Handle(void) { return (Handle); };
+		HANDLE_TYPE Get_File_Handle() { return (Handle); };
 
 		/*
 		**	These bias values enable a sub-portion of a file to appear as if it
@@ -180,7 +180,7 @@ class RawFileMClass : public FileClass
 		**	This function returns the largest size a low level DOS read or write may
 		**	perform. Larger file transfers are performed in chunks of this size or less.
 		*/
-		int Transfer_Block_Size(void) {return (int)((unsigned)UINT_MAX)-16L;};
+		int Transfer_Block_Size() {return (int)((unsigned)UINT_MAX)-16L;};
 
 		int Raw_Seek(int pos, int dir=SEEK_CUR);
 
@@ -238,7 +238,7 @@ class RawFileMClass : public FileClass
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-inline char const * RawFileMClass::File_Name(void) const
+inline char const * RawFileMClass::File_Name() const
 {
 	return(Filename);
 }
@@ -260,7 +260,7 @@ inline char const * RawFileMClass::File_Name(void) const
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-inline RawFileMClass::RawFileMClass(void) :
+inline RawFileMClass::RawFileMClass() :
 	Rights(READ),
 	BiasStart(0),
 	BiasLength(-1),
@@ -289,7 +289,7 @@ inline RawFileMClass::RawFileMClass(void) :
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-inline RawFileMClass::~RawFileMClass(void)
+inline RawFileMClass::~RawFileMClass()
 {
 	Close();
 	if (Allocated && Filename) {
@@ -315,7 +315,7 @@ inline RawFileMClass::~RawFileMClass(void)
  * HISTORY:                                                                                    *
  *   10/18/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-inline bool RawFileMClass::Is_Open(void) const
+inline bool RawFileMClass::Is_Open() const
 {
 	return(Handle != INVALID_HANDLE_VALUE);
 }


### PR DESCRIPTION
* Follow up for #2609
* Closes #2650 

Removed 1,791 redundant sole-void parameter lists from C++ declarations and definitions across 308 files, including tool sources not covered by the Visual Studio solution.