### PR TITLE
bugfix(client): Stop camera tracking units outside visibility

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -568,13 +568,27 @@ void GameClient::update()
 
   if (TheInGameUI->isCameraTrackingDrawable())
   {
+    // TheSuperHackers @bugfix Omar Aglan 12/08/2026 Stop tracking a selected drawable
+    // as soon as it is no longer visible.
     Drawable *draw = TheInGameUI->getFirstSelectedDrawable();
-    if ( draw )
+    Object *object = draw ? draw->getObject() : nullptr;
+    Bool isVisible = object && !draw->isDrawableEffectivelyHidden();
+
+#if ENABLE_CONFIGURABLE_SHROUD
+    if (isVisible && TheGlobalData->m_shroudOn)
+#else
+    if (isVisible)
+#endif
     {
-      TheTacticalView->userLookAt( draw->getPosition() );
+      const Int playerIndex = rts::getObservedOrLocalPlayer()->getPlayerIndex();
+      const ObjectShroudStatus shroudStatus = object->getShroudedStatus(playerIndex);
+      isVisible = shroudStatus == OBJECTSHROUD_CLEAR || shroudStatus == OBJECTSHROUD_PARTIAL_CLEAR;
     }
+
+    if (isVisible)
+      TheTacticalView->userLookAt(draw->getPosition());
     else
-      TheInGameUI->setCameraTrackingDrawable( FALSE );
+      TheInGameUI->setCameraTrackingDrawable(FALSE);
   }
 
 	if (m_intro != nullptr)


### PR DESCRIPTION
* Fixes #18

Stops the Zero Hour camera from tracking a selected unit after it becomes invisible to the observed or local player.

Camera tracking now stops when:

- The selected drawable or its object no longer exists.
- The drawable becomes hidden, including through stealth.
- The object becomes fully fogged or shrouded.

Partially visible objects remain trackable. Camera tracking also continues to work when shroud is disabled.

This change targets Zero Hour only. The equivalent Base Generals implementation will follow after the Zero Hour change has been tested.

## Testing

- [x] Static diff and whitespace validation
- [ ] Compile a Zero Hour build
- [ ] Confirm tracking works while a unit is visible
- [ ] Confirm tracking stops immediately when an aircraft enters fog or shroud
- [ ] Confirm tracking stops when a unit becomes hidden through stealth
- [ ] Confirm the camera remains at the last visible position
- [ ] Confirm tracking works when shroud is disabled
- [ ] Confirm observer vision uses the observed player's visibility

## AI usage

The investigation and initial implementation were produced with assistance from OpenAI Codex. The author directed the scope and project documentation format. Runtime testing is pending.