### PR TITLE
bugfix(aiupdate): Let Tunnel Network passengers exit from any Tunnel Object again

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CaveContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CaveContain.h
@@ -100,6 +100,7 @@ public:
 	virtual UnsignedInt getContainCount() const override;
 	virtual Int getContainMax() const override;
 	virtual const ContainedItemsList* getContainedItemsList() const override;
+	virtual Bool isContained( const Object *obj ) const override;
 	virtual Bool isKickOutOnCapture() override { return FALSE; }///< Caves and Tunnels don't kick out on capture.
 
 	// override the onDie we inherit from OpenContain

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
@@ -152,6 +152,7 @@ public:
 	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) = 0;		///< iterate the contain list
 	virtual UnsignedInt getContainCount() const = 0;											///< contained count
 	virtual const ContainedItemsList* getContainedItemsList() const = 0;
+	virtual Bool isContained( const Object *obj ) const = 0;	///< Return whether the object is contained in this module
 	virtual const Object *friend_getRider() const = 0; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const = 0;
 	virtual UnsignedInt getStealthUnitsContained() const = 0;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -161,6 +161,7 @@ public:
 	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
 	virtual UnsignedInt getContainCount() const override { return m_containListSize; }
 	virtual const ContainedItemsList* getContainedItemsList() const override { return &m_containList; }
+	virtual Bool isContained( const Object *obj ) const override;
 	virtual const Object *friend_getRider() const override {return nullptr;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const override;
 	virtual UnsignedInt getStealthUnitsContained() const override { return m_stealthUnitsContained; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
@@ -109,6 +109,7 @@ public:
 	virtual UnsignedInt getHeroUnitsContained() const override;
 	virtual Int getContainMax() const override;
 	virtual const ContainedItemsList* getContainedItemsList() const override;
+	virtual Bool isContained( const Object *obj ) const override;
 	virtual UnsignedInt getFullTimeForHeal() const; ///< Returns the time in frames until a contained object becomes fully healed
 	virtual Bool isDisplayedOnControlBar() const override { return TRUE; } ///< Does this container display its contents on the ControlBar?
 	virtual Bool isKickOutOnCapture() override { return FALSE; }///< Caves and Tunnels don't kick out on capture.

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/CaveContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/CaveContain.cpp
@@ -152,6 +152,18 @@ void CaveContain::onContaining( Object *obj )
 }
 
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @info A whole network shares one passenger list, so a passenger is contained by
+// the endpoint it entered and not by the one that was ordered to unload.
+Bool CaveContain::isContained( const Object *obj ) const
+{
+	if (OpenContain::isContained(obj))
+		return TRUE;
+
+	const ContainedItemsList *items = getContainedItemsList();
+	return items != nullptr && std::find(items->begin(), items->end(), obj) != items->end();
+}
+
+//-------------------------------------------------------------------------------------------------
 void CaveContain::onRemoving( Object *obj )
 {
 	OpenContain::onRemoving(obj);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -368,6 +368,11 @@ void OpenContain::addToContain( Object *rider )
 }
 
 //-------------------------------------------------------------------------------------------------
+Bool OpenContain::isContained( const Object *obj ) const
+{
+	return obj->getContainedBy() == getObject();
+}
+
 //-------------------------------------------------------------------------------------------------
 void OpenContain::addToContainList( Object *rider )
 {

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -208,6 +208,18 @@ void TunnelContain::onSelling()
 }
 
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @info A whole network shares one passenger list, so a passenger is contained by
+// the endpoint it entered and not by the one that was ordered to unload.
+Bool TunnelContain::isContained( const Object *obj ) const
+{
+	if (OpenContain::isContained(obj))
+		return TRUE;
+
+	const ContainedItemsList *items = getContainedItemsList();
+	return items != nullptr && std::find(items->begin(), items->end(), obj) != items->end();
+}
+
+//-------------------------------------------------------------------------------------------------
 Bool TunnelContain::isValidContainerFor(const Object* obj, Bool checkCapacity) const
 {
 	Player *owningPlayer = getObject()->getControllingPlayer();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3674,12 +3674,11 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 	}
 	else
 	{
-		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
+		// TheSuperHackers @bugfix Caball009 / Okladnoj 10/08/2026 Don't process invalid exit commands,
 		// because an object should not attempt to exit something it's not contained by.
 #if !RETAIL_COMPATIBLE_CRC
-		// @todo Remove function parameter 'objectToExit' because it's become obsolete.
-
-		if (us->getContainedBy() != objectToExit)
+		const ContainModuleInterface *contain = objectToExit->getContain();
+		if (contain == nullptr || !contain->isContained(us))
 			return;
 #endif
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CaveContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CaveContain.h
@@ -101,6 +101,7 @@ public:
 	virtual UnsignedInt getContainCount() const override;
 	virtual Int getContainMax() const override;
 	virtual const ContainedItemsList* getContainedItemsList() const override;
+	virtual Bool isContained( const Object *obj ) const override;
 	virtual Bool isKickOutOnCapture() override { return FALSE; }///< Caves and Tunnels don't kick out on capture.
 
 	// override the onDie we inherit from OpenContain

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
@@ -172,6 +172,7 @@ public:
 	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) = 0;		///< iterate the contain list
 	virtual UnsignedInt getContainCount() const = 0;											///< contained count
 	virtual const ContainedItemsList* getContainedItemsList() const = 0;
+	virtual Bool isContained( const Object *obj ) const = 0;	///< Return whether the object is contained in this module
 	virtual const Object *friend_getRider() const = 0; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const = 0;
 	virtual UnsignedInt getStealthUnitsContained() const = 0;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -171,6 +171,7 @@ public:
 	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
 	virtual UnsignedInt getContainCount() const override { return m_containListSize; }
 	virtual const ContainedItemsList* getContainedItemsList() const override { return &m_containList; }
+	virtual Bool isContained( const Object *obj ) const override;
 	virtual const Object *friend_getRider() const override {return nullptr;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const override;
 	virtual UnsignedInt getStealthUnitsContained() const override { return m_stealthUnitsContained; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
@@ -115,6 +115,7 @@ public:
 	virtual UnsignedInt getHeroUnitsContained() const override;
 	virtual Int getContainMax() const override;
 	virtual const ContainedItemsList* getContainedItemsList() const override;
+	virtual Bool isContained( const Object *obj ) const override;
 	virtual UnsignedInt getFullTimeForHeal() const; ///< Returns the time in frames until a contained object becomes fully healed
 	virtual Bool isDisplayedOnControlBar() const override { return TRUE; } ///< Does this container display its contents on the ControlBar?
 	virtual Bool isKickOutOnCapture() override { return FALSE; }///< Caves and Tunnels don't kick out on capture.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/CaveContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/CaveContain.cpp
@@ -152,6 +152,18 @@ void CaveContain::onContaining( Object *obj, Bool wasSelected )
 }
 
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @info A whole network shares one passenger list, so a passenger is contained by
+// the endpoint it entered and not by the one that was ordered to unload.
+Bool CaveContain::isContained( const Object *obj ) const
+{
+	if (OpenContain::isContained(obj))
+		return TRUE;
+
+	const ContainedItemsList *items = getContainedItemsList();
+	return items != nullptr && std::find(items->begin(), items->end(), obj) != items->end();
+}
+
+//-------------------------------------------------------------------------------------------------
 void CaveContain::onRemoving( Object *obj )
 {
 	OpenContain::onRemoving(obj);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -390,6 +390,11 @@ void OpenContain::addToContain( Object *rider )
 }
 
 //-------------------------------------------------------------------------------------------------
+Bool OpenContain::isContained( const Object *obj ) const
+{
+	return obj->getContainedBy() == getObject();
+}
+
 //-------------------------------------------------------------------------------------------------
 void OpenContain::addToContainList( Object *rider )
 {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -285,6 +285,18 @@ void TunnelContain::onSelling()
 }
 
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @info A whole network shares one passenger list, so a passenger is contained by
+// the endpoint it entered and not by the one that was ordered to unload.
+Bool TunnelContain::isContained( const Object *obj ) const
+{
+	if (OpenContain::isContained(obj))
+		return TRUE;
+
+	const ContainedItemsList *items = getContainedItemsList();
+	return items != nullptr && std::find(items->begin(), items->end(), obj) != items->end();
+}
+
+//-------------------------------------------------------------------------------------------------
 Bool TunnelContain::isValidContainerFor(const Object* obj, Bool checkCapacity) const
 {
 	Player *owningPlayer = getObject()->getControllingPlayer();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3829,12 +3829,11 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 	}
 	else
 	{
-		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
+		// TheSuperHackers @bugfix Caball009 / Okladnoj 10/08/2026 Don't process invalid exit commands,
 		// because an object should not attempt to exit something it's not contained by.
 #if !RETAIL_COMPATIBLE_CRC
-		// @todo Remove function parameter 'objectToExit' because it's become obsolete.
-
-		if (us->getContainedBy() != objectToExit)
+		const ContainModuleInterface *contain = objectToExit->getContain();
+		if (contain == nullptr || !contain->isContained(us))
 			return;
 #endif
 	}
@@ -3868,12 +3867,11 @@ void AIUpdateInterface::privateExitInstantly( Object *objectToExit, CommandSourc
 	}
 	else
 	{
-		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
+		// TheSuperHackers @bugfix Caball009 / Okladnoj 10/08/2026 Don't process invalid exit commands,
 		// because an object should not attempt to exit something it's not contained by.
 #if !RETAIL_COMPATIBLE_CRC
-		// @todo Remove function parameter 'objectToExit' because it's become obsolete.
-
-		if (us->getContainedBy() != objectToExit)
+		const ContainModuleInterface *contain = objectToExit->getContain();
+		if (contain == nullptr || !contain->isContained(us))
 			return;
 #endif
 	}


### PR DESCRIPTION
**Follow-up to #3089** — problem: evacuating a Tunnel Network does not work (build two
tunnels, load units through the first one, press Evacuate on the second one — nobody
comes out).

A Tunnel Network keeps a single contents list shared by every tunnel, while a
passenger's `getContainedBy()` points at the tunnel it entered, so #3089 rejects
everyone addressed to a different tunnel. Now we ask the addressed container whether it
holds the unit, instead of comparing container objects.
