### PR TITLE
bugfix(ai): Do not rebuild the locomotor set of a dead aircraft

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -826,22 +826,14 @@ Bool AIUpdateInterface::chooseLocomotorSetExplicit(LocomotorSetType wst)
 	const LocomotorTemplateVector* set = getAIUpdateModuleData()->findLocomotorTemplateVector(wst);
 	if (set)
 	{
-		// TheSuperHackers @bugfix Do not rebuild the locomotor set of a dead aircraft.
-		//
-		// A slow death module disables flight by mutating the CURRENT Locomotor instance -
-		// JetSlowDeathBehavior::beginSlowDeath() applies a negative maxLift and a zero
-		// maxTurnRate to getCurLocomotor(). Rebuilding the set here deleteInstance()s that
-		// Locomotor and constructs replacements from template, and the Locomotor constructor
-		// resets m_maxLift and m_maxTurnRate to BIGNUM. The wreck therefore regains full lift
-		// and full turn rate and keeps flying, circling forever because DestructionDelay is
-		// effectively infinite.
-		//
-		// This lives in AIUpdateInterface rather than in a slow death module because every
-		// aircraft reaches it, which is why the symptom is reported for jets and helicopters
-		// alike.
+		// TheSuperHackers @bugfix wh1ter0se69 10/08/2026 Do not rebuild the locomotor set of a dead
+		// aircraft. Rebuilding discards the Locomotor instance that a slow death module mutated to
+		// ground it, so the wreck regains full lift from template and keeps flying.
 #if !RETAIL_COMPATIBLE_CRC
 		Object* obj = getObject();
-		if (obj != nullptr && obj->isEffectivelyDead() && obj->isKindOf(KINDOF_AIRCRAFT))
+		// LOCOMOTORSET_INVALID means no set has been built yet, so this refuses rebuilds only.
+		if (obj != nullptr && obj->isEffectivelyDead() && obj->isKindOf(KINDOF_AIRCRAFT)
+				&& m_curLocomotorSet != LOCOMOTORSET_INVALID)
 			return FALSE;
 #endif
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -839,9 +839,11 @@ Bool AIUpdateInterface::chooseLocomotorSetExplicit(LocomotorSetType wst)
 		// This lives in AIUpdateInterface rather than in a slow death module because every
 		// aircraft reaches it, which is why the symptom is reported for jets and helicopters
 		// alike.
+#if !RETAIL_COMPATIBLE_CRC
 		Object* obj = getObject();
 		if (obj != nullptr && obj->isEffectivelyDead() && obj->isKindOf(KINDOF_AIRCRAFT))
 			return FALSE;
+#endif
 
 		m_locomotorSet.clear();
 		m_curLocomotor = nullptr;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -826,6 +826,23 @@ Bool AIUpdateInterface::chooseLocomotorSetExplicit(LocomotorSetType wst)
 	const LocomotorTemplateVector* set = getAIUpdateModuleData()->findLocomotorTemplateVector(wst);
 	if (set)
 	{
+		// TheSuperHackers @bugfix Do not rebuild the locomotor set of a dead aircraft.
+		//
+		// A slow death module disables flight by mutating the CURRENT Locomotor instance -
+		// JetSlowDeathBehavior::beginSlowDeath() applies a negative maxLift and a zero
+		// maxTurnRate to getCurLocomotor(). Rebuilding the set here deleteInstance()s that
+		// Locomotor and constructs replacements from template, and the Locomotor constructor
+		// resets m_maxLift and m_maxTurnRate to BIGNUM. The wreck therefore regains full lift
+		// and full turn rate and keeps flying, circling forever because DestructionDelay is
+		// effectively infinite.
+		//
+		// This lives in AIUpdateInterface rather than in a slow death module because every
+		// aircraft reaches it, which is why the symptom is reported for jets and helicopters
+		// alike.
+		Object* obj = getObject();
+		if (obj != nullptr && obj->isEffectivelyDead() && obj->isKindOf(KINDOF_AIRCRAFT))
+			return FALSE;
+
 		m_locomotorSet.clear();
 		m_curLocomotor = nullptr;
 		for (size_t i = 0; i < set->size(); ++i)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -832,6 +832,23 @@ Bool AIUpdateInterface::chooseLocomotorSetExplicit(LocomotorSetType wst)
 	const LocomotorTemplateVector* set = getAIUpdateModuleData()->findLocomotorTemplateVector(wst);
 	if (set)
 	{
+		// TheSuperHackers @bugfix Do not rebuild the locomotor set of a dead aircraft.
+		//
+		// A slow death module disables flight by mutating the CURRENT Locomotor instance -
+		// JetSlowDeathBehavior::beginSlowDeath() applies a negative maxLift and a zero
+		// maxTurnRate to getCurLocomotor(). Rebuilding the set here deleteInstance()s that
+		// Locomotor and constructs replacements from template, and the Locomotor constructor
+		// resets m_maxLift and m_maxTurnRate to BIGNUM. The wreck therefore regains full lift
+		// and full turn rate and keeps flying, circling forever because DestructionDelay is
+		// effectively infinite.
+		//
+		// This lives in AIUpdateInterface rather than in a slow death module because every
+		// aircraft reaches it, which is why the symptom is reported for jets and helicopters
+		// alike.
+		Object* obj = getObject();
+		if (obj != nullptr && obj->isEffectivelyDead() && obj->isKindOf(KINDOF_AIRCRAFT))
+			return FALSE;
+
 		m_locomotorSet.clear();
 		m_curLocomotor = nullptr;
 		for (size_t i = 0; i < set->size(); ++i)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -845,9 +845,11 @@ Bool AIUpdateInterface::chooseLocomotorSetExplicit(LocomotorSetType wst)
 		// This lives in AIUpdateInterface rather than in a slow death module because every
 		// aircraft reaches it, which is why the symptom is reported for jets and helicopters
 		// alike.
+#if !RETAIL_COMPATIBLE_CRC
 		Object* obj = getObject();
 		if (obj != nullptr && obj->isEffectivelyDead() && obj->isKindOf(KINDOF_AIRCRAFT))
 			return FALSE;
+#endif
 
 		m_locomotorSet.clear();
 		m_curLocomotor = nullptr;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -832,22 +832,14 @@ Bool AIUpdateInterface::chooseLocomotorSetExplicit(LocomotorSetType wst)
 	const LocomotorTemplateVector* set = getAIUpdateModuleData()->findLocomotorTemplateVector(wst);
 	if (set)
 	{
-		// TheSuperHackers @bugfix Do not rebuild the locomotor set of a dead aircraft.
-		//
-		// A slow death module disables flight by mutating the CURRENT Locomotor instance -
-		// JetSlowDeathBehavior::beginSlowDeath() applies a negative maxLift and a zero
-		// maxTurnRate to getCurLocomotor(). Rebuilding the set here deleteInstance()s that
-		// Locomotor and constructs replacements from template, and the Locomotor constructor
-		// resets m_maxLift and m_maxTurnRate to BIGNUM. The wreck therefore regains full lift
-		// and full turn rate and keeps flying, circling forever because DestructionDelay is
-		// effectively infinite.
-		//
-		// This lives in AIUpdateInterface rather than in a slow death module because every
-		// aircraft reaches it, which is why the symptom is reported for jets and helicopters
-		// alike.
+		// TheSuperHackers @bugfix wh1ter0se69 10/08/2026 Do not rebuild the locomotor set of a dead
+		// aircraft. Rebuilding discards the Locomotor instance that a slow death module mutated to
+		// ground it, so the wreck regains full lift from template and keeps flying.
 #if !RETAIL_COMPATIBLE_CRC
 		Object* obj = getObject();
-		if (obj != nullptr && obj->isEffectivelyDead() && obj->isKindOf(KINDOF_AIRCRAFT))
+		// LOCOMOTORSET_INVALID means no set has been built yet, so this refuses rebuilds only.
+		if (obj != nullptr && obj->isEffectivelyDead() && obj->isKindOf(KINDOF_AIRCRAFT)
+				&& m_curLocomotorSet != LOCOMOTORSET_INVALID)
 			return FALSE;
 #endif
 


### PR DESCRIPTION
* Fixes #62

## What's wrong

`JetSlowDeathBehavior::beginSlowDeath()` grounds a dying aircraft by mutating the **current**
`Locomotor` instance:

```cpp
Locomotor *locomotor = us->getAIUpdateInterface()->getCurLocomotor();
locomotor->setMaxLift( -TheGlobalData->m_gravity * (1.0f - modData->m_fallHowFast) );
locomotor->setMaxTurnRate( 0.0f );
```

A dead aircraft's AI keeps running, and when it changes locomotor set,
`chooseLocomotorSetExplicit()` throws that instance away and rebuilds from template:

```cpp
m_locomotorSet.clear();          // deleteInstance() on every Locomotor in the set
m_curLocomotor = nullptr;
for (...) m_locomotorSet.addLocomotor(lt);   // TheLocomotorStore->newLocomotor(lt)
```

`Locomotor::Locomotor(const LocomotorTemplate*)` starts fresh — `m_maxLift = BIGNUM`,
`m_maxTurnRate = BIGNUM`. The wreck silently regains full lift and turn rate. It is no longer
falling; it is a flying aircraft with no pilot, and `DestructionDelay = 99999999` means nothing
removes it. It circles until the match ends.

The fix refuses the rebuild for an effectively-dead aircraft, so the slow-death locomotor survives
and the wreck falls.

## Why this layer

`HelicopterSlowDeathUpdate` mutates the current locomotor the same way
(`setMaxLift` + `setMaxBraking`), so the exposure is not jets-only. Counting retail templates that
carry a jet or helicopter slow-death module: **77 total, of which 45 never run `JetAIUpdate`** —
27 use `DeliverPayloadAIUpdate`, 10 use `ChinookAIUpdate` (Chinook, Helix), 8 use plain
`AIUpdateInterface`. A guard in a single AI module cannot cover them; `chooseLocomotorSetExplicit`
is the one non-virtual funnel every module ends up in.

Retail already tried the per-call-site approach. `ChinookAIUpdate.cpp` refuses to restore lift on a
dead helicopter, with the right comment attached:

```cpp
// don't restore lift if dead -- this may fight with JetSlowDeathBehavior!
if (!obj->isEffectivelyDead())
    loco->setMaxLift(BIGNUM);
```

...and then six lines later calls `ai->chooseLocomotorSet(LOCOMOTORSET_TAXIING)`, which rebuilds the
set and restores `BIGNUM` anyway. Every *direct* lift restore is guarded; the *indirect* one through
the set rebuild is not. That is the bug.

## Evidence

VC6 Release build (`RTS_BUILD_OPTION_DEBUG=OFF`), with a temporary probe logging any locomotor-set
rebuild on an effectively-dead aircraft. Captured live (USA Superweapon, Auroras guarded then killed
airborne):

```
[GXWRECK] frame=18807 obj=612 tmpl=SupW_AmericaJetAurora newset=7 hadLoco=1 airborne=1
```

`newset=7` is `LOCOMOTORSET_SLUGGISH`; `hadLoco=1` confirms the slow-death locomotor was present and
about to be discarded; `airborne=1` confirms it was still in the air.

**A/B on that recording**, same binary, fix toggled by env var so playback is identical up to the
first block:

| | events | outcome |
|---|---|---|
| fix off | 1 rebuild allowed | stays `airborne=1`, circles indefinitely |
| fix on | 87 rebuilds refused | **`airborne=0` at frame 18894** — falls in ~3 seconds |

The CRC mismatch that follows in the fixed run is expected: the wreck now hits the ground, so the
simulation legitimately diverges from a recording of the broken behaviour.

**No regression**, against the full `GeneralsReplays/GeneralsZH/1.04` CI corpus — 10 replays,
roughly four hours of game time:

| | replays completed | CRC errors | wall clock |
|---|---|---|---|
| before | 10/10 | **0** | 8:23 |
| after | 10/10 | **0** | 8:25 |

Both passes produced byte-identical stdout. The corpus never reaches the guarded state, which is why
it is unaffected either way.

## Gating

The guard changes simulation state on a path retail reaches, so it sits behind
`#if !RETAIL_COMPATIBLE_CRC` like the other 85 blocks in the tree. That macro defaults to `1` and
nothing in the build system overrides it, so **this ships disabled today** and becomes live when the
project drops retail CRC compatibility. If maintainers would rather have it enabled sooner, the
paired `PRESERVE_*` form used elsewhere in `GameDefines.h` is the mechanism — that is a call for the
project, not for this PR.

## Known limits

* Which call site produced `newset=7` is **not** recoverable from this probe. It logs `wst` from
  inside `chooseLocomotorSetExplicit`, i.e. after `JetAIUpdate::chooseLocomotorSet` has already
  rewritten the requested set to `m_returningLoco`. `LOCOMOTORSET_SLUGGISH` appears in no `.cpp` at
  all, so the value can only have come from `ReturnForAmmoLocomotorType = SET_SLUGGISH`, which in
  retail is set on the five Aurora variants and nothing else. An earlier revision of this
  description attributed it to a Guard order; that attribution is not supported by the probe output
  and has been removed.
* `JetAIUpdate` calls `setMaxLift()` directly in several places for landing/takeoff sequencing.
  Those bypass the locomotor set change entirely, so this fix does not intercept them. Whether they
  are reachable on a dead jet is not established here.
* With the fix in place the AI retries the refused set change every frame (87 times in the capture
  above). Harmless and cheap, but it indicates the state machine is spinning on a transition it can
  never complete. Not driving a dead aircraft's AI at all may be the better long-term shape, and is
  a much bigger behavioural change than this one.
