### PR TITLE
unify(legacy-profiler): Make both games inherit legacy profiler

### DIFF
--- a/Core/GameEngine/CMakeLists.txt
+++ b/Core/GameEngine/CMakeLists.txt
@@ -1179,6 +1179,7 @@ target_include_directories(corei_gameengine_private INTERFACE
 
 target_link_libraries(corei_gameengine_private INTERFACE
     corei_always
+    core_profile_legacy
 )
 
 target_compile_definitions(corei_gameengine_private INTERFACE

--- a/Core/Libraries/Source/profile/CMakeLists.txt
+++ b/Core/Libraries/Source/profile/CMakeLists.txt
@@ -32,6 +32,7 @@ target_precompile_headers(core_profile_legacy PRIVATE
 )
 
 target_link_libraries(core_profile_legacy PRIVATE
+    core_debug
     core_wwcommon
     corei_always
 )


### PR DESCRIPTION
This makes both GameEngine builds inherit `core_profile_legacy` and declares `core_debug` as its private dependency.

## Prerequisite for #3070

#3070 moves `Shell.cpp` into Core, where profile builds call `Profile::StopRange("init")`.

Zero Hour already linked the legacy profiler, but Generals did not, causing an unresolved `Profile::StopRange` symbol when linking `generalsv.exe`. This PR provides the shared dependencies required by #3070.

## Verification

- VC6 Profile build with this change and #3070 combined.