### PR TITLE
bugfix(contain): Allow passengers to exit immobilized Battle Buses

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -468,11 +468,12 @@ Bool TransportContain::isSpecificRiderFreeToExit(Object* specificObject)
 		return FALSE;
 
 #if !RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @bugfix Stubbjax 02/03/2026 If our parent container is held, then we
-	// are not free to exit.
-	DEBUG_ASSERTCRASH(specificObject->getContainedBy(), ("rider must be contained"));
-	if (specificObject->getContainedBy()->isDisabledByType(DISABLED_HELD))
+	// TheSuperHackers @bugfix Stubbjax/bobtista 01/08/2026 If our container is itself contained,
+	// then we are not free to exit.
+	if (me->isContained())
+	{
 		return FALSE;
+	}
 #endif
 
   // I can always kick people out if I am in the air, I know what I'm doing

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -579,11 +579,13 @@ Bool TransportContain::isSpecificRiderFreeToExit(Object* specificObject)
 		return FALSE;
 
 #if !RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @bugfix Stubbjax 02/03/2026 If our parent container is held, then we
-	// are not free to exit.
-	DEBUG_ASSERTCRASH(specificObject->getContainedBy(), ("rider must be contained"));
-	if (specificObject->getContainedBy()->isDisabledByType(DISABLED_HELD))
+	// TheSuperHackers @bugfix Stubbjax/bobtista 01/08/2026 We are not free to exit when our container
+	// is held inside another container. A container merely held in place on the terrain,
+	// eg the battle bus, can still unload passengers.
+	if (me->getContainedBy() != nullptr && me->isDisabledByType(DISABLED_HELD))
+	{
 		return FALSE;
+	}
 #endif
 
   // I can always kick people out if I am in the air, I know what I'm doing

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -579,10 +579,10 @@ Bool TransportContain::isSpecificRiderFreeToExit(Object* specificObject)
 		return FALSE;
 
 #if !RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @bugfix Stubbjax/bobtista 01/08/2026 We are not free to exit when our container
-	// is held inside another container. A container merely held in place on the terrain,
+	// TheSuperHackers @bugfix Stubbjax/bobtista 01/08/2026 Riders are not free to exit when their
+	// container is contained by another object. A container merely held in place on the terrain,
 	// eg the battle bus, can still unload passengers.
-	if (me->getContainedBy() != nullptr && me->isDisabledByType(DISABLED_HELD))
+	if (me->getContainedBy() != nullptr)
 	{
 		return FALSE;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -579,10 +579,9 @@ Bool TransportContain::isSpecificRiderFreeToExit(Object* specificObject)
 		return FALSE;
 
 #if !RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @bugfix Stubbjax/bobtista 01/08/2026 Riders are not free to exit when their
-	// container is contained by another object. A container merely held in place on the terrain,
-	// eg the battle bus, can still unload passengers.
-	if (me->getContainedBy() != nullptr)
+	// TheSuperHackers @bugfix Stubbjax/bobtista 01/08/2026 If our container is itself contained,
+	// then we are not free to exit.
+	if (me->isContained())
 	{
 		return FALSE;
 	}


### PR DESCRIPTION
* Fixes https://github.com/TheSuperHackers/GeneralsGameCode/issues/3087
* Fixes #3040

In non-retail-compatible builds, `TransportContain::isSpecificRiderFreeToExit` rejects a passenger whenever its container has `DISABLED_HELD`. An immobilized Battle Bus uses that status for its second-life hulk, so neither evacuate-all nor individual passenger exit requests can remove its occupants.

Now exits are blocked only when the transport is itself contained by another object, preserving the nested-container guard while allowing an immobilized Battle Bus to unload its passengers and begin its empty-hulk destruction delay.

Todo:
- [x] Verify evacuate-all and individual passenger exits from an immobilized Battle Bus with `RETAIL_COMPATIBLE_CRC=0`
- [x] Replicate to Generals
