### PR TITLE
refactor(commandline): Capture ordered mod arguments

### DIFF
--- a/Core/GameEngine/Source/Common/CommandLine.cpp
+++ b/Core/GameEngine/Source/Common/CommandLine.cpp
@@ -1036,6 +1036,18 @@ Int parseUpdateImages(char *args[], int num)
 	return 1;
 }
 
+// TheSuperHackers @refactor Jaredl-Dev 08/08/2026
+// Captures each raw -mod operand in command-line order during startup.
+Int parseModForStartup(char *args[], Int num)
+{
+	if (num > 1)
+	{
+		TheWritableGlobalData->m_commandLineData.m_modArguments.push_back(args[1]);
+		return 2;
+	}
+	return 1;
+}
+
 Int parseMod(char *args[], Int num)
 {
 	if (num > 1)
@@ -1141,6 +1153,10 @@ static CommandLineParam paramsForStartup[] =
 	// (If you have 4 cores, call it with -jobs 4)
 	// If you do not call this, all replays will be simulated in sequence in the same process.
 	{ "-jobs", parseJobs },
+
+	// TheSuperHackers @refactor Jaredl-Dev 08/08/2026
+	// Captures raw -mod operands before engine initialization.
+	{ "-mod", parseModForStartup },
 };
 
 // These Params are parsed during Engine Init before INI data is loaded

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -56,8 +56,15 @@ constexpr const Int SIMULATE_REPLAYS_SEQUENTIAL = -1;
 //-------------------------------------------------------------------------------------------------
 class CommandLineData
 {
+public:
+	// TheSuperHackers @refactor Jaredl-Dev 08/08/2026
+	// Exposes the raw -mod operands captured during startup in command-line order.
+	const std::vector<AsciiString> &getModArguments() const { return m_modArguments; }
+
+private:
 	friend class CommandLine;
 	friend class GlobalData;
+	friend Int parseModForStartup(char *args[], Int num);
 
 	CommandLineData()
 		: m_hasParsedCommandLineForStartup(false)
@@ -66,6 +73,7 @@ class CommandLineData
 
 	Bool m_hasParsedCommandLineForStartup;
 	Bool m_hasParsedCommandLineForEngineInit;
+	std::vector<AsciiString> m_modArguments;
 };
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Part of #3022

This change captures each raw `-mod` operand during startup in command-line order and exposes the ordered arguments through `CommandLineData`.

The startup handler only copies the raw operand. Existing engine-init mod parsing and loading remain unchanged. This is a prerequisite for future work that consumes multiple ordered mod layers.

## Validation

- [x] Build `z_generals` with modern MSVC and VC6
- [x] Verify repeated, case-insensitive, quoted, and missing `-mod` operands
- [x] Verify existing single-file and directory mod loading

## TODO

- [ ] Replicate in Generals

**Note:** Generals fails to build until replicated.
