### PR TITLE
bugfix(selection): Prevent objects from being appended to a selection if they are not mass-selectable

### DIFF
--- a/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -659,7 +659,7 @@ GameMessageDisposition SelectionTranslator::onMouseLeftDoubleClick(MAYBE_UNUSED 
 		selectMore->appendBooleanArgument(FALSE);
 		for (DrawableListIt it = listOfSelectedDrawables.begin(); it != listOfSelectedDrawables.end(); ++it) {
 			Drawable *draw = *it;
-			if (draw && draw->isSelectable()) {
+			if (draw && draw->isMassSelectable()) {
 				TheInGameUI->selectDrawable(draw);
 				selectMore->appendObjectIDArgument(draw->getObject()->getID());
 			}


### PR DESCRIPTION
This change prevents appending an object to a selection if it is not mass-selectable.