### PR TITLE
bugfix(jetaiupdate): Save helicopter landing position

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2475,7 +2475,7 @@ void JetAIUpdate::xfer( Xfer *xfer )
 {
 
   // version
-#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 2;
 #else
 	XferVersion currentVersion = 3;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2473,7 +2473,11 @@ void JetAIUpdate::xfer( Xfer *xfer )
 {
 
   // version
-  XferVersion currentVersion = 2;
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
+	XferVersion currentVersion = 2;
+#else
+	XferVersion currentVersion = 3;
+#endif
   XferVersion version = currentVersion;
   xfer->xferVersion( &version, currentVersion );
 
@@ -2511,6 +2515,11 @@ void JetAIUpdate::xfer( Xfer *xfer )
 	if( version >= 2 )
 	{
 		xfer->xferBool( &m_enginesOn );
+
+		if (version >= 3)
+		{
+			xfer->xferCoord3D(&m_landingPosForHelipadStuff);
+		}
 	}
 	else
 	{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2467,7 +2467,9 @@ void JetAIUpdate::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version
+	* 3: TheSuperHackers @tweak Save landing position.
+	*/
 // ------------------------------------------------------------------------------------------------
 void JetAIUpdate::xfer( Xfer *xfer )
 {

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2468,6 +2468,7 @@ void JetAIUpdate::crc( Xfer *xfer )
 /** Xfer method
 	* Version Info:
 	* 1: Initial version
+	* 2: Save engine on/off state.
 	* 3: TheSuperHackers @tweak Save landing position.
 	*/
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2469,7 +2469,7 @@ void JetAIUpdate::crc( Xfer *xfer )
 	* Version Info:
 	* 1: Initial version
 	* 2: Save engine on/off state.
-	* 3: TheSuperHackers @tweak Save landing position.
+	* 3: TheSuperHackers @bugfix Save landing position.
 	*/
 // ------------------------------------------------------------------------------------------------
 void JetAIUpdate::xfer( Xfer *xfer )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2515,11 +2515,6 @@ void JetAIUpdate::xfer( Xfer *xfer )
 	if( version >= 2 )
 	{
 		xfer->xferBool( &m_enginesOn );
-
-		if (version >= 3)
-		{
-			xfer->xferCoord3D(&m_landingPosForHelipadStuff);
-		}
 	}
 	else
 	{
@@ -2534,6 +2529,10 @@ void JetAIUpdate::xfer( Xfer *xfer )
 		}
 	}
 
+	if (version >= 3)
+	{
+		xfer->xferCoord3D(&m_landingPosForHelipadStuff);
+	}
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2725,7 +2725,9 @@ void JetAIUpdate::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version
+	* 3: TheSuperHackers @tweak Save landing position.
+	*/
 // ------------------------------------------------------------------------------------------------
 void JetAIUpdate::xfer( Xfer *xfer )
 {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2726,6 +2726,7 @@ void JetAIUpdate::crc( Xfer *xfer )
 /** Xfer method
 	* Version Info:
 	* 1: Initial version
+	* 2: Save engine on/off state.
 	* 3: TheSuperHackers @tweak Save landing position.
 	*/
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2731,7 +2731,11 @@ void JetAIUpdate::xfer( Xfer *xfer )
 {
 
   // version
-  XferVersion currentVersion = 2;
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
+	XferVersion currentVersion = 2;
+#else
+	XferVersion currentVersion = 3;
+#endif
   XferVersion version = currentVersion;
   xfer->xferVersion( &version, currentVersion );
 
@@ -2769,6 +2773,11 @@ void JetAIUpdate::xfer( Xfer *xfer )
 	if( version >= 2 )
 	{
 		xfer->xferBool( &m_enginesOn );
+
+		if (version >= 3)
+		{
+			xfer->xferCoord3D(&m_landingPosForHelipadStuff);
+		}
 	}
 	else
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2733,7 +2733,7 @@ void JetAIUpdate::xfer( Xfer *xfer )
 {
 
   // version
-#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 2;
 #else
 	XferVersion currentVersion = 3;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2727,7 +2727,7 @@ void JetAIUpdate::crc( Xfer *xfer )
 	* Version Info:
 	* 1: Initial version
 	* 2: Save engine on/off state.
-	* 3: TheSuperHackers @tweak Save landing position.
+	* 3: TheSuperHackers @bugfix Save landing position.
 	*/
 // ------------------------------------------------------------------------------------------------
 void JetAIUpdate::xfer( Xfer *xfer )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2773,11 +2773,6 @@ void JetAIUpdate::xfer( Xfer *xfer )
 	if( version >= 2 )
 	{
 		xfer->xferBool( &m_enginesOn );
-
-		if (version >= 3)
-		{
-			xfer->xferCoord3D(&m_landingPosForHelipadStuff);
-		}
 	}
 	else
 	{
@@ -2792,6 +2787,10 @@ void JetAIUpdate::xfer( Xfer *xfer )
 		}
 	}
 
+	if (version >= 3)
+	{
+		xfer->xferCoord3D(&m_landingPosForHelipadStuff);
+	}
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change fixes an issue where helicopters would not store their landing position when saving the game, causing them to fly to (0,0) - the bottom-left corner of the map - when resuming a game that was saved after issuing a land command.