### PR TITLE
bugfix(audio): Apply configured volume to Bink movie audio

### DIFF
--- a/Core/GameEngine/Include/GameClient/VideoPlayer.h
+++ b/Core/GameEngine/Include/GameClient/VideoPlayer.h
@@ -295,11 +295,17 @@ class VideoPlayer : public VideoPlayerInterface
 		virtual const FieldParse *getFieldParse() const override { return m_videoFieldParseTable; }		///< Return the field parse info
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) override { }
-		virtual void setVolume( Real ) override { }
 
 		// Implementation specific
 		void remove( VideoStream *stream );										///< remove stream from active list
 
+};
+
+class NullVideoPlayer : public VideoPlayer
+{
+	public:
+
+		virtual void setVolume( Real ) override { }
 };
 
 extern VideoPlayerInterface *TheVideoPlayer;

--- a/Core/GameEngine/Include/GameClient/VideoPlayer.h
+++ b/Core/GameEngine/Include/GameClient/VideoPlayer.h
@@ -246,7 +246,7 @@ class VideoPlayerInterface : public SubsystemInterface
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) = 0;		///< Notify the video player that they can now ask for an audio handle, or they need to give theirs up.
 
-		virtual void setVolume( Real ) { }		///< Push a new speech volume to the video player's audio output
+		virtual void setVolume( Real volume ) = 0;		///< Push a new speech volume to the video player's audio output
 };
 
 
@@ -295,6 +295,7 @@ class VideoPlayer : public VideoPlayerInterface
 		virtual const FieldParse *getFieldParse() const override { return m_videoFieldParseTable; }		///< Return the field parse info
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) override { }
+		virtual void setVolume( Real ) override { }
 
 		// Implementation specific
 		void remove( VideoStream *stream );										///< remove stream from active list

--- a/Core/GameEngine/Include/GameClient/VideoPlayer.h
+++ b/Core/GameEngine/Include/GameClient/VideoPlayer.h
@@ -246,7 +246,7 @@ class VideoPlayerInterface : public SubsystemInterface
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) = 0;		///< Notify the video player that they can now ask for an audio handle, or they need to give theirs up.
 
-		virtual void setVolume( Real volume ) = 0;		///< Push a new speech volume to the video player's audio output
+		virtual void setVolume( Real ) { }		///< Push a new speech volume to the video player's audio output
 };
 
 
@@ -295,8 +295,6 @@ class VideoPlayer : public VideoPlayerInterface
 		virtual const FieldParse *getFieldParse() const override { return m_videoFieldParseTable; }		///< Return the field parse info
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) override { }
-
-		virtual void setVolume( Real volume ) override { }
 
 		// Implementation specific
 		void remove( VideoStream *stream );										///< remove stream from active list

--- a/Core/GameEngine/Include/GameClient/VideoPlayer.h
+++ b/Core/GameEngine/Include/GameClient/VideoPlayer.h
@@ -245,6 +245,8 @@ class VideoPlayerInterface : public SubsystemInterface
 		virtual const FieldParse *getFieldParse() const = 0;		///< Return the field parse info
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) = 0;		///< Notify the video player that they can now ask for an audio handle, or they need to give theirs up.
+
+		virtual void setVolume( Real volume ) = 0;		///< Push a new speech volume to the video player's audio output
 };
 
 
@@ -293,6 +295,8 @@ class VideoPlayer : public VideoPlayerInterface
 		virtual const FieldParse *getFieldParse() const override { return m_videoFieldParseTable; }		///< Return the field parse info
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) override { }
+
+		virtual void setVolume( Real volume ) override { }
 
 		// Implementation specific
 		void remove( VideoStream *stream );										///< remove stream from active list

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -104,6 +104,7 @@ class BinkVideoPlayer : public VideoPlayer
 	private:
 
 		static Int	calculateMovieAudioVolume( Real volume );
+		Bool m_volumeApplied;
 
 	protected:
 

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -101,15 +101,6 @@ class BinkVideoStream : public VideoStream
 
 class BinkVideoPlayer : public VideoPlayer
 {
-	private:
-
-		static Int	calculateMovieAudioVolume( Real volume );
-		Bool m_volumeApplied;
-
-	protected:
-
-		VideoStreamInterface* createStream( HBINK handle );
-
 	public:
 
 		// subsytem requirements
@@ -133,6 +124,14 @@ class BinkVideoPlayer : public VideoPlayer
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) override;
 		virtual void setVolume( Real volume ) override;
 		virtual void initializeBinkWithMiles();
+
+	protected:
+
+		VideoStreamInterface* createStream( HBINK handle );
+
+	private:
+
+		static Int	calculateMovieAudioVolume( Real volume );
 };
 
 

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -68,9 +68,8 @@ class BinkVideoStream : public VideoStream
 
 	protected:
 
-		HBINK					m_handle;											///< Bink streaming handle;
-		Char					*m_memFile;											///< Pointer to memory resident file
-		Bool					m_volumeSet;											///< True once the movie volume has been applied
+		HBINK					m_handle;														///< Bink streaming handle;
+		Char					*m_memFile;													///< Pointer to memory resident file
 
 		BinkVideoStream();																///< only BinkVideoPlayer can create these
 		virtual ~BinkVideoStream() override;
@@ -106,8 +105,6 @@ class BinkVideoPlayer : public VideoPlayer
 	protected:
 
 		VideoStreamInterface* createStream( HBINK handle );
-
-		Bool	m_volumeApplied;												///< True once the movie volume has been applied to a live audio output
 
 	public:
 

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -103,8 +103,7 @@ class BinkVideoPlayer : public VideoPlayer
 {
 	private:
 
-		// TheSuperHackers @bugfix Compute the Bink volume for a given speech volume.
-		static Int	calculateMovieAudioVolume( Real speechVolume );
+		static Int	calculateMovieAudioVolume( Real volume );
 
 	protected:
 

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -107,11 +107,9 @@ class BinkVideoPlayer : public VideoPlayer
 
 		VideoStreamInterface* createStream( HBINK handle );
 
-	public:
+		Bool	m_volumeApplied;												///< True once the movie volume has been applied to a live audio output
 
-		// TheSuperHackers @bugfix Compute the Bink volume for the current speech
-		// volume setting. Shared by stream creation and per-frame volume refresh.
-		static Int	calculateMovieAudioVolume();
+	public:
 
 		// subsytem requirements
 		virtual void	init() override;														///< Initialize video playback code
@@ -131,7 +129,11 @@ class BinkVideoPlayer : public VideoPlayer
 		virtual VideoStreamInterface*	open( AsciiString movieTitle ) override;	///< Open video file for playback
 		virtual VideoStreamInterface*	load( AsciiString movieTitle ) override;	///< Load video file in to memory for playback
 
+		// TheSuperHackers @bugfix Compute the Bink volume for a given speech volume.
+		static Int	calculateMovieAudioVolume( Real speechVolume );
+
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) override;
+		virtual void setVolume( Real volume ) override;
 		virtual void initializeBinkWithMiles();
 };
 

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -108,6 +108,10 @@ class BinkVideoPlayer : public VideoPlayer
 
 	public:
 
+		// TheSuperHackers @bugfix Compute the Bink volume for the current speech
+		// volume setting. Shared by stream creation and per-frame volume refresh.
+		static Int	calculateMovieAudioVolume();
+
 		// subsytem requirements
 		virtual void	init() override;														///< Initialize video playback code
 		virtual void	reset() override;													///< Reset video playback

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -101,6 +101,10 @@ class BinkVideoStream : public VideoStream
 
 class BinkVideoPlayer : public VideoPlayer
 {
+	private:
+
+		// TheSuperHackers @bugfix Compute the Bink volume for a given speech volume.
+		static Int	calculateMovieAudioVolume( Real speechVolume );
 
 	protected:
 
@@ -125,9 +129,6 @@ class BinkVideoPlayer : public VideoPlayer
 
 		virtual VideoStreamInterface*	open( AsciiString movieTitle ) override;	///< Open video file for playback
 		virtual VideoStreamInterface*	load( AsciiString movieTitle ) override;	///< Load video file in to memory for playback
-
-		// TheSuperHackers @bugfix Compute the Bink volume for a given speech volume.
-		static Int	calculateMovieAudioVolume( Real speechVolume );
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) override;
 		virtual void setVolume( Real volume ) override;

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -68,8 +68,9 @@ class BinkVideoStream : public VideoStream
 
 	protected:
 
-		HBINK					m_handle;														///< Bink streaming handle;
-		Char					*m_memFile;													///< Pointer to memory resident file
+		HBINK					m_handle;											///< Bink streaming handle;
+		Char					*m_memFile;											///< Pointer to memory resident file
+		Bool					m_volumeSet;										///< True once the movie volume has been applied
 
 		BinkVideoStream();																///< only BinkVideoPlayer can create these
 		virtual ~BinkVideoStream() override;

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -70,7 +70,7 @@ class BinkVideoStream : public VideoStream
 
 		HBINK					m_handle;											///< Bink streaming handle;
 		Char					*m_memFile;											///< Pointer to memory resident file
-		Bool					m_volumeSet;										///< True once the movie volume has been applied
+		Bool					m_volumeSet;											///< True once the movie volume has been applied
 
 		BinkVideoStream();																///< only BinkVideoPlayer can create these
 		virtual ~BinkVideoStream() override;

--- a/Core/GameEngineDevice/Include/VideoDevice/FFmpeg/FFmpegVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/FFmpeg/FFmpegVideoPlayer.h
@@ -121,6 +121,7 @@ class FFmpegVideoPlayer : public VideoPlayer
 		virtual VideoStreamInterface*	load( AsciiString movieTitle );	///< Load video file in to memory for playback
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid );
+		virtual void setVolume( Real volume );
 		virtual void initializeBinkWithMiles();
 };
 

--- a/Core/GameEngineDevice/Include/VideoDevice/FFmpeg/FFmpegVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/FFmpeg/FFmpegVideoPlayer.h
@@ -121,6 +121,7 @@ class FFmpegVideoPlayer : public VideoPlayer
 		virtual VideoStreamInterface*	load( AsciiString movieTitle );	///< Load video file in to memory for playback
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid );
+		virtual void setVolume( Real ) override { }
 		virtual void initializeBinkWithMiles();
 };
 

--- a/Core/GameEngineDevice/Include/VideoDevice/FFmpeg/FFmpegVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/FFmpeg/FFmpegVideoPlayer.h
@@ -121,7 +121,6 @@ class FFmpegVideoPlayer : public VideoPlayer
 		virtual VideoStreamInterface*	load( AsciiString movieTitle );	///< Load video file in to memory for playback
 
 		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid );
-		virtual void setVolume( Real volume );
 		virtual void initializeBinkWithMiles();
 };
 

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -2270,7 +2270,7 @@ void MilesAudioManager::processPlayingList()
 	if (m_volumeHasChanged) {
 		m_volumeHasChanged = false;
 
-		// Push speech volume changes because Bink movie audio bypasses the Miles mixer.
+		// TheSuperHackers @bugfix Push speech volume changes because Bink movie audio bypasses the Miles mixer.
 		if (TheVideoPlayer) {
 			TheVideoPlayer->setVolume(getVolume(AudioAffect_Speech));
 		}

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -2270,8 +2270,7 @@ void MilesAudioManager::processPlayingList()
 	if (m_volumeHasChanged) {
 		m_volumeHasChanged = false;
 
-		// Push the new speech volume to any playing movie's audio output, which
-		// bypasses the Miles mixer and so does not see volume changes on its own.
+		// Push speech volume changes because Bink movie audio bypasses the Miles mixer.
 		if (TheVideoPlayer) {
 			TheVideoPlayer->setVolume(getVolume(AudioAffect_Speech));
 		}

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -2269,6 +2269,12 @@ void MilesAudioManager::processPlayingList()
 
 	if (m_volumeHasChanged) {
 		m_volumeHasChanged = false;
+
+		// Push the new speech volume to any playing movie's audio output, which
+		// bypasses the Miles mixer and so does not see volume changes on its own.
+		if (TheVideoPlayer) {
+			TheVideoPlayer->setVolume(getVolume(AudioAffect_Speech));
+		}
 	}
 }
 

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -108,6 +108,7 @@
 //============================================================================
 
 BinkVideoPlayer::BinkVideoPlayer()
+: m_volumeApplied(FALSE)
 {
 
 }
@@ -160,6 +161,15 @@ void	BinkVideoPlayer::update()
 {
 	VideoPlayer::update();
 
+	// Apply the volume once a stream's audio output is actually running. Setting
+	// it in createStream() is too early: Bink's audio output is not up yet, so
+	// the volume is discarded. By the first update() with a live stream the audio
+	// output exists, so the set sticks.
+	if ( !m_volumeApplied && firstStream() != nullptr )
+	{
+		setVolume( TheAudio->getVolume(AudioAffect_Speech) );
+		m_volumeApplied = TRUE;
+	}
 }
 
 //============================================================================
@@ -201,6 +211,8 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 		stream->m_next = m_firstStream;
 		stream->m_player = this;
 		m_firstStream = stream;
+
+		BinkSetVolume( stream->m_handle, 0, calculateMovieAudioVolume(TheAudio->getVolume(AudioAffect_Speech)) );
 	}
 
 	return stream;
@@ -210,17 +222,26 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 // BinkVideoPlayer::calculateMovieAudioVolume
 //============================================================================
 
-Int BinkVideoPlayer::calculateMovieAudioVolume()
+Int BinkVideoPlayer::calculateMovieAudioVolume( Real speechVolume )
 {
-	if (TheAudio == nullptr)
-	{
-		return 327;
-	}
-
 	// Never let volume go to 0, as Bink will interpret that as "play at full
 	// volume".
-	Int mod = (Int) ((TheAudio->getVolume(AudioAffect_Speech) * 0.8f) * 100) + 1;
+	Int mod = (Int) ((speechVolume * 0.8f) * 100) + 1;
 	return (32768*mod)/100;
+}
+
+//============================================================================
+// BinkVideoPlayer::setVolume
+//============================================================================
+
+void BinkVideoPlayer::setVolume( Real volume )
+{
+	// Push the new volume to every open stream's audio output.
+	Int binkVolume = calculateMovieAudioVolume( volume );
+	for ( VideoStreamInterface *stream = firstStream(); stream != nullptr; stream = stream->next() )
+	{
+		BinkSetVolume( static_cast<BinkVideoStream*>( stream )->m_handle, 0, binkVolume );
+	}
 }
 
 //============================================================================
@@ -310,7 +331,6 @@ void BinkVideoPlayer::initializeBinkWithMiles()
 
 BinkVideoStream::BinkVideoStream()
 : m_handle(nullptr)
-, m_volumeSet(FALSE)
 {
 
 }
@@ -352,17 +372,7 @@ Bool BinkVideoStream::isFrameReady()
 
 void BinkVideoStream::frameDecompress()
 {
-	BinkDoFrame( m_handle );
-
-	// Apply the volume on the first decoded frame. Setting it in createStream()
-	// is too early: Bink's audio output is not running yet, so the volume is
-	// discarded. The first BinkDoFrame() is when audio output actually starts,
-	// so that is the earliest the volume can be applied and stick.
-	if ( !m_volumeSet )
-	{
-		BinkSetVolume( m_handle, 0, BinkVideoPlayer::calculateMovieAudioVolume() );
-		m_volumeSet = TRUE;
-	}
+		BinkDoFrame( m_handle );
 }
 
 //============================================================================

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -202,9 +202,10 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 		stream->m_player = this;
 		m_firstStream = stream;
 
-		// TheSuperHackers @bugfix Service Bink before applying the initial speech volume.
+		// TheSuperHackers @bugfix BinkWait must run first or Bink ignores the initial volume.
 		BinkWait( stream->m_handle );
-		BinkSetVolume( stream->m_handle, 0, calculateMovieAudioVolume(TheAudio->getVolume(AudioAffect_Speech)) );
+		Int volume = calculateMovieAudioVolume( TheAudio->getVolume(AudioAffect_Speech) );
+		BinkSetVolume( stream->m_handle, 0, volume );
 	}
 
 	return stream;

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -202,16 +202,29 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 		stream->m_player = this;
 		m_firstStream = stream;
 
-		// never let volume go to 0, as Bink will interpret that as "play at full volume".
-		Int mod = (Int) ((TheAudio->getVolume(AudioAffect_Speech) * 0.8f) * 100) + 1;
-		Int volume = (32768*mod)/100;
-		DEBUG_LOG(("BinkVideoPlayer::createStream() - About to set volume (%g -> %d -> %d",
-			TheAudio->getVolume(AudioAffect_Speech), mod, volume));
-		BinkSetVolume( stream->m_handle,0, volume);
+		BinkSetVolume( stream->m_handle, 0, calculateMovieAudioVolume() );
 		DEBUG_LOG(("BinkVideoPlayer::createStream() - set volume"));
 	}
 
 	return stream;
+}
+
+//============================================================================
+// BinkVideoPlayer::calculateMovieAudioVolume
+//============================================================================
+
+Int BinkVideoPlayer::calculateMovieAudioVolume()
+{
+	if (TheAudio == nullptr)
+	{
+		return 0;
+	}
+
+	// Never let volume go to 0, as Bink will interpret that as "play at full
+	// volume". Floor at 1 out of 32768 (~-90dB, effectively silent) instead of
+	// the old floor of ~327, which was clearly audible at a 0 speech slider.
+	Int mod = (Int) ((TheAudio->getVolume(AudioAffect_Speech) * 0.8f) * 100) + 1;
+	return (32768*mod)/100;
 }
 
 //============================================================================
@@ -342,7 +355,16 @@ Bool BinkVideoStream::isFrameReady()
 
 void BinkVideoStream::frameDecompress()
 {
-		BinkDoFrame( m_handle );
+	BinkDoFrame( m_handle );
+
+	// Reapply the volume every decoded frame. BinkSetVolume only takes effect
+	// reliably once Bink's audio output is actually running, so the one-shot
+	// call in createStream() (before the first frame) never stuck. Refreshing
+	// here also picks up live volume slider changes during playback.
+	if ( m_player != nullptr )
+	{
+		BinkSetVolume( m_handle, 0, BinkVideoPlayer::calculateMovieAudioVolume() );
+	}
 }
 
 //============================================================================

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -161,14 +161,8 @@ void	BinkVideoPlayer::update()
 {
 	VideoPlayer::update();
 
-	if ( firstStream() == nullptr )
-	{
-		m_volumeApplied = FALSE;
-		return;
-	}
-
 	// createStream() is too early; apply once a live stream exists.
-	if ( !m_volumeApplied )
+	if ( !m_volumeApplied && firstStream() != nullptr )
 	{
 		setVolume( TheAudio->getVolume(AudioAffect_Speech) );
 		m_volumeApplied = TRUE;
@@ -214,6 +208,7 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 		stream->m_next = m_firstStream;
 		stream->m_player = this;
 		m_firstStream = stream;
+		m_volumeApplied = FALSE;
 	}
 
 	return stream;

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -201,9 +201,6 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 		stream->m_next = m_firstStream;
 		stream->m_player = this;
 		m_firstStream = stream;
-
-		BinkSetVolume( stream->m_handle, 0, calculateMovieAudioVolume() );
-		DEBUG_LOG(("BinkVideoPlayer::createStream() - set volume"));
 	}
 
 	return stream;
@@ -314,6 +311,7 @@ void BinkVideoPlayer::initializeBinkWithMiles()
 
 BinkVideoStream::BinkVideoStream()
 : m_handle(nullptr)
+, m_volumeSet(FALSE)
 {
 
 }
@@ -357,13 +355,14 @@ void BinkVideoStream::frameDecompress()
 {
 	BinkDoFrame( m_handle );
 
-	// Reapply the volume on every decoded frame. The one-shot BinkSetVolume in
-	// createStream() runs before Bink's audio output has started, so it never
-	// actually took effect. Reapplying once audio is running is what makes the
-	// setting stick.
-	if ( m_player != nullptr )
+	// Apply the volume on the first decoded frame. Setting it in createStream()
+	// is too early: Bink's audio output is not running yet, so the volume is
+	// discarded. The first BinkDoFrame() is when audio output actually starts,
+	// so that is the earliest the volume can be applied and stick.
+	if ( !m_volumeSet )
 	{
 		BinkSetVolume( m_handle, 0, BinkVideoPlayer::calculateMovieAudioVolume() );
+		m_volumeSet = TRUE;
 	}
 }
 

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -108,7 +108,6 @@
 //============================================================================
 
 BinkVideoPlayer::BinkVideoPlayer()
-: m_volumeApplied(FALSE)
 {
 
 }
@@ -160,16 +159,6 @@ void	BinkVideoPlayer::reset()
 void	BinkVideoPlayer::update()
 {
 	VideoPlayer::update();
-
-	// Apply the volume once a stream's audio output is actually running. Setting
-	// it in createStream() is too early: Bink's audio output is not up yet, so
-	// the volume is discarded. By the first update() with a live stream the audio
-	// output exists, so the set sticks.
-	if ( !m_volumeApplied && firstStream() != nullptr )
-	{
-		setVolume( TheAudio->getVolume(AudioAffect_Speech) );
-		m_volumeApplied = TRUE;
-	}
 }
 
 //============================================================================

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -108,7 +108,6 @@
 //============================================================================
 
 BinkVideoPlayer::BinkVideoPlayer()
-: m_volumeApplied(FALSE)
 {
 
 }
@@ -161,12 +160,6 @@ void	BinkVideoPlayer::update()
 {
 	VideoPlayer::update();
 
-	// createStream() is too early; apply once a live stream exists.
-	if ( !m_volumeApplied && firstStream() != nullptr )
-	{
-		setVolume( TheAudio->getVolume(AudioAffect_Speech) );
-		m_volumeApplied = TRUE;
-	}
 }
 
 //============================================================================
@@ -208,7 +201,10 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 		stream->m_next = m_firstStream;
 		stream->m_player = this;
 		m_firstStream = stream;
-		m_volumeApplied = FALSE;
+
+		// TheSuperHackers @bugfix Service Bink before applying the initial speech volume.
+		BinkWait( stream->m_handle );
+		BinkSetVolume( stream->m_handle, 0, calculateMovieAudioVolume(TheAudio->getVolume(AudioAffect_Speech)) );
 	}
 
 	return stream;

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -221,8 +221,8 @@ Int BinkVideoPlayer::calculateMovieAudioVolume()
 	}
 
 	// Never let volume go to 0, as Bink will interpret that as "play at full
-	// volume". Floor at 1 out of 32768 (~-90dB, effectively silent) instead of
-	// the old floor of ~327, which was clearly audible at a 0 speech slider.
+	// volume". Floor at 327 out of 32768 (~1%), effectively silent. This is
+	// retail's formula, unchanged.
 	Int mod = (Int) ((TheAudio->getVolume(AudioAffect_Speech) * 0.8f) * 100) + 1;
 	return (32768*mod)/100;
 }
@@ -357,10 +357,10 @@ void BinkVideoStream::frameDecompress()
 {
 	BinkDoFrame( m_handle );
 
-	// Reapply the volume every decoded frame. BinkSetVolume only takes effect
-	// reliably once Bink's audio output is actually running, so the one-shot
-	// call in createStream() (before the first frame) never stuck. Refreshing
-	// here also picks up live volume slider changes during playback.
+	// Reapply the volume on every decoded frame. The one-shot BinkSetVolume in
+	// createStream() runs before Bink's audio output has started, so it never
+	// actually took effect. Reapplying once audio is running is what makes the
+	// setting stick.
 	if ( m_player != nullptr )
 	{
 		BinkSetVolume( m_handle, 0, BinkVideoPlayer::calculateMovieAudioVolume() );

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -108,6 +108,7 @@
 //============================================================================
 
 BinkVideoPlayer::BinkVideoPlayer()
+: m_volumeApplied(FALSE)
 {
 
 }
@@ -159,6 +160,19 @@ void	BinkVideoPlayer::reset()
 void	BinkVideoPlayer::update()
 {
 	VideoPlayer::update();
+
+	if ( firstStream() == nullptr )
+	{
+		m_volumeApplied = FALSE;
+		return;
+	}
+
+	// createStream() is too early; apply once a live stream exists.
+	if ( !m_volumeApplied )
+	{
+		setVolume( TheAudio->getVolume(AudioAffect_Speech) );
+		m_volumeApplied = TRUE;
+	}
 }
 
 //============================================================================
@@ -200,8 +214,6 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 		stream->m_next = m_firstStream;
 		stream->m_player = this;
 		m_firstStream = stream;
-
-		BinkSetVolume( stream->m_handle, 0, calculateMovieAudioVolume(TheAudio->getVolume(AudioAffect_Speech)) );
 	}
 
 	return stream;

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -211,11 +211,10 @@ VideoStreamInterface* BinkVideoPlayer::createStream( HBINK handle )
 // BinkVideoPlayer::calculateMovieAudioVolume
 //============================================================================
 
-Int BinkVideoPlayer::calculateMovieAudioVolume( Real speechVolume )
+Int BinkVideoPlayer::calculateMovieAudioVolume( Real volume )
 {
-	// Never let volume go to 0, as Bink will interpret that as "play at full
-	// volume".
-	Int mod = (Int) ((speechVolume * 0.8f) * 100) + 1;
+	// Never let volume go to 0, as Bink will interpret that as "play at full volume".
+	Int mod = (Int) ((volume * 0.8f) * 100) + 1;
 	return (32768*mod)/100;
 }
 
@@ -227,7 +226,7 @@ void BinkVideoPlayer::setVolume( Real volume )
 {
 	// Push the new volume to every open stream's audio output.
 	Int binkVolume = calculateMovieAudioVolume( volume );
-	for ( VideoStreamInterface *stream = firstStream(); stream != nullptr; stream = stream->next() )
+	for ( VideoStreamInterface* stream = firstStream(); stream != nullptr; stream = stream->next() )
 	{
 		BinkSetVolume( static_cast<BinkVideoStream*>( stream )->m_handle, 0, binkVolume );
 	}

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -214,12 +214,11 @@ Int BinkVideoPlayer::calculateMovieAudioVolume()
 {
 	if (TheAudio == nullptr)
 	{
-		return 0;
+		return 327;
 	}
 
 	// Never let volume go to 0, as Bink will interpret that as "play at full
-	// volume". Floor at 327 out of 32768 (~1%), effectively silent. This is
-	// retail's formula, unchanged.
+	// volume".
 	Int mod = (Int) ((TheAudio->getVolume(AudioAffect_Speech) * 0.8f) * 100) + 1;
 	return (32768*mod)/100;
 }

--- a/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
@@ -208,7 +208,13 @@ VideoStreamInterface* FFmpegVideoPlayer::createStream( File* file )
 		stream->m_player = this;
 		m_firstStream = stream;
 
-		setVolume( TheAudio->getVolume(AudioAffect_Speech) );
+		// never let volume go to 0, as Bink will interpret that as "play at full volume".
+		Int mod = (Int) ((TheAudio->getVolume(AudioAffect_Speech) * 0.8f) * 100) + 1;
+		[[maybe_unused]]  Int volume = (32768 * mod) / 100;
+		DEBUG_LOG(("FFmpegVideoPlayer::createStream() - About to set volume (%g -> %d -> %d",
+			TheAudio->getVolume(AudioAffect_Speech), mod, volume));
+		//BinkSetVolume( stream->m_handle,0, volume);
+		DEBUG_LOG(("FFmpegVideoPlayer::createStream() - set volume"));
 	}
 
 	return stream;
@@ -267,26 +273,6 @@ VideoStreamInterface*	FFmpegVideoPlayer::load( AsciiString movieTitle )
 }
 
 //============================================================================
-// FFmpegVideoPlayer::setVolume
-//============================================================================
-
-void FFmpegVideoPlayer::setVolume( [[maybe_unused]] Real volume )
-{
-#ifdef RTS_USE_OPENAL
-	if ( firstStream() == nullptr )
-	{
-		return;
-	}
-
-	OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
-	if ( audioStream )
-	{
-		audioStream->setVolume( volume );
-	}
-#endif
-}
-
-//============================================================================
 //============================================================================
 void FFmpegVideoPlayer::notifyVideoPlayerOfNewProvider( Bool nowHasValid )
 {
@@ -329,7 +315,6 @@ FFmpegVideoStream::FFmpegVideoStream(FFmpegFile* file)
 	// Release the audio handle if it's already in use
 	OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
 	audioStream->reset();
-	audioStream->setVolume(TheAudio->getVolume(AudioAffect_Speech));
 #endif
 
 	// Decode until we have our first video frame

--- a/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
@@ -208,13 +208,7 @@ VideoStreamInterface* FFmpegVideoPlayer::createStream( File* file )
 		stream->m_player = this;
 		m_firstStream = stream;
 
-		// never let volume go to 0, as Bink will interpret that as "play at full volume".
-		Int mod = (Int) ((TheAudio->getVolume(AudioAffect_Speech) * 0.8f) * 100) + 1;
-		[[maybe_unused]]  Int volume = (32768 * mod) / 100;
-		DEBUG_LOG(("FFmpegVideoPlayer::createStream() - About to set volume (%g -> %d -> %d",
-			TheAudio->getVolume(AudioAffect_Speech), mod, volume));
-		//BinkSetVolume( stream->m_handle,0, volume);
-		DEBUG_LOG(("FFmpegVideoPlayer::createStream() - set volume"));
+		setVolume( TheAudio->getVolume(AudioAffect_Speech) );
 	}
 
 	return stream;
@@ -273,6 +267,26 @@ VideoStreamInterface*	FFmpegVideoPlayer::load( AsciiString movieTitle )
 }
 
 //============================================================================
+// FFmpegVideoPlayer::setVolume
+//============================================================================
+
+void FFmpegVideoPlayer::setVolume( [[maybe_unused]] Real volume )
+{
+#ifdef RTS_USE_OPENAL
+	if ( firstStream() == nullptr )
+	{
+		return;
+	}
+
+	OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
+	if ( audioStream )
+	{
+		audioStream->setVolume( volume );
+	}
+#endif
+}
+
+//============================================================================
 //============================================================================
 void FFmpegVideoPlayer::notifyVideoPlayerOfNewProvider( Bool nowHasValid )
 {
@@ -315,6 +329,7 @@ FFmpegVideoStream::FFmpegVideoStream(FFmpegFile* file)
 	// Release the audio handle if it's already in use
 	OpenALAudioStream* audioStream = (OpenALAudioStream*)TheAudio->getHandleForBink();
 	audioStream->reset();
+	audioStream->setVolume(TheAudio->getVolume(AudioAffect_Speech));
 #endif
 
 	// Decode until we have our first video frame

--- a/Core/Tools/MapCacheBuilder/Source/WinMain.cpp
+++ b/Core/Tools/MapCacheBuilder/Source/WinMain.cpp
@@ -259,7 +259,7 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	initSubsystem(TheTerrainRoads, new TerrainRoadCollection(), "Data\\INI\\Default\\Roads", "Data\\INI\\Roads");
 	initSubsystem(TheScriptEngine, (ScriptEngine*)(new ScriptEngine()));
 	initSubsystem(TheAudio, (AudioManager*)new MilesAudioManager());
-	initSubsystem(TheVideoPlayer, (VideoPlayerInterface*)(new VideoPlayer()));
+	initSubsystem(TheVideoPlayer, (VideoPlayerInterface*)(new NullVideoPlayer()));
 	initSubsystem(TheModuleFactory, (ModuleFactory*)(new W3DModuleFactory()));
 	initSubsystem(TheSidesList, new SidesList());
 	initSubsystem(TheCaveSystem, new CaveSystem());

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -367,7 +367,7 @@ BOOL CWorldBuilderApp::InitInstance()
 
 	initSubsystem(TheScriptEngine, (ScriptEngine*)(new ScriptEngine()));
 	initSubsystem(TheAudio, (AudioManager*)new MilesAudioManager());
-	initSubsystem(TheVideoPlayer, (VideoPlayerInterface*)(new VideoPlayer()));
+	initSubsystem(TheVideoPlayer, (VideoPlayerInterface*)(new NullVideoPlayer()));
 	initSubsystem(TheModuleFactory, (ModuleFactory*)(new W3DModuleFactory()));
 	initSubsystem(TheSidesList, new SidesList());
 	initSubsystem(TheCaveSystem, new CaveSystem());

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -384,7 +384,7 @@ BOOL CWorldBuilderApp::InitInstance()
 	ini.loadFileDirectory( "Data\\Scripts\\Scripts", INI_LOAD_OVERWRITE, nullptr );
 
 	initSubsystem(TheAudio, (AudioManager*)new MilesAudioManager());
-	initSubsystem(TheVideoPlayer, (VideoPlayerInterface*)(new VideoPlayer()));
+	initSubsystem(TheVideoPlayer, (VideoPlayerInterface*)(new NullVideoPlayer()));
 	initSubsystem(TheModuleFactory, (ModuleFactory*)(new W3DModuleFactory()));
 	initSubsystem(TheSidesList, new SidesList());
 	initSubsystem(TheCaveSystem, new CaveSystem());


### PR DESCRIPTION
Fixes #2850.

## Problem

Bink movie audio bypasses the Miles mixer. The initial `BinkSetVolume()` call ran before Bink's audio output was ready, so movies ignored the configured Speech volume and could play at full volume.

## Changes

- Call `BinkWait()` before applying the initial volume in `BinkVideoPlayer::createStream()`.
- Add `VideoPlayerInterface::setVolume()` and implement it in `BinkVideoPlayer` so Speech-volume changes update every open Bink stream.
- Keep the retail volume conversion, including its nonzero minimum because Bink treats a literal volume of 0 as full volume.
- Use explicit no-op implementations for FFmpeg and tool-only video players, whose audio volume is not handled by this Bink path.

## Testing

- Built all Win32 Release targets for Generals and Zero Hour with MSVC, including MapCacheBuilder and WorldBuilder.
- Started Zero Hour through the rebuilt executable and verified Bink intro playback, the Options Voice Volume control, menu flow, and clean exit.
- Started a Challenge at Speech 0 and Speech 100. The loading interval measured -28.8 dB mean / -12.0 dB peak at Speech 0 and -18.3 dB mean / -0.1 dB peak at Speech 100. The capture also contained unaffected music and sound effects.
- Replaced `EALogoMovie` synchronously with `Sizzle` in a test harness. The replacement rendered normally and received the configured volume. The same 35-second interval measured -83.3 dB mean / -66.2 dB peak at Speech 0 and -19.7 dB mean / -2.5 dB peak at Speech 100.