### PR TITLE
fix(client): Prevent movies from playing in headless mode

### DIFF
--- a/Core/GameEngine/Source/GameClient/Display.cpp
+++ b/Core/GameEngine/Source/GameClient/Display.cpp
@@ -201,6 +201,8 @@ void Display::setHeight( UnsignedInt height )
 
 void Display::playMovie( AsciiString movieName)
 {
+	if (TheGlobalData->m_headless)
+		return;
 
 	stopMovie();
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -4135,6 +4135,8 @@ void InGameUI::createReplayControl()
 // ------------------------------------------------------------------------------------------------
 void InGameUI::playMovie( const AsciiString& movieName )
 {
+	if (TheGlobalData->m_headless)
+		return;
 
 	stopMovie();
 
@@ -4190,6 +4192,8 @@ VideoBuffer* InGameUI::videoBuffer()
 // ------------------------------------------------------------------------------------------------
 void InGameUI::playCameoMovie( const AsciiString& movieName )
 {
+	if (TheGlobalData->m_headless)
+		return;
 
 	stopCameoMovie();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -4249,6 +4249,8 @@ void InGameUI::createReplayControl()
 // ------------------------------------------------------------------------------------------------
 void InGameUI::playMovie( const AsciiString& movieName )
 {
+	if (TheGlobalData->m_headless)
+		return;
 
 	stopMovie();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -4306,6 +4306,8 @@ VideoBuffer* InGameUI::videoBuffer()
 // ------------------------------------------------------------------------------------------------
 void InGameUI::playCameoMovie( const AsciiString& movieName )
 {
+	if (TheGlobalData->m_headless)
+		return;
 
 	stopCameoMovie();
 


### PR DESCRIPTION
This PR adds 3 early returns to prevent movies from being played in headless mode. This can be triggered from scripts, but headless mode cannot handle this properly and crashes with this call stack:

```
generalszh.exe!DX8Caps::Support_Texture_Format(WW3DFormat format) Line 245
generalszh.exe!W3DDisplay::createVideoBuffer() Line 2904
generalszh.exe!InGameUI::playMovie(const AsciiString & movieName) Line 4265
generalszh.exe!ScriptActions::doMoviePlayRadar(const AsciiString & movieName) Line 2788
generalszh.exe!ScriptActions::executeAction(ScriptAction * pAction) Line 6934
generalszh.exe!ScriptEngine::executeActions(ScriptAction * pActionHead) Line 7633
generalszh.exe!ScriptEngine::executeScript(Script * pScript) Line 7021
generalszh.exe!ScriptEngine::executeScripts(Script * pScriptHead) Line 7680
generalszh.exe!ScriptEngine::update() Line 5577
generalszh.exe!SubsystemInterface::UPDATE() Line 131
generalszh.exe!GameLogic::update() Line 3745
generalszh.exe!SubsystemInterface::UPDATE() Line 131
generalszh.exe!ReplaySimulation::simulateReplaysInThisProcess(const std::vector<AsciiString,std::allocator<AsciiString>> & filenames) Line 99
generalszh.exe!ReplaySimulation::simulateReplays(const std::vector<AsciiString,std::allocator<AsciiString>> & filenames, int maxProcesses) Line 250
generalszh.exe!GameMain() Line 50
generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 929
```

`DX8Wrapper::Get_Current_Caps` returns a `nullptr` in headless mode here: https://github.com/TheSuperHackers/GeneralsGameCode/blob/c30b17b208f36465f60cddfca974d30f5b8d70e3/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp#L2904

Note: there's no code calling `InGameUI::playCameoMovie` from a script, but I've added the headless mode check there as well for consistency.

## TODO:
- [x] Replicate to Generals.