### PR TITLE
bugfix(neutronmissile): Fix and improve Nuke Missile damage for large objects inside the outer blast radius

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -20,9 +20,6 @@
 
 #include "WWLib/WWDefines.h"
 
-// Note: Retail compatibility must not be broken before this project officially does.
-// Use RETAIL_COMPATIBLE_CRC and RETAIL_COMPATIBLE_XFER_SAVE to guard breaking changes.
-
 #ifndef PRESERVE_BUILDING_RESUMPTION_DELAY
 #define PRESERVE_BUILDING_RESUMPTION_DELAY (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
 #endif
@@ -90,6 +87,17 @@
 #ifndef PRESERVE_RETAIL_PARTICLES
 #define PRESERVE_RETAIL_PARTICLES (1) // Preserve original look of particles present in retail Generals 1.08 and Zero Hour 1.04
 #endif
+
+#ifndef PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_SEARCH
+#define PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_SEARCH (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
+#endif
+
+#ifndef PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_DAMAGE
+#define PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_DAMAGE (1)
+#endif
+
+// Note: Retail compatibility must not be broken before this project officially does.
+// Use RETAIL_COMPATIBLE_CRC and RETAIL_COMPATIBLE_XFER_SAVE to guard breaking changes.
 
 #ifndef RETAIL_COMPATIBLE_CRC
 #define RETAIL_COMPATIBLE_CRC (1) // Game is expected to be CRC compatible with retail Generals 1.08, Zero Hour 1.04

--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -93,7 +93,7 @@
 #endif
 
 #ifndef PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_DAMAGE
-#define PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_DAMAGE (1)
+#define PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_DAMAGE (0) // The fix for this unfavorable behavior was approved by the Game Design Committee.
 #endif
 
 // Note: Retail compatibility must not be broken before this project officially does.

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -320,6 +320,19 @@ struct Coord2D
 		sub(a);
 	}
 
+	Coord2D operator+() const
+	{
+		return *this;
+	}
+
+	Coord2D operator-() const
+	{
+		Coord2D c;
+		c.x = -x;
+		c.y = -y;
+		return c;
+	}
+
 	void set( const Coord2D &a )
 	{
 		x = a.x;
@@ -445,6 +458,19 @@ struct ICoord2D
 	void operator-=( const ICoord2D &a )
 	{
 		sub(a);
+	}
+
+	ICoord2D operator+() const
+	{
+		return *this;
+	}
+
+	ICoord2D operator-() const
+	{
+		ICoord2D c;
+		c.x = -x;
+		c.y = -y;
+		return c;
 	}
 
 	void set( const ICoord2D &a )
@@ -577,6 +603,20 @@ struct Coord3D
 		sub(a);
 	}
 
+	Coord3D operator+() const
+	{
+		return *this;
+	}
+
+	Coord3D operator-() const
+	{
+		Coord3D c;
+		c.x = -x;
+		c.y = -y;
+		c.z = -z;
+		return c;
+	}
+
 	void set( const Coord3D &a )
 	{
 		x = a.x;
@@ -668,6 +708,20 @@ struct ICoord3D
 	void operator-=( const ICoord3D &a )
 	{
 		sub(a);
+	}
+
+	ICoord3D operator+() const
+	{
+		return *this;
+	}
+
+	ICoord3D operator-() const
+	{
+		ICoord3D c;
+		c.x = -x;
+		c.y = -y;
+		c.z = -z;
+		return c;
 	}
 
 	void set( const ICoord3D &a )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -349,6 +349,7 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 	damageInfo.in.m_amount = blastInfo->minDamage;
 
 	// scan objects around us and do damage to objects we have "passed over" and are behind us
+	// TheSuperHackers @todo Optimize this function. Iterates through the blasts even if they apply zero damage.
 	if( blastInfo->outerRadius )
 	{
 #if defined(RTS_DEBUG)
@@ -359,9 +360,17 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 		}
 #endif
 
+#if RETAIL_COMPATIBLE_CRC || PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_SEARCH
+		const DistanceCalculationType dc = FROM_CENTER_2D;
+#else
+		// TheSuperHackers @bugfix xezon 16/08/2026 From FROM_CENTER_2D,
+		// because objects that reach into the outer radius should also receive damage.
+		const DistanceCalculationType dc = FROM_BOUNDINGSPHERE_3D;
+#endif
+
 		ObjectIterator *iter = ThePartitionManager->iterateObjectsInRange( missilePos,
 																																			 blastInfo->outerRadius,
-																																			 FROM_CENTER_2D,
+																																			 dc,
 																																			 nullptr );
 		MemoryPoolObjectHolder hold( iter );
 		Object *other;
@@ -374,10 +383,26 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 			// get other position
 			otherPos = other->getPosition();
 
+#if RETAIL_COMPATIBLE_CRC || PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_DAMAGE
 			// compute vector from the missile to other object
-			forceVector.x = otherPos->x - missilePos->x;
-			forceVector.y = otherPos->y - missilePos->y;
-			forceVector.z = otherPos->z - missilePos->z;
+			forceVector = *otherPos - *missilePos;
+#else
+			// compute vector from the missile to other object
+			// TheSuperHackers @tweak xezon 16/08/2026 No longer calculate the force vector to the center of the object,
+			// but to half way between the closest edge and the center of the object. This way a more appropriate
+			// damage value is sampled for a large structure inside the damage fall off range.
+			const Coord3D missileToObjectCenter = *otherPos - *missilePos;
+
+			Coord3D missileToObjectEdge;
+			ThePartitionManager->getVectorTo(other, missilePos, dc, missileToObjectEdge);
+
+			// flip direction
+			missileToObjectEdge = -missileToObjectEdge;
+
+			// take the average between the edge and center vectors
+			forceVector = missileToObjectEdge + missileToObjectCenter;
+			forceVector.scale(0.5f);
+#endif
 
 			// try to topple other object
 			other->topple( &forceVector, blastInfo->toppleSpeed, TOPPLE_OPTIONS_NO_BOUNCE |

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -394,7 +394,7 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 			const Coord3D missileToObjectCenter = *otherPos - *missilePos;
 
 			Coord3D missileToObjectEdge;
-			ThePartitionManager->getVectorTo(other, missilePos, dc, missileToObjectEdge);
+			ThePartitionManager->getVectorTo(other, missilePos, FROM_BOUNDINGSPHERE_3D, missileToObjectEdge);
 
 			// flip direction
 			missileToObjectEdge = -missileToObjectEdge;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -349,6 +349,7 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 	damageInfo.in.m_amount = blastInfo->minDamage;
 
 	// scan objects around us and do damage to objects we have "passed over" and are behind us
+	// TheSuperHackers @todo Optimize this function. Iterates through the blasts even if they apply zero damage.
 	if( blastInfo->outerRadius )
 	{
 #if defined(RTS_DEBUG)
@@ -359,9 +360,17 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 		}
 #endif
 
+#if RETAIL_COMPATIBLE_CRC || PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_SEARCH
+		const DistanceCalculationType dc = FROM_CENTER_2D;
+#else
+		// TheSuperHackers @bugfix xezon 16/08/2026 From FROM_CENTER_2D,
+		// because objects that reach into the outer radius should also receive damage.
+		const DistanceCalculationType dc = FROM_BOUNDINGSPHERE_2D;
+#endif
+
 		ObjectIterator *iter = ThePartitionManager->iterateObjectsInRange( missilePos,
 																																			 blastInfo->outerRadius,
-																																			 FROM_CENTER_2D,
+																																			 dc,
 																																			 nullptr );
 		MemoryPoolObjectHolder hold( iter );
 		Object *other;
@@ -374,10 +383,31 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 			// get other position
 			otherPos = other->getPosition();
 
+#if RETAIL_COMPATIBLE_CRC || PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_DAMAGE
 			// compute vector from the missile to other object
 			forceVector.x = otherPos->x - missilePos->x;
 			forceVector.y = otherPos->y - missilePos->y;
 			forceVector.z = otherPos->z - missilePos->z;
+#else
+			// compute vector from the missile to other object
+			// TheSuperHackers @tweak xezon 16/08/2026 No longer calculate the force vector to the center of the object,
+			// but to half way between the closest edge and the center of the object. This way a more appropriate
+			// damage value is sampled for a large structure inside the damage fall off range.
+			Coord2D toCenterVector;
+			toCenterVector.x = otherPos->x - missilePos->x;
+			toCenterVector.y = otherPos->y - missilePos->y;
+
+			ThePartitionManager->getVectorTo(other, missilePos, FROM_BOUNDINGSPHERE_2D, forceVector);
+
+			// flip direction
+			forceVector.x = -forceVector.x;
+			forceVector.y = -forceVector.y;
+
+			// take average between min and max force
+			forceVector.x = (forceVector.x + toCenterVector.x) * 0.5f;
+			forceVector.y = (forceVector.y + toCenterVector.y) * 0.5f;
+			forceVector.z = 0.0f;
+#endif
 
 			// try to topple other object
 			other->topple( &forceVector, blastInfo->toppleSpeed, TOPPLE_OPTIONS_NO_BOUNCE |

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -394,7 +394,7 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 			const Coord3D missileToObjectCenter = *otherPos - *missilePos;
 
 			Coord3D missileToObjectEdge;
-			ThePartitionManager->getVectorTo(other, missilePos, FROM_BOUNDINGSPHERE_2D, missileToObjectEdge);
+			ThePartitionManager->getVectorTo(other, missilePos, dc, missileToObjectEdge);
 
 			// flip direction
 			missileToObjectEdge = -missileToObjectEdge;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -365,7 +365,7 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 #else
 		// TheSuperHackers @bugfix xezon 16/08/2026 From FROM_CENTER_2D,
 		// because objects that reach into the outer radius should also receive damage.
-		const DistanceCalculationType dc = FROM_BOUNDINGSPHERE_2D;
+		const DistanceCalculationType dc = FROM_BOUNDINGSPHERE_3D;
 #endif
 
 		ObjectIterator *iter = ThePartitionManager->iterateObjectsInRange( missilePos,

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -385,31 +385,23 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 
 #if RETAIL_COMPATIBLE_CRC || PRESERVE_RETAIL_NUKE_MISSILE_OUTER_RADIUS_DAMAGE
 			// compute vector from the missile to other object
-			forceVector.x = otherPos->x - missilePos->x;
-			forceVector.y = otherPos->y - missilePos->y;
-			forceVector.z = otherPos->z - missilePos->z;
+			forceVector = *otherPos - *missilePos;
 #else
 			// compute vector from the missile to other object
 			// TheSuperHackers @tweak xezon 16/08/2026 No longer calculate the force vector to the center of the object,
 			// but to half way between the closest edge and the center of the object. This way a more appropriate
 			// damage value is sampled for a large structure inside the damage fall off range.
-			Coord3D missileToObjectCenter;
-			missileToObjectCenter.x = otherPos->x - missilePos->x;
-			missileToObjectCenter.y = otherPos->y - missilePos->y;
-			missileToObjectCenter.z = otherPos->z - missilePos->z;
+			const Coord3D missileToObjectCenter = *otherPos - *missilePos;
 
 			Coord3D missileToObjectEdge;
 			ThePartitionManager->getVectorTo(other, missilePos, FROM_BOUNDINGSPHERE_2D, missileToObjectEdge);
 
 			// flip direction
-			missileToObjectEdge.x = -missileToObjectEdge.x;
-			missileToObjectEdge.y = -missileToObjectEdge.y;
-			missileToObjectEdge.z = -missileToObjectEdge.z;
+			missileToObjectEdge = -missileToObjectEdge;
 
 			// take the average between the edge and center vectors
-			forceVector.x = (missileToObjectEdge.x + missileToObjectCenter.x) * 0.5f;
-			forceVector.y = (missileToObjectEdge.y + missileToObjectCenter.y) * 0.5f;
-			forceVector.z = (missileToObjectEdge.z + missileToObjectCenter.z) * 0.5f;
+			forceVector = missileToObjectEdge + missileToObjectCenter;
+			forceVector.scale(0.5f);
 #endif
 
 			// try to topple other object

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -393,20 +393,23 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 			// TheSuperHackers @tweak xezon 16/08/2026 No longer calculate the force vector to the center of the object,
 			// but to half way between the closest edge and the center of the object. This way a more appropriate
 			// damage value is sampled for a large structure inside the damage fall off range.
-			Coord2D toCenterVector;
-			toCenterVector.x = otherPos->x - missilePos->x;
-			toCenterVector.y = otherPos->y - missilePos->y;
+			Coord3D missileToObjectCenter;
+			missileToObjectCenter.x = otherPos->x - missilePos->x;
+			missileToObjectCenter.y = otherPos->y - missilePos->y;
+			missileToObjectCenter.z = otherPos->z - missilePos->z;
 
-			ThePartitionManager->getVectorTo(other, missilePos, FROM_BOUNDINGSPHERE_2D, forceVector);
+			Coord3D missileToObjectEdge;
+			ThePartitionManager->getVectorTo(other, missilePos, FROM_BOUNDINGSPHERE_2D, missileToObjectEdge);
 
 			// flip direction
-			forceVector.x = -forceVector.x;
-			forceVector.y = -forceVector.y;
+			missileToObjectEdge.x = -missileToObjectEdge.x;
+			missileToObjectEdge.y = -missileToObjectEdge.y;
+			missileToObjectEdge.z = -missileToObjectEdge.z;
 
-			// take average between min and max force
-			forceVector.x = (forceVector.x + toCenterVector.x) * 0.5f;
-			forceVector.y = (forceVector.y + toCenterVector.y) * 0.5f;
-			forceVector.z = 0.0f;
+			// take the average between the edge and center vectors
+			forceVector.x = (missileToObjectEdge.x + missileToObjectCenter.x) * 0.5f;
+			forceVector.y = (missileToObjectEdge.y + missileToObjectCenter.y) * 0.5f;
+			forceVector.z = (missileToObjectEdge.z + missileToObjectCenter.z) * 0.5f;
 #endif
 
 			// try to topple other object

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/NeutronMissileSlowDeathUpdate.cpp
@@ -394,7 +394,7 @@ void NeutronMissileSlowDeathBehavior::doBlast( const BlastInfo *blastInfo )
 			const Coord3D missileToObjectCenter = *otherPos - *missilePos;
 
 			Coord3D missileToObjectEdge;
-			ThePartitionManager->getVectorTo(other, missilePos, dc, missileToObjectEdge);
+			ThePartitionManager->getVectorTo(other, missilePos, FROM_BOUNDINGSPHERE_3D, missileToObjectEdge);
 
 			// flip direction
 			missileToObjectEdge = -missileToObjectEdge;


### PR DESCRIPTION
* Fixes #2301

Large structures are now properly damaged if they reach into the outer blast radius and more damage is applied by taking the closest edge into the damage calculation.

## Original behavior 1

The China Nuke Missile applies no damage to the edges of buildings (and units). This is mostly noticeable with large structures, such as the Airfield. The blast radius needs to reach the center of every building (and unit).

Note that the Nuke Missile has an outer and inner damage radius. The outer radius applies less damage than the inner radius. The damage transition from inner to outer radius is linear.

Firing the Nuke Missile as follows applies NO damage to the structure:

<img width="1600" height="1200" alt="633231665-200d1536-3762-4c19-9744-8471d9e692bf" src="https://github.com/user-attachments/assets/155e280b-2964-43ab-af78-e7e25c7065a1" />

### Fixed behavior 1

The China Nuke Missile now applies damage to the edges of a building like all other weapons do.

This is a BUFF, but a very small one, because the building will receive the SMALLEST damage of the outer blast radius.

This is how much damage is applied to the Airfield after fixing the bug:

<img width="1600" height="1200" alt="633231842-caa75d36-45d5-4463-b429-5acf4c6fee08" src="https://github.com/user-attachments/assets/9707e85a-9019-49e2-99ce-35fa6984fc0f" />

### Rationale

The China Nuke blast radius is already not competitive compared to the SCUD Storm. The Nuke Missile needs buffing anyway and this bug fix is a good step into this direction.


## Original behavior 2

Structures that are located between the inner and outer radii of the Nuke Missile do receive an interpolated damage between the max (inner) and min (outer) damages. This works well enough for small structures like a Gattling Cannon or Tunnel Network, but does not work well for large structures, such as the Airfield or SCUD Storm, because the damage sample point will be the center of the structure instead of a point closer to the actual damage radius of the Nuke Missile.

In practice this means that large structures at the egdes of the Nuke Missile will receive rather tiny damages, even if they reach reasonably far into the outer damage radius.

| Nuke Blast  | Radius | Damage |
|-------------|--------|--------|
| Inner (max) | 60     | 3500   |
| Outer (min) | 210    | 300    |

To fix this, the damage sample point needs to be moved closer to the Nuke Missile origins.

### Showcase

The Nuke Missile applies little damage to large structures at the outer edge

https://github.com/user-attachments/assets/55d7e9e8-5ea8-4dd4-8f3c-b55056e5da43

## Improved behavior 2

The logic now samples the damage point from the center to half of the outer edge of the object closest to the Nuke Missile origin. This works well for small and large objects.

BUFF for China. Does NOT make the Nuke Missile any better against small buildings and units, nor against targets inside the inner damage radius. The Nuke Missile will still perform worse than the SCUD Storm.

<img width="1598" height="1198" alt="nukedmg" src="https://github.com/user-attachments/assets/aac39f3b-660b-4f99-aac8-8041bd81f549" />

## Showcase

The Nuke Missile applies considerably more damage to large structures at the outer edge

https://github.com/user-attachments/assets/0ca7c678-246d-4004-abc5-08d08d794521

The SCUD Storm still applies more damage to large structures at the outer edge, because it applies around 20% more damage overall.

https://github.com/user-attachments/assets/519d7756-f41c-4d1e-95d2-49ed41721211

## TODO

- [x] Replicate to Generals
- [x] Wait for Committee Approval
- [x] Simplify the Coord operators
- [x] Default enable fix