### PR TITLE
chore(crcdebug): Log DieOnDetonate on projectile detonation

### DIFF
--- a/Core/GameEngine/Include/Common/CRCDebug.h
+++ b/Core/GameEngine/Include/Common/CRCDebug.h
@@ -73,6 +73,7 @@
 	void addCRCDumpLine(const char *fmt, ...);
 	void addCRCGenLine(const char *fmt, ...);
 	#define CRCDEBUG_LOG(x) addCRCDebugLine x
+	#define CRCDEBUG_LOG_NOCOUNTER(x) addCRCDebugLineNoCounter x
 	#define CRCDUMP_LOG(x) addCRCDumpLine x
 	#define CRCGEN_LOG(x) addCRCGenLine x
 
@@ -116,6 +117,7 @@
 	#define DUMPREALNAMED(x, y)
 
 	#define CRCDEBUG_LOG(x)
+	#define CRCDEBUG_LOG_NOCOUNTER(x)
 	#define CRCDUMP_LOG(x)
 	#define CRCGEN_LOG(x)
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
@@ -32,6 +32,7 @@
 #include "Common/ThingTemplate.h"
 #include "Common/RandomValue.h"
 #include "Common/BitFlagsIO.h"
+#include "Common/CRCDebug.h"
 
 #include "GameLogic/AIPathfind.h"
 #include "GameLogic/ExperienceTracker.h"
@@ -386,6 +387,11 @@ void MissileAIUpdate::detonate()
 
 	if (m_detonationWeaponTmpl)
 	{
+		// TheSuperHackers @info Okladnoj 03/08/2026 DieOnDetonate decides whether the projectile dies here
+		// or a frame later in doKillSelfState, which moves its die modules to a different frame. Record it,
+		// because a client that disagrees on this flag desyncs at the frame the projectile detonates.
+		CRCDEBUG_LOG_NOCOUNTER(("MissileAIUpdate::detonate() obj=%d weapon=%s dieOnDetonate=%d",
+			obj->getID(), m_detonationWeaponTmpl->getName().str(), m_detonationWeaponTmpl->getDieOnDetonate() ? 1 : 0));
 
 		TheWeaponStore->handleProjectileDetonation(m_detonationWeaponTmpl, obj, obj->getPosition(), m_extraBonusFlags, !m_noDamage );
 


### PR DESCRIPTION
`addCRCDebugLineNoCounter` exists but has no macro wrapper, so it cannot be used. This adds
`CRCDEBUG_LOG_NOCOUNTER` next to `CRCDEBUG_LOG`.

`MissileAIUpdate::detonate` uses it to record the weapon's `DieOnDetonate` flag. The flag decides whether
the projectile dies right there or a frame later in `doKillSelfState`, which moves its die modules to a
different frame. Two clients that disagree on it desync at that frame, and nothing in the CRC dump pointed
at the flag. The no-counter variant keeps the ordinals in the frame identical to a client without this
change, so the log itself cannot shift a comparison.

Debug builds only, no effect on release.

Todo:
- [x] Replicate to Generals — N/A, `MissileCallsOnDie` does not exist in Generals