### PR TITLE
perf(script): Reduce cost of ScriptEngine::findScript() by around 85%

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Scripts.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Scripts.h
@@ -142,7 +142,7 @@ public:
 	void setWarnings(Bool warnings) { m_hasWarnings = warnings;}
 	void setNextGroup(ScriptGroup *pGr) {m_nextGroup = pGr;}
 
-	AsciiString getName() const { return m_groupName;}
+	const AsciiString& getName() const { return m_groupName;}
 	Bool isActive() const { return m_isGroupActive;}
 	Bool isSubroutine() const { return m_isGroupSubroutine;}
 	Bool hasWarnings() const { return m_hasWarnings;}
@@ -661,7 +661,7 @@ public:
 	Real getCurTime() {return m_curTime;}
 	Int getDelayEvalSeconds() {return m_delayEvaluationSeconds;}
 
-	AsciiString getName() const { return m_scriptName;}
+	const AsciiString& getName() const { return m_scriptName;}
 	AsciiString getComment() const {return m_comment;}
 	AsciiString getActionComment() const {return m_actionComment;}
 	AsciiString getConditionComment() const {return m_conditionComment;}
@@ -691,7 +691,7 @@ public:
 	OrCondition *findPreviousOrCondition( OrCondition *curOr );
 
 	// Support routines for ScriptEngine -
-	AsciiString getConditionTeamName() {return m_conditionTeamName;}
+	const AsciiString& getConditionTeamName() const {return m_conditionTeamName;}
 	void setConditionTeamName(AsciiString teamName) {m_conditionTeamName = teamName;}
 };
 

--- a/Generals/Code/GameEngine/Include/GameLogic/SidesList.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/SidesList.h
@@ -330,7 +330,7 @@ public:
 	const Coord2D *getRallyOffset() const {return &m_rallyPointOffset;}
 	Real getAngle() const {return m_angle;}
 	Bool isInitiallyBuilt() {return m_isInitiallyBuilt;}
-	AsciiString getScript() {return m_script;}
+	const AsciiString& getScript() const {return m_script;}
 	Int getHealth() {return m_health;}
 	Bool getWhiner() {return m_whiner;}
 	Bool getUnsellable() {return m_unsellable;}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Scripts.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Scripts.h
@@ -135,7 +135,7 @@ public:
 	void setWarnings(Bool warnings) { m_hasWarnings = warnings;}
 	void setNextGroup(ScriptGroup *pGr) {m_nextGroup = pGr;}
 
-	AsciiString getName() const { return m_groupName;}
+	const AsciiString& getName() const { return m_groupName;}
 	Bool isActive() const { return m_isGroupActive;}
 	Bool isSubroutine() const { return m_isGroupSubroutine;}
 	Bool hasWarnings() const { return m_hasWarnings;}
@@ -669,7 +669,7 @@ public:
 	Real getCurTime() {return m_curTime;}
 	Int getDelayEvalSeconds() {return m_delayEvaluationSeconds;}
 
-	AsciiString getName() const { return m_scriptName;}
+	const AsciiString& getName() const { return m_scriptName;}
 	AsciiString getComment() const {return m_comment;}
 	AsciiString getActionComment() const {return m_actionComment;}
 	AsciiString getConditionComment() const {return m_conditionComment;}
@@ -699,7 +699,7 @@ public:
 	OrCondition *findPreviousOrCondition( OrCondition *curOr );
 
 	// Support routines for ScriptEngine -
-	AsciiString getConditionTeamName() {return m_conditionTeamName;}
+	const AsciiString& getConditionTeamName() const {return m_conditionTeamName;}
 	void setConditionTeamName(AsciiString teamName) {m_conditionTeamName = teamName;}
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/SidesList.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/SidesList.h
@@ -330,7 +330,7 @@ public:
 	const Coord2D *getRallyOffset() const {return &m_rallyPointOffset;}
 	Real getAngle() const {return m_angle;}
 	Bool isInitiallyBuilt() {return m_isInitiallyBuilt;}
-	AsciiString getScript() {return m_script;}
+	const AsciiString& getScript() const {return m_script;}
 	Int getHealth() {return m_health;}
 	Bool getWhiner() {return m_whiner;}
 	Bool getUnsellable() {return m_unsellable;}


### PR DESCRIPTION
This PR dramatically improves script search performance by removing the allocation overhead when comparing script names.

I also tested the same performance degradation against a version of asciistring that does not use the global locks.
But like with the similar waypoint names fix #2761, returning constant references to the asciistrings was significantly more performant.

All of these tests were performed in a retail release, letting the same AoD map level run to its conclusion.
So this is not a debug only issue.

---
**Flame graphs and function usage comparisons.**

Before:
<img width="1177" height="370" alt="image" src="https://github.com/user-attachments/assets/4a598df7-ea90-4fa3-bb56-149322f4a5d4" />
<img width="661" height="344" alt="image" src="https://github.com/user-attachments/assets/3fb37273-1698-41ec-9ab0-423c5b8d0bfd" />


After:
<img width="1042" height="340" alt="image" src="https://github.com/user-attachments/assets/2496b991-565e-40dc-be3c-30559c9f3fb3" />

<img width="654" height="369" alt="image" src="https://github.com/user-attachments/assets/6b55ffa7-061c-4799-9a32-0d8a64135f85" />

---
**video comparison.** 

This video shows the most recent GO build against a tweaked GO build with the fixes from this PR.

https://youtu.be/aDy8w4sHPKU

---
**TODO**

- [x] Replicate in generals
