### PR TITLE
refactor: Use slot indices for player conversions

### DIFF
--- a/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2383,12 +2383,16 @@ bool GameLogic::onLogicCrc(MAYBE_UNUSED GameMessage *msg)
 	Player *msgPlayer = getMessagePlayer(msg);
 	if (TheNetwork)
 	{
-		const Int slotIndex = msgPlayer->getPlayerType() == PLAYER_HUMAN
-			? ThePlayerList->getSlotIndex(msgPlayer->getPlayerIndex())
-			: -1;
-
-		if (slotIndex < 0 || !TheNetwork->isPlayerConnected(slotIndex))
+		if (msgPlayer->getPlayerType() != PLAYER_HUMAN)
+		{
 			return false;
+		}
+
+		const Int slotIndex = ThePlayerList->getSlotIndex(msgPlayer->getPlayerIndex());
+		if (slotIndex < 0 || !TheNetwork->isPlayerConnected(slotIndex))
+		{
+			return false;
+		}
 
 		if (msgPlayer->isLocalPlayer())
 		{

--- a/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2383,15 +2383,9 @@ bool GameLogic::onLogicCrc(MAYBE_UNUSED GameMessage *msg)
 	Player *msgPlayer = getMessagePlayer(msg);
 	if (TheNetwork)
 	{
-		Int slotIndex = -1;
-		for (Int i=0; i<MAX_SLOTS; ++i)
-		{
-			if (msgPlayer->getPlayerType() == PLAYER_HUMAN && TheNetwork->getPlayerName(i) == msgPlayer->getPlayerDisplayName())
-			{
-				slotIndex = i;
-				break;
-			}
-		}
+		const Int slotIndex = msgPlayer->getPlayerType() == PLAYER_HUMAN
+			? ThePlayerList->getSlotIndex(msgPlayer->getPlayerIndex())
+			: -1;
 
 		if (slotIndex < 0 || !TheNetwork->isPlayerConnected(slotIndex))
 			return false;

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -989,12 +989,9 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 	}
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
-	Bool samePlayer = FALSE;
-	AsciiString playerName;
-	playerName.format("player%d", localPlayerIndex);
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	if (!p || (p->getPlayerNameKey() == NAMEKEY(playerName)))
-		samePlayer = TRUE;
+	const Int slotIndex = ThePlayerList->getSlotIndex(playerIndex);
+	const Bool samePlayer = !p || slotIndex == localPlayerIndex;
 	if (samePlayer || (localPlayerIndex < 0))
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -990,8 +990,8 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	const Bool samePlayer = !p || localPlayerIndex < 0 || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
-	if (samePlayer)
+	const Bool isLocalPlayer = !p || localPlayerIndex < 0 || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
+	if (isLocalPlayer)
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();
 		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Comparing CRCs of InGame:%8.8X Replay:%8.8X Frame:%d from Player %d",

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -990,9 +990,8 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	const Int slotIndex = ThePlayerList->getSlotIndex(playerIndex);
-	const Bool samePlayer = !p || slotIndex == localPlayerIndex;
-	if (samePlayer || (localPlayerIndex < 0))
+	const Bool samePlayer = !p || localPlayerIndex < 0 || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
+	if (samePlayer)
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();
 		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Comparing CRCs of InGame:%8.8X Replay:%8.8X Frame:%d from Player %d",

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -990,7 +990,7 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	const Bool isLocalPlayer = !p || localPlayerIndex < 0 || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
+	const Bool isLocalPlayer = !p || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
 	if (isLocalPlayer)
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -214,7 +214,7 @@ void VictoryConditions::update()
 			if (TheGameInfo)
 			{
 				const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
-				GameSlot *const slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+				const GameSlot* slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
 
 				if (slot && slot->isAI())
 				{

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -214,7 +214,7 @@ void VictoryConditions::update()
 			if (TheGameInfo)
 			{
 				const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
-				GameSlot *slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+				GameSlot *const slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
 
 				if (slot && slot->isAI())
 				{

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -211,19 +211,12 @@ void VictoryConditions::update()
 				TheAudio->addAudioEvent(&leftGameSound);
 			}
 
-			for (Int idx = 0; idx < MAX_SLOTS; ++idx)
+			const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
+			GameSlot *slot = TheGameInfo && slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+			if (slot && slot->isAI())
 			{
-				AsciiString pName;
-				pName.format("player%d", idx);
-				if (p->getPlayerNameKey() == NAMEKEY(pName))
-				{
-					GameSlot *slot = (TheGameInfo)?TheGameInfo->getSlot(idx):nullptr;
-					if (slot && slot->isAI())
-					{
-						DEBUG_LOG(("Marking AI player %s as defeated", pName.str()));
-						slot->setLastFrameInGame(TheGameLogic->getFrame());
-					}
-				}
+				DEBUG_LOG(("Marking AI player %s as defeated", TheNameKeyGenerator->keyToName(p->getPlayerNameKey()).str()));
+				slot->setLastFrameInGame(TheGameLogic->getFrame());
 			}
 
 			// destroy any remaining units (infantry if its a short game, for example)

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -211,12 +211,16 @@ void VictoryConditions::update()
 				TheAudio->addAudioEvent(&leftGameSound);
 			}
 
-			const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
-			GameSlot *slot = TheGameInfo && slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
-			if (slot && slot->isAI())
+			if (TheGameInfo)
 			{
-				DEBUG_LOG(("Marking AI player %s as defeated", TheNameKeyGenerator->keyToName(p->getPlayerNameKey()).str()));
-				slot->setLastFrameInGame(TheGameLogic->getFrame());
+				const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
+				GameSlot *slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+
+				if (slot && slot->isAI())
+				{
+					DEBUG_LOG(("Marking AI player %s as defeated", TheNameKeyGenerator->keyToName(p->getPlayerNameKey()).str()));
+					slot->setLastFrameInGame(TheGameLogic->getFrame());
+				}
 			}
 
 			// destroy any remaining units (infantry if its a short game, for example)

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -992,9 +992,8 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	const Int slotIndex = ThePlayerList->getSlotIndex(playerIndex);
-	const Bool samePlayer = !p || slotIndex == localPlayerIndex;
-	if (samePlayer || (localPlayerIndex < 0))
+	const Bool samePlayer = !p || localPlayerIndex < 0 || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
+	if (samePlayer)
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();
 		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Comparing CRCs of InGame:%8.8X Replay:%8.8X Frame:%d from Player %d",

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -992,8 +992,8 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	const Bool samePlayer = !p || localPlayerIndex < 0 || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
-	if (samePlayer)
+	const Bool isLocalPlayer = !p || localPlayerIndex < 0 || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
+	if (isLocalPlayer)
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();
 		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Comparing CRCs of InGame:%8.8X Replay:%8.8X Frame:%d from Player %d",

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -991,12 +991,9 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 	}
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
-	Bool samePlayer = FALSE;
-	AsciiString playerName;
-	playerName.format("player%d", localPlayerIndex);
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	if (!p || (p->getPlayerNameKey() == NAMEKEY(playerName)))
-		samePlayer = TRUE;
+	const Int slotIndex = ThePlayerList->getSlotIndex(playerIndex);
+	const Bool samePlayer = !p || slotIndex == localPlayerIndex;
 	if (samePlayer || (localPlayerIndex < 0))
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -992,7 +992,7 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	const Bool isLocalPlayer = !p || localPlayerIndex < 0 || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
+	const Bool isLocalPlayer = !p || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
 	if (isLocalPlayer)
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -216,7 +216,7 @@ void VictoryConditions::update()
 			if (TheGameInfo)
 			{
 				const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
-				GameSlot *slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+				GameSlot *const slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
 
 				if (slot && slot->isAI())
 				{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -213,19 +213,12 @@ void VictoryConditions::update()
 				TheAudio->addAudioEvent(&leftGameSound);
 			}
 
-			for (Int idx = 0; idx < MAX_SLOTS; ++idx)
+			const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
+			GameSlot *slot = TheGameInfo && slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+			if (slot && slot->isAI())
 			{
-				AsciiString pName;
-				pName.format("player%d", idx);
-				if (p->getPlayerNameKey() == NAMEKEY(pName))
-				{
-					GameSlot *slot = (TheGameInfo)?TheGameInfo->getSlot(idx):nullptr;
-					if (slot && slot->isAI())
-					{
-						DEBUG_LOG(("Marking AI player %s as defeated", pName.str()));
-						slot->setLastFrameInGame(TheGameLogic->getFrame());
-					}
-				}
+				DEBUG_LOG(("Marking AI player %s as defeated", TheNameKeyGenerator->keyToName(p->getPlayerNameKey()).str()));
+				slot->setLastFrameInGame(TheGameLogic->getFrame());
 			}
 
 			// destroy any remaining units (infantry if its a short game, for example)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -213,12 +213,16 @@ void VictoryConditions::update()
 				TheAudio->addAudioEvent(&leftGameSound);
 			}
 
-			const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
-			GameSlot *slot = TheGameInfo && slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
-			if (slot && slot->isAI())
+			if (TheGameInfo)
 			{
-				DEBUG_LOG(("Marking AI player %s as defeated", TheNameKeyGenerator->keyToName(p->getPlayerNameKey()).str()));
-				slot->setLastFrameInGame(TheGameLogic->getFrame());
+				const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
+				GameSlot *slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+
+				if (slot && slot->isAI())
+				{
+					DEBUG_LOG(("Marking AI player %s as defeated", TheNameKeyGenerator->keyToName(p->getPlayerNameKey()).str()));
+					slot->setLastFrameInGame(TheGameLogic->getFrame());
+				}
 			}
 
 			// destroy any remaining units (infantry if its a short game, for example)


### PR DESCRIPTION
Replaces the remaining player-index-to-slot-index reconstruction with `PlayerList::getSlotIndex`.
Update `GameLogic::onLogicCrc`, `RecorderClass::handleCRCMessage`, and `VictoryConditions::update`.

Related: #2897 
Merge before #3034 