### PR TITLE
refactor(particlesys): Cleanup retail smudge particle type identification

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -87,6 +87,10 @@
 #define PRESERVE_RETAIL_SCRIPTED_CAMERA (1) // Retain scripted camera behavior present in retail Generals 1.08 and Zero Hour 1.04
 #endif
 
+#ifndef PRESERVE_RETAIL_PARTICLES
+#define PRESERVE_RETAIL_PARTICLES (1) // Preserve original look of particles present in retail Generals 1.08 and Zero Hour 1.04
+#endif
+
 #ifndef RETAIL_COMPATIBLE_CRC
 #define RETAIL_COMPATIBLE_CRC (1) // Game is expected to be CRC compatible with retail Generals 1.08, Zero Hour 1.04
 #endif

--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1190,6 +1190,15 @@ ParticleSystem::ParticleSystem( const ParticleSystemTemplate *sysTemplate,
 	m_particleType = sysTemplate->m_particleType;
 	m_particleTypeName = sysTemplate->m_particleTypeName;
 
+#if PRESERVE_RETAIL_PARTICLES
+	// TheSuperHackers @info Hack to allow isUsingSmudge() functionality with retail smudge particles
+	// The retail data template for smudge particles is not correctly configured with the smudge particle type
+	if (m_particleType != ParticleType::SMUDGE && m_particleTypeName.startsWithNoCase("SMUDGE."))
+	{
+		m_particleType = ParticleType::SMUDGE;
+	}
+#endif
+
 	m_isStopped = false;
 
 	// set up slave particle system, if any
@@ -3023,8 +3032,8 @@ void ParticleSystemManager::update()
 			if (sys->isUsingDrawables())
 				continue;
 
-			// temporary hack that checks if texture name starts with "SMUD" - if so, we can assume it's a smudge type
-			if (/*sys->isUsingSmudge()*/ *((DWORD *)sys->getParticleTypeName().str()) == 0x44554D53)
+			// Handle smudge type particles
+			if (sys->isUsingSmudge())
 			{
 				for (Particle *p = sys->getFirstParticle(); p; p = p->m_systemNext)
 				{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
@@ -156,8 +156,8 @@ void W3DParticleSystemManager::doParticles(RenderInfoClass &rinfo)
 		if (sys->isUsingDrawables())
 			continue;
 
-		//temporary hack that checks if texture name starts with "SMUD" - if so, we can assume it's a smudge type
-		if (/*sys->isUsingSmudge()*/ *((DWORD *)sys->getParticleTypeName().str()) == 0x44554D53)
+		// Handle smudge type particles
+		if (sys->isUsingSmudge())
 		{
 			if (drawSmudge)
 			{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
@@ -159,28 +159,28 @@ void W3DParticleSystemManager::doParticles(RenderInfoClass &rinfo)
 		// Handle smudge type particles
 		if (sys->isUsingSmudge())
 		{
-			if (drawSmudge)
+			if (!drawSmudge)
+				continue;
+
+			for (Particle *p = sys->getFirstParticle(); p; p = p->m_systemNext)
 			{
-				for (Particle *p = sys->getFirstParticle(); p; p = p->m_systemNext)
+				const Coord3D *pos = p->getPosition();
+				Real psize = p->getSize();
+
+				//Cull particle to edges of screen and terrain.
+				if (WWMath::Fabs( pos->x - bcX ) > ( beX + psize ) )
+					continue;
+
+				if (WWMath::Fabs( pos->y - bcY ) > ( beY + psize ) )
+					continue;
+
+				if (WWMath::Fabs( pos->z - bcZ ) > ( beZ + psize ) )
+					continue;
+
+				if (Smudge *smudge = TheSmudgeManager->findSmudge(p))
 				{
-					const Coord3D *pos = p->getPosition();
-					Real psize = p->getSize();
-
-					//Cull particle to edges of screen and terrain.
-					if (WWMath::Fabs( pos->x - bcX ) > ( beX + psize ) )
-						continue;
-
-					if (WWMath::Fabs( pos->y - bcY ) > ( beY + psize ) )
-						continue;
-
-					if (WWMath::Fabs( pos->z - bcZ ) > ( beZ + psize ) )
-						continue;
-
-					if (Smudge *smudge = TheSmudgeManager->findSmudge(p))
-					{
-						// The particle is in view. Draw the smudge!
-						smudge->m_draw = true;
-					}
+					// The particle is in view. Draw the smudge!
+					smudge->m_draw = true;
 				}
 			}
 			continue;


### PR DESCRIPTION
**Squash Merge**

This PR is a simple refactor to cleanup the identification of smudge type particles.

The particle system manager originally had a hack to look for smudges based on the particles name.
Particles already contained code that allowed their type to be set as smudge and to query if they were smudge particles using the `isUsingSmudge()` helper function.

With this refactor, the retail "hack" check occurs within the particles constructor, allowing the particle type to be set to the smudge type.
This then allows external code to use the `isUsingSmudge()` helper function as originally intended.