### PR TITLE
chore: Update retail behaviour preservation flags

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -48,11 +48,11 @@
 #endif
 
 #ifndef PRESERVE_NO_XP_FROM_POISON_KILLS
-#define PRESERVE_NO_XP_FROM_POISON_KILLS (1)
+#define PRESERVE_NO_XP_FROM_POISON_KILLS (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
 #endif
 
 #ifndef PRESERVE_OCCUPANT_DETECTION_VIA_DRAG_SELECTION
-#define PRESERVE_OCCUPANT_DETECTION_VIA_DRAG_SELECTION (1)
+#define PRESERVE_OCCUPANT_DETECTION_VIA_DRAG_SELECTION (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
 #endif
 
 #ifndef PRESERVE_PERPETUAL_HORDE_BONUS
@@ -60,7 +60,7 @@
 #endif
 
 #ifndef PRESERVE_PREMATURE_BATTLE_BUS_DEATH
-#define PRESERVE_PREMATURE_BATTLE_BUS_DEATH (1)
+#define PRESERVE_PREMATURE_BATTLE_BUS_DEATH (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
 #endif
 
 #ifndef PRESERVE_RADAR_WARNING_SUPPRESSION


### PR DESCRIPTION
This change defaults several retail behaviour preservation flags to (0) to reflect the approval status of the Game Design Committee.

```
PRESERVE_NO_XP_FROM_POISON_KILLS (0)
PRESERVE_OCCUPANT_DETECTION_VIA_DRAG_SELECTION (0)
PRESERVE_PREMATURE_BATTLE_BUS_DEATH (0)
```