### PR TITLE
bugfix(modulefactory): Fix mismatch caused by W3D module additions in Generals

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/Common/Thing/W3DModuleFactory.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/Common/Thing/W3DModuleFactory.cpp
@@ -64,8 +64,10 @@ void W3DModuleFactory::init()
 	addModule( W3DModelDraw );
 	addModule( W3DLaserDraw );
 	addModule( W3DOverlordTankDraw );
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	addModule( W3DOverlordTruckDraw );
 	addModule( W3DOverlordAircraftDraw );
+#endif
 	addModule( W3DProjectileStreamDraw );
 	addModule( W3DPoliceCarDraw );
 	addModule( W3DRopeDraw );
@@ -76,7 +78,9 @@ void W3DModuleFactory::init()
 	addModule( W3DTruckDraw );
 	addModule( W3DTracerDraw );
 	addModule( W3DTankTruckDraw );
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	addModule( W3DTreeDraw );
 	addModule( W3DPropDraw );
+#endif
 
 }


### PR DESCRIPTION
* Fixes #3176
* Follow up for #3073

Prevents the Zero Hour draw modules introduced by #3073 from being registered in retail-compatible Generals builds.

## Verification

- Generals and Zero Hour VC6 Release builds succeed.
- Both replays linked in #3176 were manually tested and passed.