### PR TITLE
bugfix(object): The KINDOF_NO_SELECT flag now prevents an object from being selected

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2822,11 +2822,7 @@ Bool Object::isSelectable() const
 				|| (m_isSelectable
 						&& !testStatus(OBJECT_STATUS_UNSELECTABLE)
 						&& !isEffectivelyDead()
-#if RETAIL_COMPATIBLE_CRC
-						&& !getTemplate()->isKindOf(KINDOF_DRONE)//Most drones are unselectable from being slaved, but the SpyDrone needs help
-#else
 						&& !getTemplate()->isKindOf(KINDOF_NO_SELECT)
-#endif
 						);
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2822,7 +2822,11 @@ Bool Object::isSelectable() const
 				|| (m_isSelectable
 						&& !testStatus(OBJECT_STATUS_UNSELECTABLE)
 						&& !isEffectivelyDead()
+#if RETAIL_COMPATIBLE_CRC
+						&& !getTemplate()->isKindOf(KINDOF_DRONE)//Most drones are unselectable from being slaved, but the SpyDrone needs help
+#else
 						&& !getTemplate()->isKindOf(KINDOF_NO_SELECT)
+#endif
 						);
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2822,7 +2822,7 @@ Bool Object::isSelectable() const
 				|| (m_isSelectable
 						&& !testStatus(OBJECT_STATUS_UNSELECTABLE)
 						&& !isEffectivelyDead()
-						&& !getTemplate()->isKindOf(KINDOF_DRONE)//Most drones are unselectable from being slaved, but the SpyDrone needs help
+						&& !getTemplate()->isKindOf(KINDOF_NO_SELECT)
 						);
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3113,7 +3113,7 @@ Bool Object::isSelectable() const
 //				|| (m_isSelectable
 //						&& !testStatus(OBJECT_STATUS_UNSELECTABLE)
 //						&& !isEffectivelyDead()
-//						&& !getTemplate()->isKindOf(KINDOF_NO_SELECT)
+//						&& !getTemplate()->isKindOf(KINDOF_DRONE)//Most drones are unselectable from being slaved, but the SpyDrone needs help
 //						);
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3123,7 +3123,9 @@ Bool Object::isSelectable() const
 	if ( m_isSelectable )
     if ( !testStatus(OBJECT_STATUS_UNSELECTABLE) )
 		  if ( !isEffectivelyDead() )
+#if !RETAIL_COMPATIBLE_CRC
 				if ( !getTemplate()->isKindOf(KINDOF_NO_SELECT) )
+#endif
 					return TRUE;
 
   return FALSE;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3113,7 +3113,7 @@ Bool Object::isSelectable() const
 //				|| (m_isSelectable
 //						&& !testStatus(OBJECT_STATUS_UNSELECTABLE)
 //						&& !isEffectivelyDead()
-//						&& !getTemplate()->isKindOf(KINDOF_DRONE)//Most drones are unselectable from being slaved, but the SpyDrone needs help
+//						&& !getTemplate()->isKindOf(KINDOF_NO_SELECT)
 //						);
 
 
@@ -3123,7 +3123,7 @@ Bool Object::isSelectable() const
 	if ( m_isSelectable )
     if ( !testStatus(OBJECT_STATUS_UNSELECTABLE) )
 		  if ( !isEffectivelyDead() )
-				//if ( !getTemplate()->isKindOf(KINDOF_DRONE) )//Most drones are unselectable from being slaved, but the SpyDrone needs help
+				if ( !getTemplate()->isKindOf(KINDOF_NO_SELECT) )
 					return TRUE;
 
   return FALSE;


### PR DESCRIPTION
This change corrects object selection logic so that `KINDOF_NO_SELECT` now prevents an object from being selected as expected. It was originally only used when selecting previous/next units.

As a result, existing objects that define `NO_SELECT` in their `KindOf` field are no longer selectable, but can be still attacked. This already applies to all USA Drones (including the Spy Drone), though vehicle drones are masked via a different process and thus the flag made no difference. The only other object affected by this change is the emerging Sneak Attack, which will require a data change if undesirable.