### PR TITLE
chore: Correct the game title in Copyright headers of CommandLine source files

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/CommandLine.h
+++ b/Generals/Code/GameEngine/Include/Common/CommandLine.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals Zero Hour(tm)
+**	Command & Conquer Generals(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals Zero Hour(tm)
+**	Command & Conquer Generals(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
* Relates to #3037

This corrects the product name in the opening license banners of the Generals `CommandLine.h` and `CommandLine.cpp` files. Both banners incorrectly name Zero Hour.

With the banners corrected, the follow-up unification can be detected as moving the GeneralsMD files to Core.