### PR TITLE
bugfix(scorch): Prevent volatile scorches from evicting static map scorches

### DIFF
--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
@@ -152,6 +152,7 @@ public:
 	/// Update the diffuse value from static light info for one vertex.
 	void doTheLight(VERTEX_FORMAT *vb, const Vector3*light, Vector3*normal, RefRenderObjListIterator *pLightsIterator, UnsignedByte alpha);
 	void addScorch(Vector3 location, Real radius, Scorches type);
+	void addStaticScorch(Vector3 location, Real radius, Scorches type);
 	void addTree(DrawableID id, Coord3D location, Real scale, Real angle,
 								Real randomScaleAmount,  const W3DTreeDrawModuleData *data);
 	void removeAllTrees();
@@ -268,6 +269,7 @@ protected:
 #endif
 	W3DBridgeBuffer *m_bridgeBuffer;
 	W3DScorchInterface *m_scorches;
+	W3DScorchInterface *m_staticScorches;
 	W3DShroud *m_shroud;	///< Class for drawing the shroud over terrain.
 	struct shoreLineTileInfo
 	{	Int m_xy;	//x,y position of tile

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DScorch.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DScorch.h
@@ -44,7 +44,7 @@ public:
 class W3DScorch : public W3DScorchInterface
 {
 public:
-	W3DScorch(bool dedupeScorches);
+	W3DScorch(bool deduplicateScorches);
 	virtual ~W3DScorch() override;
 
 	virtual void allocateBuffers() override;    ///< allocate static buffers for drawing scorch marks.
@@ -82,7 +82,7 @@ private:
 	TScorch m_scorches[MAX_SCORCH_MARKS];
 	Int m_numScorches;
 	Int m_scorchesInBuffer;    ///< how many are in the buffers.  If less than numScorches, we need to update
-	Bool m_dedupeScorches;
+	Bool m_deduplicateScorches;
 };
 
 class W3DScorchDummy : public W3DScorchInterface

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DScorch.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DScorch.h
@@ -44,7 +44,7 @@ public:
 class W3DScorch : public W3DScorchInterface
 {
 public:
-	W3DScorch();
+	W3DScorch(bool dedupeScorches);
 	virtual ~W3DScorch() override;
 
 	virtual void allocateBuffers() override;    ///< allocate static buffers for drawing scorch marks.
@@ -82,6 +82,7 @@ private:
 	TScorch m_scorches[MAX_SCORCH_MARKS];
 	Int m_numScorches;
 	Int m_scorchesInBuffer;    ///< how many are in the buffers.  If less than numScorches, we need to update
+	Bool m_dedupeScorches;
 };
 
 class W3DScorchDummy : public W3DScorchInterface

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -324,6 +324,7 @@ void BaseHeightMapRenderObjClass::setTextureLOD(Int lod)
 	if (m_map)
 		m_map->setTextureLOD(lod);
 	m_scorches->invalidateTexture();
+	m_staticScorches->invalidateTexture();
 }
 
 //=============================================================================

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -276,8 +276,8 @@ BaseHeightMapRenderObjClass::BaseHeightMapRenderObjClass()
 	m_roadBuffer = nullptr;
 #endif
 #if DO_SCORCH
-	m_scorches = NEW W3DScorch;
-	m_staticScorches = NEW W3DScorch;
+	m_scorches = NEW W3DScorch(true);
+	m_staticScorches = NEW W3DScorch(false);
 #else
 	m_scorches = NEW W3DScorchDummy;
 	m_staticScorches = NEW W3DScorchDummy;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -1880,7 +1880,8 @@ void BaseHeightMapRenderObjClass::addScorch(Vector3 location, Real radius, Scorc
 //=============================================================================
 // BaseHeightMapRenderObjClass::addStaticScorch
 //=============================================================================
-/** Adds a permanent scorch mark loaded from the map. */
+/** TheSuperHackers @feature stephanmeesters 13/08/2026 Adds a permanent scorch mark loaded from the map. Static
+ * scorch marks are managed separately so adding gameplay scorch marks cannot evict them. */
 //=============================================================================
 void BaseHeightMapRenderObjClass::addStaticScorch(Vector3 location, Real radius, Scorches type)
 {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -150,6 +150,7 @@ inline Int IABS(Int x) {	if (x>=0) return x; return -x;};
 Int BaseHeightMapRenderObjClass::freeMapResources()
 {
 	m_scorches->freeBuffers();
+	m_staticScorches->freeBuffers();
 
 	REF_PTR_RELEASE(m_vertexMaterialClass);
 	REF_PTR_RELEASE(m_stageZeroTexture);
@@ -171,6 +172,7 @@ void BaseHeightMapRenderObjClass::drawScorches()
 {
 	ShaderClass::Invalidate();
 	if (m_map && Is_Hidden() == 0 && !ShaderClass::Is_Backface_Culling_Inverted()) {
+		m_staticScorches->drawScorches(*m_map);
 		m_scorches->drawScorches(*m_map);
 	}
 }
@@ -213,6 +215,9 @@ BaseHeightMapRenderObjClass::~BaseHeightMapRenderObjClass()
 
 	delete m_scorches;
 	m_scorches = nullptr;
+
+	delete m_staticScorches;
+	m_staticScorches = nullptr;
 
 	delete [] m_shoreLineTilePositions;
 	m_shoreLineTilePositions = nullptr;
@@ -272,8 +277,10 @@ BaseHeightMapRenderObjClass::BaseHeightMapRenderObjClass()
 #endif
 #if DO_SCORCH
 	m_scorches = NEW W3DScorch;
+	m_staticScorches = NEW W3DScorch;
 #else
 	m_scorches = NEW W3DScorchDummy;
+	m_staticScorches = NEW W3DScorchDummy;
 #endif
 	m_bridgeBuffer = NEW W3DBridgeBuffer;
 
@@ -1822,6 +1829,7 @@ Int BaseHeightMapRenderObjClass::initHeightData(Int x, Int y, WorldHeightMap *pM
 	scheduleFullUpdate();
 
 	m_scorches->invalidateBuffers();
+	m_staticScorches->invalidateBuffers();
 
 	// If the textures aren't allocated (usually because of a hardware reset) need to allocate.
 	Bool needToAllocate = false;
@@ -1838,6 +1846,7 @@ Int BaseHeightMapRenderObjClass::initHeightData(Int x, Int y, WorldHeightMap *pM
 		m_destAlphaTexture=MSGNEW("TextureClass") TextureClass(256,1,WW3D_FORMAT_A8R8G8B8,MIP_LEVELS_1);
 		initDestAlphaLUT();
 		m_scorches->allocateBuffers();
+		m_staticScorches->allocateBuffers();
 
 		m_vertexMaterialClass=VertexMaterialClass::Get_Preset(VertexMaterialClass::PRELIT_DIFFUSE);
 
@@ -1855,6 +1864,7 @@ Int BaseHeightMapRenderObjClass::initHeightData(Int x, Int y, WorldHeightMap *pM
 void BaseHeightMapRenderObjClass::clearAllScorches()
 {
 	m_scorches->clearAllScorches();
+	m_staticScorches->clearAllScorches();
 }
 
 //=============================================================================
@@ -1865,6 +1875,16 @@ void BaseHeightMapRenderObjClass::clearAllScorches()
 void BaseHeightMapRenderObjClass::addScorch(Vector3 location, Real radius, Scorches type)
 {
 	m_scorches->addScorch(location, radius, type);
+}
+
+//=============================================================================
+// BaseHeightMapRenderObjClass::addStaticScorch
+//=============================================================================
+/** Adds a permanent scorch mark loaded from the map. */
+//=============================================================================
+void BaseHeightMapRenderObjClass::addStaticScorch(Vector3 location, Real radius, Scorches type)
+{
+	m_staticScorches->addScorch(location, radius, type);
 }
 
 //=============================================================================
@@ -2158,6 +2178,7 @@ void BaseHeightMapRenderObjClass::staticLightingChanged()
 
 	// Cause the scorches to get updated with new lighting.
 	m_scorches->invalidateBuffers();
+	m_staticScorches->invalidateBuffers();
 
 	if (m_roadBuffer)
 		m_roadBuffer->updateLighting();

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DScorch.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DScorch.cpp
@@ -26,7 +26,7 @@
 #include "W3DDevice/GameClient/WorldHeightMap.h"
 #include "WW3D2/dx8wrapper.h"
 
-W3DScorch::W3DScorch()
+W3DScorch::W3DScorch(bool dedupeScorches)
   : m_vertexScorch(nullptr)
   , m_indexScorch(nullptr)
   , m_scorchTexture(nullptr)
@@ -34,6 +34,7 @@ W3DScorch::W3DScorch()
   , m_curNumScorchIndices(0)
   , m_numScorches(0)
   , m_scorchesInBuffer(0)
+  , m_dedupeScorches(dedupeScorches)
 {}
 
 W3DScorch::~W3DScorch() { freeBuffers(); }
@@ -93,16 +94,18 @@ void W3DScorch::addScorch(Vector3 location, Real radius, Scorches type)
 		m_numScorches--;
 	}
 
-	Int i;
-	Real limit = radius / 4;
-	for (i = 0; i < m_numScorches; i++)
+	if (m_dedupeScorches)
 	{
-		if (abs(location.X - m_scorches[i].location.X) < limit &&
-		    abs(location.Y - m_scorches[i].location.Y) < limit &&
-		    abs(radius - m_scorches[i].radius) < limit &&
-		    m_scorches[i].scorchType == type)
+		const Real limit = radius / 4;
+		for (Int i = 0; i < m_numScorches; i++)
 		{
-			return;    // basically a duplicate.
+			if (abs(location.X - m_scorches[i].location.X) < limit &&
+			    abs(location.Y - m_scorches[i].location.Y) < limit &&
+			    abs(radius - m_scorches[i].radius) < limit &&
+			    m_scorches[i].scorchType == type)
+			{
+				return;    // basically a duplicate.
+			}
 		}
 	}
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DScorch.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DScorch.cpp
@@ -26,7 +26,7 @@
 #include "W3DDevice/GameClient/WorldHeightMap.h"
 #include "WW3D2/dx8wrapper.h"
 
-W3DScorch::W3DScorch(bool dedupeScorches)
+W3DScorch::W3DScorch(bool deduplicateScorches)
   : m_vertexScorch(nullptr)
   , m_indexScorch(nullptr)
   , m_scorchTexture(nullptr)
@@ -34,7 +34,7 @@ W3DScorch::W3DScorch(bool dedupeScorches)
   , m_curNumScorchIndices(0)
   , m_numScorches(0)
   , m_scorchesInBuffer(0)
-  , m_dedupeScorches(dedupeScorches)
+  , m_deduplicateScorches(deduplicateScorches)
 {}
 
 W3DScorch::~W3DScorch() { freeBuffers(); }
@@ -94,7 +94,7 @@ void W3DScorch::addScorch(Vector3 location, Real radius, Scorches type)
 		m_numScorches--;
 	}
 
-	if (m_dedupeScorches)
+	if (m_deduplicateScorches)
 	{
 		const Real limit = radius / 4;
 		for (Int i = 0; i < m_numScorches; i++)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -661,7 +661,7 @@ Bool W3DTerrainVisual::load( AsciiString filename )
 			Vector3 loc(pos->x, pos->y, pos->z);
 			Real radius = d->getReal(TheKey_objectRadius);
 			Scorches type = (Scorches)d->getInt(TheKey_scorchType);
-			m_terrainRenderObject->addScorch(loc, radius, type);
+			m_terrainRenderObject->addStaticScorch(loc, radius, type);
 		}
 		pMapObj = pMapObj->getNext();
 	}

--- a/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -973,7 +973,7 @@ void WbView3d::updateScorches()
 			Scorches type = (Scorches) pMapObj->getProperties()->getInt(TheKey_scorchType);
 
 			Vector3 loc(pos->x, pos->y, pos->z);
-			TheTerrainRenderObject->addScorch(loc, radius, type);
+			TheTerrainRenderObject->addStaticScorch(loc, radius, type);
 		}
 	}
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -998,7 +998,7 @@ void WbView3d::updateScorches()
 			Scorches type = (Scorches) pMapObj->getProperties()->getInt(TheKey_scorchType);
 
 			Vector3 loc(pos->x, pos->y, pos->z);
-			TheTerrainRenderObject->addScorch(loc, radius, type);
+			TheTerrainRenderObject->addStaticScorch(loc, radius, type);
 		}
 	}
 }


### PR DESCRIPTION
- Closes #364

Adds a separate instance of `W3DScorch` to be used only for "static" scorch marks placed on a map using World Builder. This fixes the issue that these static scorches eventually disappear during gameplay.

By using the separate instance of `W3DScorch`, with its own GPU buffers, the static scorches will not have much performance impact: the buffer does not change often and is cheap to draw. The exception is changes to terrain geometry or changes to the map lighting, which invalidates all of the scorch buffers.

Deduplication of static scorches is disabled, as dedup checking adds to map loading time (especially if we were to increase the max nr of scorches later), and we can trust map makers to place the scorch marks correctly.

## Todo

- [x] Rebase after #3119
