### PR TITLE
bugfix(horde): Prevent dead units from being considered for horde membership

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
@@ -80,6 +80,12 @@ public:
 
 	virtual Bool allow(Object *objOther) override
 	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Stubbjax 07/08/2026 Prevent dead units from being considered for horde membership.
+		if (objOther->isEffectivelyDead())
+			return false;
+#endif
+
 		// must be exact same type as us (well, maybe)
 		if (m_data->m_exactMatch && m_obj->getTemplate() != objOther->getTemplate())
 			return false;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
@@ -80,6 +80,12 @@ public:
 
 	virtual Bool allow(Object *objOther) override
 	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Stubbjax 07/08/2026 Prevent dead units from being considered for horde membership.
+		if (objOther->isEffectivelyDead())
+			return false;
+#endif
+		
 		// must be exact same type as us (well, maybe)
 		if (m_data->m_exactMatch && m_obj->getTemplate() != objOther->getTemplate())
 			return false;


### PR DESCRIPTION
This change prevents dead units from being considered for horde membership.

### Before
The horde bonus remains active until the dead Tank Hunter fully sinks into the ground and disappears

https://github.com/user-attachments/assets/59b3639f-193e-4c4d-b8d8-6713d9d3f5ff

### After
The horde bonus is lost as soon as the Tank Hunter dies

https://github.com/user-attachments/assets/3b40d3ae-c87f-4f76-88fa-800df02c793b