### PR TITLE
bugfix(ai): Attacking infantry no longer attempt to path to their targets when force-evacuated from a vehicle

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -1016,6 +1016,13 @@ void AIStateMachine::clear()
 	m_goalWaypoint = nullptr;
 	m_goalSquad = nullptr;
 
+#if !RETAIL_COMPATIBLE_CRC
+	if (m_temporaryState)
+		m_temporaryState->onExit(EXIT_RESET);
+
+	m_temporaryState = nullptr;
+#endif
+
 	AIUpdateInterface* ai = getOwner()->getAI();
 	if (ai)
 		ai->friend_notifyStateMachineChanged();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -672,6 +672,9 @@ void OpenContain::scatterToNearbyPosition(Object* rider)
 		// set position of the object at center of building and move them toward pos
 		rider->setPosition( theContainer->getPosition() );
 		ai->ignoreObstacle(theContainer);
+#if !RETAIL_COMPATIBLE_CRC
+		ai->friend_setGoalObject(nullptr);
+#endif
 		ai->aiMoveToPosition( &pos, CMD_FROM_AI );
 
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -1021,6 +1021,13 @@ void AIStateMachine::clear()
 	m_goalWaypoint = nullptr;
 	m_goalSquad = nullptr;
 
+#if !RETAIL_COMPATIBLE_CRC
+	if (m_temporaryState)
+		m_temporaryState->onExit(EXIT_RESET);
+
+	m_temporaryState = nullptr;
+#endif
+
 	AIUpdateInterface* ai = getOwner()->getAI();
 	if (ai)
 		ai->friend_notifyStateMachineChanged();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -768,6 +768,9 @@ void OpenContain::scatterToNearbyPosition(Object* rider)
 		// set position of the object at center of building and move them toward pos
 		rider->setPosition( theContainer->getPosition() );
 		ai->ignoreObstacle(theContainer);
+#if !RETAIL_COMPATIBLE_CRC
+		ai->friend_setGoalObject(nullptr);
+#endif
 		ai->aiMoveToPosition( &pos, CMD_FROM_AI );
 
 	}


### PR DESCRIPTION
* Fixes #199
* Fixes #1337

This change fixes an issue where infantry would attempt to path to their targets when force-evacuated from a vehicle.

Force-evacuated infantry would incorrectly retain their goal object reference, which would override the path/destination the infantry were given upon evacuation to that of their attack target instead of their scatter position. Furthermore, temporary AI states would not be cleared when the state machine was cleared upon receiving new commands, causing subsequent commands to effectively provide the temporary state with new data (i.e. giving an attack command during the scatter state would just assign a goal object and cause the unit to path to the target).

The fix is to clear the goal object when infantry are scattered as well as any temporary states when the main state machine is cleared (usually when receiving a new command). As a result, evacuation behaviour is consistent across all vehicles under all circumstances and units feel nice and responsive.

### Before

The force-evacuated Tank Hunters attempt to path to the Emperor Overlord

https://github.com/user-attachments/assets/f9a592ee-a730-48d5-8572-55fb09266238

### After

The force-evacuated Tank Hunters are correctly scattered

https://github.com/user-attachments/assets/61d27beb-4272-44a2-8728-d585d6f44249