### PR TITLE
bugfix(shell): Prevent menu crashing by avoiding initializing layouts during teardown

### DIFF
--- a/Core/GameEngine/Include/GameClient/Shell.h
+++ b/Core/GameEngine/Include/GameClient/Shell.h
@@ -166,7 +166,7 @@ protected:
 	void unlinkScreen( WindowLayout *screen );							///< remove screen from list
 
 	void doPush( AsciiString layoutFile );									///< workhorse for push action
-	void doPop( Bool impendingPush );												///< workhorse for pop action
+	void doPop( Bool suppressInit );													///< workhorse for pop action
 
 	enum { MAX_SHELL_STACK = 16 };													///< max simultaneous shell screens
 	WindowLayout *m_screenStack[ MAX_SHELL_STACK ];					///< the screen layout stack

--- a/Core/GameEngine/Include/GameClient/Shell.h
+++ b/Core/GameEngine/Include/GameClient/Shell.h
@@ -131,7 +131,7 @@ public:
 	// pseudo-stack operations for manipulating layouts
 	void push( AsciiString filename, Bool shutdownImmediate = FALSE );	///< load new screen on top, optionally doing an immediate shutdown
 	void pop();																				///< pop top layout
-	void popImmediate( Bool suppressInit = FALSE );							///< pop now, optionally suppressing init of the uncovered layout
+	void popImmediate();															///< pop now
 	void showShell( Bool runInit = TRUE );									///< init the top of stack
 	void hideShell();																	///< shutdown the top of stack
 	WindowLayout *top();															///< return top layout
@@ -161,12 +161,13 @@ protected:
 
 	void construct();
 	void deconstruct();
+	void destroyScreenStack();													///< tear down all screens without initializing uncovered layouts
 
 	void linkScreen( WindowLayout *screen );								///< link screen to list
 	void unlinkScreen( WindowLayout *screen );							///< remove screen from list
 
 	void doPush( AsciiString layoutFile );									///< workhorse for push action
-	void doPop( Bool suppressInit );													///< workhorse for pop action
+	void doPop( Bool impendingPush );													///< workhorse for pop action
 
 	enum { MAX_SHELL_STACK = 16 };													///< max simultaneous shell screens
 	WindowLayout *m_screenStack[ MAX_SHELL_STACK ];					///< the screen layout stack

--- a/Core/GameEngine/Include/GameClient/Shell.h
+++ b/Core/GameEngine/Include/GameClient/Shell.h
@@ -131,7 +131,7 @@ public:
 	// pseudo-stack operations for manipulating layouts
 	void push( AsciiString filename, Bool shutdownImmediate = FALSE );	///< load new screen on top, optionally doing an immediate shutdown
 	void pop();																				///< pop top layout
-	void popImmediate();															///< pop now, don't wait for shutdown
+	void popImmediate( Bool suppressInit = FALSE );							///< pop now, optionally suppressing init of the uncovered layout
 	void showShell( Bool runInit = TRUE );									///< init the top of stack
 	void hideShell();																	///< shutdown the top of stack
 	WindowLayout *top();															///< return top layout

--- a/Core/GameEngine/Include/GameClient/Shell.h
+++ b/Core/GameEngine/Include/GameClient/Shell.h
@@ -167,7 +167,7 @@ protected:
 	void unlinkScreen( WindowLayout *screen );							///< remove screen from list
 
 	void doPush( AsciiString layoutFile );									///< workhorse for push action
-	void doPop( Bool impendingPush );													///< workhorse for pop action
+	void doPop( Bool impendingPush );												///< workhorse for pop action
 
 	enum { MAX_SHELL_STACK = 16 };													///< max simultaneous shell screens
 	WindowLayout *m_screenStack[ MAX_SHELL_STACK ];					///< the screen layout stack

--- a/Core/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -134,12 +134,11 @@ void Shell::deconstruct()
 }
 
 //-------------------------------------------------------------------------------------------------
-/** Tear down every screen on the stack without initializing uncovered layouts.
+/** TheSuperHackers @bugfix CryoTheRenegade 10/08/2026 Tear down every screen on the stack without initializing uncovered layouts.
 	* Used when the shell itself is being destroyed. */
 //-------------------------------------------------------------------------------------------------
 void Shell::destroyScreenStack()
 {
-	// TheSuperHackers @bugfix CryoTheRenegade 10/08/2026 Do not initialize uncovered screens while the shell is being destroyed.
 	while( top() )
 	{
 		WindowLayout *screen = top();

--- a/Core/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -686,7 +686,7 @@ void Shell::doPush( AsciiString layoutFile )
 //-------------------------------------------------------------------------------------------------
 /** Actually do the work for a pop */
 //-------------------------------------------------------------------------------------------------
-void Shell::doPop( Bool impendingPush )
+void Shell::doPop( Bool suppressInit )
 {
 	WindowLayout *currentTop = top();
 
@@ -707,7 +707,7 @@ void Shell::doPop( Bool impendingPush )
 
 	// run the init for the new top of the stack if present
 	WindowLayout *newTop = top();
-	if( newTop && !impendingPush )
+	if( newTop && !suppressInit )
 	{
 		newTop->runInit( nullptr );
 		//newTop->bringForward();

--- a/Core/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -93,7 +93,8 @@ void Shell::deconstruct()
 	WindowLayout *newTop = top();
 	while(newTop)
 	{
-		popImmediate();
+		// TheSuperHackers @bugfix CryoTheRenegade 10/08/2026 Do not initialize uncovered screens while the shell is being destroyed.
+		popImmediate( TRUE );
 		newTop = top();
 	}
 
@@ -424,7 +425,7 @@ void Shell::pop()
 	* from the shutdown() for the screen, it will be immediately popped off
 	* the stack */
 //-------------------------------------------------------------------------------------------------
-void Shell::popImmediate()
+void Shell::popImmediate( Bool suppressInit )
 {
 	WindowLayout *screen = top();
 
@@ -448,7 +449,7 @@ void Shell::popImmediate()
 	screen->runShutdown( &immediatePop );
 
 	// pop the screen of the stack
-	doPop( FALSE );
+	doPop( suppressInit );
 
 	if (TheIMEManager)
 		TheIMEManager->detach();

--- a/Core/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -90,13 +90,7 @@ void Shell::construct()
 //-------------------------------------------------------------------------------------------------
 void Shell::deconstruct()
 {
-	WindowLayout *newTop = top();
-	while(newTop)
-	{
-		// TheSuperHackers @bugfix CryoTheRenegade 10/08/2026 Do not initialize uncovered screens while the shell is being destroyed.
-		popImmediate( TRUE );
-		newTop = top();
-	}
+	destroyScreenStack();
 
 	if(m_background)
 	{
@@ -137,6 +131,32 @@ void Shell::deconstruct()
 		deleteInstance(m_optionsLayout);
 		m_optionsLayout = nullptr;
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Tear down every screen on the stack without initializing uncovered layouts.
+	* Used when the shell itself is being destroyed. */
+//-------------------------------------------------------------------------------------------------
+void Shell::destroyScreenStack()
+{
+	// TheSuperHackers @bugfix CryoTheRenegade 10/08/2026 Do not initialize uncovered screens while the shell is being destroyed.
+	while( top() )
+	{
+		WindowLayout *screen = top();
+
+		// do NOT set pending pop, we are going to force a pop after the shutdown is run
+		m_pendingPop = FALSE;
+
+		Bool immediatePop = TRUE;
+		screen->runShutdown( &immediatePop );
+
+		unlinkScreen( screen );
+		screen->destroyWindows();
+		deleteInstance( screen );
+	}
+
+	if (TheIMEManager)
+		TheIMEManager->detach();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -425,7 +445,7 @@ void Shell::pop()
 	* from the shutdown() for the screen, it will be immediately popped off
 	* the stack */
 //-------------------------------------------------------------------------------------------------
-void Shell::popImmediate( Bool suppressInit )
+void Shell::popImmediate()
 {
 	WindowLayout *screen = top();
 
@@ -449,7 +469,7 @@ void Shell::popImmediate( Bool suppressInit )
 	screen->runShutdown( &immediatePop );
 
 	// pop the screen of the stack
-	doPop( suppressInit );
+	doPop( FALSE );
 
 	if (TheIMEManager)
 		TheIMEManager->detach();
@@ -686,7 +706,7 @@ void Shell::doPush( AsciiString layoutFile )
 //-------------------------------------------------------------------------------------------------
 /** Actually do the work for a pop */
 //-------------------------------------------------------------------------------------------------
-void Shell::doPop( Bool suppressInit )
+void Shell::doPop( Bool impendingPush )
 {
 	WindowLayout *currentTop = top();
 
@@ -707,7 +727,7 @@ void Shell::doPop( Bool suppressInit )
 
 	// run the init for the new top of the stack if present
 	WindowLayout *newTop = top();
-	if( newTop && !suppressInit )
+	if( newTop && !impendingPush )
 	{
 		newTop->runInit( nullptr );
 		//newTop->bringForward();


### PR DESCRIPTION
Fixes #2777. Shell teardown now suppresses initialization of newly uncovered layouts while retaining each layout’s shutdown callback. This prevents the full-screen save/load menu from accessing GameState after it has been destroyed when closing the game after loading a save. I reproduced the issue with a Zero Hour skirmish save, where the process exited with code 2816 before the change and 0 afterward.