### PR TITLE
refactor: Simplify slot-to-player lookups

### DIFF
--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarObserver.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarObserver.cpp
@@ -255,9 +255,7 @@ void ControlBar::populateObserverList()
 
 		for (i = 0; i < MAX_SLOTS; ++i)
 		{
-			AsciiString name;
-			name.format("player%d", i);
-			Player *p = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(name));
+			Player *p = ThePlayerList->getPlayerFromSlotIndex(i);
 			if(p)
 			{
 				if(p->isPlayerObserver())

--- a/Core/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
@@ -475,9 +475,7 @@ void PopulateInGameDiplomacyPopup()
 			}
 			if (slot->isAI())
 				isInGame = true;
-			AsciiString playerName;
-			playerName.format("player%d", slotNum);
-			Player *player = ThePlayerList->findPlayerWithNameKey(NAMEKEY(playerName));
+			Player *player = ThePlayerList->getPlayerFromSlotIndex(slotNum);
 			Bool isAlive = !TheVictoryConditions->hasSinglePlayerBeenDefeated(player);
 			Bool isObserver = player->isPlayerObserver();
 

--- a/Core/GameEngine/Source/GameClient/GUI/GUICallbacks/InGameChat.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GUICallbacks/InGameChat.cpp
@@ -217,13 +217,11 @@ void ToggleInGameChat( Bool immediate )
 				if (!msg.isEmpty() && !handleInGameSlashCommands(msg))
 				{
 					const Player *localPlayer = ThePlayerList->getLocalPlayer();
-					AsciiString playerName;
 					Int playerMask = 0;
 
 					for (Int i=0; i<MAX_SLOTS; ++i)
 					{
-						playerName.format("player%d", i);
-						const Player *player = ThePlayerList->findPlayerWithNameKey( TheNameKeyGenerator->nameToKey( playerName ) );
+						const Player *player = ThePlayerList->getPlayerFromSlotIndex(i);
 						if (player && localPlayer)
 						{
 							switch (inGameChatType)

--- a/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -764,9 +764,7 @@ void ConnectionManager::processChat(NetChatCommandMsg *msg)
 	unitext.format(L"[%ls] %ls", name.str(), msg->getText().str());
 //	DEBUG_LOG(("ConnectionManager::processChat - got message from player %d (mask %8.8X), message is %ls", playerID, msg->getPlayerMask(), unitext.str()));
 
-	AsciiString playerName;
-	playerName.format("player%d", msg->getPlayerID());
-	const Player *player = ThePlayerList->findPlayerWithNameKey( TheNameKeyGenerator->nameToKey( playerName ) );
+	const Player *player = ThePlayerList->getPlayerFromSlotIndex(playerID);
 	if (!player)
 	{
 		TheInGameUI->message(L"%ls", unitext.str());

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
@@ -600,9 +600,7 @@ AsciiString GameSpyStagingRoom::generateGameSpyGameResultsPacket()
 	Int lastTeamAtGameEnd = -1;
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
-		AsciiString playerName;
-		playerName.format("player%d", i);
-		Player *p = ThePlayerList->findPlayerWithNameKey(NAMEKEY(playerName));
+		Player *p = ThePlayerList->getPlayerFromSlotIndex(i);
 		if (p)
 		{
 			++numHumans;
@@ -646,9 +644,7 @@ AsciiString GameSpyStagingRoom::generateGameSpyGameResultsPacket()
 	Int playerID = 0;
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
-		AsciiString playerName;
-		playerName.format("player%d", i);
-		Player *p = ThePlayerList->findPlayerWithNameKey(NAMEKEY(playerName));
+		Player *p = ThePlayerList->getPlayerFromSlotIndex(i);
 		if (p)
 		{
 			GameSpyGameSlot *slot = &(m_GameSpySlot[i]);
@@ -694,9 +690,7 @@ AsciiString GameSpyStagingRoom::generateLadderGameResultsPacket()
 	Player* p[MAX_SLOTS];
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
-		AsciiString playerName;
-		playerName.format("player%d", i);
-		p[i] = ThePlayerList->findPlayerWithNameKey(NAMEKEY(playerName));
+		p[i] = ThePlayerList->getPlayerFromSlotIndex(i);
 		if (p[i])
 		{
 			++numPlayers;
@@ -730,8 +724,6 @@ AsciiString GameSpyStagingRoom::generateLadderGameResultsPacket()
 	Int playerID = 0;
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
-		AsciiString playerName;
-		playerName.format("player%d", i);
 		if (p[i])
 		{
 			GameSpyGameSlot *slot = &(m_GameSpySlot[i]);

--- a/Core/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
@@ -153,9 +153,7 @@ GameMessage *NetGameCommandMsg::constructGameMessage() const
 {
 	GameMessage *retval = newInstance(GameMessage)(m_type);
 
-	AsciiString name;
-	name.format("player%d", getPlayerID());
-	retval->friend_setPlayerIndex( ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(name))->getPlayerIndex());
+	retval->friend_setPlayerIndex(ThePlayerList->getPlayerFromSlotIndex(getPlayerID())->getPlayerIndex());
 
 	for (size_t i = 0; i < m_argList.size(); ++i) {
 		const GameMessageArgument* arg = m_argList[i];

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -657,14 +657,12 @@ void Network::processRunAheadCommand(NetRunAheadCommandMsg *msg) {
 
 void Network::processDestroyPlayerCommand(NetDestroyPlayerCommandMsg *msg)
 {
-	UnsignedInt playerIndex = msg->getPlayerIndex();
-	DEBUG_ASSERTCRASH(playerIndex < MAX_SLOTS, ("Bad player index"));
-	if (playerIndex >= MAX_SLOTS)
+	UnsignedInt slotIndex = msg->getPlayerIndex();
+	DEBUG_ASSERTCRASH(slotIndex < MAX_SLOTS, ("Bad slot index"));
+	if (slotIndex >= MAX_SLOTS)
 		return;
 
-	AsciiString playerName;
-	playerName.format("player%d", playerIndex);
-	Player *pPlayer = ThePlayerList->findPlayerWithNameKey(NAMEKEY(playerName));
+	Player *pPlayer = ThePlayerList->getPlayerFromSlotIndex(slotIndex);
 	if (pPlayer)
 	{
 		GameMessage *msg = newInstance(GameMessage)(GameMessage::MSG_SELF_DESTRUCT);

--- a/Generals/Code/GameEngine/Include/Common/PlayerList.h
+++ b/Generals/Code/GameEngine/Include/Common/PlayerList.h
@@ -152,6 +152,7 @@ public:
 	PlayerMaskType getPlayersWithRelationship( Int srcPlayerIndex, UnsignedInt allowedRelationships );
 
 	Int getSlotIndex(Int playerIndex) const;
+	Player *getPlayerFromSlotIndex(Int slotIndex) const;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/Common/PlayerList.h
+++ b/Generals/Code/GameEngine/Include/Common/PlayerList.h
@@ -48,6 +48,7 @@
 #include "Common/GameCommon.h"
 #include "Common/NameKeyGenerator.h"
 #include "Common/Snapshot.h"
+#include "GameNetwork/NetworkDefs.h"
 
 class DataChunkInput;
 struct DataChunkInfo;
@@ -161,6 +162,8 @@ protected:
 	virtual void xfer( Xfer *xfer ) override;
 	virtual void loadPostProcess() override;
 
+	Int getPlayerIndexFromSlotIndex(Int slotIndex) const;
+
 private:
 	void assignSlotIndices(const GameInfo& gameInfo);
 	void setSlotIndex(Int playerIndex, Int slotIndex);
@@ -169,6 +172,7 @@ private:
 	Int						m_playerCount;
 	Player				*m_players[MAX_PLAYER_COUNT];
 	Int						m_slotIndices[MAX_PLAYER_COUNT];
+	Int						m_slotToPlayerIndices[MAX_SLOTS];
 
 };
 

--- a/Generals/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
@@ -508,6 +508,21 @@ Int PlayerList::getSlotIndex(Int playerIndex) const
 }
 
 //-----------------------------------------------------------------------------
+Player *PlayerList::getPlayerFromSlotIndex(Int slotIndex) const
+{
+	if (slotIndex >= 0 && slotIndex < MAX_SLOTS)
+	{
+		for (Int playerIndex = 0; playerIndex < m_playerCount; ++playerIndex)
+		{
+			if (getSlotIndex(playerIndex) == slotIndex)
+				return m_players[playerIndex];
+		}
+	}
+
+	return nullptr;
+}
+
+//-----------------------------------------------------------------------------
 void PlayerList::assignSlotIndices(const GameInfo& gameInfo)
 {
 	AsciiString playerName;

--- a/Generals/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
@@ -242,6 +242,7 @@ void PlayerList::init()
 		m_players[i]->init(nullptr);
 
 	std::fill(m_slotIndices, m_slotIndices + ARRAY_SIZE(m_slotIndices), -1);
+	std::fill(m_slotToPlayerIndices, m_slotToPlayerIndices + ARRAY_SIZE(m_slotToPlayerIndices), -1);
 
 	// call setLocalPlayer so that becomingLocalPlayer() gets called appropriately
 	setLocalPlayer(m_players[0]);
@@ -492,7 +493,18 @@ void PlayerList::setSlotIndex(Int playerIndex, Int slotIndex)
 {
 	if (playerIndex >= 0 && playerIndex < ARRAY_SIZE(m_slotIndices))
 	{
+		const Int oldSlotIndex = m_slotIndices[playerIndex];
+		if (oldSlotIndex >= 0 && oldSlotIndex < ARRAY_SIZE(m_slotToPlayerIndices))
+		{
+			m_slotToPlayerIndices[oldSlotIndex] = -1;
+		}
+
 		m_slotIndices[playerIndex] = slotIndex;
+
+		if (slotIndex >= 0 && slotIndex < ARRAY_SIZE(m_slotToPlayerIndices))
+		{
+			m_slotToPlayerIndices[slotIndex] = playerIndex;
+		}
 	}
 }
 
@@ -508,15 +520,23 @@ Int PlayerList::getSlotIndex(Int playerIndex) const
 }
 
 //-----------------------------------------------------------------------------
+Int PlayerList::getPlayerIndexFromSlotIndex(Int slotIndex) const
+{
+	if (slotIndex >= 0 && slotIndex < ARRAY_SIZE(m_slotToPlayerIndices))
+	{
+		return m_slotToPlayerIndices[slotIndex];
+	}
+
+	return -1;
+}
+
+//-----------------------------------------------------------------------------
 Player *PlayerList::getPlayerFromSlotIndex(Int slotIndex) const
 {
-	if (slotIndex >= 0 && slotIndex < MAX_SLOTS)
+	const Int playerIndex = getPlayerIndexFromSlotIndex(slotIndex);
+	if (playerIndex >= 0 && playerIndex < m_playerCount)
 	{
-		for (Int playerIndex = 0; playerIndex < m_playerCount; ++playerIndex)
-		{
-			if (getSlotIndex(playerIndex) == slotIndex)
-				return m_players[playerIndex];
-		}
+		return m_players[playerIndex];
 	}
 
 	return nullptr;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -1775,15 +1775,13 @@ void grabMultiPlayerInfo()
 	typedef ScoreMap::reverse_iterator RevScoreMapIt;
 
 	Int playerCount = 0;
-	AsciiString playerName;
-	Player *player;
 	ScoreMap scores;
 	ScoreMapIt it;
 	scores.clear();
 	Int adder = 1; // Varible used to add on an offset to the score to make sure we don't add people to the same map
 
-	player = ThePlayerList->getLocalPlayer();
-	if (player)
+	Player *localPlayer = ThePlayerList->getLocalPlayer();
+	if (localPlayer)
 	{
 		const Image *image = TheMappedImageCollection->findImageByName("MutiPlayer_ScoreScreen");
 		if(image)
@@ -1796,8 +1794,7 @@ void grabMultiPlayerInfo()
 	// Add each player and score to the map. THis allows us to sort the players based on score.
 	for( Int i = 0; i < MAX_SLOTS; ++i)
 	{
-		playerName.format("player%d",i);
-		player = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(playerName));
+		Player *player = ThePlayerList->getPlayerFromSlotIndex(i);
 		if(player)
 		{
 			Int score = player->getScoreKeeper()->calculateScore();

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -6169,7 +6169,6 @@ void InGameUI::drawPlayerInfoList()
 	const Int lineH = m_playerInfoList.labels[PlayerInfoList::LabelType_Team]->getFont()->height;
 	const Int columnGap = static_cast<Int>(lineH * (6.0f / 12.0f) + 0.5f);
 
-	AsciiString name;
 	UnicodeString playerInfoListValue;
 	Int rowCount = 0;
 	Int maxValueWidths[PlayerInfoList::LabelType_Count] = {0};
@@ -6180,9 +6179,7 @@ void InGameUI::drawPlayerInfoList()
 
 	for (Int slotIndex = 0; slotIndex < MAX_SLOTS && rowCount < MAX_PLAYER_COUNT; ++slotIndex)
 	{
-		name.format("player%d", slotIndex);
-		const NameKeyType key = TheNameKeyGenerator->nameToKey(name);
-		Player *player = ThePlayerList->findPlayerWithNameKey(key);
+		Player *player = ThePlayerList->getPlayerFromSlotIndex(slotIndex);
 		if (!player || player->isPlayerObserver())
 			continue;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1648,13 +1648,11 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 			if (!slot || !slot->isOccupied())
 				continue;
 
-			AsciiString playerName;
-			playerName.format("player%d", i);
-			Player *player = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(playerName));
+			Player *player = ThePlayerList->getPlayerFromSlotIndex(i);
 
 			if (slot->getPlayerTemplate() == PLAYERTEMPLATE_OBSERVER)
 			{
-				DEBUG_LOG(("Clearing shroud for observer %s in playerList slot %d", playerName.str(), player->getPlayerIndex()));
+				DEBUG_LOG(("Clearing shroud for observer in slot %d with player index %d", i, player->getPlayerIndex()));
 				ThePartitionManager->revealMapForPlayerPermanently( player->getPlayerIndex() );
 			}
 			else
@@ -1785,9 +1783,7 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 			if (!slot || !slot->isOccupied())
 				continue;
 
-			AsciiString playerName;
-			playerName.format("player%d", i);
-			Player *player = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(playerName));
+			Player *player = ThePlayerList->getPlayerFromSlotIndex(i);
 
 			if (slot->getPlayerTemplate() == PLAYERTEMPLATE_OBSERVER)
 			{

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
@@ -669,9 +669,7 @@ AsciiString GameSpyGameInfo::generateGameResultsPacket()
 	Int lastTeamAtGameEnd = -1;
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
-		AsciiString playerName;
-		playerName.format("player%d", i);
-		Player *p = ThePlayerList->findPlayerWithNameKey(NAMEKEY(playerName));
+		Player *p = ThePlayerList->getPlayerFromSlotIndex(i);
 		if (p)
 		{
 			++numPlayers;
@@ -701,9 +699,7 @@ AsciiString GameSpyGameInfo::generateGameResultsPacket()
 	Int playerID = 0;
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
-		AsciiString playerName;
-		playerName.format("player%d", i);
-		Player *p = ThePlayerList->findPlayerWithNameKey(NAMEKEY(playerName));
+		Player *p = ThePlayerList->getPlayerFromSlotIndex(i);
 		if (p)
 		{
 			GameSpyGameSlot *slot = &(m_GameSpySlot[i]);

--- a/GeneralsMD/Code/GameEngine/Include/Common/PlayerList.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/PlayerList.h
@@ -152,6 +152,7 @@ public:
 	PlayerMaskType getPlayersWithRelationship( Int srcPlayerIndex, UnsignedInt allowedRelationships );
 
 	Int getSlotIndex(Int playerIndex) const;
+	Player *getPlayerFromSlotIndex(Int slotIndex) const;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/PlayerList.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/PlayerList.h
@@ -48,6 +48,7 @@
 #include "Common/GameCommon.h"
 #include "Common/NameKeyGenerator.h"
 #include "Common/Snapshot.h"
+#include "GameNetwork/NetworkDefs.h"
 
 class DataChunkInput;
 struct DataChunkInfo;
@@ -161,6 +162,8 @@ protected:
 	virtual void xfer( Xfer *xfer ) override;
 	virtual void loadPostProcess() override;
 
+	Int getPlayerIndexFromSlotIndex(Int slotIndex) const;
+
 private:
 	void assignSlotIndices(const GameInfo& gameInfo);
 	void setSlotIndex(Int playerIndex, Int slotIndex);
@@ -169,6 +172,7 @@ private:
 	Int						m_playerCount;
 	Player				*m_players[MAX_PLAYER_COUNT];
 	Int						m_slotIndices[MAX_PLAYER_COUNT];
+	Int						m_slotToPlayerIndices[MAX_SLOTS];
 
 };
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
@@ -508,6 +508,21 @@ Int PlayerList::getSlotIndex(Int playerIndex) const
 }
 
 //-----------------------------------------------------------------------------
+Player *PlayerList::getPlayerFromSlotIndex(Int slotIndex) const
+{
+	if (slotIndex >= 0 && slotIndex < MAX_SLOTS)
+	{
+		for (Int playerIndex = 0; playerIndex < m_playerCount; ++playerIndex)
+		{
+			if (getSlotIndex(playerIndex) == slotIndex)
+				return m_players[playerIndex];
+		}
+	}
+
+	return nullptr;
+}
+
+//-----------------------------------------------------------------------------
 void PlayerList::assignSlotIndices(const GameInfo& gameInfo)
 {
 	AsciiString playerName;

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
@@ -242,6 +242,7 @@ void PlayerList::init()
 		m_players[i]->init(nullptr);
 
 	std::fill(m_slotIndices, m_slotIndices + ARRAY_SIZE(m_slotIndices), -1);
+	std::fill(m_slotToPlayerIndices, m_slotToPlayerIndices + ARRAY_SIZE(m_slotToPlayerIndices), -1);
 
 	// call setLocalPlayer so that becomingLocalPlayer() gets called appropriately
 	setLocalPlayer(m_players[0]);
@@ -492,7 +493,18 @@ void PlayerList::setSlotIndex(Int playerIndex, Int slotIndex)
 {
 	if (playerIndex >= 0 && playerIndex < ARRAY_SIZE(m_slotIndices))
 	{
+		const Int oldSlotIndex = m_slotIndices[playerIndex];
+		if (oldSlotIndex >= 0 && oldSlotIndex < ARRAY_SIZE(m_slotToPlayerIndices))
+		{
+			m_slotToPlayerIndices[oldSlotIndex] = -1;
+		}
+
 		m_slotIndices[playerIndex] = slotIndex;
+
+		if (slotIndex >= 0 && slotIndex < ARRAY_SIZE(m_slotToPlayerIndices))
+		{
+			m_slotToPlayerIndices[slotIndex] = playerIndex;
+		}
 	}
 }
 
@@ -508,15 +520,23 @@ Int PlayerList::getSlotIndex(Int playerIndex) const
 }
 
 //-----------------------------------------------------------------------------
+Int PlayerList::getPlayerIndexFromSlotIndex(Int slotIndex) const
+{
+	if (slotIndex >= 0 && slotIndex < ARRAY_SIZE(m_slotToPlayerIndices))
+	{
+		return m_slotToPlayerIndices[slotIndex];
+	}
+
+	return -1;
+}
+
+//-----------------------------------------------------------------------------
 Player *PlayerList::getPlayerFromSlotIndex(Int slotIndex) const
 {
-	if (slotIndex >= 0 && slotIndex < MAX_SLOTS)
+	const Int playerIndex = getPlayerIndexFromSlotIndex(slotIndex);
+	if (playerIndex >= 0 && playerIndex < m_playerCount)
 	{
-		for (Int playerIndex = 0; playerIndex < m_playerCount; ++playerIndex)
-		{
-			if (getSlotIndex(playerIndex) == slotIndex)
-				return m_players[playerIndex];
-		}
+		return m_players[playerIndex];
 	}
 
 	return nullptr;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -2045,15 +2045,13 @@ void grabMultiPlayerInfo()
 	typedef ScoreMap::reverse_iterator RevScoreMapIt;
 
 	Int playerCount = 0;
-	AsciiString playerName;
-	Player *player;
 	ScoreMap scores;
 	ScoreMapIt it;
 	scores.clear();
 	Int adder = 1; // Varible used to add on an offset to the score to make sure we don't add people to the same map
 
-	player = ThePlayerList->getLocalPlayer();
-	if (player)
+	Player *localPlayer = ThePlayerList->getLocalPlayer();
+	if (localPlayer)
 	{
 		const Image *image = TheMappedImageCollection->findImageByName("MutiPlayer_ScoreScreen");
 		if(image)
@@ -2066,8 +2064,7 @@ void grabMultiPlayerInfo()
 	// Add each player and score to the map. THis allows us to sort the players based on score.
 	for( Int i = 0; i < MAX_SLOTS; ++i)
 	{
-		playerName.format("player%d",i);
-		player = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(playerName));
+		Player *player = ThePlayerList->getPlayerFromSlotIndex(i);
 		if(player)
 		{
 			Int score = player->getScoreKeeper()->calculateScore();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -6302,7 +6302,6 @@ void InGameUI::drawPlayerInfoList()
 	const Int lineH = m_playerInfoList.labels[PlayerInfoList::LabelType_Team]->getFont()->height;
 	const Int columnGap = static_cast<Int>(lineH * (6.0f / 12.0f) + 0.5f);
 
-	AsciiString name;
 	UnicodeString playerInfoListValue;
 	Int rowCount = 0;
 	Int maxValueWidths[PlayerInfoList::LabelType_Count] = {0};
@@ -6313,9 +6312,7 @@ void InGameUI::drawPlayerInfoList()
 
 	for (Int slotIndex = 0; slotIndex < MAX_SLOTS && rowCount < MAX_PLAYER_COUNT; ++slotIndex)
 	{
-		name.format("player%d", slotIndex);
-		const NameKeyType key = TheNameKeyGenerator->nameToKey(name);
-		Player *player = ThePlayerList->findPlayerWithNameKey(key);
+		Player *player = ThePlayerList->getPlayerFromSlotIndex(slotIndex);
 		if (!player || player->isPlayerObserver())
 			continue;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1809,13 +1809,11 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 			if (!slot || !slot->isOccupied())
 				continue;
 
-			AsciiString playerName;
-			playerName.format("player%d", i);
-			Player *player = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(playerName));
+			Player *player = ThePlayerList->getPlayerFromSlotIndex(i);
 
 			if (slot->getPlayerTemplate() == PLAYERTEMPLATE_OBSERVER)
 			{
-				DEBUG_LOG(("Clearing shroud for observer %s in playerList slot %d", playerName.str(), player->getPlayerIndex()));
+				DEBUG_LOG(("Clearing shroud for observer in slot %d with player index %d", i, player->getPlayerIndex()));
 				ThePartitionManager->revealMapForPlayerPermanently( player->getPlayerIndex() );
 			}
 			else
@@ -1998,9 +1996,7 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 			if (!slot || !slot->isOccupied())
 				continue;
 
-			AsciiString playerName;
-			playerName.format("player%d", i);
-			Player *player = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey(playerName));
+			Player *player = ThePlayerList->getPlayerFromSlotIndex(i);
 
 			if (slot->getPlayerTemplate() == PLAYERTEMPLATE_OBSERVER)
 			{

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
@@ -669,9 +669,7 @@ AsciiString GameSpyGameInfo::generateGameResultsPacket()
 	Int lastTeamAtGameEnd = -1;
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
-		AsciiString playerName;
-		playerName.format("player%d", i);
-		Player *p = ThePlayerList->findPlayerWithNameKey(NAMEKEY(playerName));
+		Player *p = ThePlayerList->getPlayerFromSlotIndex(i);
 		if (p)
 		{
 			++numPlayers;
@@ -701,9 +699,7 @@ AsciiString GameSpyGameInfo::generateGameResultsPacket()
 	Int playerID = 0;
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
-		AsciiString playerName;
-		playerName.format("player%d", i);
-		Player *p = ThePlayerList->findPlayerWithNameKey(NAMEKEY(playerName));
+		Player *p = ThePlayerList->getPlayerFromSlotIndex(i);
 		if (p)
 		{
 			GameSpyGameSlot *slot = &(m_GameSpySlot[i]);


### PR DESCRIPTION
Add `PlayerList::getPlayerFromSlotIndex` for reverse slot-to-player lookup.
Replace synthetic `"player%d"` associations
Preserve multiplayer slot ordering in result generation and UI paths.
Update the additional `GameSpyGameInfo::generateGameResultsPacket` implementation

Closes #2897 
Merge After #3033 