### PR TITLE
bugfix(fx): Destroy slave particle systems with their master instead of orphaning them

### DIFF
--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1236,9 +1236,9 @@ ParticleSystem::~ParticleSystem()
 
 		DEBUG_ASSERTCRASH( m_slaveSystem->getMaster() == this, ("~ParticleSystem: Our slave doesn't have us as a master!") );
 
-		// TheSuperHackers @bugfix Destroy the slave instead of orphaning it alive. A masterless
-		// slave has no transform of its own and starts self-emitting at the world origin.
-		// See the pull request for the full explanation.
+		// TheSuperHackers @bugfix wh1ter0se69 10/08/2026 Destroy the slave instead of orphaning it
+		// alive. A slave has no position of its own - its master merges one in on every burst - and
+		// nothing stops a masterless slave from emitting, so it starts bursting at the world origin.
 		m_slaveSystem->destroy();
 
 		m_slaveSystem->setMaster( nullptr );

--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1235,6 +1235,16 @@ ParticleSystem::~ParticleSystem()
 	{
 
 		DEBUG_ASSERTCRASH( m_slaveSystem->getMaster() == this, ("~ParticleSystem: Our slave doesn't have us as a master!") );
+
+		// TheSuperHackers @bugfix Destroy the slave instead of orphaning it alive.
+		// A slave system is never positioned or attached by anything - its master merges
+		// positions into it on every burst - and it is kept from emitting on its own only by the
+		// m_masterSystem == NULL check in update(). Clearing the master without destroying the
+		// slave therefore leaves a live system with no transform at all, which emits its
+		// particles at raw local coordinates, i.e. the world origin. destroy() already
+		// propagates to the slave for exactly this reason; the destructor did not.
+		m_slaveSystem->destroy();
+
 		m_slaveSystem->setMaster( nullptr );
 		setSlave( nullptr );
 

--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1236,13 +1236,9 @@ ParticleSystem::~ParticleSystem()
 
 		DEBUG_ASSERTCRASH( m_slaveSystem->getMaster() == this, ("~ParticleSystem: Our slave doesn't have us as a master!") );
 
-		// TheSuperHackers @bugfix Destroy the slave instead of orphaning it alive.
-		// A slave system is never positioned or attached by anything - its master merges
-		// positions into it on every burst - and it is kept from emitting on its own only by the
-		// m_masterSystem == NULL check in update(). Clearing the master without destroying the
-		// slave therefore leaves a live system with no transform at all, which emits its
-		// particles at raw local coordinates, i.e. the world origin. destroy() already
-		// propagates to the slave for exactly this reason; the destructor did not.
+		// TheSuperHackers @bugfix Destroy the slave instead of orphaning it alive. A masterless
+		// slave has no transform of its own and starts self-emitting at the world origin.
+		// See the pull request for the full explanation.
 		m_slaveSystem->destroy();
 
 		m_slaveSystem->setMaster( nullptr );


### PR DESCRIPTION
* Fixes #2645

## What's wrong

`~ParticleSystem()` clears a slave's master pointer but leaves the slave **alive**:

```cpp
m_slaveSystem->setMaster( nullptr );   // orphaned, not destroyed
setSlave( nullptr );
```

A slave has no position of its own. Its master merges one in on every burst
(`mergeRelatedParticleSystems` takes the position from the master), so a slave is never attached to
anything and never gets a local transform. Orphaning it turns both of those facts into the bug:

1. With no master, `m_isIdentity` stays true, so `generateParticleInfo` skips the transform and
   emits at raw local coordinates — **(0,0,0)**.
2. The only thing stopping a slave from emitting on its own is the master check in `update()`
   (`m_masterSystem == nullptr`). Clearing the master is exactly what opens that gate.

`destroy()` already handles this correctly and propagates to the slave, with a comment saying why:
*"If we don't it will leak forever. We are solely responsible for it."* The destructor did not.

## The fix

One line — destroy the slave with its master, matching `destroy()`.

`destroy()` sets a flag, it does not delete anything. The slave stops emitting and the particles it
already put in the air finish normally in place, so nothing that currently renders correctly is
lost. Only the burst at the origin goes away.

## Evidence

VC6 Release build (`RTS_BUILD_OPTION_DEBUG=OFF`), windowed, playing back `!Golden Replay #1.rep`,
with a temporary probe logging any particle system emitting within 250 world units of the origin:

| | frames reached | emissions at origin | CRC mismatches |
|---|---|---|---|
| before | 173,416 | **59** | 0 |
| after | 175,331 | **0** | 0 |

Every logged emission had the same signature — no transform, no owner:

```
[GXORIGINFX] frame=56644 tmpl=SpectreHotPillarArmFlameSlave pos=(0.0,0.0,0.0) burst=1 identity=1 attachObj=0 attachDraw=0
```

~550,000 particle systems were created over the run, so the probe was not starved.

**Retail compatibility.** Client-side FX only; no logic random values are consumed and the replay
stays CRC-clean before and after. The save format is unchanged — `ParticleSystemManager::xfer`
already writes a destroyed system as a null placeholder. The file is in `Core/`, so this covers both
Generals and Zero Hour.

<details>
<summary><b>Why a master can die while its slave is still running</b> (thanks @Caball009 — this is his finding, verified, with one correction)</summary>

A particle system is not deleted the moment its `SystemLifetime` runs out. `update()` returns
`true` while `getParticleCount()` is non-zero, so a system's real life is its `SystemLifetime` plus
however long its **last particle** survives. Orphaning happens when the master's last particle dies
before the slave's does.

For the pair caught in the replay:

| | Shader | SystemLifetime | particle Lifetime |
|---|---|---|---|
| `SpectreHotPillarArmFlame` (master) | ALPHA | 10 | 300 |
| `SpectreHotPillarArmFlameSlave` (slave) | ADDITIVE | 120 | 120 |

Particles also die early via `Particle::isInvisible()`, and that is where the randomness enters.
The master's `Alpha2 = -2.00 0.00 300` means the second alpha key's *value* is drawn per particle
by `GameClientRandomValueReal`, so the fade rate lands anywhere in −0.0083…−0.0017 per frame and
the particle crosses the `alpha < 0.01` threshold somewhere between ~59 and ~295 frames after birth.
When the whole batch happens to draw fast fades, the master is gone well before the slave's 120
frames are up.

The correction: this applies to the **master's** particles, not the slave's. The slave is
`ADDITIVE`, and `Particle::update` skips alpha entirely for `ADDITIVE` while `isInvisible()` decides
on colour instead — so the alpha threshold never executes for the slave at all. Its particles die on
`Lifetime = 120`.

Two more inputs shorten the master's tail the same way, which is why the count varies run to run:
the dynamic-LOD early return in `createParticle()` and the global particle cap. Three runs of the
same replay on the same binary with the fix disabled gave 18, 101 and 171 origin emissions, all
CRC-clean — identical simulation, purely client-side variance.

</details>

<details>
<summary><b>Reproduction notes</b></summary>

* Must be a **VC6 Release** build. Other toolchains diverge from this retail-recorded replay around
  frame 111 and the simulation is effectively dead by frame ~700, which still presents as a clean
  run.
* Must be **windowed**. A headless run creates almost no client-side FX — a full headless replay
  produced exactly one particle template — so headless is blind to anything downstream of the
  Drawable.
* An easier repro than a 99-minute replay: pin the client seed and disable the LOD and cap early
  returns in `createParticle()`. That makes it deterministic at the cost of unbounded particle
  counts, so it belongs behind a debug flag rather than shipped.

</details>
