### PR TITLE
tweak(w3ddisplay): Set texture bit depth to display bit depth

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -863,6 +863,7 @@ void W3DDisplay::init()
 			DEBUG_CRASH( ("Unable to set render device") );
 			return;
 		}
+		WW3D::Set_Texture_Bitdepth(getBitDepth());
 
 		//Check if level was never set and default to setting most suitable for system.
 		if (TheGameLODManager->getStaticLODLevel() == STATIC_GAME_LOD_UNKNOWN)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -826,7 +826,6 @@ void W3DDisplay::init()
 		WW3D::Enable_Static_Sort_Lists(true);
 		WW3D::Set_Thumbnail_Enabled(false);
 		WW3D::Set_Screen_UV_Bias( TRUE );  ///< this makes text look good :)
-		WW3D::Set_Texture_Bitdepth(32);
 
 		setWindowed( TheGlobalData->m_windowed );
 
@@ -914,6 +913,7 @@ void W3DDisplay::init()
 			DEBUG_CRASH( ("Unable to set render device") );
 			return;
 		}
+		WW3D::Set_Texture_Bitdepth(getBitDepth());
 
 		//Check if level was never set and default to setting most suitable for system.
 		if (TheGameLODManager->getStaticLODLevel() == STATIC_GAME_LOD_UNKNOWN)


### PR DESCRIPTION
This fixes the discolored control bar textures in Generals introduced by #726.

## Issue

The Generals control bar displays visible discoloration and quantization across its background textures.

<img width="1920" height="1080" alt="Discolored Generals control bar" src="https://github.com/user-attachments/assets/7539b47f-cbf2-4f00-8a85-aab82c289e5b" />

## Root cause

Before #726, Generals selected texture formats using the device bit depth, keeping the 32-bit control bar textures intact.

#726 made Generals honor `WW3D::Get_Texture_Bitdepth()`, matching Zero Hour. However, Generals still left the texture bit depth at its default value of 16. This caused the 32-bit control bar textures to be converted from `A8R8G8B8` to `A4R4G4B4`, producing the visible discoloration.

## Fix

Generals now sets the texture bit depth to the selected display bit depth after display initialization is complete, restoring the effective pre-#726 rendering behavior. The existing Zero Hour call is moved to the same location to keep both implementations aligned.

## Verification

- Built and launched VC6 Release builds immediately before and at #726 to isolate the regression.
- VC6 Release build succeeds.