### PR TITLE
bugfix(jetaiupdate): Fix aircraft falling to their death if their Airfield is lost during their return flight

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -816,13 +816,10 @@ public:
 		loco->setUltraAccurate(true);
 		jetAI->ignoreObstacleID(jet->getProducerID());
 
-		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
+		Object* airfield;
+		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID(), &airfield);
 		if (pp == nullptr)
-#if RETAIL_COMPATIBLE_CRC
-			return STATE_SUCCESS;
-#else
-			return STATE_FAILURE;
-#endif
+			return STATE_SUCCESS;	// no airfield? just skip this step
 
 		Coord3D landingApproach;
 		if (jet->isKindOf(KINDOF_PRODUCED_AT_HELIPAD))

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -216,9 +216,11 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
-		{
+#if RETAIL_COMPATIBLE_CRC
+			return STATE_SUCCESS;
+#else
 			return STATE_FAILURE;
-		}
+#endif
 
 		// gotta reserve a space in order to reserve a runway
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), nullptr))
@@ -447,7 +449,11 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
+#if RETAIL_COMPATIBLE_CRC
+			return STATE_SUCCESS;
+#else
 			return STATE_FAILURE;
+#endif
 
 		ParkingPlaceBehaviorInterface::PPInfo ppinfo;
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), &ppinfo))
@@ -583,7 +589,11 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
+#if RETAIL_COMPATIBLE_CRC
+			return STATE_SUCCESS;
+#else
 			return STATE_FAILURE;
+#endif
 
 		ParkingPlaceBehaviorInterface::PPInfo ppinfo;
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), &ppinfo))
@@ -808,7 +818,11 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
+#if RETAIL_COMPATIBLE_CRC
+			return STATE_SUCCESS;
+#else
 			return STATE_FAILURE;
+#endif
 
 		Coord3D landingApproach;
 		if (jet->isKindOf(KINDOF_PRODUCED_AT_HELIPAD))

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -217,8 +217,7 @@ public:
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
 		{
-			// no producer? just skip this step.
-			return STATE_SUCCESS;
+			return STATE_FAILURE;
 		}
 
 		// gotta reserve a space in order to reserve a runway
@@ -446,10 +445,9 @@ public:
 		jetAI->chooseLocomotorSet(LOCOMOTORSET_TAXIING);
 		DEBUG_ASSERTCRASH(jetAI->getCurLocomotor(), ("no loco"));
 
-		Object* airfield;
-		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID(), &airfield);
+		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
-			return STATE_SUCCESS;	// no airfield? just skip this step.
+			return STATE_FAILURE;
 
 		ParkingPlaceBehaviorInterface::PPInfo ppinfo;
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), &ppinfo))
@@ -585,7 +583,7 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
-			return STATE_SUCCESS;	// no airfield? just skip this step
+			return STATE_FAILURE;
 
 		ParkingPlaceBehaviorInterface::PPInfo ppinfo;
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), &ppinfo))
@@ -808,10 +806,9 @@ public:
 		loco->setUltraAccurate(true);
 		jetAI->ignoreObstacleID(jet->getProducerID());
 
-		Object* airfield;
-		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID(), &airfield);
+		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
-			return STATE_SUCCESS;	// no airfield? just skip this step
+			return STATE_FAILURE;
 
 		Coord3D landingApproach;
 		if (jet->isKindOf(KINDOF_PRODUCED_AT_HELIPAD))
@@ -1506,19 +1503,6 @@ public:
 		setAdjustsDestination(false);		// precision is necessary
 
 		return AIInternalMoveToState::onEnter();
-	}
-
-	virtual StateReturnType update()
-	{
-		Object* jet = getMachineOwner();
-		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
-
-		if (!pp)
-		{
-			return STATE_FAILURE;
-		}
-
-		return AIInternalMoveToState::update();
 	}
 };
 EMPTY_DTOR(JetOrHeliReturnForLandingState)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -1507,6 +1507,19 @@ public:
 
 		return AIInternalMoveToState::onEnter();
 	}
+
+	virtual StateReturnType update()
+	{
+		Object* jet = getMachineOwner();
+		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
+
+		if (!pp)
+		{
+			return STATE_FAILURE;
+		}
+
+		return AIInternalMoveToState::update();
+	}
 };
 EMPTY_DTOR(JetOrHeliReturnForLandingState)
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -234,9 +234,11 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
-		{
+#if RETAIL_COMPATIBLE_CRC
+			return STATE_SUCCESS;
+#else
 			return STATE_FAILURE;
-		}
+#endif
 
 		// gotta reserve a space in order to reserve a runway
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), nullptr))
@@ -506,7 +508,11 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
+#if RETAIL_COMPATIBLE_CRC
+			return STATE_SUCCESS;
+#else
 			return STATE_FAILURE;
+#endif
 
 		ParkingPlaceBehaviorInterface::PPInfo ppinfo;
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), &ppinfo))
@@ -745,7 +751,11 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
+#if RETAIL_COMPATIBLE_CRC
+			return STATE_SUCCESS;
+#else
 			return STATE_FAILURE;
+#endif
 
 		ParkingPlaceBehaviorInterface::PPInfo ppinfo;
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), &ppinfo))
@@ -995,7 +1005,11 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
+#if RETAIL_COMPATIBLE_CRC
+			return STATE_SUCCESS;
+#else
 			return STATE_FAILURE;
+#endif
 
 		Coord3D landingApproach;
 		if (jet->isKindOf(KINDOF_PRODUCED_AT_HELIPAD))

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -235,8 +235,7 @@ public:
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
 		{
-			// no producer? just skip this step.
-			return STATE_SUCCESS;
+			return STATE_FAILURE;
 		}
 
 		// gotta reserve a space in order to reserve a runway
@@ -505,10 +504,9 @@ public:
 		jetAI->chooseLocomotorSet(LOCOMOTORSET_TAXIING);
 		DEBUG_ASSERTCRASH(jetAI->getCurLocomotor(), ("no loco"));
 
-		Object* airfield;
-		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID(), &airfield);
+		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
-			return STATE_SUCCESS;	// no airfield? just skip this step.
+			return STATE_FAILURE;
 
 		ParkingPlaceBehaviorInterface::PPInfo ppinfo;
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), &ppinfo))
@@ -747,7 +745,7 @@ public:
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
-			return STATE_SUCCESS;	// no airfield? just skip this step
+			return STATE_FAILURE;
 
 		ParkingPlaceBehaviorInterface::PPInfo ppinfo;
 		if (!pp->reserveSpace(jet->getID(), jetAI->friend_getParkingOffset(), &ppinfo))
@@ -995,10 +993,9 @@ public:
 		loco->setUltraAccurate(true);
 		jetAI->ignoreObstacleID(jet->getProducerID());
 
-		Object* airfield;
-		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID(), &airfield);
+		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == nullptr)
-			return STATE_SUCCESS;	// no airfield? just skip this step
+			return STATE_FAILURE;
 
 		Coord3D landingApproach;
 		if (jet->isKindOf(KINDOF_PRODUCED_AT_HELIPAD))
@@ -1698,19 +1695,6 @@ public:
 		setAdjustsDestination(false);		// precision is necessary
 
 		return AIInternalMoveToState::onEnter();
-	}
-
-	virtual StateReturnType update()
-	{
-		Object* jet = getMachineOwner();
-		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
-
-		if (!pp)
-		{
-			return STATE_FAILURE;
-		}
-
-		return AIInternalMoveToState::update();
 	}
 };
 EMPTY_DTOR(JetOrHeliReturnForLandingState)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -1699,6 +1699,19 @@ public:
 
 		return AIInternalMoveToState::onEnter();
 	}
+
+	virtual StateReturnType update()
+	{
+		Object* jet = getMachineOwner();
+		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
+
+		if (!pp)
+		{
+			return STATE_FAILURE;
+		}
+
+		return AIInternalMoveToState::update();
+	}
 };
 EMPTY_DTOR(JetOrHeliReturnForLandingState)
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -1003,13 +1003,10 @@ public:
 		loco->setUltraAccurate(true);
 		jetAI->ignoreObstacleID(jet->getProducerID());
 
-		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
+		Object* airfield;
+		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID(), &airfield);
 		if (pp == nullptr)
-#if RETAIL_COMPATIBLE_CRC
-			return STATE_SUCCESS;
-#else
-			return STATE_FAILURE;
-#endif
+			return STATE_SUCCESS;	// no airfield? just skip this step
 
 		Coord3D landingApproach;
 		if (jet->isKindOf(KINDOF_PRODUCED_AT_HELIPAD))


### PR DESCRIPTION
Fixes #27

This change fixes an issue where aircraft would stall and fall to the ground upon returning to an Airfield that was lost during their return flight.

A missing Airfield would erroneously return `STATE_SUCCESS` from the `JetAIUpdate` state machine's various states, which would transition through the state chain until the jet was idle; `RETURN_FOR_LANDING` → `LANDING_AWAIT_CLEARANCE` → `LANDING` → `TAXI_FROM_LANDING` → `ORIENT_FOR_PARKING_PLACE`.

The `ORIENT_FOR_PARKING_PLACE` state already correctly returns `STATE_FAILURE` if the Airfield does not exist, ending the chain and causing the jet to go idle. However, `TAXI_FROM_LANDING` applies the parking/taxiing locomotor and so the jet gets stuck and falls to the ground.

All missing Airfield conditions along the chain now correctly return `STATE_FAILURE`, which aligns with the other failure conditions (e.g. is dead, no available runways, no available parking places) and sets the jet to idle before swapping its locomotor, preventing the undesirable behaviour.

### Before

https://github.com/user-attachments/assets/33f88ce2-a463-4f07-8f0f-085c30aed25a

### After

https://github.com/user-attachments/assets/4c458126-541f-4edc-9223-d14d3716c33f