### PR TITLE
unify(drawable): Merge most of Drawable and Locomotor

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Drawable.h
@@ -53,6 +53,7 @@ class Shadow;
 class ModuleInfo;
 class Anim2DTemplate;
 class Image;
+class DynamicAudioEventInfo;
 enum BodyDamageType CPP_11(: Int);
 
 // this is a very worthwhile performance win. left conditionally defined for now, just
@@ -148,6 +149,8 @@ public:
 	Real m_overlapZVel;					///< fake Z velocity
 	Real m_overlapZ;						///< current height (additional)
 	Real m_wobble;							///< for wobbling
+  Real m_yawModulator;        ///< for the swimmy soft hover of a helicopter
+  Real m_pitchModulator;        ///< for the swimmy soft hover of a helicopter
 	TWheelInfo m_wheelInfo;			///< Wheel offset & angle info for a wheeled type locomotor.
 
 	DrawableLocoInfo();
@@ -240,6 +243,8 @@ enum TintStatus CPP_11(: Int)
 	TINT_STATUS_DISABLED		= 0x00000001,///< drawable tint color is deathly dark grey
 	TINT_STATUS_IRRADIATED	= 0x00000002,///< drawable tint color is sickly green
 	TINT_STATUS_POISONED		= 0x00000004,///< drawable tint color is open-sore red
+	TINT_STATUS_GAINING_SUBDUAL_DAMAGE		= 0x00000008,///< When gaining subdual damage, we tint SUBDUAL_DAMAGE_COLOR
+	TINT_STATUS_FRENZY			= 0x00000010,///< When frenzied, we tint FRENZY_COLOR
 
 };
 
@@ -297,6 +302,7 @@ public:
 	Drawable( const ThingTemplate *thing, DrawableStatusBits statusBits = DRAWABLE_STATUS_DEFAULT );
 
 	void onDestroy();																							///< run from GameClient::destroyDrawable
+  void onLevelStart();                                                ///< run from GameLogic::startNewGame
 
 	Drawable *getNextDrawable() const { return m_nextDrawable; }	///< return the next drawable in the global list
 	Drawable *getPrevDrawable() const { return m_prevDrawable; }  ///< return the prev drawable in the global list
@@ -360,6 +366,7 @@ public:
 	ClientUpdateModule* findClientUpdateModule( NameKeyType key );
 
 	// never returns null
+	DrawModule** getDrawModulesNonDirty();
 	DrawModule** getDrawModules();
 	DrawModule const** getDrawModules() const;
 
@@ -409,10 +416,11 @@ public:
 
 	void drawIconUI();													///< draw "icon"(s) needed on drawable (health bars, veterency, etc)
 
-	void startAmbientSound();
+	void startAmbientSound( Bool onlyIfPermanent = false );
 	void stopAmbientSound();
 	void enableAmbientSound( Bool enable );
 	void setTimeOfDay( TimeOfDay tod );
+  Bool getAmbientSoundEnabledFromScript() const { return m_ambientSoundEnabledFromScript; }
 
 	void prependToList(Drawable **pListHead);
 	void removeFromList(Drawable **pListHead);
@@ -455,6 +463,8 @@ public:
 
 	const TWheelInfo *getWheelInfo() const { return m_locoInfo ? &m_locoInfo->m_wheelInfo : nullptr; }
 
+	const DrawableLocoInfo *getLocoInfo() const { return m_locoInfo; }
+
 	// this method must ONLY be called from the client, NEVER From the logic, not even indirectly.
 	Bool clientOnly_getFirstRenderObjInfo(Coord3D* pos, Real* boundingSphereRadius, Matrix3D* transform);
 
@@ -492,6 +502,10 @@ public:
 		"in between", it is included in the completion time.
 	*/
 	void setAnimationCompletionTime(UnsignedInt numFrames);
+
+	//Kris: Manually set a drawable's current animation to specific frame.
+	virtual void setAnimationFrame( int frame );
+
 	void updateSubObjects();
 	void showSubObject( const AsciiString& name, Bool show );
 
@@ -554,10 +568,25 @@ public:
 	void killIcon(DrawableIconType t) { if (m_iconInfo) m_iconInfo->killIcon(t); }
 	Bool hasIconInfo() const { return m_iconInfo != nullptr; }
 
-  const AudioEventRTS * getAmbientSound() const { return m_ambientSound == nullptr ? nullptr : &m_ambientSound->m_event; }
 
   Bool getReceivesDynamicLights() { return m_receivesDynamicLights; };
   void setReceivesDynamicLights( Bool set ) { m_receivesDynamicLights = set; };
+
+  //---------------------------------------------------------------------------------
+  // Stuff for overriding ambient sound
+  const AudioEventInfo * getBaseSoundAmbientInfo() const; //< Possible starting point if only some parameters are customized
+  void enableAmbientSoundFromScript( Bool enable );
+  const AudioEventRTS * getAmbientSound() const { return m_ambientSound == nullptr ? nullptr : &m_ambientSound->m_event; }
+  void setCustomSoundAmbientOff(); //< Kill the ambient sound
+  void setCustomSoundAmbientInfo( DynamicAudioEventInfo * customAmbientInfo ); //< Set ambient sound.
+  void clearCustomSoundAmbient() { clearCustomSoundAmbient( true ); } //< Return to using defaults
+  Bool getAmbientSoundEnabled() const { return m_ambientSoundEnabled; }
+  void mangleCustomAudioName( DynamicAudioEventInfo * audioToMangle ) const;
+
+
+  Real friend_getStealthOpacity() { return m_stealthOpacity; }
+  Real friend_getExplicitOpacity() { return m_explicitOpacity; }
+  Real friend_getEffectiveStealthOpacity() { return m_effectiveStealthOpacity; }
 
 protected:
 
@@ -567,7 +596,7 @@ protected:
 	virtual void loadPostProcess() override;
 	void xferDrawableModules( Xfer *xfer );
 
-	void	startAmbientSound(BodyDamageType dt, TimeOfDay tod);
+	void	startAmbientSound( BodyDamageType dt, TimeOfDay tod, Bool onlyIfPermanent = false );
 
 	virtual Drawable *asDrawableMeth() override { return this; }
 	virtual const Drawable *asDrawableMeth() const override { return this; }
@@ -601,8 +630,11 @@ protected:
 	void calcPhysicsXformHoverOrWings(const Locomotor *locomotor, PhysicsXformInfo& info);
 	void calcPhysicsXformTreads(const Locomotor *locomotor, PhysicsXformInfo& info);
 	void calcPhysicsXformWheels(const Locomotor *locomotor, PhysicsXformInfo& info);
+	void calcPhysicsXformMotorcycle( const Locomotor *locomotor, PhysicsXformInfo& info );
 
 	const AudioEventRTS& getAmbientSoundByDamage(BodyDamageType dt);
+
+  void clearCustomSoundAmbient( bool restartSound ); //< Return to using defaults
 
 #ifdef RTS_DEBUG
 	void validatePos() const;
@@ -642,6 +674,8 @@ private:
 	Drawable *m_nextDrawable;
 	Drawable *m_prevDrawable;		///< list links
 
+  DynamicAudioEventInfo *m_customSoundAmbientInfo; ///< If not nullptr, info about the ambient sound to attach to this object
+
 	DrawableStatusBits m_status;		///< status bits (see DrawableStatus enum)
 	UnsignedInt m_tintStatus;				///< tint color status bits (see TintStatus enum)
 	UnsignedInt m_prevTintStatus;///< for edge testing with m_tintStatus
@@ -663,7 +697,6 @@ private:
 	PhysicsXformInfo* m_physicsXform;
 
 	DynamicAudioEventRTS*	m_ambientSound;		///< sound module for ambient sound (lazily allocated)
-	Bool								m_ambientSoundEnabled;
 
 	Module** m_modules[NUM_DRAWABLE_MODULE_TYPES];
 
@@ -694,6 +727,8 @@ private:
 	Bool m_hiddenByStealth;			///< drawable is hidden due to stealth
 	Bool m_instanceIsIdentity;	///< If true, instance matrix can be skipped
 	Bool m_drawableFullyObscuredByShroud;	///<drawable is hidden by shroud/fog
+  Bool m_ambientSoundEnabled;
+  Bool m_ambientSoundEnabledFromScript;
 
   Bool m_receivesDynamicLights;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Locomotor.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Locomotor.h
@@ -58,6 +58,7 @@ enum LocomotorAppearance CPP_11(: Int)
 	LOCO_WINGS,
 	LOCO_CLIMBER,			// human climber - backs down cliffs.
 	LOCO_OTHER,
+	LOCO_MOTORCYCLE, // Added in Zero Hour
 
 	LOCOMOTOR_APPEARANCE_COUNT
 };
@@ -82,6 +83,7 @@ static const char *const TheLocomotorAppearanceNames[] =
 	"WINGS",
 	"CLIMBER",
 	"OTHER",
+	"MOTORCYCLE",
 
 	nullptr
 };
@@ -171,7 +173,8 @@ private:
 	LocomotorAppearance				m_appearance;						///< how we should diddle the Drawable to imitate this motion
 	LocomotorPriority					m_movePriority;					///< Where we move - front, middle, back.
 
-	Real											m_accelPitchLimit;			///< Maximum amount we will pitch up or down under acceleration (including recoil.)
+	Real											m_accelPitchLimit;			///< Maximum amount we will pitch up  under acceleration (including recoil.)
+	Real											m_decelPitchLimit;			///< Maximum amount we will pitch down under deceleration (including recoil.)
 	Real											m_bounceKick;						///< How much simulating rough terrain "bounces" a wheel up.
 	Real											m_pitchStiffness;				///< How stiff the springs are forward & back.
 	Real											m_rollStiffness;				///< How stiff the springs are side to side.
@@ -209,6 +212,12 @@ private:
 	Real											m_wanderWidthFactor;
 	Real											m_wanderLengthFactor;
 	Real											m_wanderAboutPointRadius;
+
+
+	Real											m_rudderCorrectionDegree;
+	Real											m_rudderCorrectionRate;
+	Real											m_elevatorCorrectionDegree;
+	Real											m_elevatorCorrectionRate;
 };
 
 typedef OVERRIDE<LocomotorTemplate> LocomotorTemplateOverride;
@@ -251,6 +260,7 @@ public:
 	AsciiString getTemplateName() const { return m_template->m_name;}
 	Real getMinSpeed() const { return m_template->m_minSpeed;}
 	Real getAccelPitchLimit() const { return m_template->m_accelPitchLimit;}	///< Maximum amount we will pitch up or down under acceleration (including recoil.)
+	Real getDecelPitchLimit() const { return m_template->m_decelPitchLimit;}	///< Maximum amount we will pitch down under deceleration (including recoil.)
 	Real getBounceKick() const { return m_template->m_bounceKick;}						///< How much simulating rough terrain "bounces" a wheel up.
 	Real getPitchStiffness() const { return m_template->m_pitchStiffness;}			///< How stiff the springs are forward & back.
 	Real getRollStiffness() const { return m_template->m_rollStiffness;}				///< How stiff the springs are side to side.
@@ -282,6 +292,13 @@ public:
 	Real getMaxWheelCompression() const {return m_template->m_maximumWheelCompression;}
 	Real getWheelTurnAngle() const {return m_template->m_wheelTurnAngle;}
 
+
+	Real getRudderCorrectionDegree()	  const { return m_template->m_rudderCorrectionDegree;}			///< How much we roll in response to acceleration.
+	Real getRudderCorrectionRate()	    const { return m_template->m_rudderCorrectionRate;}			///< How much we roll in response to acceleration.
+	Real getElevatorCorrectionDegree() const { return m_template->m_elevatorCorrectionDegree;}			///< How much we roll in response to acceleration.
+	Real getElevatorCorrectionRate()	  const { return m_template->m_elevatorCorrectionRate;}			///< How much we roll in response to acceleration.
+
+
 	Real getWanderWidthFactor() const {return m_template->m_wanderWidthFactor;}
 	Real getWanderAboutPointRadius() const {return m_template->m_wanderAboutPointRadius;}
 
@@ -300,6 +317,7 @@ public:
 	void setAllowInvalidPosition(Bool allow) { setFlag(ALLOW_INVALID_POSITION, allow); }
 	void setCloseEnoughDist( Real dist ) { m_closeEnoughDist = dist; }
 	void setCloseEnoughDist3D( Bool setting ) { setFlag(IS_CLOSE_ENOUGH_DIST_3D, setting); }
+	Bool isInvalidPositionAllowed() const { return getFlag( ALLOW_INVALID_POSITION ); }
 
 	void setPreferredHeight( Real height ) { m_preferredHeight = height; }
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
@@ -170,11 +170,14 @@ public:
 	void setAllowCollideForce(Bool allow) { setFlag(ALLOW_COLLIDE_FORCE, allow); }
 	void setAllowAirborneFriction(Bool allow) { setFlag(APPLY_FRICTION2D_WHEN_AIRBORNE, allow); }
 	void setImmuneToFallingDamage(Bool allow) { setFlag(IMMUNE_TO_FALLING_DAMAGE, allow); }
+	void setStunned(Bool allow) { setFlag(IS_STUNNED, allow); }
 
 	Bool getAllowToFall() const { return getFlag(ALLOW_TO_FALL); }
 
 	void setIsInFreeFall(Bool allow) { setFlag(IS_IN_FREEFALL, allow); }
 	Bool getIsInFreeFall() const { return getFlag(IS_IN_FREEFALL); }
+
+	Bool getIsStunned() const { return getFlag(IS_STUNNED); }
 
 	void setExtraBounciness(Real b) { m_extraBounciness = b; }
 	void setExtraFriction(Real b) { m_extraFriction = b; }
@@ -238,7 +241,8 @@ private:
 		HAS_PITCHROLLYAW								= 0x0080,
 		IMMUNE_TO_FALLING_DAMAGE				= 0x0100,
 		IS_IN_FREEFALL									= 0x0200,
-		IS_IN_UPDATE										= 0x0400
+		IS_IN_UPDATE										= 0x0400,
+		IS_STUNNED											= 0x0800, // Added in Zero Hour
 	};
 
 	/*

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -261,6 +261,7 @@ public:
 
 	void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
 
+	Real getCarrierDeckHeight() const;
 	// access to modules
 	//-----------------------------------------------------------------------------
 

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -5019,11 +5019,7 @@ void Drawable::xfer( Xfer *xfer )
 	// tint status
 	xfer->xferUnsignedInt( &m_tintStatus );
 
-#if RTS_GENERALS
-	if (version <= 5)
-#else
 	if (version <= 7)
-#endif
 	{
 		// prev tint status
 		xfer->xferUnsignedInt( &m_prevTintStatus );

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -30,6 +30,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
 #include "Common/AudioEventInfo.h"
+#include "Common/DynamicAudioEventInfo.h"
 #include "Common/AudioSettings.h"
 #include "Common/BitFlagsIO.h"
 #include "Common/BuildAssistant.h"
@@ -108,6 +109,22 @@ static const char *const TheDrawableIconNames[] =
 static_assert(ARRAY_SIZE(TheDrawableIconNames) == MAX_ICONS + 1, "Incorrect array size");
 
 
+/**
+ * Returns a special DynamicAudioEventInfo which can be used to mark a sound as "no sound".
+ * E.g. if m_customSoundAmbientInfo equals the value returned from this function, we
+ * know it really means don't allow an ambient sound to be attached.
+ *
+ * OK, so it's a bit of a hack, but it saves memory in every Drawable
+ */
+class DynamicAudioEventInfoStatic : public DynamicAudioEventInfo
+{};
+static DynamicAudioEventInfoStatic s_noSoundMarker;
+
+static DynamicAudioEventInfo* getNoSoundMarker()
+{
+	return &s_noSoundMarker;
+}
+
 
 
 // ------------------------------------------------------------------------------------------------
@@ -176,6 +193,9 @@ DrawableLocoInfo::DrawableLocoInfo()
 	m_wheelInfo.m_framesAirborneCounter = 0;
 	m_wheelInfo.m_framesAirborne = 0;
 	m_wheelInfo.m_wheelAngle = 0;
+
+  m_yawModulator = 0.0f;
+  m_pitchModulator = 0.0f;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -219,6 +239,9 @@ const UnsignedInt DEFAULT_HEAL_ICON_HEIGHT	= 32;
 const RGBColor SICKLY_GREEN_POISONED_COLOR	= {-1.0f,  1.0f, -1.0f};
 const RGBColor DARK_GRAY_DISABLED_COLOR			= {-0.5f, -0.5f, -0.5f};
 const RGBColor RED_IRRADIATED_COLOR					= { 1.0f, -1.0f, -1.0f};
+const RGBColor SUBDUAL_DAMAGE_COLOR					= {-0.2f, -0.2f,  0.8f};
+const RGBColor FRENZY_COLOR									= { 0.2f, -0.2f, -0.2f};
+const RGBColor FRENZY_COLOR_INFANTRY				= { 0.0f, -0.7f, -0.7f};
 const Int MAX_ENABLED_MODULES								= 16;
 
 // ------------------------------------------------------------------------------------------------
@@ -319,6 +342,8 @@ Drawable::Drawable( const ThingTemplate *thingTemplate, DrawableStatusBits statu
 	m_nextDrawable = nullptr;
 	m_prevDrawable = nullptr;
 
+  m_customSoundAmbientInfo = nullptr;
+
 	// register drawable with the GameClient ... do this first before we start doing anything
 	// complex that uses any of the drawable data so that we have and ID!!  It's ok to initialize
 	// members of the drawable before this registration happens
@@ -340,6 +365,8 @@ Drawable::Drawable( const ThingTemplate *thingTemplate, DrawableStatusBits statu
 																TheInGameUI->isDrawableCaptionBold() ));
 
 	m_ambientSound = nullptr;
+  m_ambientSoundEnabled = true;
+  m_ambientSoundEnabledFromScript = true;
 
 	m_decalOpacityFadeTarget = 0;
 	m_decalOpacityFadeRate = 0;
@@ -397,8 +424,6 @@ Drawable::Drawable( const ThingTemplate *thingTemplate, DrawableStatusBits statu
 	m_hiddenByStealth = false;
 	m_heatVisionOpacity = 0.0f;
 	m_drawableFullyObscuredByShroud = false;
-
-	m_ambientSoundEnabled = TRUE;
 
   m_receivesDynamicLights = TRUE; // a good default... overridden by one of my draw modules if at all
 
@@ -471,7 +496,22 @@ Drawable::Drawable( const ThingTemplate *thingTemplate, DrawableStatusBits statu
 
 	initStaticImages();
 
-	startAmbientSound();
+  // If we are inside GameLogic::startNewGame(), then starting the ambient sound
+  // will be taken care of by Drawable::onLevelStart(). It's important that we
+  // wait until Drawable::onLevelStart(), because we may have a customized ambient
+  // sound which we'll only learn about after the constructor is finished. The
+  // map maker may also have disabled the ambient sound; again, we only learn that
+  // after the constructor is done.
+  // By the same token, when loading from save, we may learn that the ambient sound
+  // is enabled or disabled in xfer(), and we may learn we have a customized sound there,
+  // so don't start the ambient sound yet.
+  // This is all really traceable to the fact that stopAmbientSound() won't stop a sound which
+  // is in the middle of playing; it will only stop it when the current wavefile is finished.
+  // So we have to be very careful of called startAmbientSound() because we can't "take it back" later.
+  if ( TheGameLogic != nullptr && !TheGameLogic->isLoadingMap() && TheGameState != nullptr && !TheGameState->isInLoadGame() )
+  {
+  	startAmbientSound();
+  }
 
 }
 
@@ -507,6 +547,8 @@ Drawable::~Drawable()
 
 	deleteInstance(m_ambientSound);
 	m_ambientSound = nullptr;
+
+  clearCustomSoundAmbient( false );
 
 	/// @todo this is nasty, we need a real general effects system
 	// remove any entries that might be present from the ray effect system
@@ -576,13 +618,19 @@ Bool Drawable::getShouldAnimate( Bool considerPower ) const
 
 		if (obj->isDisabled())
 		{
-			if( obj->isDisabledByType( DISABLED_HACKED )
+			if(
+         ! obj->isKindOf( KINDOF_PRODUCED_AT_HELIPAD )  &&
+        // mal sez: helicopters just look goofy if they stop animating, so keep animating them, anyway
+
+        (  obj->isDisabledByType( DISABLED_HACKED )
 				|| obj->isDisabledByType( DISABLED_PARALYZED )
 				|| obj->isDisabledByType( DISABLED_EMP )
+				|| obj->isDisabledByType( DISABLED_SUBDUED )
 				// srj sez: unmanned things also should not animate. (eg, gattling tanks,
 				// which have a slight barrel animation even when at rest). if this causes
 				// a problem, we will need to fix gattling tanks in another way.
-				|| obj->isDisabledByType( DISABLED_UNMANNED )
+				|| obj->isDisabledByType( DISABLED_UNMANNED ) )
+
 				)
 				return FALSE;
 
@@ -642,6 +690,18 @@ void Drawable::setAnimationCompletionTime(UnsignedInt numFrames)
 		ObjectDrawInterface* di = (*dm)->getObjectDrawInterface();
 		if (di)
 			di->setAnimationCompletionTime(numFrames);
+	}
+}
+
+//Kris: Manually set a drawable's current animation to specific frame.
+//-------------------------------------------------------------------------------------------------
+void Drawable::setAnimationFrame( int frame )
+{
+	for (DrawModule** dm = getDrawModules(); *dm; ++dm)
+	{
+		ObjectDrawInterface* di = (*dm)->getObjectDrawInterface();
+		if (di)
+			di->setAnimationFrame( frame );
 	}
 }
 
@@ -1029,7 +1089,10 @@ void Drawable::reactToBodyDamageStateChange(BodyDamageType newState)
 		MAKE_MODELCONDITION_MASK3(MODELCONDITION_DAMAGED, MODELCONDITION_REALLY_DAMAGED, MODELCONDITION_RUBBLE),
 		newDamage);
 
-	startAmbientSound(newState, TheGlobalData->m_timeOfDay);
+  // When loading map, ambient sound starting is handled by onLevelStart(), so that we can
+  // correctly react to customizations
+  if ( !TheGameLogic->isLoadingMap() )
+ 	  startAmbientSound(newState, TheGlobalData->m_timeOfDay);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1051,6 +1114,12 @@ void Drawable::setEffectiveOpacity( Real pulseFactor, Real explicitOpacity /* = 
 //-------------------------------------------------------------------------------------------------
 void Drawable::imitateStealthLook( Drawable& otherDraw )
 {
+  m_stealthOpacity = otherDraw.friend_getStealthOpacity();
+  m_explicitOpacity = otherDraw.friend_getExplicitOpacity();
+  m_effectiveStealthOpacity = otherDraw.friend_getEffectiveStealthOpacity();
+  m_hidden = otherDraw.isDrawableEffectivelyHidden();
+  m_hiddenByStealth = otherDraw.isDrawableEffectivelyHidden();
+  m_stealthLook = otherDraw.getStealthLook();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1151,6 +1220,22 @@ void Drawable::updateDrawable()
 				m_colorTintEnvelope = newInstance(TintEnvelope);
 			m_colorTintEnvelope->play( &DARK_GRAY_DISABLED_COLOR, 30, 30, SUSTAIN_INDEFINITELY);
 		}
+		else if( testTintStatus(TINT_STATUS_GAINING_SUBDUAL_DAMAGE) )
+		{
+			// Disabled has precedence, so it goes first
+			if (m_colorTintEnvelope == nullptr)
+				m_colorTintEnvelope = newInstance(TintEnvelope);
+			m_colorTintEnvelope->play( &SUBDUAL_DAMAGE_COLOR, 150, 150, SUSTAIN_INDEFINITELY);
+		}
+		else if( testTintStatus(TINT_STATUS_FRENZY) )
+		{
+			// Disabled has precedence, so it goes first
+			if (m_colorTintEnvelope == nullptr)
+				m_colorTintEnvelope = newInstance(TintEnvelope);
+
+      m_colorTintEnvelope->play( isKindOf( KINDOF_INFANTRY) ? &FRENZY_COLOR_INFANTRY:&FRENZY_COLOR, 30, 30, SUSTAIN_INDEFINITELY);
+
+    }
 //		else if ( testTintStatus( TINT_STATUS_POISONED) )
 //		{
 //			if (m_colorTintEnvelope == nullptr)
@@ -1187,11 +1272,48 @@ void Drawable::updateDrawable()
 	if (m_selectionFlashEnvelope)
 		m_selectionFlashEnvelope->update(); // selection flashing
 
-	//If we have an ambient sound, and we aren't currently playing it, attempt to play it now
-	if( m_ambientSound && m_ambientSoundEnabled && !m_ambientSound->m_event.getEventName().isEmpty() && !m_ambientSound->m_event.isCurrentlyPlaying() )
-	{
-		startAmbientSound();
-	}
+	//If we have an ambient sound, and we aren't currently playing it, attempt to play it now.
+  // However, if the attached sound is a one-shot (non-looping) sound, don't restart it -- only
+  // start it ONCE. The problem is, looping sounds need to keep being restarted. Why? Because
+  // MilesAudioManager will kill the sound (in MilesAudioManager::processPlayingList) if gets
+  // out of range. Looping ambient sounds need to restart if the user moves back into range.
+  // The MilesAudioManager doesn't handle this, so we need to keep checking looping sounds
+  // to see if they are in range. But this messes up non-looping sounds -- they keep looping!
+  // End result: a hack of testing the looping bit and only restarting the sound if the looping
+  // bit is on and the loop count is 0 (loop forever).
+  if( m_ambientSound && m_ambientSoundEnabled && m_ambientSoundEnabledFromScript &&
+      !m_ambientSound->m_event.getEventName().isEmpty() && !m_ambientSound->m_event.isCurrentlyPlaying() )
+  {
+    const AudioEventInfo * eventInfo = m_ambientSound->m_event.getAudioEventInfo();
+
+    if ( eventInfo == nullptr && TheAudio != nullptr )
+    {
+      // We'll need this in a second anyway so cache it
+      TheAudio->getInfoForAudioEvent( &m_ambientSound->m_event );
+      eventInfo = m_ambientSound->m_event.getAudioEventInfo();
+    }
+
+    if ( eventInfo == nullptr || ( eventInfo->isPermanentSound() ) )
+    {
+  		startAmbientSound();
+    }
+ 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+// Called just after the level loads. Only called for NEW games, not save games.
+void Drawable::onLevelStart()
+{
+  // Make sure the current ambient sound is playing if it should be playing. Needed because
+  // the call to startAmbientSound in the constructor is too early to
+  // actually start the sound if the constructor is called during level load.
+  if( m_ambientSoundEnabled && m_ambientSoundEnabledFromScript &&
+      ( m_ambientSound == nullptr ||
+        ( !m_ambientSound->m_event.getEventName().isEmpty() && !m_ambientSound->m_event.isCurrentlyPlaying() ) ) )
+  {
+    // Unlike the check in the update() function, we want to do this for looping & one-shot sounds equally
+    startAmbientSound();
+  }
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1256,6 +1378,10 @@ Bool Drawable::calcPhysicsXform(PhysicsXformInfo& info)
 				calcPhysicsXformWheels(locomotor, info);
 				hasPhysicsXform = true;
 				break;
+			case LOCO_MOTORCYCLE:
+				calcPhysicsXformMotorcycle( locomotor, info );
+				hasPhysicsXform = true;
+				break;
 			case LOCO_TREADS:
 				calcPhysicsXformTreads(locomotor, info);
 				hasPhysicsXform = true;
@@ -1272,19 +1398,19 @@ Bool Drawable::calcPhysicsXform(PhysicsXformInfo& info)
 		}
 	}
 
-	if (hasPhysicsXform)
-	{
-     // HOTFIX: Ensure that we are not passing denormalized values back to caller
-     // @todo remove hotfix
-     if (info.m_totalPitch>-1e-20f&&info.m_totalPitch<1e-20f)
-       info.m_totalPitch=0.f;
-     if (info.m_totalRoll>-1e-20f&&info.m_totalRoll<1e-20f)
-       info.m_totalRoll=0.f;
-     if (info.m_totalYaw>-1e-20f&&info.m_totalYaw<1e-20f)
-       info.m_totalYaw=0.f;
-     if (info.m_totalZ>-1e-20f&&info.m_totalZ<1e-20f)
-       info.m_totalZ=0.f;
-	}
+  if (hasPhysicsXform)
+  {
+    // HOTFIX: Ensure that we are not passing denormalized values back to caller
+    // @todo remove hotfix
+    if (info.m_totalPitch>-1e-20f&&info.m_totalPitch<1e-20f)
+      info.m_totalPitch=0.f;
+    if (info.m_totalRoll>-1e-20f&&info.m_totalRoll<1e-20f)
+      info.m_totalRoll=0.f;
+    if (info.m_totalYaw>-1e-20f&&info.m_totalYaw<1e-20f)
+      info.m_totalYaw=0.f;
+    if (info.m_totalZ>-1e-20f&&info.m_totalZ<1e-20f)
+      info.m_totalZ=0.f;
+  }
 
 	return hasPhysicsXform;
 }
@@ -1376,6 +1502,7 @@ void Drawable::calcPhysicsXformHoverOrWings( const Locomotor *locomotor, Physics
 		m_locoInfo = newInstance(DrawableLocoInfo);
 
 	const Real ACCEL_PITCH_LIMIT = locomotor->getAccelPitchLimit();
+	const Real DECEL_PITCH_LIMIT = locomotor->getDecelPitchLimit();
 	const Real PITCH_STIFFNESS = locomotor->getPitchStiffness();
 	const Real ROLL_STIFFNESS =  locomotor->getRollStiffness();
 	const Real PITCH_DAMPING = locomotor->getPitchDamping();
@@ -1454,15 +1581,26 @@ void Drawable::calcPhysicsXformHoverOrWings( const Locomotor *locomotor, Physics
 
 	// limit acceleration pitch and roll
 
-	if (m_locoInfo->m_accelerationPitch > ACCEL_PITCH_LIMIT)
-		m_locoInfo->m_accelerationPitch = ACCEL_PITCH_LIMIT;
+	if (m_locoInfo->m_accelerationPitch > DECEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationPitch = DECEL_PITCH_LIMIT;
 	else if (m_locoInfo->m_accelerationPitch < -ACCEL_PITCH_LIMIT)
 		m_locoInfo->m_accelerationPitch = -ACCEL_PITCH_LIMIT;
 
-	if (m_locoInfo->m_accelerationRoll > ACCEL_PITCH_LIMIT)
-		m_locoInfo->m_accelerationRoll = ACCEL_PITCH_LIMIT;
+	if (m_locoInfo->m_accelerationRoll > DECEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationRoll = DECEL_PITCH_LIMIT;
 	else if (m_locoInfo->m_accelerationRoll < -ACCEL_PITCH_LIMIT)
 		m_locoInfo->m_accelerationRoll = -ACCEL_PITCH_LIMIT;
+
+
+
+	const Real RUDDER_CORRECTION_DEGREE   = locomotor->getRudderCorrectionDegree();
+	const Real RUDDER_CORRECTION_RATE     = locomotor->getRudderCorrectionRate();
+	const Real ELEVATOR_CORRECTION_DEGREE = locomotor->getElevatorCorrectionDegree();
+	const Real ELEVATOR_CORRECTION_RATE   = locomotor->getElevatorCorrectionRate();
+
+  info.m_totalYaw = RUDDER_CORRECTION_DEGREE * sin( m_locoInfo->m_yawModulator += RUDDER_CORRECTION_RATE );
+  info.m_totalPitch += ELEVATOR_CORRECTION_DEGREE * cos( m_locoInfo->m_pitchModulator += ELEVATOR_CORRECTION_RATE );
+
 
 	info.m_totalZ = 0.0f;
 }
@@ -1480,6 +1618,7 @@ void Drawable::calcPhysicsXformTreads( const Locomotor *locomotor, PhysicsXformI
 	const Real OVERLAP_ROUGH_VIBRATION_FACTOR = 5.0f;
 	const Real MAX_ROUGH_VIBRATION = 0.5f;
 	const Real ACCEL_PITCH_LIMIT = locomotor->getAccelPitchLimit();
+	const Real DECEL_PITCH_LIMIT = locomotor->getDecelPitchLimit();
 	const Real PITCH_STIFFNESS = locomotor->getPitchStiffness();
 	const Real ROLL_STIFFNESS =  locomotor->getRollStiffness();
 	const Real PITCH_DAMPING = locomotor->getPitchDamping();
@@ -1688,13 +1827,13 @@ void Drawable::calcPhysicsXformTreads( const Locomotor *locomotor, PhysicsXformI
 
 	// limit recoil pitch and roll
 
-	if (m_locoInfo->m_accelerationPitch > ACCEL_PITCH_LIMIT)
-		m_locoInfo->m_accelerationPitch = ACCEL_PITCH_LIMIT;
+	if (m_locoInfo->m_accelerationPitch > DECEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationPitch = DECEL_PITCH_LIMIT;
 	else if (m_locoInfo->m_accelerationPitch < -ACCEL_PITCH_LIMIT)
 		m_locoInfo->m_accelerationPitch = -ACCEL_PITCH_LIMIT;
 
-	if (m_locoInfo->m_accelerationRoll > ACCEL_PITCH_LIMIT)
-		m_locoInfo->m_accelerationRoll = ACCEL_PITCH_LIMIT;
+	if (m_locoInfo->m_accelerationRoll > DECEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationRoll = DECEL_PITCH_LIMIT;
 	else if (m_locoInfo->m_accelerationRoll < -ACCEL_PITCH_LIMIT)
 		m_locoInfo->m_accelerationRoll = -ACCEL_PITCH_LIMIT;
 
@@ -1732,6 +1871,7 @@ void Drawable::calcPhysicsXformWheels( const Locomotor *locomotor, PhysicsXformI
 		m_locoInfo = newInstance(DrawableLocoInfo);
 
 	const Real ACCEL_PITCH_LIMIT = locomotor->getAccelPitchLimit();
+	const Real DECEL_PITCH_LIMIT = locomotor->getDecelPitchLimit();
 	const Real BOUNCE_ANGLE_KICK = locomotor->getBounceKick();
 	const Real PITCH_STIFFNESS = locomotor->getPitchStiffness();
 	const Real ROLL_STIFFNESS =  locomotor->getRollStiffness();
@@ -1884,13 +2024,13 @@ void Drawable::calcPhysicsXformWheels( const Locomotor *locomotor, PhysicsXformI
 
 	// limit acceleration pitch and roll
 
-	if (m_locoInfo->m_accelerationPitch > ACCEL_PITCH_LIMIT)
-		m_locoInfo->m_accelerationPitch = ACCEL_PITCH_LIMIT;
+	if (m_locoInfo->m_accelerationPitch > DECEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationPitch = DECEL_PITCH_LIMIT;
 	else if (m_locoInfo->m_accelerationPitch < -ACCEL_PITCH_LIMIT)
 		m_locoInfo->m_accelerationPitch = -ACCEL_PITCH_LIMIT;
 
-	if (m_locoInfo->m_accelerationRoll > ACCEL_PITCH_LIMIT)
-		m_locoInfo->m_accelerationRoll = ACCEL_PITCH_LIMIT;
+	if (m_locoInfo->m_accelerationRoll > DECEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationRoll = DECEL_PITCH_LIMIT;
 	else if (m_locoInfo->m_accelerationRoll < -ACCEL_PITCH_LIMIT)
 		m_locoInfo->m_accelerationRoll = -ACCEL_PITCH_LIMIT;
 
@@ -2017,6 +2157,303 @@ void Drawable::calcPhysicsXformWheels( const Locomotor *locomotor, PhysicsXformI
 	info.m_totalZ += fabs(pitchHeight)/divisor;
 	info.m_totalZ += fabs(rollHeight)/divisor;
 }
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+void Drawable::calcPhysicsXformMotorcycle( const Locomotor *locomotor, PhysicsXformInfo& info )
+{
+	if (m_locoInfo == nullptr)
+		m_locoInfo = newInstance(DrawableLocoInfo);
+
+	const Real ACCEL_PITCH_LIMIT = locomotor->getAccelPitchLimit();
+	const Real DECEL_PITCH_LIMIT = locomotor->getDecelPitchLimit();
+	const Real BOUNCE_ANGLE_KICK = locomotor->getBounceKick();
+	const Real PITCH_STIFFNESS = locomotor->getPitchStiffness();
+	const Real ROLL_STIFFNESS =  locomotor->getRollStiffness();
+	const Real PITCH_DAMPING = locomotor->getPitchDamping();
+	const Real ROLL_DAMPING = locomotor->getRollDamping();
+	const Real FORWARD_ACCEL_COEFF = locomotor->getForwardAccelCoef();
+	const Real LATERAL_ACCEL_COEFF = locomotor->getLateralAccelCoef();
+	const Real UNIFORM_AXIAL_DAMPING = locomotor->getUniformAxialDamping();
+
+	const Real MAX_SUSPENSION_EXTENSION = locomotor->getMaxWheelExtension(); //-2.3f;
+//	const Real MAX_SUSPENSION_COMPRESSION = locomotor->getMaxWheelCompression(); //1.4f;
+	const Real WHEEL_ANGLE = locomotor->getWheelTurnAngle(); //PI/8;
+
+	const Bool DO_WHEELS = locomotor->hasSuspension();
+
+	// get object from logic
+	Object *obj = getObject();
+	if (obj == nullptr)
+		return;
+
+	AIUpdateInterface *ai = obj->getAIUpdateInterface();
+	if (ai == nullptr)
+		return ;
+
+	// get object physics state
+	PhysicsBehavior *physics = obj->getPhysics();
+	if (physics == nullptr)
+		return ;
+
+	// get our position and direction vector
+	const Coord3D *pos = getPosition();
+	const Coord3D *dir = getUnitDirectionVector2D();
+	const Coord3D *accel = physics->getAcceleration();
+
+	// compute perpendicular (2d)
+	Coord3D perp;
+	perp.x = -dir->y;
+	perp.y = dir->x;
+	perp.z = 0.0f;
+
+	// find pitch and roll of terrain under chassis
+	Coord3D normal;
+	Real hheight = TheTerrainLogic->getLayerHeight( pos->x, pos->y, obj->getLayer(), &normal );
+
+	Real dot = normal.x * dir->x + normal.y * dir->y;
+	Real groundPitch = dot * (PI/2.0f);
+
+	dot = normal.x * perp.x + normal.y * perp.y;
+	Real groundRoll = dot * (PI/2.0f);
+
+	Bool airborne = obj->isSignificantlyAboveTerrain();
+
+	if (airborne)
+	{
+		if (DO_WHEELS)
+		{
+			// Wheels extend when airborne.
+			m_locoInfo->m_wheelInfo.m_framesAirborne = 0;
+			m_locoInfo->m_wheelInfo.m_framesAirborneCounter++;
+			if (pos->z - hheight > -MAX_SUSPENSION_EXTENSION)
+			{
+				m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset += (MAX_SUSPENSION_EXTENSION - m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset)/2.0f;
+				m_locoInfo->m_wheelInfo.m_rearRightHeightOffset = m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset;
+			}
+			else
+			{
+				m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset += (0 - m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset)/2.0f;
+				m_locoInfo->m_wheelInfo.m_rearRightHeightOffset = m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset;
+			}
+		}
+		// Calculate suspension info.
+		Real length = obj->getGeometryInfo().getMajorRadius();
+		//Real width = obj->getGeometryInfo().getMinorRadius();
+		Real pitchHeight = length*Sin(m_locoInfo->m_pitch + m_locoInfo->m_accelerationPitch - groundPitch);
+		//Real rollHeight = width*Sin(m_locoInfo->m_roll + m_locoInfo->m_accelerationRoll - groundRoll);
+		info.m_totalZ = fabs(pitchHeight)/4;// + fabs(rollHeight)/4;
+		//return; // maintain the same orientation while we fly through the air.
+	}
+
+	// Bouncy.
+	Real curSpeed = physics->getVelocityMagnitude();
+#if 1
+	Real maxSpeed = ai->getCurLocomotorSpeed();
+	if (!airborne && curSpeed > maxSpeed/10)
+	{
+		Real factor = curSpeed/maxSpeed;
+		if (fabs(m_locoInfo->m_pitchRate)<factor*BOUNCE_ANGLE_KICK/4 && fabs(m_locoInfo->m_rollRate)<factor*BOUNCE_ANGLE_KICK/8)
+		{
+			// do the bouncy.
+			switch (GameClientRandomValue(0,3))
+			{
+			case 0:
+				m_locoInfo->m_pitchRate -= BOUNCE_ANGLE_KICK*factor;
+				m_locoInfo->m_rollRate -= BOUNCE_ANGLE_KICK*factor/2;
+				break;
+			case 1:
+				m_locoInfo->m_pitchRate += BOUNCE_ANGLE_KICK*factor;
+				m_locoInfo->m_rollRate -= BOUNCE_ANGLE_KICK*factor/2;
+				break;
+			case 2:
+				m_locoInfo->m_pitchRate -= BOUNCE_ANGLE_KICK*factor;
+				m_locoInfo->m_rollRate += BOUNCE_ANGLE_KICK*factor/2;
+				break;
+			case 3:
+				m_locoInfo->m_pitchRate += BOUNCE_ANGLE_KICK*factor;
+				m_locoInfo->m_rollRate += BOUNCE_ANGLE_KICK*factor/2;
+				break;
+			}
+		}
+	}
+
+#endif
+
+	// process chassis suspension dynamics - damp back towards groundPitch
+
+	// the ground can only push back if we're touching it
+	if (!airborne)
+	{
+		m_locoInfo->m_pitchRate += ((-PITCH_STIFFNESS * (m_locoInfo->m_pitch - groundPitch)) + (-PITCH_DAMPING * m_locoInfo->m_pitchRate));		// spring/damper
+		m_locoInfo->m_rollRate += ((-ROLL_STIFFNESS * (m_locoInfo->m_roll - groundRoll)) + (-ROLL_DAMPING * m_locoInfo->m_rollRate));		// spring/damper
+	}
+	else
+	{
+		//Autolevel
+		m_locoInfo->m_pitchRate += ( (-PITCH_STIFFNESS * m_locoInfo->m_pitch) + (-PITCH_DAMPING * m_locoInfo->m_pitchRate) );		// spring/damper
+		m_locoInfo->m_rollRate += ( (-ROLL_STIFFNESS * m_locoInfo->m_roll) + (-ROLL_DAMPING * m_locoInfo->m_rollRate) );		// spring/damper
+	}
+
+	m_locoInfo->m_pitch += m_locoInfo->m_pitchRate * UNIFORM_AXIAL_DAMPING;
+	m_locoInfo->m_roll += m_locoInfo->m_rollRate   * UNIFORM_AXIAL_DAMPING;
+
+	// process chassis acceleration dynamics - damp back towards zero
+
+	m_locoInfo->m_accelerationPitchRate += ((-PITCH_STIFFNESS * (m_locoInfo->m_accelerationPitch)) + (-PITCH_DAMPING * m_locoInfo->m_accelerationPitchRate));		// spring/damper
+	m_locoInfo->m_accelerationPitch += m_locoInfo->m_accelerationPitchRate;
+
+	m_locoInfo->m_accelerationRollRate += ((-ROLL_STIFFNESS * m_locoInfo->m_accelerationRoll) + (-ROLL_DAMPING * m_locoInfo->m_accelerationRollRate));		// spring/damper
+	m_locoInfo->m_accelerationRoll += m_locoInfo->m_accelerationRollRate;
+
+	// compute total pitch and roll of tank
+	info.m_totalPitch = m_locoInfo->m_pitch + m_locoInfo->m_accelerationPitch;
+
+
+  // THis logic had recently been added to Drawable::applyPhysicsXform(), which was naughty, since it clamped the roll in every drawable in the game
+  // Now only motorcycles enjoy this constraint
+  Real unclampedRoll = m_locoInfo->m_roll + m_locoInfo->m_accelerationRoll;
+  info.m_totalRoll = (unclampedRoll > 0.5f && unclampedRoll < -0.5f ? unclampedRoll : 0.0f);
+
+	if( airborne )
+	{
+	}
+
+	if (physics->isMotive())
+	{
+		// cause the chassis to pitch & roll in reaction to acceleration/deceleration
+		Real forwardAccel = dir->x * accel->x + dir->y * accel->y;
+		m_locoInfo->m_accelerationPitchRate += -(FORWARD_ACCEL_COEFF * forwardAccel);
+
+		Real lateralAccel = -dir->y * accel->x + dir->x * accel->y;
+		m_locoInfo->m_accelerationRollRate += -(LATERAL_ACCEL_COEFF * lateralAccel);
+	}
+
+	// limit acceleration pitch and roll
+
+	if (m_locoInfo->m_accelerationPitch > DECEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationPitch = DECEL_PITCH_LIMIT;
+	else if (m_locoInfo->m_accelerationPitch < -ACCEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationPitch = -ACCEL_PITCH_LIMIT;
+
+	if (m_locoInfo->m_accelerationRoll > DECEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationRoll = DECEL_PITCH_LIMIT;
+	else if (m_locoInfo->m_accelerationRoll < -ACCEL_PITCH_LIMIT)
+		m_locoInfo->m_accelerationRoll = -ACCEL_PITCH_LIMIT;
+
+	info.m_totalZ = 0;
+
+	// Calculate suspension info.
+	Real length = obj->getGeometryInfo().getMajorRadius();
+	Real width = obj->getGeometryInfo().getMinorRadius();
+	Real pitchHeight = length*Sin(info.m_totalPitch-groundPitch);
+	Real rollHeight = width*Sin(info.m_totalRoll-groundRoll);
+	if (DO_WHEELS)
+	{
+		// calculate each wheel position
+		m_locoInfo->m_wheelInfo.m_framesAirborne = m_locoInfo->m_wheelInfo.m_framesAirborneCounter;
+		m_locoInfo->m_wheelInfo.m_framesAirborneCounter = 0;
+		TWheelInfo newInfo = m_locoInfo->m_wheelInfo;
+		PhysicsTurningType rotation = physics->getTurning();
+		if (rotation == TURN_NEGATIVE) {
+			newInfo.m_wheelAngle = -WHEEL_ANGLE;
+		} else if (rotation == TURN_POSITIVE) {
+			newInfo.m_wheelAngle = WHEEL_ANGLE;
+		}	else {
+			newInfo.m_wheelAngle = 0;
+		}
+		if (physics->getForwardSpeed2D() < 0.0f) {
+			// if we're moving backwards, the wheels rotate in the opposite direction.
+			newInfo.m_wheelAngle = -newInfo.m_wheelAngle;
+		}
+
+		//
+		///@todo Steven/John ... please review this and make sure it makes sense (CBD)
+		// we're going to add the angle to the current wheel rotation ... but we're going to
+		// divide that number to add small angles.  This allows for "smoother" wheel turning
+		// transitions ... and when the AI has things move in a straight line, since it's
+		// constantly telling the object to go left, go straight, go right, go straight,
+		// etc, this smaller angle we'll be adding covers the constant wheel shifting
+		// left and right when moving in a relatively straight line
+		//
+		#define WHEEL_SMOOTHNESS 10.0f  // higher numbers add smaller angles, make it more "smooth"
+		m_locoInfo->m_wheelInfo.m_wheelAngle += (newInfo.m_wheelAngle - m_locoInfo->m_wheelInfo.m_wheelAngle)/WHEEL_SMOOTHNESS;
+
+		const Real SPRING_FACTOR = 0.9f;
+		if (pitchHeight<0)
+		{
+			// Front raising up
+			newInfo.m_frontLeftHeightOffset		= SPRING_FACTOR*(pitchHeight/3+pitchHeight/2);
+			newInfo.m_rearLeftHeightOffset		= -pitchHeight/2 + pitchHeight/4;
+			newInfo.m_frontRightHeightOffset	= newInfo.m_frontLeftHeightOffset;
+			newInfo.m_rearRightHeightOffset		= newInfo.m_rearLeftHeightOffset;
+		}
+		else
+		{
+			// Back raising up.
+			newInfo.m_frontLeftHeightOffset		= (-pitchHeight/4+pitchHeight/2);
+			newInfo.m_rearLeftHeightOffset		= SPRING_FACTOR*(-pitchHeight/2 + -pitchHeight/3);
+			newInfo.m_frontRightHeightOffset	= newInfo.m_frontLeftHeightOffset;
+			newInfo.m_rearRightHeightOffset		= newInfo.m_rearLeftHeightOffset;
+		}
+		/*
+		if (rollHeight>0) {	// Right raising up
+			newInfo.m_frontRightHeightOffset += -SPRING_FACTOR*(rollHeight/3+rollHeight/2);
+			newInfo.m_rearLeftHeightOffset += rollHeight/2 - rollHeight/4;
+		}	else {	// Left raising up.
+			newInfo.m_frontRightHeightOffset += -rollHeight/2 + rollHeight/4;
+			newInfo.m_rearLeftHeightOffset += SPRING_FACTOR*(rollHeight/3+rollHeight/2);
+		}
+		*/
+		if (newInfo.m_frontLeftHeightOffset < m_locoInfo->m_wheelInfo.m_frontLeftHeightOffset)
+		{
+			// If it's going down, dampen the movement a bit
+			m_locoInfo->m_wheelInfo.m_frontLeftHeightOffset += (newInfo.m_frontLeftHeightOffset - m_locoInfo->m_wheelInfo.m_frontLeftHeightOffset)/2.0f;
+			m_locoInfo->m_wheelInfo.m_frontRightHeightOffset = m_locoInfo->m_wheelInfo.m_frontLeftHeightOffset;
+		}
+		else
+		{
+			m_locoInfo->m_wheelInfo.m_frontLeftHeightOffset = newInfo.m_frontLeftHeightOffset;
+			m_locoInfo->m_wheelInfo.m_frontRightHeightOffset = newInfo.m_frontLeftHeightOffset;
+		}
+		if (newInfo.m_rearLeftHeightOffset < m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset)
+		{
+			// If it's going down, dampen the movement a bit
+			m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset += (newInfo.m_rearLeftHeightOffset - m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset)/2.0f;
+			m_locoInfo->m_wheelInfo.m_rearRightHeightOffset = m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset;
+		}
+		else
+		{
+			m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset = newInfo.m_rearLeftHeightOffset;
+			m_locoInfo->m_wheelInfo.m_rearRightHeightOffset = newInfo.m_rearLeftHeightOffset;
+		}
+		//m_locoInfo->m_wheelInfo = newInfo;
+		if (m_locoInfo->m_wheelInfo.m_frontLeftHeightOffset<MAX_SUSPENSION_EXTENSION)
+		{
+			m_locoInfo->m_wheelInfo.m_frontLeftHeightOffset = MAX_SUSPENSION_EXTENSION;
+			m_locoInfo->m_wheelInfo.m_frontRightHeightOffset = MAX_SUSPENSION_EXTENSION;
+		}
+		if (m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset<MAX_SUSPENSION_EXTENSION)
+		{
+			m_locoInfo->m_wheelInfo.m_rearLeftHeightOffset = MAX_SUSPENSION_EXTENSION;
+			m_locoInfo->m_wheelInfo.m_rearRightHeightOffset = MAX_SUSPENSION_EXTENSION;
+		}
+	}
+	// If we are > 22 degrees, need to raise height;
+	Real divisor = 4;
+	Real pitch = fabs(info.m_totalPitch-groundPitch);
+
+	if (pitch>PI/8) {
+		divisor = ((4*PI/8) + (1*(pitch-PI/8)))/pitch;
+	}
+
+	if( !airborne )
+	{
+		info.m_totalZ += fabs(pitchHeight)/divisor;
+		info.m_totalZ += fabs(rollHeight)/divisor;
+	}
+}
+
 
 //-------------------------------------------------------------------------------------------------
 /** decodes the current previous damage type and sets the ambient sound set from that. */
@@ -2706,8 +3143,6 @@ void Drawable::drawUIText()
 													TheDrawGroupInfo->m_dropShadowOffsetY);
 
 	}
-
-
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -2862,7 +3297,7 @@ void Drawable::drawEnthusiastic(const IRegion2D* healthBarRegion)
 			// given our scaled width and height we need to find the bottom left point to draw the image at
 			ICoord2D screen;
 			screen.x = REAL_TO_INT( healthBarRegion->lo.x + (barWidth * 0.25f) - (frameWidth * 0.5f) );
-			screen.y = healthBarRegion->hi.y;
+			screen.y = healthBarRegion->hi.y + (frameHeight * 0.25);
 			getIconInfo()->m_icon[ iconIndex ]->draw( screen.x, screen.y, frameWidth, frameHeight );
 
 		}
@@ -2928,6 +3363,11 @@ void Drawable::drawDemoralized(const IRegion2D* healthBarRegion)
 }
 #endif
 
+enum
+{
+	// The code tries to be below the health bar, but that pus it square under passenger pips.
+	BOMB_ICON_EXTRA_OFFSET = 5
+};
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 void Drawable::drawBombed(const IRegion2D* healthBarRegion)
@@ -2966,7 +3406,7 @@ void Drawable::drawBombed(const IRegion2D* healthBarRegion)
 				// given our scaled width and height we need to find the top left point to draw the image at
 				ICoord2D screen;
 				screen.x = REAL_TO_INT( healthBarRegion->lo.x + (barWidth * 0.5f) - (frameWidth * 0.5f) );
-				screen.y = REAL_TO_INT( healthBarRegion->lo.y + barHeight * 0.5f );
+				screen.y = REAL_TO_INT( healthBarRegion->lo.y + barHeight * 0.5f ) + BOMB_ICON_EXTRA_OFFSET;
 
 				getIconInfo()->m_icon[ ICON_CARBOMB ]->draw( screen.x, screen.y, frameWidth, frameHeight );
 				getIconInfo()->m_keepTillFrame[ ICON_CARBOMB ] = FOREVER;
@@ -3043,7 +3483,7 @@ void Drawable::drawBombed(const IRegion2D* healthBarRegion)
 						// given our scaled width and height we need to find the top left point to draw the image at
 						ICoord2D screen;
 						screen.x = REAL_TO_INT( healthBarRegion->lo.x + (barWidth * 0.5f) - (frameWidth * 0.5f) );
-						screen.y = REAL_TO_INT( healthBarRegion->lo.y + barHeight * 0.5f );
+						screen.y = REAL_TO_INT( healthBarRegion->lo.y + barHeight * 0.5f ) + BOMB_ICON_EXTRA_OFFSET;
 
 						getIconInfo()->m_icon[ ICON_BOMB_REMOTE ]->draw( screen.x, screen.y, frameWidth, frameHeight );
 						getIconInfo()->m_keepTillFrame[ ICON_BOMB_REMOTE ] = now + 1;
@@ -3083,7 +3523,7 @@ void Drawable::drawBombed(const IRegion2D* healthBarRegion)
 						// given our scaled width and height we need to find the top left point to draw the image at
 						ICoord2D screen;
 						screen.x = REAL_TO_INT( healthBarRegion->lo.x + (barWidth * 0.5f) - (frameWidth * 0.5f) );
-						screen.y = REAL_TO_INT( healthBarRegion->lo.y + barHeight * 0.5f );
+						screen.y = REAL_TO_INT( healthBarRegion->lo.y + barHeight * 0.5f ) + BOMB_ICON_EXTRA_OFFSET;
 
 						getIconInfo()->m_icon[ ICON_BOMB_REMOTE ]->draw( screen.x, screen.y, frameWidth, frameHeight );
 						getIconInfo()->m_keepTillFrame[ ICON_BOMB_REMOTE ] = now + 1;
@@ -3121,6 +3561,7 @@ void Drawable::drawDisabled(const IRegion2D* healthBarRegion)
 	if( obj->isDisabledByType( DISABLED_HACKED )
 		|| obj->isDisabledByType( DISABLED_PARALYZED )
 		|| obj->isDisabledByType( DISABLED_EMP )
+		|| obj->isDisabledByType( DISABLED_SUBDUED )
 		|| obj->isDisabledByType( DISABLED_UNDERPOWERED )
 		)
 	{
@@ -3216,6 +3657,9 @@ void Drawable::drawConstructPercent( const IRegion2D *healthBarRegion )
 
 	// convert drawable center position to screen coords
 	TheTacticalView->worldToScreen( &pos, &screen );
+
+  if ( screen.x < 1 )
+    return;
 
 	// draw the text
 	Color color = GameMakeColor( 255, 255, 255, 255 );
@@ -3448,6 +3892,14 @@ void Drawable::clearAndSetModelConditionState( ModelConditionFlagType clr, Model
 }
 
 //-------------------------------------------------------------------------------------------------
+DrawModule** Drawable::getDrawModulesNonDirty()
+{
+	DrawModule** dm = (DrawModule**)getModuleList(MODULETYPE_DRAW);
+	DEBUG_ASSERTCRASH(dm != nullptr, ("Draw Module List is not expected null"));
+	return dm;
+}
+
+//-------------------------------------------------------------------------------------------------
 DrawModule** Drawable::getDrawModules()
 {
 	DrawModule** dm = (DrawModule**)getModuleList(MODULETYPE_DRAW);
@@ -3635,6 +4087,15 @@ void Drawable::friend_bindToObject( Object *obj ) ///< bind this drawable to an 
 			setIndicatorColor(getObject()->getNightIndicatorColor());
 		else
 			setIndicatorColor(getObject()->getIndicatorColor());
+
+		if (getObject()->isKindOf(KINDOF_FS_FAKE))
+		{
+			Relationship rel = rts::getObservedOrLocalPlayer()->getRelationship(getObject()->getTeam());
+			if (rel == ALLIES || rel == NEUTRAL)
+				setTerrainDecal(TERRAIN_DECAL_SHADOW_TEXTURE);
+			else
+				setTerrainDecal(TERRAIN_DECAL_NONE);
+		}
 	}
 
 	for (DrawModule** dm = getDrawModules(); *dm; ++dm)
@@ -3664,6 +4125,15 @@ void Drawable::changedTeam()
 			setIndicatorColor( object->getNightIndicatorColor() );
 		else
 			setIndicatorColor( object->getIndicatorColor() );
+
+		if (object->isKindOf(KINDOF_FS_FAKE))
+		{
+			Relationship rel = rts::getObservedOrLocalPlayer()->getRelationship(object->getTeam());
+			if (rel == ALLIES || rel == NEUTRAL)
+				setTerrainDecal(TERRAIN_DECAL_SHADOW_TEXTURE);
+			else
+				setTerrainDecal(TERRAIN_DECAL_NONE);
+		}
 	}
 }
 
@@ -3835,64 +4305,164 @@ void	Drawable::setTimeOfDay(TimeOfDay tod)
 	replaceModelConditionFlags(c);
 }
 
+
+/**
+ * If you wish to change some parameters of the default ambient sound, but keep the rest,
+ * this function will give you the default ambient sound's info
+ */
+const AudioEventInfo * Drawable::getBaseSoundAmbientInfo() const
+{
+  const AudioEventRTS * baseAmbient = getTemplate()->getSoundAmbient();
+  if ( baseAmbient )
+    return baseAmbient->getAudioEventInfo();
+
+  return nullptr;
+}
+
+/**
+ * Produce a unique-across-entire-level name for this audio event
+ */
+void Drawable::mangleCustomAudioName( DynamicAudioEventInfo * audioToMangle ) const
+{
+  AsciiString customizedName;
+  customizedName.format( " CUSTOM %d ", (Int)getID() ); // Note space at beginning prevents collision with any names from INI file
+  customizedName.concat( audioToMangle->m_audioName );
+  audioToMangle->overrideAudioName( customizedName );
+}
+
+/**
+ * Force the Drawable to not ever get an ambient sound attached to it (except possibly for RUBBLE)
+ */
+void Drawable::setCustomSoundAmbientOff()
+{
+  clearCustomSoundAmbient( false );
+
+  m_customSoundAmbientInfo = getNoSoundMarker();
+}
+
+/**
+ * Force the Drawable to use the sound described by customAmbientInfo as its ambient sound.
+ * The Drawable expects TheAudio to own the actual info pointer
+ */
+void Drawable::setCustomSoundAmbientInfo( DynamicAudioEventInfo * customAmbientInfo )
+{
+  clearCustomSoundAmbient( false );
+
+  // This is mostly to make sure no one delete's the no sound marker, causing it to be
+  // recycled as a new no sound marker
+  DEBUG_ASSERTCRASH( customAmbientInfo != getNoSoundMarker(), ("No sound marker passed as custom ambient") );
+
+  // Set name to something different so we don't get confused
+
+  m_customSoundAmbientInfo = customAmbientInfo;
+
+  startAmbientSound(); // Note: checks for enabled flag
+}
+
+/**
+ * Return to using default ambient sound
+ */
+void Drawable::clearCustomSoundAmbient( bool restartSound )
+{
+  if ( m_ambientSound )
+  {
+    // Make sure sound doesn't keep a reference to the deleted pointer
+    m_ambientSound->m_event.setAudioEventInfo( nullptr );
+  }
+
+  // Stop using old info
+  stopAmbientSound();
+
+  m_customSoundAmbientInfo = nullptr;
+
+  if ( restartSound )
+  {
+    startAmbientSound(); // Note: checks for enabled flag
+  }
+}
+
+
 //-------------------------------------------------------------------------------------------------
 /** Attach and start playing an ambient sound to this drawable */
 //-------------------------------------------------------------------------------------------------
-void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod)
+void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPermanent)
 {
 	stopAmbientSound();
 
-	//Get the specific ambient sound for the damage type.
-	const AudioEventRTS& audio = getAmbientSoundByDamage(dt);
-	Bool trySound = FALSE;
-	if( audio.getEventName().isNotEmpty() )
-	{
-		if (m_ambientSound == nullptr)
-			m_ambientSound = newInstance(DynamicAudioEventRTS);
+  Bool trySound = FALSE;
 
-		(m_ambientSound->m_event) = audio;
-		trySound = TRUE;
-	}
-	else if( dt != BODY_PRISTINE && dt != BODY_RUBBLE )
-	{
-		//If the ambient sound was absent in the case of non-pristine damage types,
-		//try getting the pristine one. Most of our cases actually specify just the
-		//pristine sound and want to use it for all states (except dead/rubble).
-		const AudioEventRTS& pristineAudio = getAmbientSoundByDamage( BODY_PRISTINE );
-		if( pristineAudio.getEventName().isNotEmpty() )
-		{
-			if (m_ambientSound == nullptr)
-				m_ambientSound = newInstance(DynamicAudioEventRTS);
-			(m_ambientSound->m_event) = pristineAudio;
-			trySound = TRUE;
-		}
-	}
+  // Look for customized sound info
+  if ( dt != BODY_RUBBLE && m_customSoundAmbientInfo != nullptr )
+  {
+    if ( m_customSoundAmbientInfo != getNoSoundMarker() )
+    {
+      if (m_ambientSound == nullptr)
+        m_ambientSound = newInstance(DynamicAudioEventRTS);
+
+      // Make sure m_event will accept the custom info
+      m_ambientSound->m_event.setEventName( m_customSoundAmbientInfo->m_audioName );
+      m_ambientSound->m_event.setAudioEventInfo( m_customSoundAmbientInfo );
+      trySound = TRUE;
+    }
+  }
+  else
+  {
+    // Didn't get customized sound
+    //Get the specific ambient sound for the damage type.
+	  const AudioEventRTS& audio = getAmbientSoundByDamage(dt);
+	  if( audio.getEventName().isNotEmpty() )
+	  {
+		  if (m_ambientSound == nullptr)
+			  m_ambientSound = newInstance(DynamicAudioEventRTS);
+
+		  (m_ambientSound->m_event) = audio;
+		  trySound = TRUE;
+	  }
+	  else if( dt != BODY_PRISTINE && dt != BODY_RUBBLE )
+	  {
+		  //If the ambient sound was absent in the case of non-pristine damage types,
+		  //try getting the pristine one. Most of our cases actually specify just the
+		  //pristine sound and want to use it for all states (except dead/rubble).
+		  const AudioEventRTS& pristineAudio = getAmbientSoundByDamage( BODY_PRISTINE );
+		  if( pristineAudio.getEventName().isNotEmpty() )
+		  {
+			  if (m_ambientSound == nullptr)
+				  m_ambientSound = newInstance(DynamicAudioEventRTS);
+			  (m_ambientSound->m_event) = pristineAudio;
+			  trySound = TRUE;
+		  }
+	  }
+  }
+
 
 	if( trySound && m_ambientSound )
 	{
 		const AudioEventInfo *info = m_ambientSound->m_event.getAudioEventInfo();
 		if( info )
 		{
-			if( BitIsSet( info->m_type, ST_GLOBAL) || info->m_priority == AP_CRITICAL )
-			{
-				//Play it anyways.
-				m_ambientSound->m_event.setDrawableID(getID());
-				m_ambientSound->m_event.setTimeOfDay(tod);
-				m_ambientSound->m_event.setPlayingHandle(TheAudio->addAudioEvent( &m_ambientSound->m_event ));
-			}
-			else
-			{
-				//Check if it's close enough to try playing (optimization)
-				Coord3D vector = *getPosition();
-				vector.sub( *TheAudio->getListenerPosition() );
-				Real distSqr = vector.lengthSqr();
-				if( distSqr < sqr( info->m_maxDistance ) )
-				{
-					m_ambientSound->m_event.setDrawableID(getID());
-					m_ambientSound->m_event.setTimeOfDay(tod);
-					m_ambientSound->m_event.setPlayingHandle(TheAudio->addAudioEvent( &m_ambientSound->m_event ));
-				}
-			}
+      if ( !onlyIfPermanent || info->isPermanentSound() )
+      {
+			  if( BitIsSet( info->m_type, ST_GLOBAL) || info->m_priority == AP_CRITICAL )
+			  {
+				  //Play it anyways.
+				  m_ambientSound->m_event.setDrawableID(getID());
+				  m_ambientSound->m_event.setTimeOfDay(tod);
+				  m_ambientSound->m_event.setPlayingHandle(TheAudio->addAudioEvent( &m_ambientSound->m_event ));
+			  }
+			  else
+			  {
+				  //Check if it's close enough to try playing (optimization)
+				  Coord3D vector = *getPosition();
+				  vector.sub( *TheAudio->getListenerPosition() );
+				  Real distSqr = vector.lengthSqr();
+				  if( distSqr < sqr( info->m_maxDistance ) )
+				  {
+					  m_ambientSound->m_event.setDrawableID(getID());
+					  m_ambientSound->m_event.setTimeOfDay(tod);
+					  m_ambientSound->m_event.setPlayingHandle(TheAudio->addAudioEvent( &m_ambientSound->m_event ));
+				  }
+			  }
+      }
 		}
 		else
 		{
@@ -3906,16 +4476,20 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod)
 //-------------------------------------------------------------------------------------------------
 // Attach and start playing an ambient sound to this drawable. Calculates states automatically.
 //-------------------------------------------------------------------------------------------------
-void Drawable::startAmbientSound()
+void Drawable::startAmbientSound( Bool onlyIfPermanent )
 {
-	stopAmbientSound();
+  // Must go through enableAmbientSound() if sound is disabled
+  if ( !m_ambientSoundEnabled || !m_ambientSoundEnabledFromScript )
+    return;
+
+  stopAmbientSound();
 	BodyDamageType bodyCondition = BODY_PRISTINE;
 	Object *obj = getObject();
 	if( obj )
 	{
 		bodyCondition = obj->getBodyModule()->getDamageState();
 	}
-	startAmbientSound( bodyCondition, TheGlobalData->m_timeOfDay );
+	startAmbientSound( bodyCondition, TheGlobalData->m_timeOfDay, onlyIfPermanent );
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -3924,10 +4498,13 @@ void Drawable::startAmbientSound()
 void	Drawable::stopAmbientSound()
 {
 	if (m_ambientSound)
+  {
 		TheAudio->removeAudioEvent(m_ambientSound->m_event.getPlayingHandle());
+  }
 }
 
 //-------------------------------------------------------------------------------------------------
+// Enable and disable ambient sound from the game logic
 void Drawable::enableAmbientSound( Bool enable )
 {
 	if( m_ambientSoundEnabled == enable )
@@ -3938,13 +4515,38 @@ void Drawable::enableAmbientSound( Bool enable )
 	m_ambientSoundEnabled = enable;
 	if( enable )
 	{
-		startAmbientSound();
+    if ( m_ambientSoundEnabledFromScript )
+    {
+      startAmbientSound();
+    }
 	}
 	else
 	{
 		stopAmbientSound();
 	}
 }
+
+//-------------------------------------------------------------------------------------------------
+// Enable and disable sound because the map designer wants us too
+void Drawable::enableAmbientSoundFromScript( Bool enable )
+{
+  // Note: deliberately skipping if( m_ambientSoundEnabledFromScript == enable ) check here
+  // Allow ENABLE_OBJECT_SOUND to trigger one-shot attached sound multiple times
+
+  m_ambientSoundEnabledFromScript = enable;
+  if( enable )
+  {
+    if ( m_ambientSoundEnabled )
+    {
+      startAmbientSound();
+    }
+  }
+  else
+  {
+    stopAmbientSound();
+  }
+}
+
 
 //-------------------------------------------------------------------------------------------------
 /** add self to the linked list */
@@ -4005,7 +4607,7 @@ void Drawable::setDrawableHidden( Bool hidden )
 //-------------------------------------------------------------------------------------------------
 void Drawable::updateDrawableClipStatus( UnsignedInt shotsRemaining, UnsignedInt maxShots, WeaponSlotType slot )
 {
-	for (DrawModule** dm = getDrawModules(); *dm; ++dm)
+	for (DrawModule** dm = getDrawModulesNonDirty(); *dm; ++dm)
 	{
 		ObjectDrawInterface* di = (*dm)->getObjectDrawInterface();
 		if (di)
@@ -4242,17 +4844,21 @@ void Drawable::xferDrawableModules( Xfer *xfer )
 	*    during the module xfer (CBD)
 	* 4: Added m_ambientSoundEnabled flag
 	* 5: save full mtx, not pos+orient.
-	* 6: TheSuperHackers @bugfix Removed m_prevTintStatus because loading its value is unnecessary and undesirable
+	* 6: Added m_ambientSoundEnabledFromScript flag
+	* 7: Save the customize ambient sound info
+	* 8: TheSuperHackers @bugfix Removed m_prevTintStatus because loading its value is unnecessary and undesirable
 	*/
 // ------------------------------------------------------------------------------------------------
 void Drawable::xfer( Xfer *xfer )
 {
 
 	// version
-#if RETAIL_COMPATIBLE_XFER_SAVE
+#if RETAIL_COMPATIBLE_XFER_SAVE && RTS_GENERALS
 	const XferVersion currentVersion = 5;
+#elif RETAIL_COMPATIBLE_XFER_SAVE
+	const XferVersion currentVersion = 7;
 #else
-	const XferVersion currentVersion = 6;
+	const XferVersion currentVersion = 8;
 #endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
@@ -4649,11 +5255,103 @@ void Drawable::xfer( Xfer *xfer )
 		m_isModelDirty = TRUE;
 #endif
 
-	if( version >= 4 )
+  if( xfer->getXferMode() == XFER_LOAD )
+  {
+    stopAmbientSound(); // Restarted in loadPostProcess()
+  }
+
+  if( version >= 4 )
 	{
 		xfer->xferBool( &m_ambientSoundEnabled );
 	}
 
+  if( version >= 6 )
+  {
+    xfer->xferBool( &m_ambientSoundEnabledFromScript );
+  }
+
+
+  if ( version >= 7 )
+  {
+    Bool customized = ( m_customSoundAmbientInfo != nullptr );
+    xfer->xferBool( &customized );
+
+    if ( customized )
+    {
+      Bool customizedToSilence = ( m_customSoundAmbientInfo == getNoSoundMarker() );
+
+      xfer->xferBool( &customizedToSilence );
+      if ( xfer->getXferMode() == XFER_LOAD )
+      {
+        if ( customizedToSilence )
+        {
+          setCustomSoundAmbientOff();
+        }
+        else
+        {
+          AsciiString baseInfoName;
+          xfer->xferAsciiString( &baseInfoName );
+
+          const AudioEventInfo * baseInfo = TheAudio->findAudioEventInfo( baseInfoName );
+          DynamicAudioEventInfo * customizedInfo;
+          Bool successfulLoad = true;
+
+          if ( baseInfo == nullptr )
+          {
+            DEBUG_CRASH( ( "Load failed to load customized ambient sound because sound '%s' no longer exists", baseInfoName.str() ) );
+
+            // Keep trying to load if we possibly can... Don't completely ruin save files just because an old sound
+            // entry in the INI files was removed or renamed
+            customizedInfo = newInstance( DynamicAudioEventInfo );
+            successfulLoad = false;
+          }
+          else
+          {
+            customizedInfo = newInstance( DynamicAudioEventInfo )( *baseInfo );
+          }
+
+          try
+          {
+            // Get custom name back
+            mangleCustomAudioName( customizedInfo );
+
+            customizedInfo->xferNoName( xfer );
+
+            if ( successfulLoad )
+            {
+              TheAudio->addAudioEventInfo( customizedInfo );
+
+              clearCustomSoundAmbient( false );
+              m_customSoundAmbientInfo = customizedInfo;
+
+              customizedInfo = nullptr; // Belongs to TheAudio now
+            }
+            else
+            {
+              deleteInstance(customizedInfo);
+              customizedInfo = nullptr;
+            }
+          }
+          catch( ... )
+          {
+            // since Xfer can throw exceptions -- don't leak memory!
+            deleteInstance(customizedInfo);
+
+            throw; //rethrow
+          }
+        }
+      }
+      else // else we are saving...
+      {
+        if ( !customizedToSilence )
+        {
+          AsciiString baseInfoName = m_customSoundAmbientInfo->getOriginalName();
+          xfer->xferAsciiString( &baseInfoName );
+          m_customSoundAmbientInfo->xferNoName( xfer );
+        }
+      }
+    }
+  }
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -4668,9 +5366,16 @@ void Drawable::loadPostProcess()
 		setTransformMatrix(m_object->getTransformMatrix());
 	}
 
-	if( m_ambientSoundEnabled )
+	if( m_ambientSoundEnabled && m_ambientSoundEnabledFromScript )
 	{
-		startAmbientSound();
+    // Do we actually want to start the ambient sound up?
+    // If it is a permanent sound, then yes; but if it is
+    // a one-shot sound, we don't want to start it even
+    // if it's enabled (because the sound might have finished
+    // playing long ago). This is what the "onlyIfPermanent"
+    // parameter does -- almost like it was added just for
+    // this special case!
+    startAmbientSound( true );
 	}
 	else
 	{

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -4844,8 +4844,8 @@ void Drawable::xferDrawableModules( Xfer *xfer )
 	*    during the module xfer (CBD)
 	* 4: Added m_ambientSoundEnabled flag
 	* 5: save full mtx, not pos+orient.
-	* 6: Added m_ambientSoundEnabledFromScript flag
-	* 7: Save the customize ambient sound info
+	* 6: Added m_ambientSoundEnabledFromScript flag (Added in Zero Hour)
+	* 7: Save the customize ambient sound info (Added in Zero Hour)
 	* 8: TheSuperHackers @bugfix Removed m_prevTintStatus because loading its value is unnecessary and undesirable
 	*/
 // ------------------------------------------------------------------------------------------------
@@ -5019,7 +5019,11 @@ void Drawable::xfer( Xfer *xfer )
 	// tint status
 	xfer->xferUnsignedInt( &m_tintStatus );
 
+#if RTS_GENERALS
 	if (version <= 5)
+#else
+	if (version <= 7)
+#endif
 	{
 		// prev tint status
 		xfer->xferUnsignedInt( &m_prevTintStatus );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -879,13 +879,11 @@ void Locomotor::locoUpdate_moveTowardsAngle(Object* obj, Real goalAngle)
 		return;
 	}
 
-#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	// Skip moveTowardsAngle if physics say you're stunned
 	if(physics->getIsStunned())
 	{
 		return;
 	}
-#endif
 
 #ifdef DEBUG_OBJECT_ID_EXISTS
 //	DEBUG_ASSERTLOG(obj->getID() != TheObjectIDToDebug, ("locoUpdate_moveTowardsAngle %f (%f deg), spd %f (%f)",goalAngle,goalAngle*180/PI,physics->getSpeed(),physics->getForwardSpeed2D()));
@@ -974,13 +972,11 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 		return;
 	}
 
-#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	// Skip moveTowardsPosition if physics say you're stunned
 	if(physics->getIsStunned())
 	{
 		return;
 	}
-#endif
 
 #ifdef DEBUG_OBJECT_ID_EXISTS
 //	DEBUG_ASSERTLOG(obj->getID() != TheObjectIDToDebug, ("locoUpdate_moveTowardsPosition %f %f %f (dtg %f, spd %f), speed %f (%f)",goalPos.x,goalPos.y,goalPos.z,onPathDistToGoal,desiredSpeed,physics->getSpeed(),physics->getForwardSpeed2D()));
@@ -1022,12 +1018,10 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 	Coord3D pos = *obj->getPosition();
 	Real heightAboveSurface = pos.z - TheTerrainLogic->getLayerHeight(pos.x, pos.y, obj->getLayer());
 
-#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	if( obj->getStatusBits().test( OBJECT_STATUS_DECK_HEIGHT_OFFSET ) )
 	{
 		heightAboveSurface -= obj->getCarrierDeckHeight();
 	}
-#endif
 
 	if (heightAboveSurface > -(3*3)*TheGlobalData->m_gravity)
 	{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -301,6 +301,7 @@ LocomotorTemplate::LocomotorTemplate()
 	m_extra2DFriction = 0.0f;
 
 	m_accelPitchLimit = 0;
+	m_decelPitchLimit = 0;
 	m_bounceKick = 0;
 
 //	m_pitchStiffness = 0;
@@ -343,6 +344,12 @@ LocomotorTemplate::LocomotorTemplate()
 	m_wanderWidthFactor = 0.0f;
 	m_wanderLengthFactor = 1.0f;
 	m_wanderAboutPointRadius = 0.0f;
+
+	m_rudderCorrectionDegree    = 0.0f;
+	m_rudderCorrectionRate      = 0.0f;
+	m_elevatorCorrectionDegree  = 0.0f;
+	m_elevatorCorrectionRate    = 0.0f;
+
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -415,6 +422,13 @@ void LocomotorTemplate::validate()
 			m_minSpeed = 0.01f;
 		}
 	}
+
+#if RTS_GENERALS
+	// TheSuperHackers @info DecelerationPitchLimit was just added in Zero Hour and is therefore defaulted to
+	// AccelerationPitchLimit when zero to preserve the original behavior of Generals.
+	if (m_decelPitchLimit == 0.0f)
+		m_decelPitchLimit = m_accelPitchLimit;
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -453,6 +467,7 @@ const FieldParse* LocomotorTemplate::getFieldParse() const
 		{ "GroupMovementPriority", INI::parseIndexList, TheLocomotorPriorityNames, offsetof(LocomotorTemplate, m_movePriority) },		\
 
 		{ "AccelerationPitchLimit", INI::parseAngleReal, nullptr, offsetof(LocomotorTemplate, m_accelPitchLimit) },
+		{ "DecelerationPitchLimit", INI::parseAngleReal, nullptr, offsetof(LocomotorTemplate, m_decelPitchLimit) }, // Added in Zero Hour
 		{ "BounceAmount", INI::parseAngularVelocityReal, nullptr, offsetof(LocomotorTemplate, m_bounceKick) },
 		{ "PitchStiffness", INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_pitchStiffness) },
 		{ "RollStiffness", INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_rollStiffness) },
@@ -488,6 +503,10 @@ const FieldParse* LocomotorTemplate::getFieldParse() const
 		{ "WanderLengthFactor",				 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_wanderLengthFactor) },
 		{ "WanderAboutPointRadius",				 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_wanderAboutPointRadius) },
 
+		{ "RudderCorrectionDegree",		 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_rudderCorrectionDegree) }, // Added in Zero Hour
+		{ "RudderCorrectionRate",			 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_rudderCorrectionRate) }, // Added in Zero Hour
+		{ "ElevatorCorrectionDegree",	 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_elevatorCorrectionDegree) }, // Added in Zero Hour
+		{ "ElevatorCorrectionRate",		 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_elevatorCorrectionRate) }, // Added in Zero Hour
 		{ nullptr, nullptr, nullptr, 0 }
 
 	};
@@ -860,6 +879,14 @@ void Locomotor::locoUpdate_moveTowardsAngle(Object* obj, Real goalAngle)
 		return;
 	}
 
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
+	// Skip moveTowardsAngle if physics say you're stunned
+	if(physics->getIsStunned())
+	{
+		return;
+	}
+#endif
+
 #ifdef DEBUG_OBJECT_ID_EXISTS
 //	DEBUG_ASSERTLOG(obj->getID() != TheObjectIDToDebug, ("locoUpdate_moveTowardsAngle %f (%f deg), spd %f (%f)",goalAngle,goalAngle*180/PI,physics->getSpeed(),physics->getForwardSpeed2D()));
 #endif
@@ -947,6 +974,14 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 		return;
 	}
 
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
+	// Skip moveTowardsPosition if physics say you're stunned
+	if(physics->getIsStunned())
+	{
+		return;
+	}
+#endif
+
 #ifdef DEBUG_OBJECT_ID_EXISTS
 //	DEBUG_ASSERTLOG(obj->getID() != TheObjectIDToDebug, ("locoUpdate_moveTowardsPosition %f %f %f (dtg %f, spd %f), speed %f (%f)",goalPos.x,goalPos.y,goalPos.z,onPathDistToGoal,desiredSpeed,physics->getSpeed(),physics->getForwardSpeed2D()));
 #endif
@@ -986,6 +1021,13 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 	Bool treatAsAirborne = false;
 	Coord3D pos = *obj->getPosition();
 	Real heightAboveSurface = pos.z - TheTerrainLogic->getLayerHeight(pos.x, pos.y, obj->getLayer());
+
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
+	if( obj->getStatusBits().test( OBJECT_STATUS_DECK_HEIGHT_OFFSET ) )
+	{
+		heightAboveSurface -= obj->getCarrierDeckHeight();
+	}
+#endif
 
 	if (heightAboveSurface > -(3*3)*TheGlobalData->m_gravity)
 	{
@@ -1048,6 +1090,7 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 					moveTowardsPositionClimb(obj, physics, goalPos, onPathDistToGoal, desiredSpeed);
 					break;
 			case LOCO_WHEELS_FOUR:
+			case LOCO_MOTORCYCLE:
 					moveTowardsPositionWheels(obj, physics, goalPos, onPathDistToGoal, desiredSpeed);
 					break;
 			case LOCO_TREADS:
@@ -1992,11 +2035,11 @@ Real Locomotor::getSurfaceHtAtPt(Real x, Real y)
 {
 	Real ht = 0;
 
-	Real waterZ;
-	if (TheTerrainLogic->isUnderwater(x, y, &waterZ)) {
+	Real z,waterZ;
+	if (TheTerrainLogic->isUnderwater(x, y, &waterZ, &z)) {
 		ht += waterZ;
 	} else {
-		ht += TheTerrainLogic->getGroundHeight(x, y);
+		ht += z;
 	}
 
 	return ht;
@@ -2430,6 +2473,7 @@ Bool Locomotor::locoUpdate_maintainCurrentPosition(Object* obj)
 			requiresConstantCalling = FALSE;
 			break;
 		case LOCO_WHEELS_FOUR:
+		case LOCO_MOTORCYCLE:
 			maintainCurrentPositionWheels(obj, physics);
 			requiresConstantCalling = FALSE;
 			break;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -5631,3 +5631,8 @@ void Object::leaveGroup()
 	}
 }
 
+//-------------------------------------------------------------------------------------------------
+Real Object::getCarrierDeckHeight() const
+{
+	return 0.0f;
+}

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2107,6 +2107,18 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 		TheGameSpyBuddyMessageQueue->addRequest(req);
 	}
 
+  if( loadingSaveGame == FALSE )
+  {
+    // Drawables need to do some work on level start; give them a chance to do it
+    Drawable * drawable = TheGameClient->getDrawableList();
+
+    while ( drawable != nullptr )
+    {
+      drawable->onLevelStart();
+      drawable = drawable->getNextDrawable();
+    }
+  }
+
 	//ReAllows quit menu to work during loading scene
 	//setGameLoading(FALSE);
 	setLoadingMap( FALSE );

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
@@ -317,7 +317,6 @@ public:
 	TintEnvelope *getColorTintEnvelope() { return m_colorTintEnvelope; }
 	void setColorTintEnvelope( TintEnvelope &source ) { if (m_colorTintEnvelope) *m_colorTintEnvelope = source; }
 
-
   void imitateStealthLook( Drawable& otherDraw );
 
 	void setTerrainDecal(TerrainDecalType type);	///<decal that is to appear under the drawable
@@ -387,9 +386,6 @@ public:
 
 	void setFullyObscuredByShroud(Bool fullyObscured);
 	Bool getFullyObscuredByShroud() {return m_drawableFullyObscuredByShroud;}
-
-  // Put on ice until later... M Lorenzen
-  //	inline UnsignedByte getFullyObscuredByShroudWithCheatSpy() {return (UnsignedByte)m_drawableFullyObscuredByShroud | 128;}//8 looks like a zero in most fonts
 
 	Bool getDrawsInMirror() const { return BitIsSet(m_status, DRAWABLE_STATUS_DRAWS_IN_MIRROR) || isKindOf(KINDOF_CAN_CAST_REFLECTIONS); }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Locomotor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Locomotor.h
@@ -58,7 +58,7 @@ enum LocomotorAppearance CPP_11(: Int)
 	LOCO_WINGS,
 	LOCO_CLIMBER,			// human climber - backs down cliffs.
 	LOCO_OTHER,
-	LOCO_MOTORCYCLE,
+	LOCO_MOTORCYCLE, // Added in Zero Hour
 
 	LOCOMOTOR_APPEARANCE_COUNT
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
@@ -252,7 +252,7 @@ private:
 		IMMUNE_TO_FALLING_DAMAGE				= 0x0100,
 		IS_IN_FREEFALL									= 0x0200,
 		IS_IN_UPDATE										= 0x0400,
-		IS_STUNNED											= 0x0800,
+		IS_STUNNED											= 0x0800, // Added in Zero Hour
 	};
 
 	/*

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -5024,11 +5024,7 @@ void Drawable::xfer( Xfer *xfer )
 	// tint status
 	xfer->xferUnsignedInt( &m_tintStatus );
 
-#if RTS_GENERALS
-	if (version <= 5)
-#else
 	if (version <= 7)
-#endif
 	{
 		// prev tint status
 		xfer->xferUnsignedInt( &m_prevTintStatus );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -4849,8 +4849,8 @@ void Drawable::xferDrawableModules( Xfer *xfer )
 	*    during the module xfer (CBD)
 	* 4: Added m_ambientSoundEnabled flag
 	* 5: save full mtx, not pos+orient.
-	* 6: Added m_ambientSoundEnabledFromScript flag
-	* 7: Save the customize ambient sound info
+	* 6: Added m_ambientSoundEnabledFromScript flag (Added in Zero Hour)
+	* 7: Save the customize ambient sound info (Added in Zero Hour)
 	* 8: TheSuperHackers @bugfix Removed m_prevTintStatus because loading its value is unnecessary and undesirable
 	*/
 // ------------------------------------------------------------------------------------------------
@@ -5024,7 +5024,11 @@ void Drawable::xfer( Xfer *xfer )
 	// tint status
 	xfer->xferUnsignedInt( &m_tintStatus );
 
+#if RTS_GENERALS
 	if (version <= 5)
+#else
+	if (version <= 7)
+#endif
 	{
 		// prev tint status
 		xfer->xferUnsignedInt( &m_prevTintStatus );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -1111,8 +1111,6 @@ void Drawable::setEffectiveOpacity( Real pulseFactor, Real explicitOpacity /* = 
 	m_effectiveStealthOpacity = m_stealthOpacity + pulseAmount;
 }
 
-
-
 //-------------------------------------------------------------------------------------------------
 void Drawable::imitateStealthLook( Drawable& otherDraw )
 {
@@ -1125,14 +1123,6 @@ void Drawable::imitateStealthLook( Drawable& otherDraw )
   m_secondMaterialPassOpacity = otherDraw.getSecondMaterialPassOpacity();
 
 }
-
-
-
-
-
-
-
-
 
 //-------------------------------------------------------------------------------------------------
 /** update is called once per frame */
@@ -1525,7 +1515,6 @@ void Drawable::calcPhysicsXformHoverOrWings( const Locomotor *locomotor, Physics
 	const Real FORWARD_ACCEL_COEFF = locomotor->getForwardAccelCoef();
 	const Real LATERAL_ACCEL_COEFF = locomotor->getLateralAccelCoef();
 	const Real UNIFORM_AXIAL_DAMPING = locomotor->getUniformAxialDamping();
-
 
 	// get object from logic
 	Object *obj = getObject();
@@ -4869,7 +4858,9 @@ void Drawable::xfer( Xfer *xfer )
 {
 
 	// version
-#if RETAIL_COMPATIBLE_XFER_SAVE
+#if RETAIL_COMPATIBLE_XFER_SAVE && RTS_GENERALS
+	const XferVersion currentVersion = 5;
+#elif RETAIL_COMPATIBLE_XFER_SAVE
 	const XferVersion currentVersion = 7;
 #else
 	const XferVersion currentVersion = 8;
@@ -5033,7 +5024,7 @@ void Drawable::xfer( Xfer *xfer )
 	// tint status
 	xfer->xferUnsignedInt( &m_tintStatus );
 
-	if (version <= 7)
+	if (version <= 5)
 	{
 		// prev tint status
 		xfer->xferUnsignedInt( &m_prevTintStatus );
@@ -5512,7 +5503,7 @@ void TintEnvelope::update()
 		{
 			const Vector3 decayRate = m_decayRate * timeScale;
 
-			if (decayRate.Length() > m_currentColor.Length() || m_currentColor.Length() <= FADE_RATE_EPSILON) 
+			if (decayRate.Length() > m_currentColor.Length() || m_currentColor.Length() <= FADE_RATE_EPSILON)
 			{
 				// We are at rest
 				m_envState = ENVELOPE_STATE_REST;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -879,13 +879,11 @@ void Locomotor::locoUpdate_moveTowardsAngle(Object* obj, Real goalAngle)
 		return;
 	}
 
-#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	// Skip moveTowardsAngle if physics say you're stunned
 	if(physics->getIsStunned())
 	{
 		return;
 	}
-#endif
 
 #ifdef DEBUG_OBJECT_ID_EXISTS
 //	DEBUG_ASSERTLOG(obj->getID() != TheObjectIDToDebug, ("locoUpdate_moveTowardsAngle %f (%f deg), spd %f (%f)",goalAngle,goalAngle*180/PI,physics->getSpeed(),physics->getForwardSpeed2D()));
@@ -974,13 +972,11 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 		return;
 	}
 
-#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	// Skip moveTowardsPosition if physics say you're stunned
 	if(physics->getIsStunned())
 	{
 		return;
 	}
-#endif
 
 #ifdef DEBUG_OBJECT_ID_EXISTS
 //	DEBUG_ASSERTLOG(obj->getID() != TheObjectIDToDebug, ("locoUpdate_moveTowardsPosition %f %f %f (dtg %f, spd %f), speed %f (%f)",goalPos.x,goalPos.y,goalPos.z,onPathDistToGoal,desiredSpeed,physics->getSpeed(),physics->getForwardSpeed2D()));
@@ -1022,12 +1018,10 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 	Coord3D pos = *obj->getPosition();
 	Real heightAboveSurface = pos.z - TheTerrainLogic->getLayerHeight(pos.x, pos.y, obj->getLayer());
 
-#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	if( obj->getStatusBits().test( OBJECT_STATUS_DECK_HEIGHT_OFFSET ) )
 	{
 		heightAboveSurface -= obj->getCarrierDeckHeight();
 	}
-#endif
 
 	if (heightAboveSurface > -(3*3)*TheGlobalData->m_gravity)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -422,6 +422,13 @@ void LocomotorTemplate::validate()
 			m_minSpeed = 0.01f;
 		}
 	}
+
+#if RTS_GENERALS
+	// TheSuperHackers @info DecelerationPitchLimit was just added in Zero Hour and is therefore defaulted to
+	// AccelerationPitchLimit when zero to preserve the original behavior of Generals.
+	if (m_decelPitchLimit == 0.0f)
+		m_decelPitchLimit = m_accelPitchLimit;
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -460,7 +467,7 @@ const FieldParse* LocomotorTemplate::getFieldParse() const
 		{ "GroupMovementPriority", INI::parseIndexList, TheLocomotorPriorityNames, offsetof(LocomotorTemplate, m_movePriority) },		\
 
 		{ "AccelerationPitchLimit", INI::parseAngleReal, nullptr, offsetof(LocomotorTemplate, m_accelPitchLimit) },
-		{ "DecelerationPitchLimit", INI::parseAngleReal, nullptr, offsetof(LocomotorTemplate, m_decelPitchLimit) },
+		{ "DecelerationPitchLimit", INI::parseAngleReal, nullptr, offsetof(LocomotorTemplate, m_decelPitchLimit) }, // Added in Zero Hour
 		{ "BounceAmount", INI::parseAngularVelocityReal, nullptr, offsetof(LocomotorTemplate, m_bounceKick) },
 		{ "PitchStiffness", INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_pitchStiffness) },
 		{ "RollStiffness", INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_rollStiffness) },
@@ -496,10 +503,10 @@ const FieldParse* LocomotorTemplate::getFieldParse() const
 		{ "WanderLengthFactor",				 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_wanderLengthFactor) },
 		{ "WanderAboutPointRadius",				 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_wanderAboutPointRadius) },
 
-		{ "RudderCorrectionDegree",		 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_rudderCorrectionDegree) },
-		{ "RudderCorrectionRate",			 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_rudderCorrectionRate) },
-		{ "ElevatorCorrectionDegree",	 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_elevatorCorrectionDegree) },
-		{ "ElevatorCorrectionRate",		 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_elevatorCorrectionRate) },
+		{ "RudderCorrectionDegree",		 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_rudderCorrectionDegree) }, // Added in Zero Hour
+		{ "RudderCorrectionRate",			 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_rudderCorrectionRate) }, // Added in Zero Hour
+		{ "ElevatorCorrectionDegree",	 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_elevatorCorrectionDegree) }, // Added in Zero Hour
+		{ "ElevatorCorrectionRate",		 INI::parseReal, nullptr, offsetof(LocomotorTemplate, m_elevatorCorrectionRate) }, // Added in Zero Hour
 		{ nullptr, nullptr, nullptr, 0 }
 
 	};
@@ -872,11 +879,13 @@ void Locomotor::locoUpdate_moveTowardsAngle(Object* obj, Real goalAngle)
 		return;
 	}
 
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	// Skip moveTowardsAngle if physics say you're stunned
 	if(physics->getIsStunned())
 	{
 		return;
 	}
+#endif
 
 #ifdef DEBUG_OBJECT_ID_EXISTS
 //	DEBUG_ASSERTLOG(obj->getID() != TheObjectIDToDebug, ("locoUpdate_moveTowardsAngle %f (%f deg), spd %f (%f)",goalAngle,goalAngle*180/PI,physics->getSpeed(),physics->getForwardSpeed2D()));
@@ -965,11 +974,13 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 		return;
 	}
 
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	// Skip moveTowardsPosition if physics say you're stunned
 	if(physics->getIsStunned())
 	{
 		return;
 	}
+#endif
 
 #ifdef DEBUG_OBJECT_ID_EXISTS
 //	DEBUG_ASSERTLOG(obj->getID() != TheObjectIDToDebug, ("locoUpdate_moveTowardsPosition %f %f %f (dtg %f, spd %f), speed %f (%f)",goalPos.x,goalPos.y,goalPos.z,onPathDistToGoal,desiredSpeed,physics->getSpeed(),physics->getForwardSpeed2D()));
@@ -1011,10 +1022,12 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 	Coord3D pos = *obj->getPosition();
 	Real heightAboveSurface = pos.z - TheTerrainLogic->getLayerHeight(pos.x, pos.y, obj->getLayer());
 
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	if( obj->getStatusBits().test( OBJECT_STATUS_DECK_HEIGHT_OFFSET ) )
 	{
 		heightAboveSurface -= obj->getCarrierDeckHeight();
 	}
+#endif
 
 	if (heightAboveSurface > -(3*3)*TheGlobalData->m_gravity)
 	{
@@ -1078,7 +1091,7 @@ void Locomotor::locoUpdate_moveTowardsPosition(Object* obj, const Coord3D& goalP
 					break;
 			case LOCO_WHEELS_FOUR:
 			case LOCO_MOTORCYCLE:
-					moveTowardsPositionWheels( obj, physics, goalPos, onPathDistToGoal, desiredSpeed );
+					moveTowardsPositionWheels(obj, physics, goalPos, onPathDistToGoal, desiredSpeed);
 					break;
 			case LOCO_TREADS:
 					moveTowardsPositionTreads(obj, physics, goalPos, onPathDistToGoal, desiredSpeed);
@@ -2573,14 +2586,6 @@ void Locomotor::maintainCurrentPositionHover(Object* obj, PhysicsBehavior *physi
 			force.x = accelForce * dir->x;
 			force.y = accelForce * dir->y;
 			force.z = 0.0f;
-
-
-      // Apply a random kick (if applicable) to dirty-up visually.
-      // The idea is that chopper pilots have to do course corrections all the time
-      // Because of changes in wind, pressure, etc.
-      // Those changes are added here, then the
-
-
 
 			// apply forces to object
 			physics->applyMotiveForce( &force );


### PR DESCRIPTION
This change is merging most of Drawable and all of Locomotor. (Is needed for #2774 to merge ambient sound related changes.)

The "Heat Vision" related code in Drawable was not merged to minimize the scope of this change.

## Generals gets

* New ambient sound logic, controls and tweaks in Drawable
* Tint: `TINT_STATUS_GAINING_SUBDUAL_DAMAGE`, `TINT_STATUS_FRENZY` and related code in Drawable
* Physics: `IS_STUNNED`
* Locomotor: `DecelerationPitchLimit`, `RudderCorrectionDegree`, `RudderCorrectionRate`, `ElevatorCorrectionDegree`, `ElevatorCorrectionRate` and related code in Drawable
* Locomotor: `LOCO_MOTORCYCLE` and related code in Drawable
* Icon pos tweak in `Drawable::drawEnthusiastic`
* Icon pos tweak in `Drawable::drawBombed`
* Optimization in `Drawable::drawConstructPercent`
* Optimization in `Drawable::updateDrawableClipStatus`