### PR TITLE
bugfix(missileaiupdate): Diving missiles no longer miss moving targets

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
@@ -521,7 +521,20 @@ void MissileAIUpdate::doAttackState(Bool turnOK)
 	if(curLoco && curLoco->getPreferredHeight() > 0)
 	{
 		// Am I close enough to the target to ignore my preferred height setting?
-		Real distanceToTargetSquared = ThePartitionManager->getDistanceSquared( getObject(), getGoalPosition(), FROM_CENTER_2D );
+#if RETAIL_COMPATIBLE_CRC
+		Real distanceToTargetSquared = ThePartitionManager->getDistanceSquared(getObject(), getGoalPosition(), FROM_CENTER_2D);
+#else
+		// TheSuperHackers @bugfix Stubbjax 23/08/2026 Diving missiles now use their target's position to determine distance
+		// when applicable rather than the goal position. This allows them to properly determine when to dive on moving targets.
+		Real distanceToTargetSquared;
+		if (m_isTrackingTarget && (getGoalObject() != nullptr)) {
+			distanceToTargetSquared = ThePartitionManager->getDistanceSquared(getObject(), getGoalObject(), FROM_CENTER_2D);
+		}
+		else {
+			distanceToTargetSquared = ThePartitionManager->getDistanceSquared(getObject(), getGoalPosition(), FROM_CENTER_2D);
+		}
+#endif
+
 		Real diveDistanceSquared = d->m_diveDistance;
 		if (curLoco && curLoco->getPreferredHeight()) {
 				diveDistanceSquared *= diveDistanceSquared;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
@@ -551,7 +551,20 @@ void MissileAIUpdate::doAttackState(Bool turnOK)
 	if(curLoco && curLoco->getPreferredHeight() > 0)
 	{
 		// Am I close enough to the target to ignore my preferred height setting?
-		Real distanceToTargetSquared = ThePartitionManager->getDistanceSquared( getObject(), getGoalPosition(), FROM_CENTER_2D );
+#if RETAIL_COMPATIBLE_CRC
+		Real distanceToTargetSquared = ThePartitionManager->getDistanceSquared(getObject(), getGoalPosition(), FROM_CENTER_2D);
+#else
+		// TheSuperHackers @bugfix Stubbjax 23/08/2026 Diving missiles now use their target's position to determine distance
+		// when applicable rather than the goal position. This allows them to properly determine when to dive on moving targets.
+		Real distanceToTargetSquared;
+		if (m_isTrackingTarget && (getGoalObject() != nullptr)) {
+			distanceToTargetSquared = ThePartitionManager->getDistanceSquared(getObject(), getGoalObject(), FROM_CENTER_2D);
+		}
+		else {
+			distanceToTargetSquared = ThePartitionManager->getDistanceSquared(getObject(), getGoalPosition(), FROM_CENTER_2D);
+		}
+#endif
+
 		Real diveDistanceSquared = d->m_diveDistance;
 		if (curLoco && curLoco->getPreferredHeight()) {
 				diveDistanceSquared *= diveDistanceSquared;


### PR DESCRIPTION
This change fixes an issue where diving missiles (such as Tomahawk missiles) would miss moving targets. This was because the distance calculation did not account for a target object, and instead calculated the distance to the target position (which is only set once). This matches the logic in the above `m_lockDistance` calculation.

### Before

https://github.com/user-attachments/assets/ce877c21-075f-4857-92de-e3faa1e2a04e

### After

https://github.com/user-attachments/assets/5cb0ebed-4d07-4af4-af12-042eb5c7099f