### PR TITLE
bugfix(stickybomb): Allow Booby Traps to be placed on a previously booby-trapped object

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StickyBombUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StickyBombUpdate.h
@@ -79,7 +79,9 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	virtual void onObjectCreated() override;
+#if !RETAIL_COMPATIBLE_CRC
 	virtual void onDelete() override;
+#endif
 
 	virtual UpdateSleepTime update() override;							///< called once per frame
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StickyBombUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StickyBombUpdate.h
@@ -79,6 +79,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	virtual void onObjectCreated() override;
+	virtual void onDelete() override;
 
 	virtual UpdateSleepTime update() override;							///< called once per frame
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StickyBombUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StickyBombUpdate.cpp
@@ -284,9 +284,9 @@ void StickyBombUpdate::detonate()
 	getObject()->kill();// Most things just fire weapons in their death modules
 }
 
+#if !RETAIL_COMPATIBLE_CRC
 void StickyBombUpdate::onDelete()
 {
-#if !RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @bugfix Stubbjax 05/08/2026 Clear booby trap status when destroyed, not just when detonated.
 	if (!getObject()->isKindOf(KINDOF_BOOBY_TRAP))
 		return;
@@ -297,8 +297,8 @@ void StickyBombUpdate::onDelete()
 
 	// This kind of sticky bomb needs to set a status, so the poor victim can trigger us from assorted places
 	boobyTrappedObject->clearStatus( MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_BOOBY_TRAPPED) );
-#endif
 }
+#endif
 
 // ------------------------------------------------------------------------------------------------
 /** CRC */

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StickyBombUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StickyBombUpdate.cpp
@@ -273,13 +273,20 @@ void StickyBombUpdate::detonate()
 		}
 	}
 
-	if( getObject()->isKindOf(KINDOF_BOOBY_TRAP) && boobyTrappedObject )
-	{
-		// This kind of sticky bomb needs to set a status, so the poor victim can trigger us from assorted places
-		boobyTrappedObject->clearStatus( MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_BOOBY_TRAPPED) );
-	}
-
 	getObject()->kill();// Most things just fire weapons in their death modules
+}
+
+void StickyBombUpdate::onDelete()
+{
+	if (!getObject()->isKindOf(KINDOF_BOOBY_TRAP))
+		return;
+
+	Object* boobyTrappedObject = getTargetObject();
+	if (!boobyTrappedObject)
+		return;
+
+	// This kind of sticky bomb needs to set a status, so the poor victim can trigger us from assorted places
+	boobyTrappedObject->clearStatus( MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_BOOBY_TRAPPED) );
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StickyBombUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StickyBombUpdate.cpp
@@ -273,11 +273,21 @@ void StickyBombUpdate::detonate()
 		}
 	}
 
+#if RETAIL_COMPATIBLE_CRC
+	if( getObject()->isKindOf(KINDOF_BOOBY_TRAP) && boobyTrappedObject )
+	{
+		// This kind of sticky bomb needs to set a status, so the poor victim can trigger us from assorted places
+		boobyTrappedObject->clearStatus( MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_BOOBY_TRAPPED) );
+	}
+#endif
+
 	getObject()->kill();// Most things just fire weapons in their death modules
 }
 
 void StickyBombUpdate::onDelete()
 {
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Stubbjax 05/08/2026 Clear booby trap status when destroyed, not just when detonated.
 	if (!getObject()->isKindOf(KINDOF_BOOBY_TRAP))
 		return;
 
@@ -287,6 +297,7 @@ void StickyBombUpdate::onDelete()
 
 	// This kind of sticky bomb needs to set a status, so the poor victim can trigger us from assorted places
 	boobyTrappedObject->clearStatus( MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_BOOBY_TRAPPED) );
+#endif
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StickyBombUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StickyBombUpdate.cpp
@@ -288,15 +288,14 @@ void StickyBombUpdate::detonate()
 void StickyBombUpdate::onDelete()
 {
 	// TheSuperHackers @bugfix Stubbjax 05/08/2026 Clear booby trap status when destroyed, not just when detonated.
-	if (!getObject()->isKindOf(KINDOF_BOOBY_TRAP))
-		return;
+	if (getObject()->isKindOf(KINDOF_BOOBY_TRAP))
+	{
+		Object* boobyTrappedObject = getTargetObject();
 
-	Object* boobyTrappedObject = getTargetObject();
-	if (!boobyTrappedObject)
-		return;
-
-	// This kind of sticky bomb needs to set a status, so the poor victim can trigger us from assorted places
-	boobyTrappedObject->clearStatus( MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_BOOBY_TRAPPED) );
+		// This kind of sticky bomb needs to set a status, so the poor victim can trigger us from assorted places
+		if (boobyTrappedObject)
+			boobyTrappedObject->clearStatus(MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_BOOBY_TRAPPED));
+	}
 }
 #endif
 


### PR DESCRIPTION
This change fixes an issue where an object could no longer be booby trapped if it had previously been cleared of booby traps.

Previously, `OBJECT_STATUS_BOOBY_TRAPPED` was only removed upon detonation, but did not account for deletion via disarming. This meant that disarming the trap did not remove the status, and no more booby traps could be placed as a result. With this change, the status is removed upon deletion, which covers all cases.

> [!NOTE]
> Booby Traps do not exist in Generals.

### Before
The Barracks cannot be booby trapped after the Worker disarms the first trap

https://github.com/user-attachments/assets/c09f2c5c-0e24-4d04-8f31-112096f79fff

### After
The Barracks can be booby trapped again after the Worker disarms the first trap

https://github.com/user-attachments/assets/7a1eab8f-f5cc-4fdf-8fd1-365da5322b4d