### PR TITLE
bugfix(chinookaiupdate): Helicopter enter commands are now ignored if the target to enter is invalid or ourselves

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1191,6 +1191,7 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 		break;
 #if !RETAIL_COMPATIBLE_CRC
 		case AICMD_ENTER:
+		{
 			// TheSuperHackers @bugfix Stubbjax 12/08/2026 Ignore the command if we are told to enter ourselves (we can be in the same group).
 			if (parms->m_obj && parms->m_obj->getID() == getObject()->getID())
 				return;
@@ -1198,6 +1199,7 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 			// TheSuperHackers @bugfix Stubbjax 12/08/2026 Ignore the command if we are told to enter something we cannot (we can be in the same group).
 			if (!TheActionManager->canEnterObject(getObject(), parms->m_obj, parms->m_cmdSource, DONT_CHECK_CAPACITY))
 				return;
+		}
 		break;
 #endif
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1165,16 +1165,6 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 		setAirfieldForHealing(INVALID_ID);
 #endif
 
-#if !RETAIL_COMPATIBLE_CRC
-	// Ignore the command if we are told to enter ourselves (we can be in the same group).
-	if (parms->m_cmd == AICMD_ENTER && parms->m_obj && parms->m_obj->getID() == getObject()->getID())
-		return;
-
-	// Ignore the command if we are told to enter something we cannot (we can be in the same group).
-	if (parms->m_cmd == AICMD_ENTER && !TheActionManager->canEnterObject(getObject(), parms->m_obj, parms->m_cmdSource, DONT_CHECK_CAPACITY))
-		return;
-#endif
-
 	if (!isAllowedToRespondToAiCommands(parms))
 		return;
 
@@ -1199,6 +1189,17 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 			// just pass it thru.
 		}
 		break;
+#if !RETAIL_COMPATIBLE_CRC
+		case AICMD_ENTER:
+			// TheSuperHackers @bugfix Stubbjax 12/08/2026 Ignore the command if we are told to enter ourselves (we can be in the same group).
+			if (parms->m_obj && parms->m_obj->getID() == getObject()->getID())
+				return;
+
+			// TheSuperHackers @bugfix Stubbjax 12/08/2026 Ignore the command if we are told to enter something we cannot (we can be in the same group).
+			if (!TheActionManager->canEnterObject(getObject(), parms->m_obj, parms->m_cmdSource, DONT_CHECK_CAPACITY))
+				return;
+		break;
+#endif
 
 		case AICMD_MOVE_TO_POSITION_AND_EVACUATE:
 		case AICMD_MOVE_TO_POSITION_AND_EVACUATE_AND_EXIT:

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1165,6 +1165,16 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 		setAirfieldForHealing(INVALID_ID);
 #endif
 
+#if !RETAIL_COMPATIBLE_CRC
+	// Ignore the command if we are told to enter ourselves (we can be in the same group).
+	if (parms->m_cmd == AICMD_ENTER && parms->m_obj && parms->m_obj->getID() == getObject()->getID())
+		return;
+
+	// Ignore the command if we are told to enter something we cannot (we can be in the same group).
+	if (parms->m_cmd == AICMD_ENTER && !TheActionManager->canEnterObject(getObject(), parms->m_obj, parms->m_cmdSource, DONT_CHECK_CAPACITY))
+		return;
+#endif
+
 	if (!isAllowedToRespondToAiCommands(parms))
 		return;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1322,6 +1322,7 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 		break;
 #if !RETAIL_COMPATIBLE_CRC
 		case AICMD_ENTER:
+		{
 			// TheSuperHackers @bugfix Stubbjax 12/08/2026 Ignore the command if we are told to enter ourselves (we can be in the same group).
 			if (parms->m_obj && parms->m_obj->getID() == getObject()->getID())
 				return;
@@ -1329,6 +1330,7 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 			// TheSuperHackers @bugfix Stubbjax 12/08/2026 Ignore the command if we are told to enter something we cannot (we can be in the same group).
 			if (!TheActionManager->canEnterObject(getObject(), parms->m_obj, parms->m_cmdSource, DONT_CHECK_CAPACITY))
 				return;
+		}
 		break;
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1296,6 +1296,16 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 		setAirfieldForHealing(INVALID_ID);
 #endif
 
+#if !RETAIL_COMPATIBLE_CRC
+	// Ignore the command if we are told to enter ourselves (we can be in the same group).
+	if (parms->m_cmd == AICMD_ENTER && parms->m_obj && parms->m_obj->getID() == getObject()->getID())
+		return;
+
+	// Ignore the command if we are told to enter something we cannot (we can be in the same group).
+	if (parms->m_cmd == AICMD_ENTER && !TheActionManager->canEnterObject(getObject(), parms->m_obj, parms->m_cmdSource, DONT_CHECK_CAPACITY))
+		return;
+#endif
+
 	if (!isAllowedToRespondToAiCommands(parms))
 		return;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1296,16 +1296,6 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 		setAirfieldForHealing(INVALID_ID);
 #endif
 
-#if !RETAIL_COMPATIBLE_CRC
-	// Ignore the command if we are told to enter ourselves (we can be in the same group).
-	if (parms->m_cmd == AICMD_ENTER && parms->m_obj && parms->m_obj->getID() == getObject()->getID())
-		return;
-
-	// Ignore the command if we are told to enter something we cannot (we can be in the same group).
-	if (parms->m_cmd == AICMD_ENTER && !TheActionManager->canEnterObject(getObject(), parms->m_obj, parms->m_cmdSource, DONT_CHECK_CAPACITY))
-		return;
-#endif
-
 	if (!isAllowedToRespondToAiCommands(parms))
 		return;
 
@@ -1330,6 +1320,17 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 			// just pass it thru.
 		}
 		break;
+#if !RETAIL_COMPATIBLE_CRC
+		case AICMD_ENTER:
+			// TheSuperHackers @bugfix Stubbjax 12/08/2026 Ignore the command if we are told to enter ourselves (we can be in the same group).
+			if (parms->m_obj && parms->m_obj->getID() == getObject()->getID())
+				return;
+
+			// TheSuperHackers @bugfix Stubbjax 12/08/2026 Ignore the command if we are told to enter something we cannot (we can be in the same group).
+			if (!TheActionManager->canEnterObject(getObject(), parms->m_obj, parms->m_cmdSource, DONT_CHECK_CAPACITY))
+				return;
+		break;
+#endif
 
 		case AICMD_MOVE_TO_POSITION_AND_EVACUATE:
 		case AICMD_MOVE_TO_POSITION_AND_EVACUATE_AND_EXIT:


### PR DESCRIPTION
This change fixes an issue where grounded Chinooks would take off when receiving invalid enter commands.

### Before

When the Chinook is in the selection, an enter command causes it to lift off

https://github.com/user-attachments/assets/6ea35555-ab8a-4ad9-a63c-fce90d387d2c

https://github.com/user-attachments/assets/0b109d4c-b9af-484d-b379-07155404b41d

### After

When the Chinook is in the selection, an enter command no longer causes it to lift off

https://github.com/user-attachments/assets/5be59537-e0c6-4b20-a3c7-d160467eb5c4

https://github.com/user-attachments/assets/4570b97f-a8e3-4d6f-bed4-a6cb307dc032