### PR TITLE
bugfix(aiupdate): Don't process invalid exit commands

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3668,10 +3668,21 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 	if (!objectToExit)
 	{
 		objectToExit = us->getContainedBy();
-	}
 
-	if (!objectToExit)
-		return;
+		if (!objectToExit)
+			return;
+	}
+	else
+	{
+		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
+		// because an object should not attempt to exit something it's not contained by.
+#if !RETAIL_COMPATIBLE_CRC
+		// @todo Remove function parameter 'objectToExit' because it's become obsolete.
+
+		if (us->getContainedBy() != objectToExit)
+			return;
+#endif
+	}
 
 	// we must go thru this state (rather than calling exitObjectViaDoor directly!),
 	// because a few containers might need to delay to allow

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3824,19 +3824,21 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 	{
 		objectToExit = us->getContainedBy();
 	}
+	else
+	{
+		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
+		// because an object should not attempt to exit something it's not contained by.
+#if !RETAIL_COMPATIBLE_CRC
+		if (us->getContainedBy() != objectToExit)
+			return;
+#endif
+	}
 
 	if (!objectToExit)
 		return;
 
   if ( objectToExit->isDisabledByType( DISABLED_SUBDUED ) )
     return;
-
-	// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
-	// because an object should not attempt to exit something it's not contained by.
-#if !RETAIL_COMPATIBLE_CRC
-	if (us->getContainedBy() != objectToExit)
-		return;
-#endif
 
 	// we must go thru this state (rather than calling exitObjectViaDoor directly!),
 	// because a few containers might need to delay to allow
@@ -3859,19 +3861,21 @@ void AIUpdateInterface::privateExitInstantly( Object *objectToExit, CommandSourc
 	{
 		objectToExit = us->getContainedBy();
 	}
+	else
+	{
+		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
+		// because an object should not attempt to exit something it's not contained by.
+#if !RETAIL_COMPATIBLE_CRC
+		if (us->getContainedBy() != objectToExit)
+			return;
+#endif
+	}
 
 	if (!objectToExit)
 		return;
 
   if ( objectToExit->isDisabledByType( DISABLED_SUBDUED ) )
     return;
-
-	// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
-	// because an object should not attempt to exit something it's not contained by.
-#if !RETAIL_COMPATIBLE_CRC
-	if (us->getContainedBy() != objectToExit)
-		return;
-#endif
 
 	// we must go thru this state (rather than calling exitObjectViaDoor directly!),
 	// because a few containers might need to delay to allow

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3823,6 +3823,9 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 	if (!objectToExit)
 	{
 		objectToExit = us->getContainedBy();
+
+		if (!objectToExit)
+			return;
 	}
 	else
 	{
@@ -3835,9 +3838,6 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 			return;
 #endif
 	}
-
-	if (!objectToExit)
-		return;
 
   if ( objectToExit->isDisabledByType( DISABLED_SUBDUED ) )
     return;
@@ -3862,6 +3862,9 @@ void AIUpdateInterface::privateExitInstantly( Object *objectToExit, CommandSourc
 	if (!objectToExit)
 	{
 		objectToExit = us->getContainedBy();
+
+		if (!objectToExit)
+			return;
 	}
 	else
 	{
@@ -3874,9 +3877,6 @@ void AIUpdateInterface::privateExitInstantly( Object *objectToExit, CommandSourc
 			return;
 #endif
 	}
-
-	if (!objectToExit)
-		return;
 
   if ( objectToExit->isDisabledByType( DISABLED_SUBDUED ) )
     return;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3829,6 +3829,8 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
 		// because an object should not attempt to exit something it's not contained by.
 #if !RETAIL_COMPATIBLE_CRC
+		// @todo Remove function parameter 'objectToExit' because it's become obsolete.
+
 		if (us->getContainedBy() != objectToExit)
 			return;
 #endif
@@ -3866,6 +3868,8 @@ void AIUpdateInterface::privateExitInstantly( Object *objectToExit, CommandSourc
 		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
 		// because an object should not attempt to exit something it's not contained by.
 #if !RETAIL_COMPATIBLE_CRC
+		// @todo Remove function parameter 'objectToExit' because it's become obsolete.
+
 		if (us->getContainedBy() != objectToExit)
 			return;
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3831,6 +3831,12 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
   if ( objectToExit->isDisabledByType( DISABLED_SUBDUED ) )
     return;
 
+	// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
+	// because an object should not attempt to exit something it's not contained by.
+#if !RETAIL_COMPATIBLE_CRC
+	if (us->getContainedBy() != objectToExit)
+		return;
+#endif
 
 	// we must go thru this state (rather than calling exitObjectViaDoor directly!),
 	// because a few containers might need to delay to allow
@@ -3859,6 +3865,13 @@ void AIUpdateInterface::privateExitInstantly( Object *objectToExit, CommandSourc
 
   if ( objectToExit->isDisabledByType( DISABLED_SUBDUED ) )
     return;
+
+	// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
+	// because an object should not attempt to exit something it's not contained by.
+#if !RETAIL_COMPATIBLE_CRC
+	if (us->getContainedBy() != objectToExit)
+		return;
+#endif
 
 	// we must go thru this state (rather than calling exitObjectViaDoor directly!),
 	// because a few containers might need to delay to allow


### PR DESCRIPTION
* Related issue: https://github.com/TheSuperHackers/GeneralsGameCode/issues/3087 (that issue would also have been fixed by this PR)

---

https://github.com/user-attachments/assets/4e3360a3-444e-4c1b-bdda-6520f9fe17c8

---

This PR fixes an issue where the game processes an exit command for a unit that's not / no longer contained by a container object. This is particularly an issue when exiting from GLA Tunnels at high latencies. See the above video. Due to the high latency a player can issue repeated exit commands, but only the first one should be processed or the unit is yanked back to the tunnel.

## TODO:
- [x] Replicate to Generals.