### PR TITLE
bugfix(debug): Skip system-modal crash dialogs in headless runs

### DIFF
--- a/Core/GameEngine/Source/Common/System/Debug.cpp
+++ b/Core/GameEngine/Source/Common/System/Debug.cpp
@@ -808,16 +808,22 @@ void ReleaseCrash(const char *reason)
 #if defined(RTS_DEBUG)
 	/* static */ char buff[8192]; // not so static so we can be threadsafe
 	snprintf(buff, 8192, "Sorry, a serious error occurred. (%s)", reason);
-	::MessageBox(nullptr, buff, "Technical Difficulties...", MB_OK|MB_SYSTEMMODAL|MB_ICONERROR);
+	if (!(TheGlobalData && TheGlobalData->m_headless))
+	{
+		::MessageBox(nullptr, buff, "Technical Difficulties...", MB_OK|MB_SYSTEMMODAL|MB_ICONERROR);
+	}
 #else
 // crash error messaged changed 3/6/03 BGC
 //	::MessageBox(nullptr, "Sorry, a serious error occurred.", "Technical Difficulties...", MB_OK|MB_TASKMODAL|MB_ICONERROR);
 //	::MessageBox(nullptr, "You have encountered a serious error.  Serious errors can be caused by many things including viruses, overheated hardware and hardware that does not meet the minimum specifications for the game. Please visit the forums at www.generals.ea.com for suggested courses of action or consult your manual for Technical Support contact information.", "Technical Difficulties...", MB_OK|MB_TASKMODAL|MB_ICONERROR);
 
 // crash error message changed again 8/22/03 M Lorenzen... made this message box modal to the system so it will appear on top of any task-modal windows, splash-screen, etc.
-  ::MessageBox(nullptr, "You have encountered a serious error.  Serious errors can be caused by many things including viruses, overheated hardware and hardware that does not meet the minimum specifications for the game. Please visit the forums at www.generals.ea.com for suggested courses of action or consult your manual for Technical Support contact information.",
-   "Technical Difficulties...",
-   MB_OK|MB_SYSTEMMODAL|MB_ICONERROR);
+	if (!(TheGlobalData && TheGlobalData->m_headless))
+	{
+		::MessageBox(nullptr, "You have encountered a serious error.  Serious errors can be caused by many things including viruses, overheated hardware and hardware that does not meet the minimum specifications for the game. Please visit the forums at www.generals.ea.com for suggested courses of action or consult your manual for Technical Support contact information.",
+			"Technical Difficulties...",
+			MB_OK|MB_SYSTEMMODAL|MB_ICONERROR);
+	}
 
 
 #endif
@@ -847,7 +853,10 @@ void ReleaseCrashLocalized(const AsciiString& p, const AsciiString& m)
 		}
 	}
 
-	::MessageBoxW(nullptr, mesg.str(), prompt.str(), MB_OK | MB_SYSTEMMODAL | MB_ICONERROR);
+	if (!(TheGlobalData && TheGlobalData->m_headless))
+	{
+		::MessageBoxW(nullptr, mesg.str(), prompt.str(), MB_OK | MB_SYSTEMMODAL | MB_ICONERROR);
+	}
 
 	char prevbuf[ _MAX_PATH ];
 	char curbuf[ _MAX_PATH ];


### PR DESCRIPTION
* Closes #3029

`ReleaseCrash` and `ReleaseCrashLocalized` call `MessageBox` even when the game runs with `-headless`. The system-modal dialog blocks `_exit(1)`, leaving an unattended process alive until somebody dismisses it.

Now only the dialog calls are skipped when `TheGlobalData->m_headless` is set. Crash reporting, minidump generation, and `_exit(1)` remain unchanged.

Todo:
- [x] Confirm `-headless` is parsed before subsystem initialization failures
- [x] Verify a `-headless` initialization failure exits 1, writes `ReleaseCrashInfo.txt`, and shows no UI
- [x] Verify the same failure without `-headless` retains the existing dialog
- [x] Verify a successful `-headless` run remains unaffected
- [x] Replicate to Generals — N/A, it's in Core

## Verification (Windows, MSVC x86)

Built `z_generals` in both `win32-debug` (`RTS_DEBUG`) and `win32` `Release` so both sides of the `#if defined(RTS_DEBUG)` split are covered. A subsystem initialization failure was induced by putting an invalid Bool (`UseTrees = Maybe`) in the install's loose `Data\INI\GameData.ini`, which makes `INI::scanBool` throw, gets rethrown as `INIException`, and lands in `GameEngine::init`'s `catch (INIException)` handler.

| Case | Debug | Release |
| --- | --- | --- |
| Headless failure | exit 1, `ReleaseCrashInfo.txt` written, no window | exit 1, `ReleaseCrashInfo.txt` written, no window |
| Same failure without `-headless` | "Technical Difficulties..." dialog shown, exit 1 after OK | "Technical Difficulties..." dialog shown, exit 1 after OK |
| Successful headless run (`-replay ... -headless`) | exit 0 | exit 0 |

Pre-fix control: reverting `Debug.cpp` and rebuilding reproduces #3029 — the headless process stays alive on a visible system-modal dialog with no game window, and only exits once the dialog is dismissed by hand.

`-headless` is parsed by `parseCommandLineForStartup` in `WinMain` before `GameMain`, so `m_headless` is already set when `GameEngine::init` loads INI data.

## Note on `TheGlobalData == nullptr`

`ReleaseCrash` already returns early when `TheGlobalData` is null, before reaching either `MessageBox`, so crashes that early show no dialog at all today. The null check in the new guards is therefore only meaningful in `ReleaseCrashLocalized`, where the dialog precedes the first `TheGlobalData` dereference. It is kept in all three for consistency.
