### PR TITLE
bugfix(replay): Validate next frame value in RecorderClass::readNextFrame for replay playback

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1277,8 +1277,19 @@ AsciiString RecorderClass::readAsciiString() {
  */
 void RecorderClass::readNextFrame() {
 	Int bytesRead = m_file->read(&m_nextFrame, sizeof(m_nextFrame));
-	if (bytesRead != sizeof(m_nextFrame)) {
-		DEBUG_LOG(("RecorderClass::readNextFrame - read failed on frame %d", TheGameLogic->getFrame()));
+
+	// TheSuperHackers @bugfix Check whether the next frame value is within a reasonable range
+	// to avoid prolonging playback due to potentially corrupted data.
+	const Bool validFrameValue = (m_mode == RECORDERMODETYPE_NONE
+		|| (m_nextFrame >= TheGameLogic->getFrame() && m_nextFrame < TheGameLogic->getFrame() + 3600 * LOGICFRAMES_PER_SECOND));
+
+	if (bytesRead != sizeof(m_nextFrame) || !validFrameValue) {
+		if (bytesRead != sizeof(m_nextFrame)) {
+			DEBUG_LOG(("RecorderClass::readNextFrame - read failed on frame %d", TheGameLogic->getFrame()));
+		} else {
+			DEBUG_CRASH(("RecorderClass::readNextFrame - current frame %d, next frame %d in the replay appears invalid",
+				TheGameLogic->getFrame(), m_nextFrame));
+		}
 		m_nextFrame = -1;
 		stopPlayback();
 	}


### PR DESCRIPTION
This PR adds a sanity check to `RecorderClass::readNextFrame` to prevent replays with corrupt data from taking forever to complete. I came across a handful of GenTool replays that had this issue.

Non-headless mode has a fail-safe that partially mitigates the issue there. The script engine triggers a call to `GameLogic::exitGame` on the final victory / defeat screen, and this adds a `GameMessage::MSG_CLEAR_GAME_DATA` message to the message stream. This ends replay playback. The message stream is ignored in headless mode, so this doesn't apply there. It's also not a complete fix because the corrupted data may occur before a victory or defeat takes place.

The maximum next frame value is set one hour away, which seems more than reasonable to me. The only way this generates a false positive is if no game action is taken for an hour or more **and** the CRC interval is set to an hour or more (it's a couple of seconds by default).

## TODO:
- [ ] Replicate to Generals.

---

@Skyaero42 Tagging you so you're aware of this PR.