### PR TITLE
bugfix(victoryconditions): Fix Generals build

### DIFF
--- a/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2383,18 +2383,16 @@ bool GameLogic::onLogicCrc(MAYBE_UNUSED GameMessage *msg)
 	Player *msgPlayer = getMessagePlayer(msg);
 	if (TheNetwork)
 	{
-		Int slotIndex = -1;
-		for (Int i=0; i<MAX_SLOTS; ++i)
+		if (msgPlayer->getPlayerType() != PLAYER_HUMAN)
 		{
-			if (msgPlayer->getPlayerType() == PLAYER_HUMAN && TheNetwork->getPlayerName(i) == msgPlayer->getPlayerDisplayName())
-			{
-				slotIndex = i;
-				break;
-			}
+			return false;
 		}
 
+		const Int slotIndex = ThePlayerList->getSlotIndex(msgPlayer->getPlayerIndex());
 		if (slotIndex < 0 || !TheNetwork->isPlayerConnected(slotIndex))
+		{
 			return false;
+		}
 
 		if (msgPlayer->isLocalPlayer())
 		{

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -989,13 +989,9 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 	}
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
-	Bool samePlayer = FALSE;
-	AsciiString playerName;
-	playerName.format("player%d", localPlayerIndex);
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	if (!p || (p->getPlayerNameKey() == NAMEKEY(playerName)))
-		samePlayer = TRUE;
-	if (samePlayer || (localPlayerIndex < 0))
+	const Bool isLocalPlayer = !p || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
+	if (isLocalPlayer)
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();
 		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Comparing CRCs of InGame:%8.8X Replay:%8.8X Frame:%d from Player %d",

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -211,18 +211,15 @@ void VictoryConditions::update()
 				TheAudio->addAudioEvent(&leftGameSound);
 			}
 
-			for (Int idx = 0; idx < MAX_SLOTS; ++idx)
+			if (TheGameInfo)
 			{
-				AsciiString pName;
-				pName.format("player%d", idx);
-				if (p->getPlayerNameKey() == NAMEKEY(pName))
+				const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
+				const GameSlot* slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+
+				if (slot && slot->isAI())
 				{
-					GameSlot *slot = (TheGameInfo)?TheGameInfo->getSlot(idx):nullptr;
-					if (slot && slot->isAI())
-					{
-						DEBUG_LOG(("Marking AI player %s as defeated", pName.str()));
-						slot->setLastFrameInGame(TheGameLogic->getFrame());
-					}
+					DEBUG_LOG(("Marking AI player %s as defeated", TheNameKeyGenerator->keyToName(p->getPlayerNameKey()).str()));
+					slot->setLastFrameInGame(TheGameLogic->getFrame());
 				}
 			}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -214,7 +214,7 @@ void VictoryConditions::update()
 			if (TheGameInfo)
 			{
 				const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
-				const GameSlot* slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+				GameSlot *const slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
 
 				if (slot && slot->isAI())
 				{

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -991,13 +991,9 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 	}
 
 	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
-	Bool samePlayer = FALSE;
-	AsciiString playerName;
-	playerName.format("player%d", localPlayerIndex);
 	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	if (!p || (p->getPlayerNameKey() == NAMEKEY(playerName)))
-		samePlayer = TRUE;
-	if (samePlayer || (localPlayerIndex < 0))
+	const Bool isLocalPlayer = !p || ThePlayerList->getSlotIndex(playerIndex) == localPlayerIndex;
+	if (isLocalPlayer)
 	{
 		UnsignedInt playbackCRC = m_crcInfo.readCRC();
 		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Comparing CRCs of InGame:%8.8X Replay:%8.8X Frame:%d from Player %d",

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -213,18 +213,15 @@ void VictoryConditions::update()
 				TheAudio->addAudioEvent(&leftGameSound);
 			}
 
-			for (Int idx = 0; idx < MAX_SLOTS; ++idx)
+			if (TheGameInfo)
 			{
-				AsciiString pName;
-				pName.format("player%d", idx);
-				if (p->getPlayerNameKey() == NAMEKEY(pName))
+				const Int slotIndex = ThePlayerList->getSlotIndex(p->getPlayerIndex());
+				GameSlot *const slot = slotIndex >= 0 ? TheGameInfo->getSlot(slotIndex) : nullptr;
+
+				if (slot && slot->isAI())
 				{
-					GameSlot *slot = (TheGameInfo)?TheGameInfo->getSlot(idx):nullptr;
-					if (slot && slot->isAI())
-					{
-						DEBUG_LOG(("Marking AI player %s as defeated", pName.str()));
-						slot->setLastFrameInGame(TheGameLogic->getFrame());
-					}
+					DEBUG_LOG(("Marking AI player %s as defeated", TheNameKeyGenerator->keyToName(p->getPlayerNameKey()).str()));
+					slot->setLastFrameInGame(TheGameLogic->getFrame());
 				}
 			}
 


### PR DESCRIPTION
I forgot to update the const correctness in the Generals side of #3033, which left the slot const and broke the build when setLastFrameInGame tried to mutate it. This restores GameSlot *const and fixes the issue.