### PR TITLE
perf(smudge): Early return W3DSmudgeManager::render when no smudges are present

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -314,7 +314,7 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 	if (!testHardwareSupport())
 		return;
 
-	// TheSuperHackers @perf stephanmeesters 14/08/2026 Early return when we have no smudge sets
+	// TheSuperHackers @performance stephanmeesters 14/08/2026 Early return when we have no smudge sets
 	// or if the global smudge set is the only set and contains no smudges.
 	if (m_usedSmudgeSetList.empty() || (m_usedSmudgeSetList.size() == 1 && m_usedSmudgeSetList.front()->getUsedSmudgeCount() == 0))
 	{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -310,6 +310,11 @@ Bool W3DSmudgeManager::testHardwareSupport()
 
 void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 {
+	// TheSuperHackers @perf stephanmeesters 14/08/2026 Early return when we have no smudge sets
+	// or if there are no smudges in the global smudge set.
+	if(m_usedSmudgeSetList.empty() || m_usedSmudgeSetList.front()->getUsedSmudgeCount() == 0)
+		return;
+
 	//Verify that the card supports the effect.
 	if (!testHardwareSupport())
 		return;
@@ -365,11 +370,8 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 	SmudgeSetDeque::iterator setIt=m_usedSmudgeSetList.begin();	//first set that didn't fit into render batch.
 	Int count = 0;
 
-	if (setIt != m_usedSmudgeSetList.end())
-	{
-		//there are possibly some smudges to render, so make sure background particles have finished drawing.
-		SortingRendererClass::Flush();	//draw sorted translucent polys like particles.
-	}
+	// make sure background particles have finished drawing.
+	SortingRendererClass::Flush();	//draw sorted translucent polys like particles.
 
 	for(; setIt != m_usedSmudgeSetList.end(); ++setIt)
 	{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -310,14 +310,17 @@ Bool W3DSmudgeManager::testHardwareSupport()
 
 void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 {
-	// TheSuperHackers @perf stephanmeesters 14/08/2026 Early return when we have no smudge sets
-	// or if there are no smudges in the global smudge set.
-	if(m_usedSmudgeSetList.empty() || m_usedSmudgeSetList.front()->getUsedSmudgeCount() == 0)
-		return;
-
 	//Verify that the card supports the effect.
 	if (!testHardwareSupport())
 		return;
+
+	// TheSuperHackers @perf stephanmeesters 14/08/2026 Early return when we have no smudge sets
+	// or if there are no smudges in the global smudge set.
+	if(m_usedSmudgeSetList.empty() || m_usedSmudgeSetList.front()->getUsedSmudgeCount() == 0)
+	{
+		m_smudgeCountLastFrame = 0;
+		return;
+	}
 
 	SurfaceClass *backBuffer = DX8Wrapper::_Get_DX8_Back_Buffer();
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -315,8 +315,8 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 		return;
 
 	// TheSuperHackers @perf stephanmeesters 14/08/2026 Early return when we have no smudge sets
-	// or if there are no smudges in the global smudge set.
-	if(m_usedSmudgeSetList.empty() || m_usedSmudgeSetList.front()->getUsedSmudgeCount() == 0)
+	// or if the global smudge set is the only set and contains no smudges.
+	if (m_usedSmudgeSetList.empty() || (m_usedSmudgeSetList.size() == 1 && m_usedSmudgeSetList.front()->getUsedSmudgeCount() == 0))
 	{
 		m_smudgeCountLastFrame = 0;
 		return;


### PR DESCRIPTION
In #2484 a global smudge set was introduced through which all smudge particles were rendered. 

As a result there is always at least one smudge set in the list, which meant that `W3DSmudgeManager::render` would always do some work before discovering there are no smudges in the set. This PR adds an early return to skip some of these calculations including a call to `SortingRendererClass::Flush()`.

Performance gain: ~7.5µs per frame

## Todo
- [x] Get some estimate of the performance gain