### PR TITLE
refactor(network): Remove obsolete Online IP option

### DIFF
--- a/Core/GameEngine/Include/Common/OptionPreferences.h
+++ b/Core/GameEngine/Include/Common/OptionPreferences.h
@@ -62,11 +62,8 @@ public:
 	TextureFilterClass::TextureFilterMode getTextureFilterMode() const;
 	TextureFilterClass::AnisotropicFilterMode getTextureAnisotropyLevel() const;
 	UnsignedInt getLANIPAddress();
-	UnsignedInt getOnlineIPAddress();
 	void setLANIPAddress(AsciiString IP);
-	void setOnlineIPAddress(AsciiString IP);
 	void setLANIPAddress(UnsignedInt IP);
-	void setOnlineIPAddress(UnsignedInt IP);
 	Bool getArchiveReplaysEnabled() const;
 	Bool getAlternateMouseModeEnabled();
 	Bool getRightMouseScrollWithAlternateMouseEnabled() const;

--- a/Core/GameEngine/Source/Common/OptionPreferences.cpp
+++ b/Core/GameEngine/Source/Common/OptionPreferences.cpp
@@ -152,34 +152,6 @@ void OptionPreferences::setLANIPAddress(UnsignedInt IP)
 	(*this)["IPAddress"] = tmp;
 }
 
-UnsignedInt OptionPreferences::getOnlineIPAddress()
-{
-	AsciiString selectedIP = (*this)["GameSpyIPAddress"];
-	IPEnumeration IPs;
-	EnumeratedIP *IPlist = IPs.getAddresses();
-	while (IPlist)
-	{
-		if (selectedIP.compareNoCase(IPlist->getIPstring()) == 0)
-		{
-			return IPlist->getIP();
-		}
-		IPlist = IPlist->getNext();
-	}
-	return TheGlobalData->m_defaultIP;
-}
-
-void OptionPreferences::setOnlineIPAddress(AsciiString IP)
-{
-	(*this)["GameSpyIPAddress"] = IP;
-}
-
-void OptionPreferences::setOnlineIPAddress(UnsignedInt IP)
-{
-	AsciiString tmp;
-	tmp.format("%d.%d.%d.%d", PRINTF_IP_AS_4_INTS(IP));
-	(*this)["GameSpyIPAddress"] = tmp;
-}
-
 Bool OptionPreferences::getArchiveReplaysEnabled() const
 {
 	OptionPreferences::const_iterator it = find("ArchiveReplays");

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1328,20 +1328,12 @@ void PeerThreadClass::Thread_Function()
 
 	OptionPreferences pref;
 	UnsignedInt preferredIP = INADDR_ANY;
-	UnsignedInt selectedIP = pref.getOnlineIPAddress();
-	DEBUG_LOG(("Looking for IP %X", selectedIP));
 	IPEnumeration IPs;
 	EnumeratedIP *IPlist = IPs.getAddresses();
-	while (IPlist)
+	if (IPlist)
 	{
-		DEBUG_LOG(("Looking at IP %s", IPlist->getIPstring().str()));
-		if (selectedIP == IPlist->getIP())
-		{
-			preferredIP = IPlist->getIP();
-			DEBUG_LOG(("Connecting to GameSpy chat server via IP address %8.8X", preferredIP));
-			break;
-		}
-		IPlist = IPlist->getNext();
+		preferredIP = IPlist->getIP();
+		DEBUG_LOG(("Connecting to GameSpy chat server via IP address %8.8X", preferredIP));
 	}
 	chatSetLocalIP(preferredIP);
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/NetworkDirectConnect.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/NetworkDirectConnect.cpp
@@ -304,35 +304,27 @@ void NetworkDirectConnectInit( WindowLayout *layout, void *userData )
 		TheLAN = NEW LANAPI();
 
 		OptionPreferences prefs;
-		UnsignedInt IP = prefs.getOnlineIPAddress();
+		UnsignedInt IP = prefs.getLANIPAddress();
 
 		IPEnumeration IPs;
+		EnumeratedIP *IPlist = IPs.getAddresses();
 
-//		if (!IP)
-//		{
-			EnumeratedIP *IPlist = IPs.getAddresses();
-			DEBUG_ASSERTCRASH(IPlist, ("No IP addresses found!"));
-			if (!IPlist)
+		Bool foundIP = FALSE;
+		EnumeratedIP *tempIP = IPlist;
+		while (tempIP != nullptr && !foundIP)
+		{
+			if (IP == tempIP->getIP())
 			{
-				/// @todo: display error and exit lan lobby if no IPs are found
+				foundIP = TRUE;
 			}
+			tempIP = tempIP->getNext();
+		}
 
-			Bool foundIP = FALSE;
-			EnumeratedIP *tempIP = IPlist;
-			while ((tempIP != nullptr) && (foundIP == FALSE)) {
-				if (IP == tempIP->getIP()) {
-					foundIP = TRUE;
-				}
-				tempIP = tempIP->getNext();
-			}
+		if (!foundIP && IPlist != nullptr)
+		{
+			IP = IPlist->getIP();
+		}
 
-			if (foundIP == FALSE) {
-				// The IP that we had no longer exists, we need to pick a new one.
-				IP = IPlist->getIP();
-			}
-
-//			IP = IPlist->getIP();
-//		}
 		TheLAN->init();
 		TheLAN->SetLocalIP(IP);
 	}

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -471,16 +471,6 @@ static void saveOptions()
 		}
 	}
 
-	if (comboBoxOnlineIP && comboBoxOnlineIP->winGetEnabled())
-	{
-		UnsignedInt ip;
-		GadgetComboBoxGetSelectedPos(comboBoxOnlineIP, &index);
-		if (index>=0)
-		{
-			ip = (UnsignedInt)GadgetComboBoxGetItemData(comboBoxOnlineIP, index);
-			pref->setOnlineIPAddress(ip);
-		}
-	}
 
 	//-------------------------------------------------------------------------------------------------
 	// Firewall Port Override
@@ -1064,42 +1054,17 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		}
 	}
 
-	// And now the GameSpy one
+#if ENABLE_GUI_HACKS
+	// TheSuperHackers @tweak 31/07/2026 Manual Online IP selection was obsoleted because
+	// match sockets automatically use the system's default network routing table interface.
+	// Hide the obsoleted UI elements accordingly.
 	if (comboBoxOnlineIP)
-	{
-		UnsignedInt selectedIP = pref->getOnlineIPAddress();
-		UnicodeString str;
-		IPEnumeration IPs;
-		EnumeratedIP *IPlist = IPs.getAddresses();
-		Int index;
-		Int selectedIndex = -1;
-		Int count = 0;
-		GadgetComboBoxReset(comboBoxOnlineIP);
-		while (IPlist)
-		{
-			count++;
-			str.translate(IPlist->getIPstring());
-			index = GadgetComboBoxAddEntry(comboBoxOnlineIP, str, color);
-			GadgetComboBoxSetItemData(comboBoxOnlineIP, index, (void *)(IPlist->getIP()));
-			if (selectedIP == IPlist->getIP())
-			{
-				selectedIndex = index;
-			}
-			IPlist = IPlist->getNext();
-		}
-		if (selectedIndex >= 0)
-		{
-			GadgetComboBoxSetSelectedPos(comboBoxOnlineIP, selectedIndex);
-		}
-		else
-		{
-			GadgetComboBoxSetSelectedPos(comboBoxOnlineIP, 0);
-			if (IPs.getAddresses())
-			{
-				pref->setOnlineIPAddress(IPs.getAddresses()->getIPstring());
-			}
-		}
-	}
+		comboBoxOnlineIP->winHide(TRUE);
+
+	GameWindow *staticTextOnlineIP = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:StaticTextOnlineIP"));
+	if (staticTextOnlineIP)
+		staticTextOnlineIP->winHide(TRUE);
+#endif
 
 #if ENABLE_GUI_HACKS
 	// TheSuperHackers @tweak 26/07/2026 The http proxy feature was obsoleted because it did nothing for the UDP game traffic or match sockets.

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1061,7 +1061,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	if (comboBoxOnlineIP)
 		comboBoxOnlineIP->winHide(TRUE);
 
-	GameWindow *staticTextOnlineIP = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:StaticTextOnlineIP"));
+	GameWindow *staticTextOnlineIP = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:StaticTextOnlineIpAddresses"));
 	if (staticTextOnlineIP)
 		staticTextOnlineIP->winHide(TRUE);
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/NetworkDirectConnect.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/NetworkDirectConnect.cpp
@@ -304,35 +304,27 @@ void NetworkDirectConnectInit( WindowLayout *layout, void *userData )
 		TheLAN = NEW LANAPI();
 
 		OptionPreferences prefs;
-		UnsignedInt IP = prefs.getOnlineIPAddress();
+		UnsignedInt IP = prefs.getLANIPAddress();
 
 		IPEnumeration IPs;
+		EnumeratedIP *IPlist = IPs.getAddresses();
 
-//		if (!IP)
-//		{
-			EnumeratedIP *IPlist = IPs.getAddresses();
-			DEBUG_ASSERTCRASH(IPlist, ("No IP addresses found!"));
-			if (!IPlist)
+		Bool foundIP = FALSE;
+		EnumeratedIP *tempIP = IPlist;
+		while (tempIP != nullptr && !foundIP)
+		{
+			if (IP == tempIP->getIP())
 			{
-				/// @todo: display error and exit lan lobby if no IPs are found
+				foundIP = TRUE;
 			}
+			tempIP = tempIP->getNext();
+		}
 
-			Bool foundIP = FALSE;
-			EnumeratedIP *tempIP = IPlist;
-			while ((tempIP != nullptr) && (foundIP == FALSE)) {
-				if (IP == tempIP->getIP()) {
-					foundIP = TRUE;
-				}
-				tempIP = tempIP->getNext();
-			}
+		if (!foundIP && IPlist != nullptr)
+		{
+			IP = IPlist->getIP();
+		}
 
-			if (foundIP == FALSE) {
-				// The IP that we had no longer exists, we need to pick a new one.
-				IP = IPlist->getIP();
-			}
-
-//			IP = IPlist->getIP();
-//		}
 		TheLAN->init();
 		TheLAN->SetLocalIP(IP);
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1093,7 +1093,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	if (comboBoxOnlineIP)
 		comboBoxOnlineIP->winHide(TRUE);
 
-	GameWindow *staticTextOnlineIP = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:StaticTextOnlineIP"));
+	GameWindow *staticTextOnlineIP = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:StaticTextOnlineIpAddresses"));
 	if (staticTextOnlineIP)
 		staticTextOnlineIP->winHide(TRUE);
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -491,17 +491,6 @@ static void saveOptions()
 		}
 	}
 
-	if (comboBoxOnlineIP && comboBoxOnlineIP->winGetEnabled())
-	{
-		UnsignedInt ip;
-		GadgetComboBoxGetSelectedPos(comboBoxOnlineIP, &index);
-		if (index>=0)
-		{
-			ip = (UnsignedInt)GadgetComboBoxGetItemData(comboBoxOnlineIP, index);
-			pref->setOnlineIPAddress(ip);
-		}
-	}
-
 	//-------------------------------------------------------------------------------------------------
 	// Firewall Port Override
 	GameWindow *textEntryFirewallPortOverride = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryFirewallPortOverride"));
@@ -1097,42 +1086,17 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		}
 	}
 
-	// And now the GameSpy one
+#if ENABLE_GUI_HACKS
+	// TheSuperHackers @tweak 31/07/2026 Manual Online IP selection was obsoleted because
+	// match sockets automatically use the system's default network routing table interface.
+	// Hide the obsoleted UI elements accordingly.
 	if (comboBoxOnlineIP)
-	{
-		UnsignedInt selectedIP = pref->getOnlineIPAddress();
-		UnicodeString str;
-		IPEnumeration IPs;
-		EnumeratedIP *IPlist = IPs.getAddresses();
-		Int index;
-		Int selectedIndex = -1;
-		Int count = 0;
-		GadgetComboBoxReset(comboBoxOnlineIP);
-		while (IPlist)
-		{
-			count++;
-			str.translate(IPlist->getIPstring());
-			index = GadgetComboBoxAddEntry(comboBoxOnlineIP, str, color);
-			GadgetComboBoxSetItemData(comboBoxOnlineIP, index, (void *)(IPlist->getIP()));
-			if (selectedIP == IPlist->getIP())
-			{
-				selectedIndex = index;
-			}
-			IPlist = IPlist->getNext();
-		}
-		if (selectedIndex >= 0)
-		{
-			GadgetComboBoxSetSelectedPos(comboBoxOnlineIP, selectedIndex);
-		}
-		else
-		{
-			GadgetComboBoxSetSelectedPos(comboBoxOnlineIP, 0);
-			if (IPs.getAddresses())
-			{
-				pref->setOnlineIPAddress(IPs.getAddresses()->getIPstring());
-			}
-		}
-	}
+		comboBoxOnlineIP->winHide(TRUE);
+
+	GameWindow *staticTextOnlineIP = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:StaticTextOnlineIP"));
+	if (staticTextOnlineIP)
+		staticTextOnlineIP->winHide(TRUE);
+#endif
 
 #if ENABLE_GUI_HACKS
 	// TheSuperHackers @tweak 26/07/2026 The http proxy feature was obsoleted because it did nothing for the UDP game traffic or match sockets.


### PR DESCRIPTION

This PR removes the obsolete **"Online IP:"** dropdown (`ComboBoxOnlineIP`) and its associated `GameSpyIPAddress` preference key from the Options menu and preferences system.

In original 2003 Generals, GameSpy chat registration offered a separate dropdown ("Online IP:") allowing players to manually select an IP for GameSpy chat connections. Outbound sockets automatically use the system's default network routing table interface, making a secondary manual IP dropdown redundant.

## Changes Made
- **Options Menu UI (`OptionsMenu.cpp` in Generals & GeneralsMD)**:
  - Hidden `ComboBoxOnlineIP` and `StaticTextOnlineIP` under `#if ENABLE_GUI_HACKS` with `@tweak` attribution matching recent options cleanup PRs.
  - Removed `pref->setOnlineIPAddress()` and `pref->getOnlineIPAddress()` populate and save logic.
- **Preferences (`OptionPreferences.h` / `OptionPreferences.cpp`)**:
  - Removed `getOnlineIPAddress()` and `setOnlineIPAddress()` methods.
  - Stopped writing the legacy `GameSpyIPAddress` key to `Options.ini`.
- **Peer Networking (`PeerThread.cpp`)**:
  - Updated GameSpy chat thread to bind dynamically using `IPEnumeration` without looking up static options preferences.
- **Direct Connect (`NetworkDirectConnect.cpp` in Generals & GeneralsMD)**:
  - Updated Direct Connect screen setup to use `prefs.getLANIPAddress()` as the single source of truth.