### PR TITLE
bugfix(object): Avoid potential crash due to dangling contain module when Troop Crawler is destroyed before reaching Reinforcement Pad

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -424,7 +424,7 @@ public:
 	void onContainedBy( Object *containedBy );
 	void onRemovedFrom( Object *removedFrom );
 	Int getTransportSlotCount() const;
-	void friend_setContainedBy( Object *containedBy ) { m_containedBy = containedBy; }
+	void friend_setContainedBy( Object *containedBy );
 	const Object* getEnclosingContainedBy() const; ///< Find the first enclosing container in the containment chain.
 	const Object* getOuterObject() const; ///< Get the top-level object
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -424,13 +424,9 @@ public:
 	void onContainedBy( Object *containedBy );
 	void onRemovedFrom( Object *removedFrom );
 	Int getTransportSlotCount() const;
-	void friend_setContainedBy( Object *containedBy );
+	void friend_setContainedBy( Object *containedBy ) { m_containedBy = containedBy; }
 	const Object* getEnclosingContainedBy() const; ///< Find the first enclosing container in the containment chain.
 	const Object* getOuterObject() const; ///< Get the top-level object
-
-#if RTS_ZEROHOUR && RETAIL_COMPATIBLE_CRC
-	void friend_setContainedByID(ObjectID id) { m_containedByID = id; }
-#endif
 
 	// Special Powers -------------------------------------------------------------------------------
 	SpecialPowerModuleInterface *getSpecialPowerModule( const SpecialPowerTemplate *specialPowerTemplate ) const;
@@ -721,7 +717,7 @@ private:
 
 	Object*												m_containedBy;					/**< an object can only be contained by at most one
 																	other object, this is that object (if present) */
-	ObjectID											m_containedByID;	///< ID of the object we're contained by; only to be used when m_containedBy cannot be used
+	ObjectID											m_xferContainedByID;	///< xfer uses IDs to store pointers and looks them up after
 	UnsignedInt										m_containedByFrame;	///< frame we were contained by m_containedBy
 
 	Real													m_constructionPercent;			///< for objects being built ... this is the amount completed (0.0 to 100.0)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -170,6 +170,12 @@ OpenContain::~OpenContain()
 										 ("OpenContain %s: m_xferContainIDList is not empty but should be",
 											getObject()->getTemplate()->getName().str() ) );
 
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Caball009 18/08/2026 Due to a potential use-after-free bug that cannot be fixed
+	// with retail compatibility, it's desirable to be able to check if the contain list is empty after its destruction.
+	// Clear the list explicitly to reset the list size.
+	m_containList.clear();
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -411,6 +417,15 @@ void OpenContain::removeFromContain( Object *rider, Bool exposeStealthUnits )
 		return;
 
 	}
+
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Caball009 18/08/2026 Due to a potential use-after-free bug that cannot be fixed
+	// with retail compatibility, the 'contained by' pointer of this object may point to an already destroyed object.
+	// Check the list size before executing the find operation below, otherwise the game crashes if the list
+	// was already destructed.
+	if (m_containList.empty())
+		return;
+#endif
 
 	ContainedItemsList::iterator it = std::find(m_containList.begin(), m_containList.end(), rider);
 	if (it != m_containList.end())

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -621,6 +621,9 @@ void Object::onContainedBy( Object *containedBy )
 		clearStatus( MAKE_OBJECT_STATUS_MASK( OBJECT_STATUS_MASKED ) );
 	m_containedBy = containedBy;
 	m_containedByFrame = TheGameLogic->getFrame();
+
+	DEBUG_ASSERTCRASH(containedBy == nullptr || !containedBy->isDestroyed(),
+		("Object::onContainedBy - Adding to a destroyed container"));
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -652,6 +655,15 @@ Int Object::getTransportSlotCount() const
 		}
 	}
 	return count;
+}
+
+void Object::friend_setContainedBy(Object* containedBy)
+{
+	m_containedBy = containedBy;
+
+#if !RETAIL_COMPATIBLE_CRC
+	m_containedByFrame = containedBy ? TheGameLogic->getFrame() : 0;
+#endif
 }
 
 const Object* Object::getEnclosingContainedBy() const

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -173,7 +173,7 @@ Object::Object( const ThingTemplate *tt, const ObjectStatusMaskType &objectStatu
 	m_physics(nullptr),
 	m_geometryInfo(tt->getTemplateGeometryInfo()),
 	m_containedBy(nullptr),
-	m_containedByID(INVALID_ID),
+	m_xferContainedByID(INVALID_ID),
 	m_containedByFrame(0),
 	m_behaviors(nullptr),
 	m_body(nullptr),
@@ -621,22 +621,6 @@ void Object::onContainedBy( Object *containedBy )
 		clearStatus( MAKE_OBJECT_STATUS_MASK( OBJECT_STATUS_MASKED ) );
 	m_containedBy = containedBy;
 	m_containedByFrame = TheGameLogic->getFrame();
-
-#if RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @info Set INVALID_ID if the container object was destroyed
-	// to indicate that the pointer will become a dangling pointer in the next frame.
-	if (containedBy && !containedBy->isDestroyed())
-	{
-		m_containedByID = containedBy->getID();
-	}
-	else
-	{
-		m_containedByID = INVALID_ID;
-	}
-#else
-	DEBUG_ASSERTCRASH(containedBy == nullptr || !containedBy->isDestroyed(),
-		("Object::onContainedBy - Adding into a destroyed container"));
-#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -647,10 +631,6 @@ void Object::onRemovedFrom( Object *removedFrom )
 	clearStatus( MAKE_OBJECT_STATUS_MASK2( OBJECT_STATUS_MASKED, OBJECT_STATUS_UNSELECTABLE ) );
 	m_containedBy = nullptr;
 	m_containedByFrame = 0;
-
-#if RETAIL_COMPATIBLE_CRC
-	m_containedByID = INVALID_ID;
-#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -672,15 +652,6 @@ Int Object::getTransportSlotCount() const
 		}
 	}
 	return count;
-}
-
-void Object::friend_setContainedBy(Object* containedBy)
-{
-	m_containedBy = containedBy;
-
-#if !RETAIL_COMPATIBLE_CRC
-	m_containedByFrame = containedBy ? TheGameLogic->getFrame() : 0;
-#endif
 }
 
 const Object* Object::getEnclosingContainedBy() const
@@ -710,33 +681,9 @@ void Object::onDestroy()
 {
 
 	// This is the old cleanUpContain safeguard.  Say goodbye so they don't try to look us up.
-	if (m_containedBy)
+	if( m_containedBy && m_containedBy->getContain() )
 	{
-#if RETAIL_COMPATIBLE_CRC
-		if (m_containedByID == INVALID_ID)
-		{
-			// TheSuperHackers @bugfix Caball009 25/05/2026 Due to a potential use-after-free bug that cannot be fixed
-			// with retail compatibility, the 'contained by' pointer of this object may point to an already destroyed object.
-			// Avoid removing this object from the contain list, because it could crash the game,
-			// as the begin / end iterator for STLPort and MSVC std::list implementations depends on dynamically allocated memory.
-			DEBUG_CRASH(("container object must be valid; this looks like use-after-free"));
-		}
-		else
-		{
-			DEBUG_ASSERTCRASH(TheGameLogic->findObjectByID(m_containedByID) == m_containedBy,
-				("contained by pointer is out of sync with contained by ID"));
-
-			if (ContainModuleInterface* contain = m_containedBy->getContain())
-			{
-				contain->removeFromContain(this);
-			}
-		}
-#else
-		if (ContainModuleInterface* contain = m_containedBy->getContain())
-		{
-			contain->removeFromContain(this);
-		}
-#endif
+		m_containedBy->getContain()->removeFromContain( this );
 	}
 
 	//
@@ -3781,19 +3728,16 @@ void Object::xfer( Xfer *xfer )
 		// No, the contain module is just going to friend_ reach in and set this for us.
 		// Containers more complicated than Open (like Tunnel) can't do that.  Our variable,
 		// our responsibility.
-#if RETAIL_COMPATIBLE_CRC
-		// TheSuperHackers @tweak Contained by ID is already set with retail compatibility; don't overwrite it.
-#else
 		if( xfer->getXferMode() == XFER_SAVE )
 		{
 			if( m_containedBy != nullptr )
-				m_containedByID = m_containedBy->getID();
+				m_xferContainedByID = m_containedBy->getID();
 			else
-				m_containedByID = INVALID_ID;
+				m_xferContainedByID = INVALID_ID;
 		}
-#endif
 
-		xfer->xferObjectID( &m_containedByID );
+
+		xfer->xferObjectID( &m_xferContainedByID );
 	}
 
 	// contained by frame
@@ -4018,8 +3962,8 @@ void Object::xfer( Xfer *xfer )
 //-------------------------------------------------------------------------------------------------
 void Object::loadPostProcess()
 {
-	if( m_containedByID != INVALID_ID )
-		m_containedBy = TheGameLogic->findObjectByID(m_containedByID);
+	if( m_xferContainedByID != INVALID_ID )
+		m_containedBy = TheGameLogic->findObjectByID(m_xferContainedByID);
 	else
 		m_containedBy = nullptr;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -448,13 +448,9 @@ public:
 	void onContainedBy( Object *containedBy );
 	void onRemovedFrom( Object *removedFrom );
 	Int getTransportSlotCount() const;
-	void friend_setContainedBy( Object *containedBy );
+	void friend_setContainedBy( Object *containedBy ) { m_containedBy = containedBy; }
 	const Object* getEnclosingContainedBy() const; ///< Find the first enclosing container in the containment chain.
 	const Object* getOuterObject() const; ///< Get the top-level object
-
-#if RTS_ZEROHOUR && RETAIL_COMPATIBLE_CRC
-	void friend_setContainedByID(ObjectID id) { m_containedByID = id; }
-#endif
 
 	// Special Powers -------------------------------------------------------------------------------
 	SpecialPowerModuleInterface *getSpecialPowerModule( const SpecialPowerTemplate *specialPowerTemplate ) const;
@@ -764,7 +760,7 @@ private:
 
 	Object*												m_containedBy;					/**< an object can only be contained by at most one
 																	other object, this is that object (if present) */
-	ObjectID											m_containedByID;	///< ID of the object we're contained by; only to be used when m_containedBy cannot be used
+	ObjectID											m_xferContainedByID;	///< xfer uses IDs to store pointers and looks them up after
 	UnsignedInt										m_containedByFrame;	///< frame we were contained by m_containedBy
 
 	Real													m_constructionPercent;			///< for objects being built ... this is the amount completed (0.0 to 100.0)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -448,7 +448,7 @@ public:
 	void onContainedBy( Object *containedBy );
 	void onRemovedFrom( Object *removedFrom );
 	Int getTransportSlotCount() const;
-	void friend_setContainedBy( Object *containedBy ) { m_containedBy = containedBy; }
+	void friend_setContainedBy( Object *containedBy );
 	const Object* getEnclosingContainedBy() const; ///< Find the first enclosing container in the containment chain.
 	const Object* getOuterObject() const; ///< Get the top-level object
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
@@ -250,28 +250,10 @@ void HelixContain::addToContainList( Object *obj )
     if ( portable )
       TheGameLogic->destroyObject( portable );
 
-    portable = obj;
+    m_portableStructureID = obj->getID();
+    obj->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
 
-    m_portableStructureID = portable->getID();
-    portable->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
 
-#if RETAIL_COMPATIBLE_CRC
-    Object* containedBy = getObject();
-
-    // TheSuperHackers @info Set INVALID_ID if the container object was destroyed
-    // to indicate that the pointer will become a dangling pointer in the next frame.
-    if (containedBy && !containedBy->isDestroyed())
-    {
-      portable->friend_setContainedByID(containedBy->getID());
-    }
-    else
-    {
-      portable->friend_setContainedByID(INVALID_ID);
-    }
-#else
-    DEBUG_ASSERTCRASH(getObject() == nullptr || !getObject()->isDestroyed(),
-      ("HelixContain::addToContainList - Adding to a destroyed container"));
-#endif
   }
   else
 		TransportContain::addToContainList( obj );
@@ -286,28 +268,10 @@ void HelixContain::addToContain( Object *obj )
     if ( portable )
       TheGameLogic->destroyObject( portable );
 
-    portable = obj;
+    m_portableStructureID = obj->getID();
+    obj->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
 
-    m_portableStructureID = portable->getID();
-    portable->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
 
-#if RETAIL_COMPATIBLE_CRC
-    Object* containedBy = getObject();
-
-    // TheSuperHackers @info Set INVALID_ID if the container object was destroyed
-    // to indicate that the pointer will become a dangling pointer in the next frame.
-    if (containedBy && !containedBy->isDestroyed())
-    {
-      portable->friend_setContainedByID(containedBy->getID());
-    }
-    else
-    {
-      portable->friend_setContainedByID(INVALID_ID);
-    }
-#else
-    DEBUG_ASSERTCRASH(getObject() == nullptr || !getObject()->isDestroyed(),
-      ("HelixContain::addToContain - Adding to a destroyed container"));
-#endif
   }
   else
 		TransportContain::addToContain( obj );
@@ -320,16 +284,10 @@ void HelixContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 	{
     Object *portable = getPortableStructure();
     if ( portable )
-    {
-#if RETAIL_COMPATIBLE_CRC
-      portable->friend_setContainedByID(INVALID_ID);
-#else
-      portable->friend_setContainedBy(nullptr);
-#endif
 
       m_portableStructureID = INVALID_ID;
       //portable->kill();
-    }
+
   }
   else
   {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/HelixContain.cpp
@@ -246,17 +246,19 @@ void HelixContain::addToContainList( Object *obj )
 {
   if ( obj->isKindOf( KINDOF_PORTABLE_STRUCTURE ) && m_portableStructureID == INVALID_ID)
   {
-    Object *portable = getPortableStructure();
-    if ( portable )
+    if ( Object *portable = getPortableStructure() )
       TheGameLogic->destroyObject( portable );
 
     m_portableStructureID = obj->getID();
     obj->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
 
-
+    DEBUG_ASSERTCRASH(getObject() == nullptr || !getObject()->isDestroyed(),
+      ("HelixContain::addToContainList - Adding to a destroyed container"));
   }
   else
-		TransportContain::addToContainList( obj );
+  {
+    TransportContain::addToContainList( obj );
+  }
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -264,17 +266,19 @@ void HelixContain::addToContain( Object *obj )
 {
   if ( obj->isKindOf( KINDOF_PORTABLE_STRUCTURE ) && m_portableStructureID == INVALID_ID)
   {
-    Object *portable = getPortableStructure();
-    if ( portable )
+    if ( Object *portable = getPortableStructure() )
       TheGameLogic->destroyObject( portable );
 
     m_portableStructureID = obj->getID();
     obj->friend_setContainedBy( getObject() );//fool portable into thinking my object is his container
 
-
+    DEBUG_ASSERTCRASH(getObject() == nullptr || !getObject()->isDestroyed(),
+      ("HelixContain::addToContain - Adding to a destroyed container"));
   }
   else
-		TransportContain::addToContain( obj );
+  {
+    TransportContain::addToContain( obj );
+  }
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -284,10 +288,14 @@ void HelixContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 	{
     Object *portable = getPortableStructure();
     if ( portable )
+    {
+#if !RETAIL_COMPATIBLE_CRC
+      portable->friend_setContainedBy(nullptr);
+#endif
 
       m_portableStructureID = INVALID_ID;
       //portable->kill();
-
+    }
   }
   else
   {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -177,6 +177,12 @@ OpenContain::~OpenContain()
 										 ("OpenContain %s: m_xferContainIDList is not empty but should be",
 											getObject()->getTemplate()->getName().str() ) );
 
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Caball009 18/08/2026 Due to a potential use-after-free bug that cannot be fixed
+	// with retail compatibility, it's desirable to be able to check if the contain list is empty after its destruction.
+	// Clear the list explicitly to reset the list size.
+	m_containList.clear();
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -433,6 +439,15 @@ void OpenContain::removeFromContain( Object *rider, Bool exposeStealthUnits )
 		return;
 
 	}
+
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Caball009 18/08/2026 Due to a potential use-after-free bug that cannot be fixed
+	// with retail compatibility, the 'contained by' pointer of this object may point to an already destroyed object.
+	// Check the list size before executing the find operation below, otherwise the game crashes if the list
+	// was already destructed.
+	if (m_containList.empty())
+		return;
+#endif
 
 	ContainedItemsList::iterator it = std::find(m_containList.begin(), m_containList.end(), rider);
 	if (it != m_containList.end())

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -182,7 +182,7 @@ Object::Object( const ThingTemplate *tt, const ObjectStatusMaskType &objectStatu
 	m_physics(nullptr),
 	m_geometryInfo(tt->getTemplateGeometryInfo()),
 	m_containedBy(nullptr),
-	m_containedByID(INVALID_ID),
+	m_xferContainedByID(INVALID_ID),
 	m_containedByFrame(0),
 	m_behaviors(nullptr),
 	m_body(nullptr),
@@ -691,22 +691,6 @@ void Object::onContainedBy( Object *containedBy )
 	m_containedBy = containedBy;
 	m_containedByFrame = TheGameLogic->getFrame();
 
-#if RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @info Set INVALID_ID if the container object was destroyed
-	// to indicate that the pointer will become a dangling pointer in the next frame.
-	if (containedBy && !containedBy->isDestroyed())
-	{
-		m_containedByID = containedBy->getID();
-	}
-	else
-	{
-		m_containedByID = INVALID_ID;
-	}
-#else
-	DEBUG_ASSERTCRASH(containedBy == nullptr || !containedBy->isDestroyed(),
-		("Object::onContainedBy - Adding into a destroyed container"));
-#endif
-
   handlePartitionCellMaintenance(); // which should unlook me now that I am contained
 
 }
@@ -719,10 +703,6 @@ void Object::onRemovedFrom( Object *removedFrom )
 	clearStatus( MAKE_OBJECT_STATUS_MASK2( OBJECT_STATUS_MASKED, OBJECT_STATUS_UNSELECTABLE ) );
 	m_containedBy = nullptr;
 	m_containedByFrame = 0;
-
-#if RETAIL_COMPATIBLE_CRC
-	m_containedByID = INVALID_ID;
-#endif
 
   handlePartitionCellMaintenance(); // get a clean look, now that I am outdoors, again
 
@@ -747,15 +727,6 @@ Int Object::getTransportSlotCount() const
 		}
 	}
 	return count;
-}
-
-void Object::friend_setContainedBy(Object* containedBy)
-{
-	m_containedBy = containedBy;
-
-#if !RETAIL_COMPATIBLE_CRC
-	m_containedByFrame = containedBy ? TheGameLogic->getFrame() : 0;
-#endif
 }
 
 const Object* Object::getEnclosingContainedBy() const
@@ -785,33 +756,9 @@ void Object::onDestroy()
 {
 
 	// This is the old cleanUpContain safeguard.  Say goodbye so they don't try to look us up.
-	if (m_containedBy)
+	if( m_containedBy && m_containedBy->getContain() )
 	{
-#if RETAIL_COMPATIBLE_CRC
-		if (m_containedByID == INVALID_ID)
-		{
-			// TheSuperHackers @bugfix Caball009 25/05/2026 Due to a potential use-after-free bug that cannot be fixed
-			// with retail compatibility, the 'contained by' pointer of this object may point to an already destroyed object.
-			// Avoid removing this object from the contain list, because it could crash the game,
-			// as the begin / end iterator for STLPort and MSVC std::list implementations depends on dynamically allocated memory.
-			DEBUG_CRASH(("container object must be valid; this looks like use-after-free"));
-		}
-		else
-		{
-			DEBUG_ASSERTCRASH(TheGameLogic->findObjectByID(m_containedByID) == m_containedBy,
-				("contained by pointer is out of sync with contained by ID"));
-
-			if (ContainModuleInterface* contain = m_containedBy->getContain())
-			{
-				contain->removeFromContain(this);
-			}
-		}
-#else
-		if (ContainModuleInterface* contain = m_containedBy->getContain())
-		{
-			contain->removeFromContain(this);
-		}
-#endif
+		m_containedBy->getContain()->removeFromContain( this );
 	}
 
 	//
@@ -4300,19 +4247,16 @@ void Object::xfer( Xfer *xfer )
 		// No, the contain module is just going to friend_ reach in and set this for us.
 		// Containers more complicated than Open (like Tunnel) can't do that.  Our variable,
 		// our responsibility.
-#if RETAIL_COMPATIBLE_CRC
-		// TheSuperHackers @tweak Contained by ID is already set with retail compatibility; don't overwrite it.
-#else
 		if( xfer->getXferMode() == XFER_SAVE )
 		{
 			if( m_containedBy != nullptr )
-				m_containedByID = m_containedBy->getID();
+				m_xferContainedByID = m_containedBy->getID();
 			else
-				m_containedByID = INVALID_ID;
+				m_xferContainedByID = INVALID_ID;
 		}
-#endif
 
-		xfer->xferObjectID( &m_containedByID );
+
+		xfer->xferObjectID( &m_xferContainedByID );
 	}
 
 	// contained by frame
@@ -4537,8 +4481,8 @@ void Object::xfer( Xfer *xfer )
 //-------------------------------------------------------------------------------------------------
 void Object::loadPostProcess()
 {
-	if( m_containedByID != INVALID_ID )
-		m_containedBy = TheGameLogic->findObjectByID(m_containedByID);
+	if( m_xferContainedByID != INVALID_ID )
+		m_containedBy = TheGameLogic->findObjectByID(m_xferContainedByID);
 	else
 		m_containedBy = nullptr;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -691,6 +691,9 @@ void Object::onContainedBy( Object *containedBy )
 	m_containedBy = containedBy;
 	m_containedByFrame = TheGameLogic->getFrame();
 
+	DEBUG_ASSERTCRASH(containedBy == nullptr || !containedBy->isDestroyed(),
+		("Object::onContainedBy - Adding to a destroyed container"));
+
   handlePartitionCellMaintenance(); // which should unlook me now that I am contained
 
 }
@@ -727,6 +730,15 @@ Int Object::getTransportSlotCount() const
 		}
 	}
 	return count;
+}
+
+void Object::friend_setContainedBy(Object* containedBy)
+{
+	m_containedBy = containedBy;
+
+#if !RETAIL_COMPATIBLE_CRC
+	m_containedByFrame = containedBy ? TheGameLogic->getFrame() : 0;
+#endif
 }
 
 const Object* Object::getEnclosingContainedBy() const


### PR DESCRIPTION
* Follow up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2747
* Follow up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2868
* Fixes issue https://github.com/TheSuperHackers/GeneralsGameCode/issues/2467

The purpose of the two pull requests was to avoid a crash while retaining retail compatibility, but the fix is rather convoluted. Additionally, this is the second time I came across one or more replays that mismatch because of those changes. So the purpose of this PR is to revert the previous two and fix the crash with a different implementation.

Here's a replay that mismatches with the current implementation. It mismatches because it relied on use-after-free bugs, which was intentionally prevented to avoid potential crashes:
[18-11-57_2v4_0_24_HardAI_HardAI_HardAI_HardAI.zip](https://github.com/user-attachments/files/31160550/18-11-57_2v4_0_24_HardAI_HardAI_HardAI_HardAI.zip)

If a troop crawler that's en route (by plane) to the reinforcement pad gets destroyed, the occupants are left in a state of limbo (see issue). They hold on to the pointer of the destroyed troop crawler, which leads to use-after-free bugs. When the occupants' objects eventually get destroyed (e.g. when a player surrenders or the game ends), the use-after-free bug may crash the game when `OpenContain::m_containList` is accessed after its destruction.

---

https://github.com/TheSuperHackers/GeneralsGameCode/blob/a40cdb66d8946f8c3dc9be37cfb42358249d8a4f/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp#L437
Here's a minimal crash reproduction that shows why the crash happens during the call to `std::find`: 
https://godbolt.org/z/znjGGrTvG
https://godbolt.org/z/MzYz6eeMb

See commits for cleaner diff.

### TODO:
- [x] Replicate to Generals.
- [x] Combine commits, change commit names and add pull request link.