### PR TITLE
fix(commandxlat): Consume the cheat and demo messages consistently when handled

### DIFF
--- a/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3677,6 +3677,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 				Money *money = localPlayer->getMoney();
 				money->deposit( 10000 );
 				TheInGameUI->messageNoFormat( TheGameText->FETCH_OR_SUBSTITUTE("GUI:DebugAddCash", L"Add Cash") );
+
+				disp = DESTROY_MESSAGE;
 			}
 			break;
 		}
@@ -3717,6 +3719,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 					TheInGameUI->messageNoFormat( TheGameText->FETCH_OR_SUBSTITUTE("GUI:DebugObjectHealthOn", L"Object Health is ON") );
 				else
 					TheInGameUI->messageNoFormat( TheGameText->FETCH_OR_SUBSTITUTE("GUI:DebugObjectHealthOff", L"Object Health is OFF") );
+
+				disp = DESTROY_MESSAGE;
 			}
 			break;
 
@@ -4860,6 +4864,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		case GameMessage::MSG_META_DEMO_TOGGLE_RENDER:
 		{
 			TheWritableGlobalData->m_disableRender = !TheGlobalData->m_disableRender;
+			disp = DESTROY_MESSAGE;
 			break;
 		}
 
@@ -4873,6 +4878,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 				Money *money = localPlayer->getMoney();
 				money->deposit( 10000 );
 				TheInGameUI->messageNoFormat( TheGameText->FETCH_OR_SUBSTITUTE("GUI:DebugAddCash", L"Add Cash") );
+
+				disp = DESTROY_MESSAGE;
 			}
 			break;
 		}
@@ -4913,6 +4920,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 					obj->kill();
 				}
 			}
+			disp = DESTROY_MESSAGE;
 		}
 		break;
 
@@ -5006,6 +5014,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 			} else {
 				TheDisplay->setDebugDisplayCallback(nullptr);
 			}
+			disp = DESTROY_MESSAGE;
 			break;
 		}
 #endif // #ifdef PERF_TIMERS
@@ -5589,6 +5598,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 
 			TheInGameUI->messageNoFormat( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugPerformStatisticalDump",
 				L"Statistics dump made on frame: %d", TheGameLogic->getFrame() ) );
+			disp = DESTROY_MESSAGE;
 			break;
 #endif // DUMP_PERF_STATS
 


### PR DESCRIPTION
* Fixes #2769

`CommandTranslator::translateGameMessage` has several cheat and demo cases that perform their action without consuming the message, unlike their sibling cases, which set `disp = DESTROY_MESSAGE` when handled. This change consumes the message in all of them:

- `MSG_CHEAT_ADD_CASH` (the issue's subject)
- `MSG_CHEAT_SHOW_HEALTH`
- `MSG_META_DEMO_ADD_CASH`
- `MSG_META_DEMO_TOGGLE_RENDER`
- `MSG_META_DEMO_KILL_AREA_SELECTION`
- `MSG_META_DEMO_TOGGLE_METRICS` (`PERF_TIMERS` builds)
- `MSG_META_DEMO_PERFORM_STATISTICAL_DUMP` (`DUMP_PERF_STATS` builds)

Found by sweeping the whole switch for cheat/demo cases that lack a `disp` assignment; the stacked `RUNSCRIPT` and `OBJECTIVE_MOVIE` blocks and the remaining cheat/demo cases already consume. Code comments are removed per review.

## Testing

Compiles with the `win32` preset (VS2019 16.11, Ninja Multi-Config, Release); `CommandXlat.cpp` builds without warnings and `generalszh.exe` links. The two `#ifdef`-guarded sites are not compiled by this preset and are syntax-identical one-liners; the debug/profile CI presets exercise them.

An earlier build of this branch (with the two add cash changes) was smoke tested in game against retail Steam Zero Hour 1.04 data: boots, loads and plays a skirmish normally. The cheat messages are not bound in normal builds, so the disposition change is verified by inspection against the sibling cases.

---

This change was developed with AI assistance (Claude), human-directed: every case in the switch was checked by hand for the missing disposition, and the change was verified to compile as above. No gameplay simulation code is touched.
