### PR TITLE
fix(spectregunship): Decouple particle system in SpectreGunshipUpdate::update from logic crc

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
@@ -616,7 +616,12 @@ UpdateSleepTime SpectreGunshipUpdate::update()
 
           // GATTLING TARGETING LOGIC------------------------------------------
 				  const ParticleSystemTemplate *tmp = data->m_gattlingStrafeFXParticleSystem;
+				  // TheSuperHackers @fix The particle system is now decoupled from the logic crc
+#if RETAIL_COMPATIBLE_CRC
 				  if (tmp && gattling && gattling->testStatus( OBJECT_STATUS_IS_FIRING_WEAPON) )
+#else
+				  if (gattling && gattling->testStatus( OBJECT_STATUS_IS_FIRING_WEAPON) )
+#endif
 				  {
 
 
@@ -645,7 +650,12 @@ UpdateSleepTime SpectreGunshipUpdate::update()
 			const Player *localPlayer = rts::getObservedOrLocalPlayer();
 
 			//Make sure the gunship is visible to the player before drawing effects.
+			// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+#if RETAIL_COMPATIBLE_CRC
 			if ( gunship->getShroudedStatus( localPlayer->getPlayerIndex() ) <= OBJECTSHROUD_PARTIAL_CLEAR )
+#else
+			if ( tmp && gunship->getShroudedStatus( localPlayer->getPlayerIndex() ) <= OBJECTSHROUD_PARTIAL_CLEAR )
+#endif
 			{
 
 				// This makes the client smoke effects of the gattling cannon strafing the ground toward the attack position

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
@@ -615,9 +615,9 @@ UpdateSleepTime SpectreGunshipUpdate::update()
 
 
           // GATTLING TARGETING LOGIC------------------------------------------
-				  const ParticleSystemTemplate *tmp = data->m_gattlingStrafeFXParticleSystem;
-				  // TheSuperHackers @fix The particle system is now decoupled from the logic crc
 #if RETAIL_COMPATIBLE_CRC
+				  // TheSuperHackers @fix The particle system is now decoupled from the logic crc
+				  const ParticleSystemTemplate *tmp = data->m_gattlingStrafeFXParticleSystem;
 				  if (tmp && gattling && gattling->testStatus( OBJECT_STATUS_IS_FIRING_WEAPON) )
 #else
 				  if (gattling && gattling->testStatus( OBJECT_STATUS_IS_FIRING_WEAPON) )
@@ -650,16 +650,11 @@ UpdateSleepTime SpectreGunshipUpdate::update()
 			const Player *localPlayer = rts::getObservedOrLocalPlayer();
 
 			//Make sure the gunship is visible to the player before drawing effects.
-			// TheSuperHackers @fix The particle system is now decoupled from the logic crc
-#if RETAIL_COMPATIBLE_CRC
 			if ( gunship->getShroudedStatus( localPlayer->getPlayerIndex() ) <= OBJECTSHROUD_PARTIAL_CLEAR )
-#else
-			if ( tmp && gunship->getShroudedStatus( localPlayer->getPlayerIndex() ) <= OBJECTSHROUD_PARTIAL_CLEAR )
-#endif
 			{
 
 				// This makes the client smoke effects of the gattling cannon strafing the ground toward the attack position
-						  ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(tmp);
+						  ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(data->m_gattlingStrafeFXParticleSystem);
 						  if (sys)
 				{
 				  Coord3D impactPosition;


### PR DESCRIPTION
* Follow up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2740/  (non-retail code)

When the game logic was decoupled from the particle systems, `SpectreGunshipUpdate` was left coupled.

The gattling targeting logic only ran when the particle template was present. In headless mode (`RETAIL_COMPATIBLE_CRC=0`) the templates are not loaded, so the pointer is null and the block was skipped → the logic CRC of a headless client diverges from a graphical one.

Decoupled following the same pattern as the neighboring fixes (marker `// TheSuperHackers @fix The particle system is now decoupled from the logic crc`):
- [EMPUpdate](https://github.com/TheSuperHackers/GeneralsGameCode/blob/d3b384604795331b94079828a4d984bd57de233e/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp#L308)
- [SpecialAbilityUpdate](https://github.com/TheSuperHackers/GeneralsGameCode/blob/d3b384604795331b94079828a4d984bd57de233e/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp#L1404)
- [TransitionDamageFX](https://github.com/TheSuperHackers/GeneralsGameCode/blob/d3b384604795331b94079828a4d984bd57de233e/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp#L391)

Retail is preserved under `#if RETAIL_COMPATIBLE_CRC`. Verified with a full deterministic replay (headless macOS ↔ Windows).
