### PR TITLE
fix(namekey): Canonicalize lowercase name keys

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -175,7 +175,7 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const AsciiString& name)
 	}
 
 	// nope, guess not. let's allocate it.
-	// TheSuperHackers @bugfix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
+	// TheSuperHackers @fix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
 	// so a regular lowercase lookup reuses this key.
 	AsciiString lowercaseName = name;
 	lowercaseName.toLower();
@@ -213,7 +213,7 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const char *name)
 	}
 
 	// nope, guess not. let's allocate it.
-	// TheSuperHackers @bugfix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
+	// TheSuperHackers @fix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
 	// so a regular lowercase lookup reuses this key.
 	AsciiString lowercaseName(name);
 	lowercaseName.toLower();

--- a/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -175,7 +175,11 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const AsciiString& name)
 	}
 
 	// nope, guess not. let's allocate it.
-	return createNameKey(hash, name);
+	// TheSuperHackers @bugfix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
+	// so a regular lowercase lookup reuses this key.
+	AsciiString lowercaseName = name;
+	lowercaseName.toLower();
+	return createNameKey(hash, lowercaseName);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -209,7 +213,11 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const char *name)
 	}
 
 	// nope, guess not. let's allocate it.
-	return createNameKey(hash, name);
+	// TheSuperHackers @bugfix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
+	// so a regular lowercase lookup reuses this key.
+	AsciiString lowercaseName(name);
+	lowercaseName.toLower();
+	return createNameKey(hash, lowercaseName);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -175,7 +175,7 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const AsciiString& name)
 	}
 
 	// nope, guess not. let's allocate it.
-	// TheSuperHackers @bugfix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
+	// TheSuperHackers @fix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
 	// so a regular lowercase lookup reuses this key.
 	AsciiString lowercaseName = name;
 	lowercaseName.toLower();
@@ -213,7 +213,7 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const char *name)
 	}
 
 	// nope, guess not. let's allocate it.
-	// TheSuperHackers @bugfix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
+	// TheSuperHackers @fix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
 	// so a regular lowercase lookup reuses this key.
 	AsciiString lowercaseName(name);
 	lowercaseName.toLower();

--- a/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -175,7 +175,11 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const AsciiString& name)
 	}
 
 	// nope, guess not. let's allocate it.
-	return createNameKey(hash, name);
+	// TheSuperHackers @bugfix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
+	// so a regular lowercase lookup reuses this key.
+	AsciiString lowercaseName = name;
+	lowercaseName.toLower();
+	return createNameKey(hash, lowercaseName);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -209,7 +213,11 @@ NameKeyType NameKeyGenerator::nameToLowercaseKey(const char *name)
 	}
 
 	// nope, guess not. let's allocate it.
-	return createNameKey(hash, name);
+	// TheSuperHackers @bugfix CryoTheRenegade 08/08/2026 Store the canonical lowercase name
+	// so a regular lowercase lookup reuses this key.
+	AsciiString lowercaseName(name);
+	lowercaseName.toLower();
+	return createNameKey(hash, lowercaseName);
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`nameToLowercaseKey()` was storing the original mixed-case name on a cache miss, so a later lowercase `nameToKey()` lookup could miss it and create a second key. This stores the lowercase name in both overloads and both game trees so the existing key gets reused. Fixes #2841.