### PR TITLE
bugfix(selection): Fix group index range in SelectionTranslator::onMetaViewTeam()

### DIFF
--- a/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1301,7 +1301,8 @@ GameMessageDisposition SelectionTranslator::onMetaAddTeam(MAYBE_UNUSED const Gam
 GameMessageDisposition SelectionTranslator::onMetaViewTeam(MAYBE_UNUSED const GameMessage *msg)
 {
 	Int group = msg->getType() - GameMessage::MSG_META_VIEW_TEAM0;
-	if ( group >= 1 && group <= 10 )
+	// TheSuperHackers @bugfix Fix the group index range so control group 0 can be viewed.
+	if ( group >= 0 && group < 10 )
 	{
 		DEBUG_LOG(("META: view team %d",group));
 		Player *player = ThePlayerList->getLocalPlayer();


### PR DESCRIPTION
* Fixes #2842

`SelectionTranslator::onMetaViewTeam` checks the group index with `group >= 1 && group <= 10`, but the index computed from `MSG_META_VIEW_TEAM0`..`MSG_META_VIEW_TEAM9` is always in the 0..9 range. The wrong bounds make viewing control group 0 do nothing, and accept an index of 10 that can never occur. This change mirrors the correct check used by the sibling handlers `onMetaSelectTeam` and `onMetaAddTeam`.

## Testing

Smoke tested in game (win32 preset build, windowed, retail Steam Zero Hour 1.04 data): in a skirmish, assigning a unit to control group 0 and pressing the view-group key for group 0 now centers the camera on the group, matching groups 1..9, which continue to behave as before. Without this change the keypress does nothing for group 0.

Compiles with the `win32` preset (VS2019 16.11, Ninja Multi-Config, Release).

<details><summary>Build log excerpt</summary>

```
[4/7] Building CXX object GeneralsMD\Code\GameEngine\CMakeFiles\z_gameengine.dir\Release\__\__\__\Core\GameEngine\Source\GameClient\MessageStream\SelectionXlat.cpp.obj
C:\Users\Bas\source\repos\GeneralsGameCode\Core\GameEngine\Source\GameClient\MessageStream\SelectionXlat.cpp(546): warning C4018: '>': signed/unsigned mismatch
[6/7] Linking CXX static library GeneralsMD\Code\GameEngine\Release\z_gameengine.lib
[7/7] Linking CXX executable GeneralsMD\Release\generalszh.exe
```

The C4018 warning at line 546 is pre-existing on `main` and unrelated to this change (which touches line 1304).

</details>

---

This change was developed with AI assistance (Claude), human-directed: the message enum ordering and both sibling handlers were compared by hand, the change was verified to compile as above, and the fixed behavior was verified by a human in game.
