### PR TITLE
bugfix(ai): Fix AICommandParmsStorage::doXfer to transfer the command source

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -126,7 +126,13 @@ void AICommandParmsStorage::reconstitute(AICommandParms& parms) const
 void AICommandParmsStorage::doXfer(Xfer *xfer)
 {
 	xfer->xferUser(&m_cmd, sizeof(m_cmd));
-	xfer->xferUser(&m_cmd, sizeof(m_cmdSource));
+	// TheSuperHackers @bugfix Transfer the command source instead of the command twice.
+	xfer->xferUser(&m_cmdSource, sizeof(m_cmdSource));
+	if (xfer->getXferMode() == XFER_LOAD && (m_cmdSource < CMD_FROM_PLAYER || m_cmdSource >= COMMAND_SOURCE_TYPE_COUNT))
+	{
+		// TheSuperHackers @info Saves from before this fix contain a copy of the command in the command source slot.
+		m_cmdSource = CMD_FROM_AI;
+	}
 	xfer->xferCoord3D(&m_pos);
 	xfer->xferObjectID(&m_obj);
 	xfer->xferObjectID(&m_otherObj);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -129,7 +129,13 @@ void AICommandParmsStorage::reconstitute(AICommandParms& parms) const
 void AICommandParmsStorage::doXfer(Xfer *xfer)
 {
 	xfer->xferUser(&m_cmd, sizeof(m_cmd));
-	xfer->xferUser(&m_cmd, sizeof(m_cmdSource));
+	// TheSuperHackers @bugfix Transfer the command source instead of the command twice.
+	xfer->xferUser(&m_cmdSource, sizeof(m_cmdSource));
+	if (xfer->getXferMode() == XFER_LOAD && (m_cmdSource < CMD_FROM_PLAYER || m_cmdSource >= COMMAND_SOURCE_TYPE_COUNT))
+	{
+		// TheSuperHackers @info Saves from before this fix contain a copy of the command in the command source slot.
+		m_cmdSource = CMD_FROM_AI;
+	}
 	xfer->xferCoord3D(&m_pos);
 	xfer->xferObjectID(&m_obj);
 	xfer->xferObjectID(&m_otherObj);


### PR DESCRIPTION
* Fixes #766

`AICommandParmsStorage::doXfer` transfers `m_cmd` twice — `xfer->xferUser(&m_cmd, sizeof(m_cmdSource))` on the second line — and never transfers `m_cmdSource`. `AICommandParmsStorage` has no constructor, so when a saved game with a pending AI command is loaded, the command executes with an uninitialized command source. This change transfers `m_cmdSource` on the second line, for both Zero Hour and Generals.

The save record layout is unchanged: `AICommandType` and `CommandSourceType` are both enum-sized and the second field is already written with `sizeof(m_cmdSource)`. Loading a save created before this change reads the duplicated command bytes into `m_cmdSource`, which can be out of range for `CommandSourceType` — and downstream code shifts by it unchecked (`okSrcs & (1 << cmdSource)` in `WeaponSet.cpp`). Loads therefore validate the value and fall back to `CMD_FROM_AI` when it is out of range. This also covers the pre-fix hazard, where `m_cmdSource` was left as uninitialized memory after loading.

## Testing

Save/load compatibility is tested manually in game (Zero Hour, `win32` preset build, retail Steam 1.04 data):

- A skirmish saved with an unpatched build **loads correctly in the patched build** — units respond to orders normally afterwards. This exercises the old-save path, where the duplicated command bytes are read into `m_cmdSource`.
- A save created and reloaded **within the patched build** round-trips cleanly.

There is no unit-test harness in the repository, so the semantic fix itself (the correct value arriving in `m_cmdSource`) is verified by inspection: the write and read sides are the same line, and `doXfer` runs only during save/load, so replays and normal simulation are unaffected.

Compiles for both games with the `win32` preset (VS2019 16.11, Ninja Multi-Config, Release): `generalszh.exe` and `generalsv.exe` link.

---

This change was developed with AI assistance (Claude), human-directed: the duplicated transfer, the missing constructor initialization, and the record-size equivalence were verified by hand against the class definition in `AI.h`.
