### PR TITLE
bugfix(contain): Preserve occupants when transferring assets to allies

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -506,6 +506,7 @@ void TransportContain::onCapture( Player *oldOwner, Player *newOwner )
 #if RETAIL_COMPATIBLE_CRC
 			orderAllPassengersToExit( CMD_FROM_AI );
 #else
+			// TheSuperHackers @bugfix Stubbjax 20/11/2025 Only eject passengers if the new owner is not allied with the old owner.
 			if (oldOwner->getRelationship(newOwner->getDefaultTeam()) != ALLIES)
 				orderAllPassengersToExit(CMD_FROM_AI);
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -503,7 +503,12 @@ void TransportContain::onCapture( Player *oldOwner, Player *newOwner )
 		else
 		{
 			//Use standard
+#if RETAIL_COMPATIBLE_CRC
 			orderAllPassengersToExit( CMD_FROM_AI );
+#else
+			if (oldOwner->getRelationship(newOwner->getDefaultTeam()) != ALLIES)
+				orderAllPassengersToExit(CMD_FROM_AI);
+#endif
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -647,6 +647,7 @@ void TransportContain::onCapture( Player *oldOwner, Player *newOwner )
 #if RETAIL_COMPATIBLE_CRC
 			orderAllPassengersToExit( CMD_FROM_AI, FALSE );
 #else
+      // TheSuperHackers @bugfix Stubbjax 20/11/2025 Only eject passengers if the new owner is not allied with the old owner.
 			if (oldOwner->getRelationship(newOwner->getDefaultTeam()) != ALLIES)
 				orderAllPassengersToExit(CMD_FROM_AI, FALSE);
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -644,7 +644,12 @@ void TransportContain::onCapture( Player *oldOwner, Player *newOwner )
 		else
 		{
 			//Use standard
+#if RETAIL_COMPATIBLE_CRC
 			orderAllPassengersToExit( CMD_FROM_AI, FALSE );
+#else
+			if (oldOwner->getRelationship(newOwner->getDefaultTeam()) != ALLIES)
+				orderAllPassengersToExit(CMD_FROM_AI, FALSE);
+#endif
 		}
 	}
 }


### PR DESCRIPTION
This change preserves contained occupants when a player's assets are transferred to an ally player.

Transferred assets run through the `onCapture` logic, which features safeguards against weird circumstances like enemy occupants being left inside a captured building or vehicle. However, this does not take assets transferred to allies on surrender into consideration, in which case preserved containment is always desirable*. Also note that not all occupants are consistently evacuated (at least prior to #1885).

*This change does leave a possible scenario where a container object is transferred to an ally under different circumstances, such as via a scripting event. In such cases, any of the original owner's occupants would hypothetically remain inside the container rather than being ejected, which might cause weird or unexpected behaviour.

I'm thinking it might be necessary to implement an optional capture path / reason into the `onCapture` signatures and make the change conditional on that reason.

```cpp
void TransportContain::onCapture(Player* oldOwner, Player* newOwner, CaptureType captureType = CT_DEFAULT)
{
  if (captureType = CT_TRANSFER_ALLIES)
  {
    // ...
  }
}
```

Or we could simply ignore such scenarios; they might not even be valid and they're certainly not likely. I'm open to suggestions.

### Before

Units are evacuated when transferred to an ally

https://github.com/user-attachments/assets/4de6bf72-4e19-43be-9062-2d2a8da05344

And with #1885 applied:
https://github.com/user-attachments/assets/7ee1b10b-4d9e-4eac-848d-6ff71622ceec

### After

Units remain contained when transferred to an ally

https://github.com/user-attachments/assets/783ca9d1-70cc-41e3-b872-b8975e30d17c

And with #1885 applied:
https://github.com/user-attachments/assets/adbcf7f1-5fa2-49dc-b614-bddc9d8804a5