### PR TITLE
bugfix: Make Helicopter and Chinook ignore repair command when ordered to repair again at the same airfield

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ChinookAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ChinookAIUpdate.h
@@ -125,6 +125,7 @@ protected:
 
   void private___TellPortableStructureToAttackWithMe( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );
 
+	ObjectID getAirfieldForHealing() const { return m_airfieldForHealing; }
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -140,7 +140,6 @@ protected:
 	void positionLockon();
 
 	virtual Bool getTreatAsAircraftForLocoDistToGoal() const override;
-	Bool isParkedAt(const Object* obj) const;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1293,7 +1293,11 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 #else
 	// TheSuperHackers @bugfix Stubbjax 31/10/2025 Don't leave healing state for evacuation commands.
 	if (parms->m_cmd != AICMD_EVACUATE && parms->m_cmd != AICMD_EXIT)
-		setAirfieldForHealing(INVALID_ID);
+	{
+		// TheSuperHackers @bugfix Caball009 12/08/2026 Don't leave healing state if chinook is already repairing at this airfield.
+		if (!(parms->m_cmd == AICMD_GET_REPAIRED && parms->m_obj->getID() == getAirfieldForHealing()))
+			setAirfieldForHealing(INVALID_ID);
+	}
 #endif
 
 	if (!isAllowedToRespondToAiCommands(parms))
@@ -1369,6 +1373,20 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 			}
 		}
 		break;
+
+#if !RETAIL_COMPATIBLE_CRC
+		case AICMD_GET_REPAIRED:
+		{
+			// TheSuperHackers @bugfix Caball009 12/08/2026 Don't process command if chinook is already repairing at this airfield.
+			if (parms->m_obj->getID() == getAirfieldForHealing())
+			{
+				passItThru = false;
+				break;
+			}
+
+			FALLTHROUGH;
+		}
+#endif
 
 		default:
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2596,7 +2596,13 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 
 			case AICMD_ENTER:
 			case AICMD_GET_REPAIRED:
+				// if we're already located at the airfield in question, just ignore.
+				// TheSuperHackers @bugfix Caball009 12/08/2026 This applies to units produced at the helipad now as well.
+#if RETAIL_COMPATIBLE_CRC
 				if (parms->m_obj && !getObject()->isKindOf(KINDOF_PRODUCED_AT_HELIPAD))
+#else
+				if (parms->m_obj)
+#endif
 				{
 					Object* airfield;
 					ParkingPlaceBehaviorInterface* pp = getPP(getObject()->getProducerID(), &airfield);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2604,9 +2604,9 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 				if (parms->m_obj)
 #endif
 				{
-					Object* airfield;
+					Object* airfield = nullptr;
 					ParkingPlaceBehaviorInterface* pp = getPP(getObject()->getProducerID(), &airfield);
-					if (pp != nullptr && airfield != nullptr && airfield == parms->m_obj)
+					if (pp != nullptr && airfield == parms->m_obj)
 						return;
 				}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2609,7 +2609,7 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 					return;
 				}
 
-				FALLTHROUGH;
+				goto defaultCase; // cannot fall through to get to the default case!
 #endif
 
 			case AICMD_ENTER:
@@ -2619,9 +2619,10 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 				if (isParkedAt(parms->m_obj))
 					return;
 
-				FALLTHROUGH; // else fall thru to the default case!
+				FALLTHROUGH; // else fall through to the default case!
 
 			default:
+			defaultCase:
 			{
 				// nuke any existing pending cmd
 				m_mostRecentCommand.store(*parms);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2528,24 +2528,6 @@ void JetAIUpdate::privateGetRepaired( Object *repairDepot, CommandSourceType cmd
 }
 
 //-------------------------------------------------------------------------------------------------
-Bool JetAIUpdate::isParkedAt(const Object* obj) const
-{
-	if (!getFlag(ALLOW_AIR_LOCO) &&
-			!getObject()->isKindOf(KINDOF_PRODUCED_AT_HELIPAD) &&
-			obj != nullptr)
-	{
-		Object* airfield;
-		ParkingPlaceBehaviorInterface* pp = getPP(getObject()->getProducerID(), &airfield);
-		if (pp != nullptr && airfield != nullptr && airfield == obj)
-		{
-			return true;
-		}
-	}
-
-	return false;
-}
-
-//-------------------------------------------------------------------------------------------------
 void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 {
 	// call this from aiDoCommand as well as update, because this can
@@ -2614,10 +2596,13 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 
 			case AICMD_ENTER:
 			case AICMD_GET_REPAIRED:
-
-				// if we're already parked at the airfield in question, just ignore.
-				if (isParkedAt(parms->m_obj))
-					return;
+				if (parms->m_obj && !getObject()->isKindOf(KINDOF_PRODUCED_AT_HELIPAD))
+				{
+					Object* airfield;
+					ParkingPlaceBehaviorInterface* pp = getPP(getObject()->getProducerID(), &airfield);
+					if (pp != nullptr && airfield != nullptr && airfield == parms->m_obj)
+						return;
+				}
 
 				FALLTHROUGH; // else fall through to the default case!
 


### PR DESCRIPTION
Helipad units (e.g. Comanches, Chinooks and Helixes) will interrupt their repair sequence even when ordered to repair at the same airfield they were already repairing at. This PR makes them ignore the repair command in that case.

See commits for cleaner diffs.

---

### Before:

https://github.com/user-attachments/assets/60522d81-c7e3-453d-8b07-f00bc51899f4

### After:

https://github.com/user-attachments/assets/4e7db455-9584-4d72-a30a-bfe728b38b5e

---

## TODO:
- [x] Verify fallthrough behavior for previous switch cases in `JetAIUpdate::aiDoCommand`.
- [ ] Replicate to Generals.