### PR TITLE
tweak(gui): Move animated GUI window smoothly at higher than 30 frames per second

### DIFF
--- a/Core/GameEngine/Include/GameClient/ProcessAnimateWindow.h
+++ b/Core/GameEngine/Include/GameClient/ProcessAnimateWindow.h
@@ -79,8 +79,9 @@ public:
 
 	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) = 0;
 	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) = 0;
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) = 0;
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) = 0;
+	// TheSuperHackers @tweak bobtista 04/08/2026 deltaFrames is a real number of frames to advance by based on a 30 fps base rate
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) = 0;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) = 0;
 	virtual void setMaxDuration(UnsignedInt maxDuration) { }
 };
 
@@ -95,8 +96,8 @@ public:
 
 	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
 	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -118,8 +119,8 @@ public:
 
 	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
 	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -141,8 +142,8 @@ public:
 
 	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
 	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -162,8 +163,8 @@ public:
 
 	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
 	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -185,8 +186,8 @@ public:
 
 	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
 	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -207,8 +208,8 @@ public:
 
 	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
 	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
 private:
 	Real m_deltaTheta;
 	Int m_maxR;
@@ -225,8 +226,8 @@ public:
 
 	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
 	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
 	virtual void setMaxDuration(UnsignedInt maxDuration) override { m_maxDuration = maxDuration; }
 
 private:
@@ -243,8 +244,8 @@ public:
 
 	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
 	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting

--- a/Core/GameEngine/Source/GameClient/GUI/ProcessAnimateWindow.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ProcessAnimateWindow.cpp
@@ -78,6 +78,13 @@ static Real getDisplayHeightScaler()
 	return static_cast<Real>(TheDisplay->getHeight()) / DEFAULT_DISPLAY_HEIGHT;
 }
 
+// TheSuperHackers @tweak bobtista 04/08/2026 The animated position is tracked with sub pixel
+// precision and is rounded to the nearest pixel when applied to the window.
+static void setWindowPosition( GameWindow *win, const Coord2D &pos )
+{
+	win->winSetPosition( (Int)floorf(pos.x + 0.5f), (Int)floorf(pos.y + 0.5f) );
+}
+
 //-----------------------------------------------------------------------------
 // ProcessAnimateWindowSlideFromRight PUBLIC FUNCTIONS ////////////////////////
 //-----------------------------------------------------------------------------
@@ -118,7 +125,7 @@ void ProcessAnimateWindowSlideFromRight::initAnimateWindow( wnd::AnimateWindow *
 {
 	ICoord2D restPos = {0,0};
 	ICoord2D startPos = {0,0};
-	ICoord2D curPos = {0,0};
+	Coord2D curPos = {0.0f,0.0f};
 	ICoord2D endPos = {0,0};
 	Coord2D	vel = {0.0f,0.0f};
 
@@ -143,8 +150,10 @@ void ProcessAnimateWindowSlideFromRight::initAnimateWindow( wnd::AnimateWindow *
 
 	//set the initial positions for the window. In this case, off the Right of the screen
 	Int travelDistance = TheDisplay->getWidth();// / 4 * 3;
-	startPos.x = curPos.x = restPos.x + travelDistance;
-	startPos.y = curPos.y = restPos.y;
+	startPos.x = restPos.x + travelDistance;
+	startPos.y = restPos.y;
+	curPos.x = (Real)startPos.x;
+	curPos.y = (Real)startPos.y;
 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
@@ -165,7 +174,7 @@ void ProcessAnimateWindowSlideFromRight::initAnimateWindow( wnd::AnimateWindow *
 
 
 //-----------------------------------------------------------------------------
-Bool ProcessAnimateWindowSlideFromRight::updateAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromRight::updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -190,22 +199,24 @@ Bool ProcessAnimateWindowSlideFromRight::updateAnimateWindow( wnd::AnimateWindow
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 	Coord2D vel = animWin->getVel();
-	curPos.x += (Int)vel.x;
+	curPos.x += vel.x * deltaFrames;
 
 	if(curPos.x < endPos.x)
 	{
-		curPos.x = endPos.x;
+		// TheSuperHackers @bugfix bobtista 05/08/2026 Apply the end position so the window does not stop short of it
+		curPos.x = (Real)endPos.x;
 		animWin->setFinished( TRUE );
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 	if( curPos.x - endPos.x <= m_slowDownThreshold )
 	{
-		vel.x *= m_slowDownRatio;
+		vel.x *= powf(m_slowDownRatio, deltaFrames);
 	}
 	if( vel.x >= -1.0f)
 		vel.x = -1.0f;
@@ -213,7 +224,7 @@ Bool ProcessAnimateWindowSlideFromRight::updateAnimateWindow( wnd::AnimateWindow
 	return FALSE;
 }
 
-Bool ProcessAnimateWindowSlideFromRight::reverseAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromRight::reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -239,25 +250,25 @@ Bool ProcessAnimateWindowSlideFromRight::reverseAnimateWindow( wnd::AnimateWindo
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D startPos = animWin->getStartPos();
 	Coord2D vel = animWin->getVel();
-	curPos.x += (Int)vel.x;
+	curPos.x += vel.x * deltaFrames;
 
 	if(curPos.x > startPos.x)
 	{
-		curPos.x = startPos.x;
+		curPos.x = (Real)startPos.x;
 		animWin->setFinished( TRUE );
-		win->winSetPosition(curPos.x, curPos.y);
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 
 	ICoord2D endPos = animWin->getEndPos();
 	if( curPos.x - endPos.x <= m_slowDownThreshold )
 	{
-		vel.x *= m_speedUpRatio;
+		vel.x *= powf(m_speedUpRatio, deltaFrames);
 	}
 	else
 	{
@@ -305,7 +316,7 @@ void ProcessAnimateWindowSlideFromLeft::initAnimateWindow( wnd::AnimateWindow *a
 {
 	ICoord2D restPos = {0,0};
 	ICoord2D startPos = {0,0};
-	ICoord2D curPos = {0,0};
+	Coord2D curPos = {0.0f,0.0f};
 	ICoord2D endPos = {0,0};
 	Coord2D	vel = {0.0f,0.0f};
 
@@ -329,8 +340,10 @@ void ProcessAnimateWindowSlideFromLeft::initAnimateWindow( wnd::AnimateWindow *a
 
 	//set the initial positions for the window. In this case, off the Left of the screen
 	Int travelDistance = TheDisplay->getWidth();// / 4 * 3;
-	startPos.x = curPos.x = restPos.x - travelDistance;
-	startPos.y = curPos.y = restPos.y;
+	startPos.x = restPos.x - travelDistance;
+	startPos.y = restPos.y;
+	curPos.x = (Real)startPos.x;
+	curPos.y = (Real)startPos.y;
 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
@@ -347,7 +360,7 @@ void ProcessAnimateWindowSlideFromLeft::initAnimateWindow( wnd::AnimateWindow *a
 	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
 }
 
-Bool ProcessAnimateWindowSlideFromLeft::updateAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromLeft::updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -373,22 +386,24 @@ Bool ProcessAnimateWindowSlideFromLeft::updateAnimateWindow( wnd::AnimateWindow 
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 	Coord2D vel = animWin->getVel();
-	curPos.x += (Int)vel.x;
+	curPos.x += vel.x * deltaFrames;
 
 	if(curPos.x > endPos.x)
 	{
-		curPos.x = endPos.x;
+		// TheSuperHackers @bugfix bobtista 05/08/2026 Apply the end position so the window does not stop short of it
+		curPos.x = (Real)endPos.x;
 		animWin->setFinished( TRUE );
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 	if( endPos.x - curPos.x <= m_slowDownThreshold )
 	{
-		vel.x *= m_slowDownRatio;
+		vel.x *= powf(m_slowDownRatio, deltaFrames);
 	}
 	if( vel.x < 1.0f)
 		vel.x = 1.0f;
@@ -396,7 +411,7 @@ Bool ProcessAnimateWindowSlideFromLeft::updateAnimateWindow( wnd::AnimateWindow 
 	return FALSE;
 }
 
-Bool ProcessAnimateWindowSlideFromLeft::reverseAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromLeft::reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -422,25 +437,25 @@ Bool ProcessAnimateWindowSlideFromLeft::reverseAnimateWindow( wnd::AnimateWindow
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D startPos = animWin->getStartPos();
 	Coord2D vel = animWin->getVel();
-	curPos.x += (Int)vel.x;
+	curPos.x += vel.x * deltaFrames;
 
 	if(curPos.x < startPos.x)
 	{
-		curPos.x = startPos.x;
+		curPos.x = (Real)startPos.x;
 		animWin->setFinished( TRUE );
-		win->winSetPosition(curPos.x, curPos.y);
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 
 	ICoord2D endPos = animWin->getEndPos();
 	if( endPos.x - curPos.x <= m_slowDownThreshold )
 	{
-		vel.x *= m_speedUpRatio;
+		vel.x *= powf(m_speedUpRatio, deltaFrames);
 	}
 	else
 	{
@@ -488,7 +503,7 @@ void ProcessAnimateWindowSlideFromTop::initAnimateWindow( wnd::AnimateWindow *an
 {
 	ICoord2D restPos = {0,0};
 	ICoord2D startPos = {0,0};
-	ICoord2D curPos = {0,0};
+	Coord2D curPos = {0.0f,0.0f};
 	ICoord2D endPos = {0,0};
 	Coord2D	vel = {0.0f,0.0f};
 
@@ -512,8 +527,10 @@ void ProcessAnimateWindowSlideFromTop::initAnimateWindow( wnd::AnimateWindow *an
 
 	//set the initial positions for the window. In this case, off the Top of the screen
 	Int travelDistance = TheDisplay->getWidth();// / 4 * 3;
-	startPos.x = curPos.x = restPos.x ;
-	startPos.y = curPos.y = restPos.y - travelDistance;
+	startPos.x = restPos.x ;
+	startPos.y = restPos.y - travelDistance;
+	curPos.x = (Real)startPos.x;
+	curPos.y = (Real)startPos.y;
 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
@@ -530,7 +547,7 @@ void ProcessAnimateWindowSlideFromTop::initAnimateWindow( wnd::AnimateWindow *an
 	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
 }
 
-Bool ProcessAnimateWindowSlideFromTop::updateAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromTop::updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -556,23 +573,23 @@ Bool ProcessAnimateWindowSlideFromTop::updateAnimateWindow( wnd::AnimateWindow *
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 	Coord2D vel = animWin->getVel();
-	curPos.y += (Int)vel.y;
+	curPos.y += vel.y * deltaFrames;
 
 	if(curPos.y > endPos.y)
 	{
-		curPos.y = endPos.y;
-		win->winSetPosition(curPos.x, curPos.y);
+		curPos.y = (Real)endPos.y;
+		setWindowPosition(win, curPos);
 		animWin->setFinished( TRUE );
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 	if( endPos.y - curPos.y  <= m_slowDownThreshold )
 	{
-		vel.y *= m_slowDownRatio;
+		vel.y *= powf(m_slowDownRatio, deltaFrames);
 	}
 	if( vel.y < 1.0f)
 		vel.y = 1.0f;
@@ -580,7 +597,7 @@ Bool ProcessAnimateWindowSlideFromTop::updateAnimateWindow( wnd::AnimateWindow *
 	return FALSE;
 }
 
-Bool ProcessAnimateWindowSlideFromTop::reverseAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromTop::reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -606,25 +623,25 @@ Bool ProcessAnimateWindowSlideFromTop::reverseAnimateWindow( wnd::AnimateWindow 
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D startPos = animWin->getStartPos();
 	Coord2D vel = animWin->getVel();
-	curPos.y += (Int)vel.y;
+	curPos.y += vel.y * deltaFrames;
 
 	if(curPos.y < startPos.y)
 	{
-		curPos.y = startPos.y;
+		curPos.y = (Real)startPos.y;
 		animWin->setFinished( TRUE );
-		win->winSetPosition(curPos.x, curPos.y);
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 
 	ICoord2D endPos = animWin->getEndPos();
 	if( endPos.y - curPos.y <= m_slowDownThreshold )
 	{
-		vel.y *= m_speedUpRatio;
+		vel.y *= powf(m_speedUpRatio, deltaFrames);
 	}
 	else
 	{
@@ -673,7 +690,7 @@ void ProcessAnimateWindowSlideFromBottom::initAnimateWindow( wnd::AnimateWindow 
 {
 	ICoord2D restPos = {0,0};
 	ICoord2D startPos = {0,0};
-	ICoord2D curPos = {0,0};
+	Coord2D curPos = {0.0f,0.0f};
 	ICoord2D endPos = {0,0};
 	Coord2D	vel = {0.0f,0.0f};
 
@@ -697,8 +714,10 @@ void ProcessAnimateWindowSlideFromBottom::initAnimateWindow( wnd::AnimateWindow 
 
 	//set the initial positions for the window. In this case, off the Bottom of the screen
 	Int travelDistance = TheDisplay->getWidth();// / 4 * 3;
-	startPos.x = curPos.x = restPos.x;
-	startPos.y = curPos.y = restPos.y + travelDistance;
+	startPos.x = restPos.x;
+	startPos.y = restPos.y + travelDistance;
+	curPos.x = (Real)startPos.x;
+	curPos.y = (Real)startPos.y;
 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
@@ -715,7 +734,7 @@ void ProcessAnimateWindowSlideFromBottom::initAnimateWindow( wnd::AnimateWindow 
 	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
 }
 
-Bool ProcessAnimateWindowSlideFromBottom::updateAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromBottom::updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -741,23 +760,23 @@ Bool ProcessAnimateWindowSlideFromBottom::updateAnimateWindow( wnd::AnimateWindo
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 	Coord2D vel = animWin->getVel();
-	curPos.y += (Int)vel.y;
+	curPos.y += vel.y * deltaFrames;
 
 	if(curPos.y < endPos.y)
 	{
-		curPos.y = endPos.y;
+		curPos.y = (Real)endPos.y;
 		animWin->setFinished( TRUE );
-		win->winSetPosition(curPos.x, curPos.y);
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 	if( curPos.y - endPos.y <= m_slowDownThreshold )
 	{
-		vel.y *= m_slowDownRatio;
+		vel.y *= powf(m_slowDownRatio, deltaFrames);
 	}
 	if( vel.y >= -1.0f)
 		vel.y = -1.0f;
@@ -765,7 +784,7 @@ Bool ProcessAnimateWindowSlideFromBottom::updateAnimateWindow( wnd::AnimateWindo
 	return FALSE;
 }
 
-Bool ProcessAnimateWindowSlideFromBottom::reverseAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromBottom::reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -791,25 +810,25 @@ Bool ProcessAnimateWindowSlideFromBottom::reverseAnimateWindow( wnd::AnimateWind
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D startPos = animWin->getStartPos();
 	Coord2D vel = animWin->getVel();
-	curPos.y += (Int)vel.y;
+	curPos.y += vel.y * deltaFrames;
 
 	if(curPos.y > startPos.y)
 	{
-		curPos.y = startPos.y;
+		curPos.y = (Real)startPos.y;
 		animWin->setFinished( TRUE );
-		win->winSetPosition(curPos.x, curPos.y);
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 
 	ICoord2D endPos = animWin->getEndPos();
 	if( curPos.y - endPos.y <= m_slowDownThreshold )
 	{
-		vel.y *= m_speedUpRatio;
+		vel.y *= powf(m_speedUpRatio, deltaFrames);
 	}
 	else
 	{
@@ -837,7 +856,7 @@ void ProcessAnimateWindowSlideFromBottomTimed::initReverseAnimateWindow( wnd::An
 {
 	ICoord2D restPos = {0,0};
 	ICoord2D startPos = {0,0};
-	ICoord2D curPos = {0,0};
+	Coord2D curPos = {0.0f,0.0f};
 	ICoord2D endPos = {0,0};
 	Coord2D	vel = {0.0f,0.0f};
 
@@ -857,11 +876,13 @@ void ProcessAnimateWindowSlideFromBottomTimed::initReverseAnimateWindow( wnd::An
 	}
 	restPos = animWin->getRestPos();
 	startPos.x = restPos.x;
-	curPos.y = startPos.y = restPos.y;
+	startPos.y = restPos.y;
+	curPos.y = (Real)startPos.y;
 
 	//set the initial positions for the window. In this case, off the Bottom of the screen
 	Int travelDistance = TheDisplay->getWidth();// / 4 * 3;
-	endPos.x = curPos.x = restPos.x;
+	endPos.x = restPos.x;
+	curPos.x = (Real)endPos.x;
 	endPos.y = restPos.y + travelDistance;
 
 	//set the window's position to the new start positions.
@@ -878,7 +899,7 @@ void ProcessAnimateWindowSlideFromBottomTimed::initAnimateWindow( wnd::AnimateWi
 {
 	ICoord2D restPos = {0,0};
 	ICoord2D startPos = {0,0};
-	ICoord2D curPos = {0,0};
+	Coord2D curPos = {0.0f,0.0f};
 	ICoord2D endPos = {0,0};
 	Coord2D	vel = {0.0f,0.0f};
 
@@ -902,8 +923,10 @@ void ProcessAnimateWindowSlideFromBottomTimed::initAnimateWindow( wnd::AnimateWi
 
 	//set the initial positions for the window. In this case, off the Bottom of the screen
 	Int travelDistance = TheDisplay->getWidth();// / 4 * 3;
-	startPos.x = curPos.x = restPos.x;
-	startPos.y = curPos.y = restPos.y + travelDistance;
+	startPos.x = restPos.x;
+	startPos.y = restPos.y + travelDistance;
+	curPos.x = (Real)startPos.x;
+	curPos.y = (Real)startPos.y;
 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
@@ -915,7 +938,7 @@ void ProcessAnimateWindowSlideFromBottomTimed::initAnimateWindow( wnd::AnimateWi
 	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, now + delay, now + m_maxDuration + delay);
 }
 
-Bool ProcessAnimateWindowSlideFromBottomTimed::updateAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromBottomTimed::updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -942,7 +965,7 @@ Bool ProcessAnimateWindowSlideFromBottomTimed::updateAnimateWindow( wnd::Animate
 	}
 
 	ICoord2D startPos = animWin->getStartPos();
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 
 	UnsignedInt now = timeGetTime();
@@ -955,25 +978,25 @@ Bool ProcessAnimateWindowSlideFromBottomTimed::updateAnimateWindow( wnd::Animate
 	Real percentDone = 1.0f - (Real)(endTime - now) / (Real)(m_maxDuration);
 	if (now >= endTime)
 	{
-		curPos.y = endPos.y;
+		curPos.y = (Real)endPos.y;
 		animWin->setFinished( TRUE );
-		win->winSetPosition(curPos.x, curPos.y);
+		setWindowPosition(win, curPos);
 		DEBUG_LOG(("window finished animating at %d (%d->%d)", now, startTime, endTime));
 		return TRUE;
 	}
 
 	curPos.y = startPos.y + percentDone*(endPos.y - startPos.y);
-	DEBUG_LOG(("(%d,%d) -> (%d,%d) -> (%d,%d) at %g",
+	DEBUG_LOG(("(%d,%d) -> (%g,%g) -> (%d,%d) at %g",
 		startPos.x, startPos.y, curPos.x, curPos.y, endPos.x, endPos.y, percentDone));
 
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 	return FALSE;
 }
 
-Bool ProcessAnimateWindowSlideFromBottomTimed::reverseAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromBottomTimed::reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
-	return updateAnimateWindow(animWin);
+	return updateAnimateWindow(animWin, deltaFrames);
 }
 
 
@@ -1012,7 +1035,7 @@ void ProcessAnimateWindowSpiral::initAnimateWindow( wnd::AnimateWindow *animWin 
 {
 	ICoord2D restPos = {0,0};
 	ICoord2D startPos = {0,0};
-	ICoord2D curPos = {0,0};
+	Coord2D curPos = {0.0f,0.0f};
 	ICoord2D endPos = {0,0};
 	ICoord2D size = {0,0};
 	Coord2D	vel = {0.0f,0.0f};
@@ -1038,8 +1061,10 @@ void ProcessAnimateWindowSpiral::initAnimateWindow( wnd::AnimateWindow *animWin 
 	//set the initial positions for the window. In this case, off the Bottom of the screen
 	vel.x = 0;
 	vel.y = m_maxR;
-	startPos.x = curPos.x = (vel.y * cos(vel.x)) + endPos.x;
-	startPos.y = curPos.y = (vel.y * sin(vel.x)) + endPos.y;
+	curPos.x = (vel.y * cos(vel.x)) + endPos.x;
+	curPos.y = (vel.y * sin(vel.x)) + endPos.y;
+	startPos.x = (Int)curPos.x;
+	startPos.y = (Int)curPos.y;
 
 
 	//set the window's position to the new start positions.
@@ -1049,7 +1074,7 @@ void ProcessAnimateWindowSpiral::initAnimateWindow( wnd::AnimateWindow *animWin 
 }
 
 //-----------------------------------------------------------------------------
-Bool ProcessAnimateWindowSpiral::updateAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSpiral::updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -1075,15 +1100,15 @@ Bool ProcessAnimateWindowSpiral::updateAnimateWindow( wnd::AnimateWindow *animWi
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 	Coord2D vel = animWin->getVel();
 
 	curPos.x = (vel.y * cos(vel.x)) + endPos.x;
 	curPos.y = (vel.y * sin(vel.x)) + endPos.y;
 
-	vel.x = vel.x + m_deltaTheta;
-	vel.y -=5;
+	vel.x = vel.x + m_deltaTheta * deltaFrames;
+	vel.y -=5 * deltaFrames;
 
 	ICoord2D size;
 	win->winGetSize(&size.x, &size.y);
@@ -1096,14 +1121,14 @@ Bool ProcessAnimateWindowSpiral::updateAnimateWindow( wnd::AnimateWindow *animWi
 		win->winSetPosition(restPos.x, restPos.y);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 	animWin->setVel(vel);
 	return FALSE;
 }
 
 //-----------------------------------------------------------------------------
-Bool ProcessAnimateWindowSpiral::reverseAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSpiral::reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -1127,15 +1152,15 @@ Bool ProcessAnimateWindowSpiral::reverseAnimateWindow( wnd::AnimateWindow *animW
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 	Coord2D vel = animWin->getVel();
 
 	curPos.x = (vel.y * cos(vel.x)) + endPos.x;
 	curPos.y = (vel.y * sin(vel.x)) + endPos.y;
 
-	vel.x = vel.x - m_deltaTheta;
-	vel.y +=5;
+	vel.x = vel.x - m_deltaTheta * deltaFrames;
+	vel.y +=5 * deltaFrames;
 
 	ICoord2D size;
 	win->winGetSize(&size.x, &size.y);
@@ -1148,7 +1173,7 @@ Bool ProcessAnimateWindowSpiral::reverseAnimateWindow( wnd::AnimateWindow *animW
 		//win->winSetPosition(restPos.x, restPos.y);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 	animWin->setVel(vel);
 	return FALSE;
@@ -1192,7 +1217,7 @@ void ProcessAnimateWindowSlideFromTopFast::initAnimateWindow( wnd::AnimateWindow
 {
 	ICoord2D restPos = {0,0};
 	ICoord2D startPos = {0,0};
-	ICoord2D curPos = {0,0};
+	Coord2D curPos = {0.0f,0.0f};
 	ICoord2D endPos = {0,0};
 	Coord2D	vel = {0.0f,0.0f};
 	ICoord2D size = {0,0};
@@ -1219,8 +1244,10 @@ void ProcessAnimateWindowSlideFromTopFast::initAnimateWindow( wnd::AnimateWindow
 
 	//set the initial positions for the window. In this case, off the Top of the screen
 	//Int travelDistance = TheDisplay->getWidth();// / 4 * 3;
-	startPos.x = curPos.x = restPos.x ;
-	startPos.y = curPos.y = -size.y;//restPos.y - travelDistance;
+	startPos.x = restPos.x ;
+	startPos.y = -size.y;//restPos.y - travelDistance;
+	curPos.x = (Real)startPos.x;
+	curPos.y = (Real)startPos.y;
 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
@@ -1231,7 +1258,7 @@ void ProcessAnimateWindowSlideFromTopFast::initAnimateWindow( wnd::AnimateWindow
 	animWin->setAnimData(startPos, endPos, curPos, restPos, vel, timeGetTime() + animWin->getDelay(), 0);
 }
 
-Bool ProcessAnimateWindowSlideFromTopFast::updateAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromTopFast::updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -1257,23 +1284,23 @@ Bool ProcessAnimateWindowSlideFromTopFast::updateAnimateWindow( wnd::AnimateWind
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 	Coord2D vel = animWin->getVel();
-	curPos.y += (Int)vel.y;
+	curPos.y += vel.y * deltaFrames;
 
 	if(curPos.y > endPos.y)
 	{
-		curPos.y = endPos.y;
-		win->winSetPosition(curPos.x, curPos.y);
+		curPos.y = (Real)endPos.y;
+		setWindowPosition(win, curPos);
 		animWin->setFinished( TRUE );
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 	if( endPos.y - curPos.y  <= m_slowDownThreshold )
 	{
-		vel.y *= m_slowDownRatio;
+		vel.y *= powf(m_slowDownRatio, deltaFrames);
 	}
 	if( vel.y < 1.0f)
 		vel.y = 1.0f;
@@ -1281,7 +1308,7 @@ Bool ProcessAnimateWindowSlideFromTopFast::updateAnimateWindow( wnd::AnimateWind
 	return FALSE;
 }
 
-Bool ProcessAnimateWindowSlideFromTopFast::reverseAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromTopFast::reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -1307,25 +1334,25 @@ Bool ProcessAnimateWindowSlideFromTopFast::reverseAnimateWindow( wnd::AnimateWin
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D startPos = animWin->getStartPos();
 	Coord2D vel = animWin->getVel();
-	curPos.y += (Int)vel.y;
+	curPos.y += vel.y * deltaFrames;
 
 	if(curPos.y < startPos.y)
 	{
-		curPos.y = startPos.y;
+		curPos.y = (Real)startPos.y;
 		animWin->setFinished( TRUE );
-		win->winSetPosition(curPos.x, curPos.y);
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 
 	ICoord2D endPos = animWin->getEndPos();
 	if( endPos.y - curPos.y <= m_slowDownThreshold )
 	{
-		vel.y *= m_speedUpRatio;
+		vel.y *= powf(m_speedUpRatio, deltaFrames);
 	}
 	else
 	{
@@ -1374,9 +1401,9 @@ void ProcessAnimateWindowSlideFromRightFast::initReverseAnimateWindow( wnd::Anim
 	GameWindow * win = animWin->getGameWindow();
 	ICoord2D pos, tempPos;
 	win->winGetPosition(&pos.x, &pos.y);
-	tempPos = animWin->getCurPos();
-	tempPos.y = pos.y;
-	animWin->setCurPos(tempPos);
+	Coord2D tempCurPos = animWin->getCurPos();
+	tempCurPos.y = (Real)pos.y;
+	animWin->setCurPos(tempCurPos);
 
 	tempPos = animWin->getEndPos();
 	tempPos.y = pos.y;
@@ -1397,7 +1424,7 @@ void ProcessAnimateWindowSlideFromRightFast::initAnimateWindow( wnd::AnimateWind
 	ICoord2D restPos = {0,0};
 	ICoord2D startPos = {0,0};
 	ICoord2D size = {0,0};
-	ICoord2D curPos = {0,0};
+	Coord2D curPos = {0.0f,0.0f};
 	ICoord2D endPos = {0,0};
 	Coord2D	vel = {0.0f,0.0f};
 
@@ -1423,8 +1450,10 @@ void ProcessAnimateWindowSlideFromRightFast::initAnimateWindow( wnd::AnimateWind
 
 	//set the initial positions for the window. In this case, off the Right of the screen
 	Int travelDistance = TheDisplay->getWidth() - restPos.x + size.x ;// / 4 * 3;
-	startPos.x = curPos.x = restPos.x + travelDistance;
-	startPos.y = curPos.y = restPos.y;
+	startPos.x = restPos.x + travelDistance;
+	startPos.y = restPos.y;
+	curPos.x = (Real)startPos.x;
+	curPos.y = (Real)startPos.y;
 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
@@ -1439,7 +1468,7 @@ void ProcessAnimateWindowSlideFromRightFast::initAnimateWindow( wnd::AnimateWind
 
 
 //-----------------------------------------------------------------------------
-Bool ProcessAnimateWindowSlideFromRightFast::updateAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromRightFast::updateAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -1464,22 +1493,24 @@ Bool ProcessAnimateWindowSlideFromRightFast::updateAnimateWindow( wnd::AnimateWi
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D endPos = animWin->getEndPos();
 	Coord2D vel = animWin->getVel();
-	curPos.x += (Int)vel.x;
+	curPos.x += vel.x * deltaFrames;
 
 	if(curPos.x < endPos.x)
 	{
-		curPos.x = endPos.x;
+		// TheSuperHackers @bugfix bobtista 05/08/2026 Apply the end position so the window does not stop short of it
+		curPos.x = (Real)endPos.x;
 		animWin->setFinished( TRUE );
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 	if( curPos.x - endPos.x <= m_slowDownThreshold )
 	{
-		vel.x *= m_slowDownRatio;
+		vel.x *= powf(m_slowDownRatio, deltaFrames);
 	}
 	if( vel.x >= -1.0f)
 		vel.x = -1.0f;
@@ -1487,7 +1518,7 @@ Bool ProcessAnimateWindowSlideFromRightFast::updateAnimateWindow( wnd::AnimateWi
 	return FALSE;
 }
 
-Bool ProcessAnimateWindowSlideFromRightFast::reverseAnimateWindow( wnd::AnimateWindow *animWin )
+Bool ProcessAnimateWindowSlideFromRightFast::reverseAnimateWindow( wnd::AnimateWindow *animWin, Real deltaFrames )
 {
 
 	if(!animWin)
@@ -1513,25 +1544,25 @@ Bool ProcessAnimateWindowSlideFromRightFast::reverseAnimateWindow( wnd::AnimateW
 		return TRUE;
 	}
 
-	ICoord2D curPos = animWin->getCurPos();
+	Coord2D curPos = animWin->getCurPos();
 	ICoord2D startPos = animWin->getStartPos();
 	Coord2D vel = animWin->getVel();
-	curPos.x += (Int)vel.x;
+	curPos.x += vel.x * deltaFrames;
 
 	if(curPos.x > startPos.x)
 	{
-		curPos.x = startPos.x;
+		curPos.x = (Real)startPos.x;
 		animWin->setFinished( TRUE );
-		win->winSetPosition(curPos.x, curPos.y);
+		setWindowPosition(win, curPos);
 		return TRUE;
 	}
-	win->winSetPosition(curPos.x, curPos.y);
+	setWindowPosition(win, curPos);
 	animWin->setCurPos(curPos);
 
 	ICoord2D endPos = animWin->getEndPos();
 	if( curPos.x - endPos.x <= m_slowDownThreshold )
 	{
-		vel.x *= m_speedUpRatio;
+		vel.x *= powf(m_speedUpRatio, deltaFrames);
 	}
 	else
 	{

--- a/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -107,10 +107,10 @@ public:
 		return newInstance(AnimateWindow);
 	}
 
-	void setAnimData( ICoord2D startPos, ICoord2D endPos, ICoord2D curPos, ICoord2D restPos, Coord2D vel, UnsignedInt startTime, UnsignedInt endTime);
+	void setAnimData( ICoord2D startPos, ICoord2D endPos, Coord2D curPos, ICoord2D restPos, Coord2D vel, UnsignedInt startTime, UnsignedInt endTime);
 
 	ICoord2D		getStartPos();							///< Get the Start Position 2D coord
-	ICoord2D		getCurPos();								///< Get the Current Position 2D coord
+	Coord2D			getCurPos();								///< Get the Current Position 2D coord
 	ICoord2D		getEndPos();								///< Get the End Position 2D coord
 	ICoord2D		getRestPos();								///< Get the Rest Position 2D coord
 	GameWindow *getGameWindow();						///< Get the GameWindow that will be animating
@@ -121,7 +121,7 @@ public:
 	UnsignedInt getEndTime();								///< Get the end time of the time-based anim
 
 	void	setStartPos( ICoord2D starPos);					///< Set the Start Position 2D coord
-	void	setCurPos( ICoord2D curPos);						///< Set the Current Position 2D coord
+	void	setCurPos( Coord2D curPos);							///< Set the Current Position 2D coord
 	void	setEndPos( ICoord2D endPos);						///< Set the End Position 2D coord
 	void	setRestPos( ICoord2D restPos);					///< Set the Rest Position 2D coord
 	void	setGameWindow( GameWindow *win);				///< Set the GameWindow that will be animating
@@ -141,7 +141,7 @@ private:
 	ICoord2D m_startPos;													///< Holds the starting position of the animation
 																								///<(usually is also the end position of the animation when the animation is reversed)
 	ICoord2D m_endPos;														///< Holds the target End Position (usually is the same as the rest position)
-	ICoord2D m_curPos;														///< It's Current Position
+	Coord2D m_curPos;															///< It's Current Position
 	ICoord2D m_restPos;														///< When the Manager Resets, It sets the window's position to this position
 	GameWindow *m_win;														///< the window that this animation is happening on
 	Coord2D m_vel;																///< the Velocity of the animation
@@ -178,13 +178,10 @@ public:
 	Bool isReversed();										///< Returns whether or not we're in our reversed state.
 	Bool isEmpty();
 private:
-	void step();															///< Runs a single base-rate step of all registered window animations
-
 	AnimateWindowList	m_winList;								///< A list of AnimationWindows that we don't care if their finished animating
 	AnimateWindowList m_winMustFinishList;			///< A list of AnimationWindows that we do care about
 	Bool m_needsUpdate;													///< If we're done animating all our monitored windows, then this will be false
 	Bool m_reverse;															///< Are we in a reverse state?
-	Real m_frameAccumulator;										///< Carries fractional base-rate frames between updates
 	ProcessAnimateWindowSlideFromRight *m_slideFromRight;			///< Holds the process in which the windows slide from the right
 	ProcessAnimateWindowSlideFromRightFast *m_slideFromRightFast;
 	ProcessAnimateWindowSlideFromTop *m_slideFromTop;					///< Holds the process in which the windows slide from the Top
@@ -203,7 +200,7 @@ private:
 namespace wnd
 {
 	inline ICoord2D			AnimateWindow::getStartPos()	{ return m_startPos; };
-	inline ICoord2D			AnimateWindow::getCurPos()		{ return m_curPos; };
+	inline Coord2D			AnimateWindow::getCurPos()		{ return m_curPos; };
 	inline ICoord2D			AnimateWindow::getEndPos()		{ return m_endPos; };
 	inline ICoord2D			AnimateWindow::getRestPos()		{ return m_restPos; };
 	inline GameWindow  *AnimateWindow::getGameWindow(){ return m_win; };
@@ -214,7 +211,7 @@ namespace wnd
 	inline UnsignedInt	AnimateWindow::getEndTime()		{ return m_endTime; };
 
 	inline void	AnimateWindow::setStartPos( ICoord2D startPos)		{ m_startPos = startPos; };
-	inline void	AnimateWindow::setCurPos( ICoord2D curPos)				{ m_curPos = curPos; };
+	inline void	AnimateWindow::setCurPos( Coord2D curPos)					{ m_curPos = curPos; };
 	inline void	AnimateWindow::setEndPos( ICoord2D endPos)				{ m_endPos = endPos; };
 	inline void	AnimateWindow::setRestPos( ICoord2D restPos)			{ m_restPos = restPos; };
 	inline void	AnimateWindow::setGameWindow( GameWindow *win)		{ m_win = win; };

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -72,7 +72,7 @@ AnimateWindow::AnimateWindow()
 	m_delay = 0;
 	m_startPos.x = m_startPos.y = 0;
 	m_endPos.x = m_endPos.y = 0;
-	m_curPos.x = m_curPos.y = 0;
+	m_curPos.x = m_curPos.y = 0.0f;
 	m_win = nullptr;
 	m_animType = WIN_ANIMATION_NONE;
 
@@ -89,7 +89,7 @@ AnimateWindow::~AnimateWindow()
 }
 
 void AnimateWindow::setAnimData( 	ICoord2D startPos, ICoord2D endPos,
-																	ICoord2D curPos, ICoord2D restPos,
+																	Coord2D curPos, ICoord2D restPos,
 																	Coord2D vel, UnsignedInt startTime,
 																	UnsignedInt endTime )
 
@@ -134,7 +134,6 @@ AnimateWindowManager::AnimateWindowManager()
 	m_winList.clear();
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_frameAccumulator = 0.0f;
 	m_winMustFinishList.clear();
 }
 AnimateWindowManager::~AnimateWindowManager()
@@ -161,7 +160,6 @@ void AnimateWindowManager::init()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_frameAccumulator = 0.0f;
 }
 
 void AnimateWindowManager::reset()
@@ -171,24 +169,13 @@ void AnimateWindowManager::reset()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_frameAccumulator = 0.0f;
 }
 
-// TheSuperHackers @tweak bobtista 27/06/2026 Decouple GUI window-move animations from the render frame rate
+// TheSuperHackers @tweak bobtista 04/08/2026 Advances the animations by a fractional base rate frame
+// so that they move fluently on high render frame rates.
 void AnimateWindowManager::update()
 {
-	m_frameAccumulator += TheFramePacer->getBaseOverUpdateFpsRatio();
-	Int steps = (Int)m_frameAccumulator;
-	m_frameAccumulator -= (Real)steps;
-
-	while (steps-- > 0)
-	{
-		step();
-	}
-}
-
-void AnimateWindowManager::step()
-{
+	const Real deltaFrames = TheFramePacer->getBaseOverUpdateFpsRatio();
 
 	ProcessAnimateWindow *processAnim = nullptr;
 
@@ -211,12 +198,12 @@ void AnimateWindowManager::step()
 			{
 				if(m_reverse)
 				{
-					if(!processAnim->reverseAnimateWindow(animWin))
+					if(!processAnim->reverseAnimateWindow(animWin, deltaFrames))
 						m_needsUpdate = TRUE;
 				}
 				else
 				{
-					if(!processAnim->updateAnimateWindow(animWin))
+					if(!processAnim->updateAnimateWindow(animWin, deltaFrames))
 						m_needsUpdate = TRUE;
 				}
 			}
@@ -239,12 +226,12 @@ void AnimateWindowManager::step()
 		if(m_reverse)
 		{
 			if(processAnim)
-				processAnim->reverseAnimateWindow(animWin);
+				processAnim->reverseAnimateWindow(animWin, deltaFrames);
 		}
 		else
 		{
 			if(processAnim)
-				processAnim->updateAnimateWindow(animWin);
+				processAnim->updateAnimateWindow(animWin, deltaFrames);
 		}
 		it ++;
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -107,10 +107,10 @@ public:
 		return newInstance(AnimateWindow);
 	}
 
-	void setAnimData( ICoord2D startPos, ICoord2D endPos, ICoord2D curPos, ICoord2D restPos, Coord2D vel, UnsignedInt startTime, UnsignedInt endTime);
+	void setAnimData( ICoord2D startPos, ICoord2D endPos, Coord2D curPos, ICoord2D restPos, Coord2D vel, UnsignedInt startTime, UnsignedInt endTime);
 
 	ICoord2D		getStartPos();							///< Get the Start Position 2D coord
-	ICoord2D		getCurPos();								///< Get the Current Position 2D coord
+	Coord2D			getCurPos();								///< Get the Current Position 2D coord
 	ICoord2D		getEndPos();								///< Get the End Position 2D coord
 	ICoord2D		getRestPos();								///< Get the Rest Position 2D coord
 	GameWindow *getGameWindow();						///< Get the GameWindow that will be animating
@@ -121,7 +121,7 @@ public:
 	UnsignedInt getEndTime();								///< Get the end time of the time-based anim
 
 	void	setStartPos( ICoord2D starPos);					///< Set the Start Position 2D coord
-	void	setCurPos( ICoord2D curPos);						///< Set the Current Position 2D coord
+	void	setCurPos( Coord2D curPos);							///< Set the Current Position 2D coord
 	void	setEndPos( ICoord2D endPos);						///< Set the End Position 2D coord
 	void	setRestPos( ICoord2D restPos);					///< Set the Rest Position 2D coord
 	void	setGameWindow( GameWindow *win);				///< Set the GameWindow that will be animating
@@ -141,7 +141,7 @@ private:
 	ICoord2D m_startPos;													///< Holds the starting position of the animation
 																								///<(usually is also the end position of the animation when the animation is reversed)
 	ICoord2D m_endPos;														///< Holds the target End Position (usually is the same as the rest position)
-	ICoord2D m_curPos;														///< It's Current Position
+	Coord2D m_curPos;															///< It's Current Position
 	ICoord2D m_restPos;														///< When the Manager Resets, It sets the window's position to this position
 	GameWindow *m_win;														///< the window that this animation is happening on
 	Coord2D m_vel;																///< the Velocity of the animation
@@ -178,13 +178,10 @@ public:
 	Bool isReversed();										///< Returns whether or not we're in our reversed state.
 	Bool isEmpty();
 private:
-	void step();															///< Runs a single base-rate step of all registered window animations
-
 	AnimateWindowList	m_winList;								///< A list of AnimationWindows that we don't care if their finished animating
 	AnimateWindowList m_winMustFinishList;			///< A list of AnimationWindows that we do care about
 	Bool m_needsUpdate;													///< If we're done animating all our monitored windows, then this will be false
 	Bool m_reverse;															///< Are we in a reverse state?
-	Real m_frameAccumulator;										///< Carries fractional base-rate frames between updates
 	ProcessAnimateWindowSlideFromRight *m_slideFromRight;			///< Holds the process in which the windows slide from the right
 	ProcessAnimateWindowSlideFromRightFast *m_slideFromRightFast;
 	ProcessAnimateWindowSlideFromTop *m_slideFromTop;					///< Holds the process in which the windows slide from the Top
@@ -203,7 +200,7 @@ private:
 namespace wnd
 {
 	inline ICoord2D			AnimateWindow::getStartPos()	{ return m_startPos; };
-	inline ICoord2D			AnimateWindow::getCurPos()		{ return m_curPos; };
+	inline Coord2D			AnimateWindow::getCurPos()		{ return m_curPos; };
 	inline ICoord2D			AnimateWindow::getEndPos()		{ return m_endPos; };
 	inline ICoord2D			AnimateWindow::getRestPos()		{ return m_restPos; };
 	inline GameWindow  *AnimateWindow::getGameWindow(){ return m_win; };
@@ -214,7 +211,7 @@ namespace wnd
 	inline UnsignedInt	AnimateWindow::getEndTime()		{ return m_endTime; };
 
 	inline void	AnimateWindow::setStartPos( ICoord2D startPos)		{ m_startPos = startPos; };
-	inline void	AnimateWindow::setCurPos( ICoord2D curPos)				{ m_curPos = curPos; };
+	inline void	AnimateWindow::setCurPos( Coord2D curPos)					{ m_curPos = curPos; };
 	inline void	AnimateWindow::setEndPos( ICoord2D endPos)				{ m_endPos = endPos; };
 	inline void	AnimateWindow::setRestPos( ICoord2D restPos)			{ m_restPos = restPos; };
 	inline void	AnimateWindow::setGameWindow( GameWindow *win)		{ m_win = win; };

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -72,7 +72,7 @@ AnimateWindow::AnimateWindow()
 	m_delay = 0;
 	m_startPos.x = m_startPos.y = 0;
 	m_endPos.x = m_endPos.y = 0;
-	m_curPos.x = m_curPos.y = 0;
+	m_curPos.x = m_curPos.y = 0.0f;
 	m_win = nullptr;
 	m_animType = WIN_ANIMATION_NONE;
 
@@ -89,7 +89,7 @@ AnimateWindow::~AnimateWindow()
 }
 
 void AnimateWindow::setAnimData( 	ICoord2D startPos, ICoord2D endPos,
-																	ICoord2D curPos, ICoord2D restPos,
+																	Coord2D curPos, ICoord2D restPos,
 																	Coord2D vel, UnsignedInt startTime,
 																	UnsignedInt endTime )
 
@@ -134,7 +134,6 @@ AnimateWindowManager::AnimateWindowManager()
 	m_winList.clear();
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_frameAccumulator = 0.0f;
 	m_winMustFinishList.clear();
 }
 AnimateWindowManager::~AnimateWindowManager()
@@ -161,7 +160,6 @@ void AnimateWindowManager::init()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_frameAccumulator = 0.0f;
 }
 
 void AnimateWindowManager::reset()
@@ -171,24 +169,13 @@ void AnimateWindowManager::reset()
 	clearWinList(m_winMustFinishList);
 	m_needsUpdate = FALSE;
 	m_reverse = FALSE;
-	m_frameAccumulator = 0.0f;
 }
 
-// TheSuperHackers @tweak bobtista 27/06/2026 Decouple GUI window-move animations from the render frame rate
+// TheSuperHackers @tweak bobtista 04/08/2026 Advances the animations by a fractional base rate frame
+// so that they move fluently on high render frame rates.
 void AnimateWindowManager::update()
 {
-	m_frameAccumulator += TheFramePacer->getBaseOverUpdateFpsRatio();
-	Int steps = (Int)m_frameAccumulator;
-	m_frameAccumulator -= (Real)steps;
-
-	while (steps-- > 0)
-	{
-		step();
-	}
-}
-
-void AnimateWindowManager::step()
-{
+	const Real deltaFrames = TheFramePacer->getBaseOverUpdateFpsRatio();
 
 	ProcessAnimateWindow *processAnim = nullptr;
 
@@ -211,12 +198,12 @@ void AnimateWindowManager::step()
 			{
 				if(m_reverse)
 				{
-					if(!processAnim->reverseAnimateWindow(animWin))
+					if(!processAnim->reverseAnimateWindow(animWin, deltaFrames))
 						m_needsUpdate = TRUE;
 				}
 				else
 				{
-					if(!processAnim->updateAnimateWindow(animWin))
+					if(!processAnim->updateAnimateWindow(animWin, deltaFrames))
 						m_needsUpdate = TRUE;
 				}
 			}
@@ -239,12 +226,12 @@ void AnimateWindowManager::step()
 		if(m_reverse)
 		{
 			if(processAnim)
-				processAnim->reverseAnimateWindow(animWin);
+				processAnim->reverseAnimateWindow(animWin, deltaFrames);
 		}
 		else
 		{
 			if(processAnim)
-				processAnim->updateAnimateWindow(animWin);
+				processAnim->updateAnimateWindow(animWin, deltaFrames);
 		}
 		it ++;
 	}


### PR DESCRIPTION
* Follow up for #2833

#2833 decoupled GUI window-move animations from the render frame rate, but
`AnimateWindowManager` still accumulates fractional base-rate time and advances the
animations only in whole steps. Window positions therefore change about 30 times per
second even when the game renders faster.

Now the manager passes fractional base-frame deltas to the movement processors, animated
positions keep subpixel precision, and coordinates are rounded only when applied to a
`GameWindow`. The subpixel precision is required because velocity clamps to
1 pixel per base frame near the rest position, which is 0.25 pixel per render frame at
120 fps and truncates to no movement at all with the previous integer position. Velocity
ratios are adjusted for the fractional delta with `powf`, which keeps the duration
approximately constant across frame rates rather than exactly equal, since the position
is still integrated once per render frame.

Every completion path now applies its terminal position. `SlideFromRight`, `SlideFromLeft`
and `SlideFromRightFast` marked the animation finished without ever writing the end
position, leaving the window short of its rest position by up to one update of travel.

On the in-game control bar, movement increased from 24 position updates in 744 ms at
30 fps to 85 updates in 736 ms at 120 fps.

`ProcessAnimateWindow.cpp` is shared Core code compiled into both games, so the Generals
manager and header change with it.

This only affects client-side GUI state and does not touch game logic, replays, or CRC
calculations.

Todo:
- [x] Measure the Zero Hour control-bar animation at 30 and 120 render fps
- [s] Replicate to generals 