### PR TITLE
bugfix: Fix cases where supply units return to collect supplies after receiving player-issued commands

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
@@ -214,6 +214,7 @@ public:
 	virtual UnsignedInt getActionDelayForDock( Object *dock ) override;
 
 	virtual UpdateSleepTime update() override;
+	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -235,6 +235,7 @@ public:
 		{
 			// A chinook given transport duty loses his supplies.
 			while( ai->loseOneBox() );
+			ai->setForceWantingState(FALSE);
 		}
 
 		// kill any drift...

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -235,7 +235,9 @@ public:
 		{
 			// A chinook given transport duty loses his supplies.
 			while( ai->loseOneBox() );
+#if !RETAIL_COMPATIBLE_CRC
 			ai->setForceWantingState(FALSE);
+#endif
 		}
 
 		// kill any drift...

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -240,10 +240,12 @@ Real SupplyTruckAIUpdate::getWarehouseScanDistance() const
 
 void SupplyTruckAIUpdate::aiDoCommand(const AICommandParms* parms)
 {
+#if !RETAIL_COMPATIBLE_CRC
 	if (parms->m_cmdSource == CMD_FROM_PLAYER)
 	{
 		setForceWantingState(FALSE);
 	}
+#endif
 
 	AIUpdateInterface::aiDoCommand(parms);
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -238,6 +238,16 @@ Real SupplyTruckAIUpdate::getWarehouseScanDistance() const
 	return getSupplyTruckAIUpdateModuleData()->m_warehouseScanDistance;
 }
 
+void SupplyTruckAIUpdate::aiDoCommand(const AICommandParms* parms)
+{
+	if (parms->m_cmdSource == CMD_FROM_PLAYER)
+	{
+		setForceWantingState(FALSE);
+	}
+
+	AIUpdateInterface::aiDoCommand(parms);
+}
+
 // ------------------------------------------------------------------------------------------------
 /** CRC */
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -396,6 +396,7 @@ Object *WorkerAIUpdate::construct( const ThingTemplate *what,
 
 	// leave the supply truck state and now behave like a dozer.
 	exitingSupplyTruckState();
+	setForceWantingState(FALSE);
 
 	// take the required money away from the player
 	if( isRebuild == FALSE )
@@ -673,6 +674,7 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 			getObject()->getAIUpdateInterface()->aiIdle(CMD_FROM_AI);
 		}
 		m_workerMachine->setState( AS_DOZER );
+		setForceWantingState(FALSE);
 		// To clarify, I leave supply truck mode when I notice I am doing something not supply
 		// truck related.  When given a construct command, I wait to do anything until I notice
 		// I'm not busy.  Both states are being polite, so I must force the switch.
@@ -1037,7 +1039,10 @@ void WorkerAIUpdate::aiDoCommand(const AICommandParms* parms)
 
 			// when a player issues commands, this will cause the dozer to re-evaluate what it's doing
 			if( parms->m_cmdSource == CMD_FROM_PLAYER )
+			{
 				m_dozerMachine->resetToDefaultState();
+				setForceWantingState(FALSE);
+			}
 			break;
 
 		}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -396,7 +396,9 @@ Object *WorkerAIUpdate::construct( const ThingTemplate *what,
 
 	// leave the supply truck state and now behave like a dozer.
 	exitingSupplyTruckState();
+#if !RETAIL_COMPATIBLE_CRC
 	setForceWantingState(FALSE);
+#endif
 
 	// take the required money away from the player
 	if( isRebuild == FALSE )
@@ -674,7 +676,9 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 			getObject()->getAIUpdateInterface()->aiIdle(CMD_FROM_AI);
 		}
 		m_workerMachine->setState( AS_DOZER );
+#if !RETAIL_COMPATIBLE_CRC
 		setForceWantingState(FALSE);
+#endif
 		// To clarify, I leave supply truck mode when I notice I am doing something not supply
 		// truck related.  When given a construct command, I wait to do anything until I notice
 		// I'm not busy.  Both states are being polite, so I must force the switch.
@@ -1041,7 +1045,9 @@ void WorkerAIUpdate::aiDoCommand(const AICommandParms* parms)
 			if( parms->m_cmdSource == CMD_FROM_PLAYER )
 			{
 				m_dozerMachine->resetToDefaultState();
+#if !RETAIL_COMPATIBLE_CRC
 				setForceWantingState(FALSE);
+#endif
 			}
 			break;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
@@ -219,6 +219,7 @@ public:
 	virtual Int getUpgradedSupplyBoost() const override { return 0; }
 
 	virtual UpdateSleepTime update() override;
+	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -234,6 +234,7 @@ public:
 		{
 			// A chinook given transport duty loses his supplies.
 			while( ai->loseOneBox() );
+			ai->setForceWantingState(FALSE);
 		}
 
 		// kill any drift...

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -234,7 +234,9 @@ public:
 		{
 			// A chinook given transport duty loses his supplies.
 			while( ai->loseOneBox() );
+#if !RETAIL_COMPATIBLE_CRC
 			ai->setForceWantingState(FALSE);
+#endif
 		}
 
 		// kill any drift...

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -246,10 +246,12 @@ Real SupplyTruckAIUpdate::getWarehouseScanDistance() const
 
 void SupplyTruckAIUpdate::aiDoCommand(const AICommandParms* parms)
 {
+#if !RETAIL_COMPATIBLE_CRC
 	if (parms->m_cmdSource == CMD_FROM_PLAYER)
 	{
 		setForceWantingState(FALSE);
 	}
+#endif
 
 	AIUpdateInterface::aiDoCommand(parms);
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -244,6 +244,16 @@ Real SupplyTruckAIUpdate::getWarehouseScanDistance() const
 	return getSupplyTruckAIUpdateModuleData()->m_warehouseScanDistance;
 }
 
+void SupplyTruckAIUpdate::aiDoCommand(const AICommandParms* parms)
+{
+	if (parms->m_cmdSource == CMD_FROM_PLAYER)
+	{
+		setForceWantingState(FALSE);
+	}
+
+	AIUpdateInterface::aiDoCommand(parms);
+}
+
 // ------------------------------------------------------------------------------------------------
 /** CRC */
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -396,6 +396,7 @@ Object *WorkerAIUpdate::construct( const ThingTemplate *what,
 
 	// leave the supply truck state and now behave like a dozer.
 	exitingSupplyTruckState();
+	setForceWantingState(FALSE);
 
 	// take the required money away from the player
 	if( isRebuild == FALSE )
@@ -673,6 +674,7 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 			getObject()->getAIUpdateInterface()->aiIdle(CMD_FROM_AI);
 		}
 		m_workerMachine->setState( AS_DOZER );
+		setForceWantingState(FALSE);
 		// To clarify, I leave supply truck mode when I notice I am doing something not supply
 		// truck related.  When given a construct command, I wait to do anything until I notice
 		// I'm not busy.  Both states are being polite, so I must force the switch.
@@ -1037,7 +1039,10 @@ void WorkerAIUpdate::aiDoCommand(const AICommandParms* parms)
 
 			// when a player issues commands, this will cause the dozer to re-evaluate what it's doing
 			if( parms->m_cmdSource == CMD_FROM_PLAYER )
+			{
 				m_dozerMachine->resetToDefaultState();
+				setForceWantingState(FALSE);
+			}
 			break;
 
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -396,7 +396,9 @@ Object *WorkerAIUpdate::construct( const ThingTemplate *what,
 
 	// leave the supply truck state and now behave like a dozer.
 	exitingSupplyTruckState();
+#if !RETAIL_COMPATIBLE_CRC
 	setForceWantingState(FALSE);
+#endif
 
 	// take the required money away from the player
 	if( isRebuild == FALSE )
@@ -674,7 +676,9 @@ void WorkerAIUpdate::newTask( DozerTask task, Object* target )
 			getObject()->getAIUpdateInterface()->aiIdle(CMD_FROM_AI);
 		}
 		m_workerMachine->setState( AS_DOZER );
+#if !RETAIL_COMPATIBLE_CRC
 		setForceWantingState(FALSE);
+#endif
 		// To clarify, I leave supply truck mode when I notice I am doing something not supply
 		// truck related.  When given a construct command, I wait to do anything until I notice
 		// I'm not busy.  Both states are being polite, so I must force the switch.
@@ -1041,7 +1045,9 @@ void WorkerAIUpdate::aiDoCommand(const AICommandParms* parms)
 			if( parms->m_cmdSource == CMD_FROM_PLAYER )
 			{
 				m_dozerMachine->resetToDefaultState();
+#if !RETAIL_COMPATIBLE_CRC
 				setForceWantingState(FALSE);
+#endif
 			}
 			break;
 


### PR DESCRIPTION
* Closes: #225

This change fixes an issue where supply units would remain in a collection state if given a command during their initial path out from the Supply Center/Stash. This would cause them to either outright ignore commands (such as a construct or repair command) or resume collection after going idle (such as after completing a move command).

The issue is exacerbated if the supply unit is following a rally point.

> [!NOTE]
> Supply Workers ignoring Stop commands is a separate issue not covered by this change.

### Before

https://github.com/user-attachments/assets/b31ededd-5c2e-446b-bfc5-6a0c7158f1cd

### After

https://github.com/user-attachments/assets/97d400e7-2c84-4f61-8062-4d6f14768ec8