### PR TITLE
tweak(controlbar): Allow observer to view units and structures if not following player

### DIFF
--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -703,6 +703,7 @@ public:
 	Bool hasAnyShortcutSelection() const;
 	Bool canShowSpecialPowerShortcut() const;
 	Bool isApparentControllingPlayerNeutral(const Object* obj) const;
+	Bool isControllingPlayerNeutral(const Object* obj) const;
 	void showSpecialPowerShortcut();
 	void hideSpecialPowerShortcut();
 	void animateSpecialPowerShortcut( Bool isOn );

--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -849,6 +849,7 @@ protected:
 	void populateUnderConstruction( Object *objectUnderConstruction );
 	void populateOCLTimer( Object *creatorObject );
 	void doTransportInventoryUI( Object *transport, const CommandSet *commandSet );
+	void populateTransportInventoryReadOnly(Object* transport);
 	static void populateInvDataCallback( Object *obj, void *userData );
 
 	// the following methods are for updating the currently showing context

--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -975,6 +975,7 @@ protected:
 	Color m_buildUpClockColor;
 
 	Bool m_isObserverCommandBar;												///< If this is true, the command bar behaves greatly different
+	Bool m_isReadOnly;                                  ///< If this is true, the command bar will not allow any commands to be issued
 	Player *m_observerLookAtPlayer;											///< The current player we're looking at, Null if we're not looking at anyone.
 	Player *m_observedPlayer;														///< The current player we're observing, Null if we're not observing anyone.
 

--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -976,7 +976,6 @@ protected:
 	Color m_buildUpClockColor;
 
 	Bool m_isObserverCommandBar;												///< If this is true, the command bar behaves greatly different
-	Bool m_isReadOnly;                                  ///< If this is true, the command bar will not allow any commands to be issued
 	Player *m_observerLookAtPlayer;											///< The current player we're looking at, Null if we're not looking at anyone.
 	Player *m_observedPlayer;														///< The current player we're observing, Null if we're not observing anyone.
 

--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -702,6 +702,7 @@ public:
 
 	Bool hasAnyShortcutSelection() const;
 	Bool canShowSpecialPowerShortcut() const;
+	Bool isApparentControllingPlayerNeutral(const Object* obj) const;
 	void showSpecialPowerShortcut();
 	void hideSpecialPowerShortcut();
 	void animateSpecialPowerShortcut( Bool isOn );

--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -816,7 +816,7 @@ protected:
 
 	/// switch the interface context to the new mode and populate as needed
 	void switchToContext( ControlBarContext context, Drawable *draw );
-
+	void switchToDefaultContext(Drawable* draw);
 	/// set the command data into the button
 	void setControlCommand( const AsciiString& buttonWindowName, GameWindow *parent,
 											 const CommandButton *commandButton );

--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -745,6 +745,7 @@ public:
 	void populateObserverInfoWindow ();
 	void populateObserverList();
 	Bool isObserverControlBarOn() { return m_isObserverCommandBar;}
+	Bool isControlEnabled() { return !isObserverControlBarOn();}
 
 	void setObserverLookAtPlayer (Player *player); ///< Sets the looked at player. Used to present information about the player.
 	Player *getObserverLookAtPlayer () const { return m_observerLookAtPlayer; } ///< Returns the looked at player. Can return null.

--- a/Core/GameEngine/Include/GameClient/ControlBar.h
+++ b/Core/GameEngine/Include/GameClient/ControlBar.h
@@ -744,8 +744,8 @@ public:
 	void initObserverControls();
 	void populateObserverInfoWindow ();
 	void populateObserverList();
-	Bool isObserverControlBarOn() { return m_isObserverCommandBar;}
-	Bool isControlEnabled() { return !isObserverControlBarOn();}
+	Bool isObserverControlBarOn() const { return m_isObserverCommandBar;}
+	Bool isControlEnabled() const { return !isObserverControlBarOn();}
 
 	void setObserverLookAtPlayer (Player *player); ///< Sets the looked at player. Used to present information about the player.
 	Player *getObserverLookAtPlayer () const { return m_observerLookAtPlayer; } ///< Returns the looked at player. Can return null.

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -884,7 +884,6 @@ ControlBar::ControlBar()
 	m_commandSets = nullptr;
 	m_controlBarSchemeManager = nullptr;
 	m_isObserverCommandBar = FALSE;
-	m_isReadOnly = FALSE;
 	m_observerLookAtPlayer = nullptr;
 	m_observedPlayer = nullptr;
 	m_buildToolTipLayout = nullptr;
@@ -1322,7 +1321,6 @@ void ControlBar::reset()
 	m_displayedOCLTimerSeconds = 0;
 
 	m_isObserverCommandBar = FALSE; // reset us to use a normal command bar
-	m_isReadOnly = FALSE;
 	m_observerLookAtPlayer = nullptr;
 	m_observedPlayer = nullptr;
 
@@ -2799,7 +2797,6 @@ void ControlBar::setControlBarSchemeByPlayer(Player *p)
 	if( !p->isPlayerActive() )
 	{
 		m_isObserverCommandBar = TRUE;
-		m_isReadOnly = TRUE;
 		switchToContext( CB_CONTEXT_OBSERVER_LIST, nullptr );
 		DEBUG_LOG(("We're loading the Observer Command Bar"));
 
@@ -2814,7 +2811,6 @@ void ControlBar::setControlBarSchemeByPlayer(Player *p)
 	{
 		switchToContext( CB_CONTEXT_NONE, nullptr );
 		m_isObserverCommandBar = FALSE;
-		m_isReadOnly = FALSE;
 
 		if (buttonPlaceBeacon)
 			buttonPlaceBeacon->winHide(
@@ -2846,7 +2842,6 @@ void ControlBar::setControlBarSchemeByPlayerTemplate( const PlayerTemplate *pt)
 	if(pt == ThePlayerTemplateStore->findPlayerTemplate(TheNameKeyGenerator->nameToKey("FactionObserver")))
 	{
 		m_isObserverCommandBar = TRUE;
-		m_isReadOnly = TRUE;
 		switchToContext( CB_CONTEXT_OBSERVER_LIST, nullptr );
 		DEBUG_LOG(("We're loading the Observer Command Bar"));
 
@@ -2861,7 +2856,6 @@ void ControlBar::setControlBarSchemeByPlayerTemplate( const PlayerTemplate *pt)
 	{
 		switchToContext( CB_CONTEXT_NONE, nullptr );
 		m_isObserverCommandBar = FALSE;
-		m_isReadOnly = FALSE;
 
 		if (buttonPlaceBeacon)
 			buttonPlaceBeacon->winHide(

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1484,7 +1484,7 @@ void ControlBar::update()
 		Bool showObserverInventory = observerContain != nullptr
 			&& observerContain->getContainMax() > 0
 			&& m_observerLookAtPlayer == nullptr
-			&& isApparentControllingPlayerNeutral(obj);
+			&& isControllingPlayerNeutral(obj);
 
 		if (showObserverInventory)
 		{
@@ -1920,12 +1920,9 @@ void ControlBar::evaluateContextUI()
 				//a commandset defined. If we do, then trust that the commandset will
 				//handle it!
 
-				Player *localPlayer = ThePlayerList->getLocalPlayer();
-				Relationship relationship;
-
 				// we cannot select objects that are controlled by our enemies
-				relationship = localPlayer->getRelationship( obj->getTeam() );
-				if( obj->isLocallyControlled() == TRUE || relationship == NEUTRAL )
+				bool isRelationshipNeutral = isControllingPlayerNeutral(obj);
+				if( obj->isLocallyControlled() == TRUE || isRelationshipNeutral )
 					switchToContext( CB_CONTEXT_STRUCTURE_INVENTORY, drawToEvaluateFor );
 
 			}
@@ -3606,6 +3603,13 @@ Bool ControlBar::isApparentControllingPlayerNeutral(const Object* obj) const
 	}
 
 	Relationship relation = player->getRelationship(otherPlayer->getDefaultTeam());
+	return relation == NEUTRAL;
+}
+
+Bool ControlBar::isControllingPlayerNeutral(const Object* obj) const
+{
+	const Player* player = ThePlayerList->getLocalPlayer();
+	Relationship relation = player->getRelationship(obj->getTeam());
 	return relation == NEUTRAL;
 }
 

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1479,6 +1479,22 @@ void ControlBar::update()
 			exitPosition = obj->getObjectExitInterface()->getRallyPoint();
 
 		showRallyPoint(exitPosition);
+
+		ContainModuleInterface* observerContain = obj ? obj->getContain() : nullptr;
+		Bool showObserverInventory = (observerContain != nullptr && observerContain->getContainMax() > 0);
+
+		if (showObserverInventory && m_observerLookAtPlayer == nullptr)
+		{
+			if (m_currContext != CB_CONTEXT_STRUCTURE_INVENTORY || m_currentSelectedDrawable != drawToEvaluateFor)
+				switchToContext(CB_CONTEXT_STRUCTURE_INVENTORY, drawToEvaluateFor);
+			else
+				updateContextStructureInventory();
+		}
+		else if (m_currContext != CB_CONTEXT_OBSERVER_LIST)
+		{
+			switchToContext(CB_CONTEXT_OBSERVER_LIST, nullptr);
+		}
+
 		return;
 	}
 

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1483,10 +1483,14 @@ void ControlBar::update()
 		showRallyPoint(exitPosition);
 
 		ContainModuleInterface* observerContain = obj ? obj->getContain() : nullptr;
-		Bool showObserverInventory = (observerContain != nullptr && observerContain->getContainMax() > 0);
+		Bool showObserverInventory = observerContain != nullptr
+			&& observerContain->getContainMax() > 0
+			&& m_observerLookAtPlayer == nullptr
+			&& isApparentControllingPlayerNeutral(obj);
 
-		if (showObserverInventory && m_observerLookAtPlayer == nullptr)
+		if (showObserverInventory)
 		{
+
 			if (m_currContext != CB_CONTEXT_STRUCTURE_INVENTORY || m_currentSelectedDrawable != drawToEvaluateFor)
 				switchToContext(CB_CONTEXT_STRUCTURE_INVENTORY, drawToEvaluateFor);
 			else
@@ -1823,24 +1827,12 @@ void ControlBar::evaluateContextUI()
 		ContainModuleInterface *contain = obj->getContain();
 		if( contain && contain->getContainMax() > 0 )
 		{
-
-			const Player *otherPlayer = contain->getApparentControllingPlayer(ThePlayerList->getLocalPlayer());
-			if (!otherPlayer)
-				otherPlayer = obj->getControllingPlayer();
-			Player *player = ThePlayerList->getLocalPlayer();
-
-			if( !player || !otherPlayer )
-			{
-				//Sanity.
-				return;
-			}
-			Relationship relation = player->getRelationship( otherPlayer->getDefaultTeam() );
-
+			Bool apparentControllingPlayerNeutral = isApparentControllingPlayerNeutral(obj);
 			//Note: All following checks already account for the fact that this object
 			//isn't ours.
 
 			//The only case we can actually see a non-controlled controlbar is a neutral garrisonable structure.
-			if( !contain->isGarrisonable() || relation != NEUTRAL )
+			if( !contain->isGarrisonable() || !apparentControllingPlayerNeutral)
 			{
 				//Can't peek inside enemy/allied containers period!
 				return;
@@ -2822,6 +2814,7 @@ void ControlBar::setControlBarSchemeByPlayer(Player *p)
 	{
 		switchToContext( CB_CONTEXT_NONE, nullptr );
 		m_isObserverCommandBar = FALSE;
+		m_isReadOnly = FALSE;
 
 		if (buttonPlaceBeacon)
 			buttonPlaceBeacon->winHide(
@@ -2853,6 +2846,7 @@ void ControlBar::setControlBarSchemeByPlayerTemplate( const PlayerTemplate *pt)
 	if(pt == ThePlayerTemplateStore->findPlayerTemplate(TheNameKeyGenerator->nameToKey("FactionObserver")))
 	{
 		m_isObserverCommandBar = TRUE;
+		m_isReadOnly = TRUE;
 		switchToContext( CB_CONTEXT_OBSERVER_LIST, nullptr );
 		DEBUG_LOG(("We're loading the Observer Command Bar"));
 
@@ -2867,6 +2861,7 @@ void ControlBar::setControlBarSchemeByPlayerTemplate( const PlayerTemplate *pt)
 	{
 		switchToContext( CB_CONTEXT_NONE, nullptr );
 		m_isObserverCommandBar = FALSE;
+		m_isReadOnly = FALSE;
 
 		if (buttonPlaceBeacon)
 			buttonPlaceBeacon->winHide(
@@ -3599,6 +3594,25 @@ Bool ControlBar::canShowSpecialPowerShortcut() const
 		return true;
 
 	return false;
+}
+
+//-------------------------------------------------------------------------------------------------
+Bool ControlBar::isApparentControllingPlayerNeutral(const Object* obj) const
+{
+	ContainModuleInterface* contain = obj->getContain();
+	const Player* otherPlayer = contain->getApparentControllingPlayer(ThePlayerList->getLocalPlayer());
+	if (!otherPlayer)
+		otherPlayer = obj->getControllingPlayer();
+	const Player* player = ThePlayerList->getLocalPlayer();
+
+	if (!player || !otherPlayer)
+	{
+		//Sanity.
+		return FALSE;
+	}
+
+	Relationship relation = player->getRelationship(otherPlayer->getDefaultTeam());
+	return relation == NEUTRAL;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -884,6 +884,7 @@ ControlBar::ControlBar()
 	m_commandSets = nullptr;
 	m_controlBarSchemeManager = nullptr;
 	m_isObserverCommandBar = FALSE;
+	m_isReadOnly = FALSE;
 	m_observerLookAtPlayer = nullptr;
 	m_observedPlayer = nullptr;
 	m_buildToolTipLayout = nullptr;
@@ -1321,6 +1322,7 @@ void ControlBar::reset()
 	m_displayedOCLTimerSeconds = 0;
 
 	m_isObserverCommandBar = FALSE; // reset us to use a normal command bar
+	m_isReadOnly = FALSE;
 	m_observerLookAtPlayer = nullptr;
 	m_observedPlayer = nullptr;
 
@@ -2805,6 +2807,7 @@ void ControlBar::setControlBarSchemeByPlayer(Player *p)
 	if( !p->isPlayerActive() )
 	{
 		m_isObserverCommandBar = TRUE;
+		m_isReadOnly = TRUE;
 		switchToContext( CB_CONTEXT_OBSERVER_LIST, nullptr );
 		DEBUG_LOG(("We're loading the Observer Command Bar"));
 

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1488,11 +1488,20 @@ void ControlBar::update()
 
 		if (showObserverInventory)
 		{
-
-			if (m_currContext != CB_CONTEXT_STRUCTURE_INVENTORY || m_currentSelectedDrawable != drawToEvaluateFor)
-				switchToContext(CB_CONTEXT_STRUCTURE_INVENTORY, drawToEvaluateFor);
-			else
-				updateContextStructureInventory();
+			
+			if (observerContain->isGarrisonable() && obj->getCommandSetString().isEmpty())
+			{
+				if (m_currContext != CB_CONTEXT_STRUCTURE_INVENTORY || m_currentSelectedDrawable != drawToEvaluateFor)
+					switchToContext(CB_CONTEXT_STRUCTURE_INVENTORY, drawToEvaluateFor);
+				else
+					updateContextStructureInventory();
+			}
+			else {
+				if (m_currContext != CB_CONTEXT_COMMAND || m_currentSelectedDrawable != drawToEvaluateFor)
+					switchToContext(CB_CONTEXT_COMMAND, drawToEvaluateFor);
+				else
+					updateContextCommand();
+			}
 		}
 		else if (m_currContext != CB_CONTEXT_OBSERVER_LIST)
 		{

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1480,35 +1480,14 @@ void ControlBar::update()
 
 		showRallyPoint(exitPosition);
 
-		const ContainModuleInterface* observerContain = obj ? obj->getContain() : nullptr;
-		const Bool showObserverInventory = observerContain != nullptr
-			&& observerContain->getContainMax() > 0
-			&& m_observerLookAtPlayer == nullptr
-			&& isControllingPlayerNeutral(obj);
+		if(getObservedPlayer() != nullptr )
+		{
+			if( m_currContext != CB_CONTEXT_OBSERVER_LIST )
+				switchToContext( CB_CONTEXT_OBSERVER_LIST, nullptr );
 
-		if (showObserverInventory)
-		{
-			if (observerContain->isGarrisonable() && obj->getCommandSetString().isEmpty())
-			{
-				if (m_currContext != CB_CONTEXT_STRUCTURE_INVENTORY || m_currentSelectedDrawable != drawToEvaluateFor)
-					switchToContext(CB_CONTEXT_STRUCTURE_INVENTORY, drawToEvaluateFor);
-				else
-					updateContextStructureInventory();
-			}
-			else
-			{
-				if (m_currContext != CB_CONTEXT_COMMAND || m_currentSelectedDrawable != drawToEvaluateFor)
-					switchToContext(CB_CONTEXT_COMMAND, drawToEvaluateFor);
-				else
-					updateContextCommand();
-			}
-		}
-		else if (m_currContext != CB_CONTEXT_OBSERVER_LIST)
-		{
-			switchToContext(CB_CONTEXT_OBSERVER_LIST, nullptr);
+			return;
 		}
 
-		return;
 	}
 
 
@@ -1789,20 +1768,26 @@ void ControlBar::evaluateContextUI()
 
 	// sanity, nothing selected
 	if( TheInGameUI->getSelectCount() == 0 )
+	{
+		switchToDefaultContext(nullptr);
 		return;
+	}
 
 	// get the list of drawable IDs from the in game UI
 	const DrawableList *selectedDrawables = TheInGameUI->getAllSelectedDrawables();
 
 	// sanity
 	if( selectedDrawables->empty() == TRUE )
+	{
+		switchToDefaultContext(nullptr);
 		return;
+	}
 
 	//Make sure the selected objects are in fact, controllable! If not, then
 	//we don't show any GUI commands for them!!!
 	//This is used when we select enemy objects or objects on another team.
 	//@todo we may want to show their portrait
-	if( !TheInGameUI->areSelectedObjectsControllable() )
+	if( !isObserverControlBarOn() && !TheInGameUI->areSelectedObjectsControllable())
 	{
 		//Also make sure the unit isn't a garrisonable neutral civ team building!
 		Drawable *draw = selectedDrawables->front();
@@ -1827,7 +1812,7 @@ void ControlBar::evaluateContextUI()
 		}
 		else
 		{
-			switchToContext( CB_CONTEXT_NONE, draw );
+			switchToDefaultContext(draw);
 		}
 
 		//Check for a contain interface and a enemy relationship and reject that!
@@ -1868,7 +1853,7 @@ void ControlBar::evaluateContextUI()
 		// but is represented in the UI as a single unit,
 		// so we must isolate and evaluate only the Nexus
 		drawToEvaluateFor = TheGameClient->findDrawableByID( TheInGameUI->getSoloNexusSelectedDrawableID() ) ;
-		multiSelect = ( drawToEvaluateFor == nullptr );
+		multiSelect = ( drawToEvaluateFor == nullptr ) && !isObserverControlBarOn();
 
 	}
 	else // get the first and only drawble in the selection list
@@ -1939,8 +1924,8 @@ void ControlBar::evaluateContextUI()
 			}
 			else if( obj->getCommandSetString().isEmpty() == FALSE )
 			{
-
-				switchToContext( CB_CONTEXT_COMMAND, drawToEvaluateFor );
+				if (obj->isLocallyControlled() == TRUE || isControllingPlayerNeutral(obj))
+					switchToContext( CB_CONTEXT_COMMAND, drawToEvaluateFor );
 
 			}
 			else if (obj->getControllingPlayer()->getPlayerTemplate()->getBeaconTemplate().compare(obj->getTemplate()->getName()) == 0)
@@ -1948,7 +1933,7 @@ void ControlBar::evaluateContextUI()
 				switchToContext( CB_CONTEXT_BEACON, drawToEvaluateFor );
 			}
 			else
-				switchToContext( CB_CONTEXT_NONE, drawToEvaluateFor );
+				switchToDefaultContext(drawToEvaluateFor);
 		}
 
 	}
@@ -2163,6 +2148,14 @@ CBCommandStatus ControlBar::processContextSensitiveButtonTransition( GameWindow 
 	* art and/or buttons that we need to for the new context using data from the object
 	* passed in */
 //-------------------------------------------------------------------------------------------------
+void ControlBar::switchToDefaultContext(Drawable* draw)
+{
+	if (isObserverControlBarOn() && getObservedPlayer() == nullptr)
+		switchToContext(CB_CONTEXT_OBSERVER_LIST, nullptr);
+	else
+		switchToContext(CB_CONTEXT_NONE, draw);
+}
+
 void ControlBar::switchToContext( ControlBarContext context, Drawable *draw )
 {
 

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1480,15 +1480,14 @@ void ControlBar::update()
 
 		showRallyPoint(exitPosition);
 
-		ContainModuleInterface* observerContain = obj ? obj->getContain() : nullptr;
-		Bool showObserverInventory = observerContain != nullptr
+		const ContainModuleInterface* observerContain = obj ? obj->getContain() : nullptr;
+		const Bool showObserverInventory = observerContain != nullptr
 			&& observerContain->getContainMax() > 0
 			&& m_observerLookAtPlayer == nullptr
 			&& isControllingPlayerNeutral(obj);
 
 		if (showObserverInventory)
 		{
-			
 			if (observerContain->isGarrisonable() && obj->getCommandSetString().isEmpty())
 			{
 				if (m_currContext != CB_CONTEXT_STRUCTURE_INVENTORY || m_currentSelectedDrawable != drawToEvaluateFor)
@@ -1496,7 +1495,8 @@ void ControlBar::update()
 				else
 					updateContextStructureInventory();
 			}
-			else {
+			else
+			{
 				if (m_currContext != CB_CONTEXT_COMMAND || m_currentSelectedDrawable != drawToEvaluateFor)
 					switchToContext(CB_CONTEXT_COMMAND, drawToEvaluateFor);
 				else
@@ -1834,12 +1834,11 @@ void ControlBar::evaluateContextUI()
 		ContainModuleInterface *contain = obj->getContain();
 		if( contain && contain->getContainMax() > 0 )
 		{
-			Bool apparentControllingPlayerNeutral = isApparentControllingPlayerNeutral(obj);
 			//Note: All following checks already account for the fact that this object
 			//isn't ours.
 
 			//The only case we can actually see a non-controlled controlbar is a neutral garrisonable structure.
-			if( !contain->isGarrisonable() || !apparentControllingPlayerNeutral)
+			if( !contain->isGarrisonable() || !isApparentControllingPlayerNeutral(obj))
 			{
 				//Can't peek inside enemy/allied containers period!
 				return;
@@ -1930,8 +1929,7 @@ void ControlBar::evaluateContextUI()
 				//handle it!
 
 				// we cannot select objects that are controlled by our enemies
-				bool isRelationshipNeutral = isControllingPlayerNeutral(obj);
-				if( obj->isLocallyControlled() == TRUE || isRelationshipNeutral )
+				if( obj->isLocallyControlled() == TRUE || isControllingPlayerNeutral(obj))
 					switchToContext( CB_CONTEXT_STRUCTURE_INVENTORY, drawToEvaluateFor );
 
 			}
@@ -3600,26 +3598,26 @@ Bool ControlBar::canShowSpecialPowerShortcut() const
 Bool ControlBar::isApparentControllingPlayerNeutral(const Object* obj) const
 {
 	ContainModuleInterface* contain = obj->getContain();
-	const Player* otherPlayer = contain->getApparentControllingPlayer(ThePlayerList->getLocalPlayer());
-	if (!otherPlayer)
-		otherPlayer = obj->getControllingPlayer();
-	const Player* player = ThePlayerList->getLocalPlayer();
-
-	if (!player || !otherPlayer)
-	{
-		//Sanity.
+	if(!contain)
 		return FALSE;
-	}
 
-	Relationship relation = player->getRelationship(otherPlayer->getDefaultTeam());
-	return relation == NEUTRAL;
+	Player* localPlayer = ThePlayerList->getLocalPlayer();
+	const Player* otherPlayer = contain->getApparentControllingPlayer(localPlayer);
+
+	if (!otherPlayer)
+	{
+		otherPlayer = obj->getControllingPlayer();
+		//Sanity.
+		if (!otherPlayer)
+			return FALSE;
+	}
+	return localPlayer->getRelationship(otherPlayer->getDefaultTeam()) == NEUTRAL;
 }
 
 Bool ControlBar::isControllingPlayerNeutral(const Object* obj) const
 {
 	const Player* player = ThePlayerList->getLocalPlayer();
-	Relationship relation = player->getRelationship(obj->getTeam());
-	return relation == NEUTRAL;
+	return player->getRelationship(obj->getTeam()) == NEUTRAL;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1914,7 +1914,7 @@ void ControlBar::evaluateContextUI()
 				//handle it!
 
 				// we cannot select objects that are controlled by our enemies
-				if( obj->isLocallyControlled() == TRUE || isControllingPlayerNeutral(obj))
+				if( obj->isLocallyControlled() == TRUE || isObserverControlBarOn() || isControllingPlayerNeutral(obj))
 					switchToContext( CB_CONTEXT_STRUCTURE_INVENTORY, drawToEvaluateFor );
 
 			}
@@ -1924,7 +1924,7 @@ void ControlBar::evaluateContextUI()
 			}
 			else if( obj->getCommandSetString().isEmpty() == FALSE )
 			{
-				if (obj->isLocallyControlled() == TRUE || isControllingPlayerNeutral(obj))
+				if (obj->isLocallyControlled() == TRUE || isObserverControlBarOn() || isControllingPlayerNeutral(obj))
 					switchToContext( CB_CONTEXT_COMMAND, drawToEvaluateFor );
 
 			}

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3591,20 +3591,14 @@ Bool ControlBar::canShowSpecialPowerShortcut() const
 Bool ControlBar::isApparentControllingPlayerNeutral(const Object* obj) const
 {
 	ContainModuleInterface* contain = obj->getContain();
-	if(!contain)
+	if (!contain)
 		return FALSE;
 
 	Player* localPlayer = ThePlayerList->getLocalPlayer();
-	const Player* otherPlayer = contain->getApparentControllingPlayer(localPlayer);
+	if (const Player* otherPlayer = contain->getApparentControllingPlayer(localPlayer))
+		return localPlayer->getRelationship(otherPlayer->getDefaultTeam()) == NEUTRAL;
 
-	if (!otherPlayer)
-	{
-		otherPlayer = obj->getControllingPlayer();
-		//Sanity.
-		if (!otherPlayer)
-			return FALSE;
-	}
-	return localPlayer->getRelationship(otherPlayer->getDefaultTeam()) == NEUTRAL;
+	return isControllingPlayerNeutral(obj);
 }
 
 Bool ControlBar::isControllingPlayerNeutral(const Object* obj) const

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
@@ -77,6 +77,7 @@ struct PopulateInvButtonData
 	Int maxIndex;					   ///< this is the last valid control we can use
 	GameWindow **controls;   ///< the controls
 	Object *transport;			 ///< the transport
+	ControlBar* self;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -124,7 +125,7 @@ void ControlBar::populateInvDataCallback( Object *obj, void *userData )
 	GadgetButtonDrawOverlayImage( control, image );
 
 	// enable the control
-	control->winEnable( TRUE );
+	control->winEnable(!data->self->isObserverControlBarOn());
 
 }
 
@@ -244,6 +245,7 @@ void ControlBar::doTransportInventoryUI( Object *transport, const CommandSet *co
 		data.currIndex = firstInventoryIndex;
 		data.maxIndex = lastInventoryIndex;
 		data.transport = transport;
+		data.self = this;
 		contain->iterateContained( populateInvDataCallback, &data, FALSE );
 
 	}
@@ -332,7 +334,7 @@ void ControlBar::populateCommand( Object *obj )
 				m_commandWindows[ i ]->winHide( FALSE );
 
 				// enable by default
-				m_commandWindows[ i ]->winEnable( TRUE );
+				m_commandWindows[ i ]->winEnable( !isObserverControlBarOn() );
 
 				// populate the visible button with data from the command button
 				setControlCommand( m_commandWindows[ i ], commandButton );
@@ -622,7 +624,7 @@ void ControlBar::populateBuildQueue( Object *producer )
 			m_queueData[ windowIndex ].productionID = production->getProductionID();
 
 			// set the images
-			m_queueData[ windowIndex ].control->winEnable( TRUE );
+			m_queueData[ windowIndex ].control->winEnable( !isObserverControlBarOn() );
 			m_queueData[ windowIndex ].control->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
 			image = production->getProductionObject()->getButtonImage();
 			GadgetButtonSetEnabledImage( m_queueData[ windowIndex ].control, image );
@@ -655,7 +657,7 @@ void ControlBar::populateBuildQueue( Object *producer )
 			m_queueData[ windowIndex ].upgradeToResearch = production->getProductionUpgrade();
 
 			// set the images
-			m_queueData[ windowIndex ].control->winEnable( TRUE );
+			m_queueData[ windowIndex ].control->winEnable( !isObserverControlBarOn() );
 			m_queueData[ windowIndex ].control->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
 			image = ut->getButtonImage();
 			GadgetButtonSetEnabledImage( m_queueData[ windowIndex ].control, image );
@@ -861,7 +863,7 @@ void ControlBar::updateContextCommand()
 				win->winSetStatus( WIN_STATUS_ALWAYS_COLOR );
 				break;
 			default:
-				win->winEnable( TRUE );
+				win->winEnable( !isObserverControlBarOn() );
 				break;
 		}
 

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
@@ -837,9 +837,14 @@ void ControlBar::updateContextCommand()
 //			continue;
 //		}
 //		else
+		if (isObserverControlBarOn())
 		{
-			win->winClearStatus( WIN_STATUS_NOT_READY );
-			win->winClearStatus( WIN_STATUS_ALWAYS_COLOR );
+			win->winSetStatus(WIN_STATUS_ALWAYS_COLOR);
+		}
+		else
+		{
+			win->winClearStatus(WIN_STATUS_NOT_READY);
+			win->winClearStatus(WIN_STATUS_ALWAYS_COLOR);
 		}
 
 		// is the command available

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
@@ -77,7 +77,7 @@ struct PopulateInvButtonData
 	Int maxIndex;					   ///< this is the last valid control we can use
 	GameWindow **controls;   ///< the controls
 	Object *transport;			 ///< the transport
-	ControlBar* self;
+	Bool enableButton;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -125,7 +125,7 @@ void ControlBar::populateInvDataCallback( Object *obj, void *userData )
 	GadgetButtonDrawOverlayImage( control, image );
 
 	// enable the control
-	control->winEnable(!data->self->isObserverControlBarOn());
+	control->winEnable(data->enableButton);
 
 }
 
@@ -245,7 +245,7 @@ void ControlBar::doTransportInventoryUI( Object *transport, const CommandSet *co
 		data.currIndex = firstInventoryIndex;
 		data.maxIndex = lastInventoryIndex;
 		data.transport = transport;
-		data.self = this;
+		data.enableButton = !this->isObserverControlBarOn();
 		contain->iterateContained( populateInvDataCallback, &data, FALSE );
 
 	}

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
@@ -245,7 +245,7 @@ void ControlBar::doTransportInventoryUI( Object *transport, const CommandSet *co
 		data.currIndex = firstInventoryIndex;
 		data.maxIndex = lastInventoryIndex;
 		data.transport = transport;
-		data.enableButton = !this->isObserverControlBarOn();
+		data.enableButton = isControlEnabled();
 		contain->iterateContained( populateInvDataCallback, &data, FALSE );
 
 	}
@@ -334,7 +334,7 @@ void ControlBar::populateCommand( Object *obj )
 				m_commandWindows[ i ]->winHide( FALSE );
 
 				// enable by default
-				m_commandWindows[ i ]->winEnable( !isObserverControlBarOn() );
+				m_commandWindows[ i ]->winEnable( isControlEnabled() );
 
 				// populate the visible button with data from the command button
 				setControlCommand( m_commandWindows[ i ], commandButton );
@@ -624,7 +624,7 @@ void ControlBar::populateBuildQueue( Object *producer )
 			m_queueData[ windowIndex ].productionID = production->getProductionID();
 
 			// set the images
-			m_queueData[ windowIndex ].control->winEnable( !isObserverControlBarOn() );
+			m_queueData[ windowIndex ].control->winEnable( isControlEnabled() );
 			m_queueData[ windowIndex ].control->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
 			image = production->getProductionObject()->getButtonImage();
 			GadgetButtonSetEnabledImage( m_queueData[ windowIndex ].control, image );
@@ -657,7 +657,7 @@ void ControlBar::populateBuildQueue( Object *producer )
 			m_queueData[ windowIndex ].upgradeToResearch = production->getProductionUpgrade();
 
 			// set the images
-			m_queueData[ windowIndex ].control->winEnable( !isObserverControlBarOn() );
+			m_queueData[ windowIndex ].control->winEnable( isControlEnabled() );
 			m_queueData[ windowIndex ].control->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
 			image = ut->getButtonImage();
 			GadgetButtonSetEnabledImage( m_queueData[ windowIndex ].control, image );
@@ -879,7 +879,7 @@ void ControlBar::updateContextCommand()
 				win->winSetStatus( WIN_STATUS_ALWAYS_COLOR );
 				break;
 			default:
-				win->winEnable( !isObserverControlBarOn() );
+				win->winEnable( isControlEnabled() );
 				break;
 		}
 

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
@@ -701,6 +701,17 @@ void ControlBar::updateContextCommand()
 	if( m_currentSelectedDrawable )
 		obj = m_currentSelectedDrawable->getObject();
 
+	Player *localPlayer = ThePlayerList->getLocalPlayer();
+	if (obj->isLocallyControlled() == FALSE &&
+			localPlayer->getRelationship(obj->getTeam()) != NEUTRAL)
+	{
+		Drawable *draw = obj->getDrawable();
+
+		if (draw)
+			TheInGameUI->deselectDrawable(draw);
+		return;
+	}
+
 	//
 	// the contents of objects are usually showed on the UI, when those contents change
 	// we always to update the UI

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
@@ -703,7 +703,7 @@ void ControlBar::updateContextCommand()
 
 	Player *localPlayer = ThePlayerList->getLocalPlayer();
 	if (obj->isLocallyControlled() == FALSE &&
-			localPlayer->getRelationship(obj->getTeam()) != NEUTRAL)
+		(localPlayer->getRelationship(obj->getTeam()) != NEUTRAL && !isObserverControlBarOn()) )
 	{
 		Drawable *draw = obj->getDrawable();
 

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -175,6 +175,11 @@ void ControlBar::populateStructureInventory( Object *building )
 		m_commandWindows[ STOP_ID ]->winEnable( TRUE );
 	}
 
+	if(isObserverControlBarOn())
+	{
+		m_commandWindows[ EVACUATE_ID ]->winSetStatus(WIN_STATUS_ALWAYS_COLOR);
+		m_commandWindows[ STOP_ID ]->winSetStatus(WIN_STATUS_ALWAYS_COLOR);
+	}
 	//
 	// iterate each of the objects inside the container and put them in a button, note
 	// we're iterating in reverse order here

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -82,7 +82,7 @@ void ControlBar::populateButtonProc( Object *obj, void *userData )
 	GadgetButtonDrawOverlayImage( info->inventoryButtons[ info->buttonIndex ], image );
 
 	// Enable the button
-	info->inventoryButtons[ info->buttonIndex ]->winEnable( !info->self->m_isReadOnly );
+	info->inventoryButtons[ info->buttonIndex ]->winEnable( !info->self->isObserverControlBarOn() );
 
 	// move to the next button index
 	info->buttonIndex++;
@@ -169,7 +169,7 @@ void ControlBar::populateStructureInventory( Object *building )
 	m_commandWindows[ STOP_ID ]->winHide( FALSE );
 
 	// if there is at least one item in there enable the evacuate and stop buttons
-	if(!m_isReadOnly && contain->getContainCount() != 0 )
+	if( !isObserverControlBarOn() && contain->getContainCount() != 0 )
 	{
 		m_commandWindows[ EVACUATE_ID ]->winEnable( TRUE );
 		m_commandWindows[ STOP_ID ]->winEnable( TRUE );

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -83,7 +83,7 @@ void ControlBar::populateButtonProc( Object *obj, void *userData )
 	GadgetButtonDrawOverlayImage( info->inventoryButtons[ info->buttonIndex ], image );
 
 	// Enable the button
-	info->inventoryButtons[ info->buttonIndex ]->winEnable( TRUE );
+	info->inventoryButtons[ info->buttonIndex ]->winEnable( !info->self->m_isReadOnly );
 
 	// move to the next button index
 	info->buttonIndex++;
@@ -170,7 +170,7 @@ void ControlBar::populateStructureInventory( Object *building )
 	m_commandWindows[ STOP_ID ]->winHide( FALSE );
 
 	// if there is at least one item in there enable the evacuate and stop buttons
-	if( contain->getContainCount() != 0 )
+	if(!m_isReadOnly && contain->getContainCount() != 0 )
 	{
 		m_commandWindows[ EVACUATE_ID ]->winEnable( TRUE );
 		m_commandWindows[ STOP_ID ]->winEnable( TRUE );

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -64,11 +64,10 @@ void ControlBar::populateButtonProc( Object *obj, void *userData )
 {
 	PopulateButtonInfo* info = (PopulateButtonInfo*)userData;
 
-	// sanity
-	DEBUG_ASSERTCRASH( info->buttonIndex < MAX_STRUCTURE_INVENTORY_BUTTONS,
-										 ("Too many objects inside '%s' for the inventory buttons to hold",
-											info->source->getTemplate()->getName().str()) );
-
+	
+	if (info->buttonIndex>= MAX_STRUCTURE_INVENTORY_BUTTONS) {
+		return;
+	}
 	// put object in inventory data
 	info->self->m_containData[ info->buttonIndex ].control = info->inventoryButtons[ info->buttonIndex ];
 	info->self->m_containData[ info->buttonIndex ].objectID = obj->getID();

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -82,7 +82,7 @@ void ControlBar::populateButtonProc( Object *obj, void *userData )
 	GadgetButtonDrawOverlayImage( info->inventoryButtons[ info->buttonIndex ], image );
 
 	// Enable the button
-	info->inventoryButtons[ info->buttonIndex ]->winEnable( !info->self->isObserverControlBarOn() );
+	info->inventoryButtons[ info->buttonIndex ]->winEnable( info->self->isControlEnabled() );
 
 	// move to the next button index
 	info->buttonIndex++;
@@ -169,7 +169,7 @@ void ControlBar::populateStructureInventory( Object *building )
 	m_commandWindows[ STOP_ID ]->winHide( FALSE );
 
 	// if there is at least one item in there enable the evacuate and stop buttons
-	if( !isObserverControlBarOn() && contain->getContainCount() != 0 )
+	if( isControlEnabled() && contain->getContainCount() != 0 )
 	{
 		m_commandWindows[ EVACUATE_ID ]->winEnable( TRUE );
 		m_commandWindows[ STOP_ID ]->winEnable( TRUE );

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -65,9 +65,9 @@ void ControlBar::populateButtonProc( Object *obj, void *userData )
 	PopulateButtonInfo* info = (PopulateButtonInfo*)userData;
 
 	
-	if (info->buttonIndex>= MAX_STRUCTURE_INVENTORY_BUTTONS) {
+	if (info->buttonIndex>= MAX_STRUCTURE_INVENTORY_BUTTONS) 
 		return;
-	}
+	
 	// put object in inventory data
 	info->self->m_containData[ info->buttonIndex ].control = info->inventoryButtons[ info->buttonIndex ];
 	info->self->m_containData[ info->buttonIndex ].objectID = obj->getID();

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -212,7 +212,7 @@ void ControlBar::updateContextStructureInventory()
 	//
 	Player *localPlayer = ThePlayerList->getLocalPlayer();
 	if( source->isLocallyControlled() == FALSE &&
-			localPlayer->getRelationship( source->getTeam() ) != NEUTRAL )
+		(localPlayer->getRelationship(source->getTeam()) != NEUTRAL && !isObserverControlBarOn()) )
 	{
 		Drawable *draw = source->getDrawable();
 

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarUnderConstruction.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarUnderConstruction.cpp
@@ -87,6 +87,10 @@ void ControlBar::populateUnderConstruction( Object *objectUnderConstruction )
 	setControlCommand( win, commandButton );
 	win->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
 
+	if (!isControlEnabled()) {
+		win->winSetStatus(WIN_STATUS_ALWAYS_COLOR);
+		win->winEnable(FALSE);
+	}
 	// set the text description of what is building
 	updateConstructionTextDisplay( objectUnderConstruction );
 


### PR DESCRIPTION
This PR is an enhancement/suggestion for observer Controlbar functionality. It allows an observer to view exact units contained by a building/unit. 

I added the ```m_observerLookAtPlayer``` null check because otherwise when following a player and the player selects a containing building/unit the UI doesn't support a way to stop following the player. 

Verification: 
- [x] Checked civilian buildings, technicals/battle busses, china bunkers, GLA multiple tunnels and palace in ZH and Generals.
- [x] Verified Evacuation & Stop Commands don't execute when pressing on any unit. 
- [x] Tested buttons and hotkeys from observer point of view
- [x] Tested switching from observer to skirmish player

limitations: 
a limitation I just thought about: would be lovely if we can select a garrisoned unit and view its own garrisoned units too. 
