### PR TITLE
bugfix(scorch): Fix diffuse color calculation of scorches

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DScorch.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DScorch.cpp
@@ -162,20 +162,13 @@ void W3DScorch::updateScorches(WorldHeightMap& map)
 	VertexFormatXYZDUV1* vb = (VertexFormatXYZDUV1*)lockVtxBuffer.Get_Vertex_Array();
 	VertexFormatXYZDUV1* curVb = vb;
 
-	Int curScorch;
-	Real shadeR, shadeG, shadeB;
-	shadeR = TheGlobalData->m_terrainAmbient[0].red;
-	shadeG = TheGlobalData->m_terrainAmbient[0].green;
-	shadeB = TheGlobalData->m_terrainAmbient[0].blue;
-	shadeR += TheGlobalData->m_terrainDiffuse[0].red / 2;
-	shadeG += TheGlobalData->m_terrainDiffuse[0].green / 2;
-	shadeB += TheGlobalData->m_terrainDiffuse[0].blue / 2;
-	shadeR *= 255.0f;
-	shadeG *= 255.0f;
-	shadeB *= 255.0f;
-	Int diffuse = REAL_TO_INT(shadeB) | (REAL_TO_INT(shadeG) << 8) | (REAL_TO_INT(shadeR) << 16) | ((int)255 << 24);
+	Real shadeR = (TheGlobalData->m_terrainAmbient[0].red + TheGlobalData->m_terrainDiffuse[0].red) / 2.0f;
+	Real shadeG = (TheGlobalData->m_terrainAmbient[0].green + TheGlobalData->m_terrainDiffuse[0].green) / 2.0f;
+	Real shadeB = (TheGlobalData->m_terrainAmbient[0].blue + TheGlobalData->m_terrainDiffuse[0].blue) / 2.0f;
+	UnsignedInt diffuse = DX8Wrapper::Convert_Color_Clamp(Vector4(shadeR, shadeG, shadeB, 1.0f));
+
 	m_scorchesInBuffer = 0;
-	for (curScorch = m_numScorches - 1; curScorch >= 0; curScorch--)
+	for (Int curScorch = m_numScorches - 1; curScorch >= 0; curScorch--)
 	{
 		m_scorchesInBuffer++;
 		Real radius = m_scorches[curScorch].radius;


### PR DESCRIPTION
This fixes an incorrect calculation of the diffuse color of scorch marks. In the old code, the ambient and diffuse colors were not equally blended, which meant it could overflow if the map lighting settings of both ambient and diffuse were high in any channel.

The fix applied here is to equally blend the colors (as assumed original devs meant to do) and also to clamp the colors, and to use `UnsignedInt diffuse` instead of `Int diffuse`.

<details>

<summary>Image gallery</summary>

### Map with red channel overflow. Note the scorch becomes darker in original code as a result of overflow

<img width="1920" height="1077" alt="Screenshot From 2026-08-15 12-37-03" src="https://github.com/user-attachments/assets/8358b019-0574-4a64-874c-aa3c38236bf4" />
<img width="1920" height="1077" alt="Screenshot From 2026-08-15 12-37-23" src="https://github.com/user-attachments/assets/50cc4882-0262-4919-8750-ede05f8bd9aa" />


### Map with regular lighting settings, no overflow, looks slightly different now

<img width="1920" height="1077" alt="Screenshot From 2026-08-15 12-36-44" src="https://github.com/user-attachments/assets/e682fe74-30cb-4fb4-8b62-9d28cb29c919" />
<img width="1920" height="1077" alt="Screenshot From 2026-08-15 12-36-52" src="https://github.com/user-attachments/assets/a6fdd195-7ab8-4124-9bc5-be2cac832f65" />


</details>




