### PR TITLE
test(neutronmissile): Add debug draw for nuke missile radius

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -30,6 +30,7 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 #include "Common/GameState.h"
+#include "Common/GlobalData.h"
 #include "Common/Player.h"
 #include "Common/Xfer.h"
 #include "GameClient/FXList.h"
@@ -287,6 +288,42 @@ UpdateSleepTime NeutronMissileSlowDeathBehavior::update()
 
 }
 
+static void debugDrawBlastCircle( const Coord3D *center, Real radius, Real tileWidth,
+																 Int frameDuration, const RGBColor &color )
+{
+	extern void addIcon(const Coord3D *pos, Real width, Int frameDuration, RGBColor color);
+
+	if( radius <= 0.0f )
+		return;
+
+	// space the icons roughly one tile apart along the circumference, within sane bounds
+	tileWidth = max( tileWidth, 1.0f );
+	Int segments = (Int)ceilf( (2.0f * PI * radius) / tileWidth * 0.5f );
+	segments = clamp(1, segments, 256);
+
+	for( Int i = 0; i < segments; ++i )
+	{
+		Real angle = (2.0f * PI * i) / segments;
+		Coord3D pos;
+
+		pos.x = center->x + radius * cosf( angle );
+		pos.y = center->y + radius * sinf( angle );
+		pos.z = TheTerrainLogic->getGroundHeight( pos.x, pos.y );
+
+		addIcon( &pos, tileWidth, frameDuration, color );
+	}
+}
+
+static void debugDrawBlastRadii( Object *missile, const BlastInfo *blastInfo, Real tileWidth, Int frameDuration )
+{
+	constexpr const RGBColor innerColor = { 0.0f, 1.0f, 1.0f }; // cyan, everything in here takes full damage
+	constexpr const RGBColor outerColor = { 1.0f, 1.0f, 0.0f }; // yellow, damage falls off out here
+	const Coord3D *missilePos = missile->getPosition();
+
+	debugDrawBlastCircle( missilePos, blastInfo->innerRadius, tileWidth, frameDuration, innerColor );
+	debugDrawBlastCircle( missilePos, blastInfo->outerRadius, tileWidth, frameDuration, outerColor );
+}
+
 // ------------------------------------------------------------------------------------------------
 /** Do a single blast for the bomb */
 // ------------------------------------------------------------------------------------------------
@@ -314,6 +351,14 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 	// scan objects around us and do damage to objects we have "passed over" and are behind us
 	if( blastInfo->outerRadius )
 	{
+#if defined(RTS_DEBUG)
+		if( TheGlobalData->m_debugProjectilePath && (blastInfo->maxDamage > 0.0f || blastInfo->minDamage > 0.0f) )
+		{
+			constexpr const Int frameDuration = 60 * LOGICFRAMES_PER_SECOND;
+			debugDrawBlastRadii( missile, blastInfo, TheGlobalData->m_debugProjectileTileWidth, frameDuration );
+		}
+#endif
+
 		ObjectIterator *iter = ThePartitionManager->iterateObjectsInRange( missilePos,
 																																			 blastInfo->outerRadius,
 																																			 FROM_CENTER_2D,

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -30,6 +30,7 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 #include "Common/GameState.h"
+#include "Common/GlobalData.h"
 #include "Common/Player.h"
 #include "Common/Xfer.h"
 #include "GameClient/FXList.h"
@@ -287,6 +288,55 @@ UpdateSleepTime NeutronMissileSlowDeathBehavior::update()
 
 }
 
+#if defined(RTS_DEBUG)
+
+static void drawDebugRadiusRing( const Coord3D *center, Real radius, Real tileWidth,
+																 Int numFramesDuration, const RGBColor &color )
+{
+	extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
+
+	if( radius <= 0.0f )
+		return;
+
+	// space the icons roughly one tile apart along the circumference, within sane bounds
+	Int segments = (Int)ceilf( (2.0f * PI * radius) / max( tileWidth, 1.0f ) * 0.5f );
+	segments = clamp(1, segments, 256);
+
+	for( Int i = 0; i < segments; ++i )
+	{
+		Real angle = (2.0f * PI * i) / segments;
+		Coord3D pos;
+
+		pos.x = center->x + radius * cosf( angle );
+		pos.y = center->y + radius * sinf( angle );
+		pos.z = TheTerrainLogic->getGroundHeight( pos.x, pos.y );
+
+		addIcon( &pos, tileWidth, numFramesDuration, color );
+	}
+}
+
+static void displayBlastRadii( Object *missile, const BlastInfo *blastInfo )
+{
+	const Int duration = 60 * LOGICFRAMES_PER_SECOND;
+	const Real tileWidth = TheGlobalData->m_debugProjectileTileWidth;
+	constexpr const RGBColor innerColor = { 0.0f, 1.0f, 1.0f }; // cyan, everything in here takes full damage
+	constexpr const RGBColor outerColor = { 1.0f, 1.0f, 0.0f }; // yellow, damage falls off out here
+
+	const Coord3D *missilePos = missile->getPosition();
+
+	if (blastInfo->maxDamage > 0.0f)
+	{
+		drawDebugRadiusRing( missilePos, blastInfo->innerRadius, tileWidth, duration, innerColor );
+	}
+
+	if (blastInfo->minDamage > 0.0f)
+	{
+		drawDebugRadiusRing( missilePos, blastInfo->outerRadius, tileWidth, duration, outerColor );
+	}
+}
+
+#endif // defined(RTS_DEBUG)
+
 // ------------------------------------------------------------------------------------------------
 /** Do a single blast for the bomb */
 // ------------------------------------------------------------------------------------------------
@@ -314,6 +364,11 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 	// scan objects around us and do damage to objects we have "passed over" and are behind us
 	if( blastInfo->outerRadius )
 	{
+#if defined(RTS_DEBUG)
+		if( TheGlobalData->m_debugProjectilePath )
+			displayBlastRadii( missile, blastInfo );
+#endif
+
 		ObjectIterator *iter = ThePartitionManager->iterateObjectsInRange( missilePos,
 																																			 blastInfo->outerRadius,
 																																			 FROM_CENTER_2D,

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -299,7 +299,8 @@ static void drawDebugRadiusRing( const Coord3D *center, Real radius, Real tileWi
 		return;
 
 	// space the icons roughly one tile apart along the circumference, within sane bounds
-	Int segments = (Int)ceilf( (2.0f * PI * radius) / max( tileWidth, 1.0f ) * 0.5f );
+	tileWidth = max( tileWidth, 1.0f );
+	Int segments = (Int)ceilf( (2.0f * PI * radius) / tileWidth * 0.5f );
 	segments = clamp(1, segments, 256);
 
 	for( Int i = 0; i < segments; ++i )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -316,6 +316,9 @@ static void debugDrawBlastCircle( const Coord3D *center, Real radius, Real tileW
 
 static void debugDrawBlastRadii( Object *missile, const BlastInfo *blastInfo )
 {
+	if (!(blastInfo->maxDamage > 0.0f || blastInfo->minDamage > 0.0f))
+		return;
+
 	const Int duration = 60 * LOGICFRAMES_PER_SECOND;
 	const Real tileWidth = TheGlobalData->m_debugProjectileTileWidth;
 	constexpr const RGBColor innerColor = { 0.0f, 1.0f, 1.0f }; // cyan, everything in here takes full damage
@@ -323,11 +326,8 @@ static void debugDrawBlastRadii( Object *missile, const BlastInfo *blastInfo )
 
 	const Coord3D *missilePos = missile->getPosition();
 
-	if (blastInfo->maxDamage > 0.0f || blastInfo->minDamage > 0.0f)
-	{
-		debugDrawBlastCircle( missilePos, blastInfo->innerRadius, tileWidth, duration, innerColor );
-		debugDrawBlastCircle( missilePos, blastInfo->outerRadius, tileWidth, duration, outerColor );
-	}
+	debugDrawBlastCircle( missilePos, blastInfo->innerRadius, tileWidth, duration, innerColor );
+	debugDrawBlastCircle( missilePos, blastInfo->outerRadius, tileWidth, duration, outerColor );
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -288,9 +288,7 @@ UpdateSleepTime NeutronMissileSlowDeathBehavior::update()
 
 }
 
-#if defined(RTS_DEBUG)
-
-static void drawDebugRadiusRing( const Coord3D *center, Real radius, Real tileWidth,
+static void debugDrawBlastCircle( const Coord3D *center, Real radius, Real tileWidth,
 																 Int numFramesDuration, const RGBColor &color )
 {
 	extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
@@ -316,7 +314,7 @@ static void drawDebugRadiusRing( const Coord3D *center, Real radius, Real tileWi
 	}
 }
 
-static void displayBlastRadii( Object *missile, const BlastInfo *blastInfo )
+static void debugDrawBlastRadii( Object *missile, const BlastInfo *blastInfo )
 {
 	const Int duration = 60 * LOGICFRAMES_PER_SECOND;
 	const Real tileWidth = TheGlobalData->m_debugProjectileTileWidth;
@@ -325,14 +323,12 @@ static void displayBlastRadii( Object *missile, const BlastInfo *blastInfo )
 
 	const Coord3D *missilePos = missile->getPosition();
 
-		drawDebugRadiusRing( missilePos, blastInfo->innerRadius, tileWidth, duration, innerColor );
 	if (blastInfo->maxDamage > 0.0f || blastInfo->minDamage > 0.0f)
 	{
-		drawDebugRadiusRing( missilePos, blastInfo->outerRadius, tileWidth, duration, outerColor );
+		debugDrawBlastCircle( missilePos, blastInfo->innerRadius, tileWidth, duration, innerColor );
+		debugDrawBlastCircle( missilePos, blastInfo->outerRadius, tileWidth, duration, outerColor );
 	}
 }
-
-#endif // defined(RTS_DEBUG)
 
 // ------------------------------------------------------------------------------------------------
 /** Do a single blast for the bomb */
@@ -363,7 +359,7 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 	{
 #if defined(RTS_DEBUG)
 		if( TheGlobalData->m_debugProjectilePath )
-			displayBlastRadii( missile, blastInfo );
+			debugDrawBlastRadii( missile, blastInfo );
 #endif
 
 		ObjectIterator *iter = ThePartitionManager->iterateObjectsInRange( missilePos,

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -325,12 +325,8 @@ static void displayBlastRadii( Object *missile, const BlastInfo *blastInfo )
 
 	const Coord3D *missilePos = missile->getPosition();
 
-	if (blastInfo->maxDamage > 0.0f)
-	{
 		drawDebugRadiusRing( missilePos, blastInfo->innerRadius, tileWidth, duration, innerColor );
-	}
-
-	if (blastInfo->minDamage > 0.0f)
+	if (blastInfo->maxDamage > 0.0f || blastInfo->minDamage > 0.0f)
 	{
 		drawDebugRadiusRing( missilePos, blastInfo->outerRadius, tileWidth, duration, outerColor );
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -289,9 +289,9 @@ UpdateSleepTime NeutronMissileSlowDeathBehavior::update()
 }
 
 static void debugDrawBlastCircle( const Coord3D *center, Real radius, Real tileWidth,
-																 Int numFramesDuration, const RGBColor &color )
+																 Int frameDuration, const RGBColor &color )
 {
-	extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
+	extern void addIcon(const Coord3D *pos, Real width, Int frameDuration, RGBColor color);
 
 	if( radius <= 0.0f )
 		return;
@@ -310,24 +310,18 @@ static void debugDrawBlastCircle( const Coord3D *center, Real radius, Real tileW
 		pos.y = center->y + radius * sinf( angle );
 		pos.z = TheTerrainLogic->getGroundHeight( pos.x, pos.y );
 
-		addIcon( &pos, tileWidth, numFramesDuration, color );
+		addIcon( &pos, tileWidth, frameDuration, color );
 	}
 }
 
-static void debugDrawBlastRadii( Object *missile, const BlastInfo *blastInfo )
+static void debugDrawBlastRadii( Object *missile, const BlastInfo *blastInfo, Real tileWidth, Int frameDuration )
 {
-	if (!(blastInfo->maxDamage > 0.0f || blastInfo->minDamage > 0.0f))
-		return;
-
-	const Int duration = 60 * LOGICFRAMES_PER_SECOND;
-	const Real tileWidth = TheGlobalData->m_debugProjectileTileWidth;
 	constexpr const RGBColor innerColor = { 0.0f, 1.0f, 1.0f }; // cyan, everything in here takes full damage
 	constexpr const RGBColor outerColor = { 1.0f, 1.0f, 0.0f }; // yellow, damage falls off out here
-
 	const Coord3D *missilePos = missile->getPosition();
 
-	debugDrawBlastCircle( missilePos, blastInfo->innerRadius, tileWidth, duration, innerColor );
-	debugDrawBlastCircle( missilePos, blastInfo->outerRadius, tileWidth, duration, outerColor );
+	debugDrawBlastCircle( missilePos, blastInfo->innerRadius, tileWidth, frameDuration, innerColor );
+	debugDrawBlastCircle( missilePos, blastInfo->outerRadius, tileWidth, frameDuration, outerColor );
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -358,8 +352,11 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 	if( blastInfo->outerRadius )
 	{
 #if defined(RTS_DEBUG)
-		if( TheGlobalData->m_debugProjectilePath )
-			debugDrawBlastRadii( missile, blastInfo );
+		if( TheGlobalData->m_debugProjectilePath && (blastInfo->maxDamage > 0.0f || blastInfo->minDamage > 0.0f) )
+		{
+			constexpr const Int frameDuration = 60 * LOGICFRAMES_PER_SECOND;
+			debugDrawBlastRadii( missile, blastInfo, TheGlobalData->m_debugProjectileTileWidth, frameDuration );
+		}
 #endif
 
 		ObjectIterator *iter = ThePartitionManager->iterateObjectsInRange( missilePos,


### PR DESCRIPTION
This change adds a debug draw for the nuke missile radius in RTS_DEBUG.

Can be toggled with particle path debug CTRL+SHIFT+B

Base code was generated by Claude Opus and tweaked by hand.

<img width="1600" height="1200" alt="sshot_20260816_174324_617" src="https://github.com/user-attachments/assets/7ff7dcf0-f72c-4f47-951e-6318ebf2eeb4" />

## TODO

- [x] Replicate in Generals