### PR TITLE
fix(filesystem): Delay StdBIGFile allocation until after archive validation

### DIFF
--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -127,7 +127,6 @@ ArchiveFile * StdBIGFileSystem::openArchiveFile(const Char *filename) {
 	fp->seek(0x10, File::START);
 	// read in each directory listing.
 	ArchivedFileInfo *fileInfo = NEW ArchivedFileInfo;
-	// TheSuperHackers @fix CryoTheRenegade 24/08/2026 Allocate after validation so failed opens and invalid BIG identifiers cannot leak the archive object.
 	ArchiveFile *archiveFile = NEW StdBIGFile(filename, AsciiString::TheEmptyString);
 
 	for (Int i = 0; i < numLittleFiles; ++i) {

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -86,8 +86,6 @@ ArchiveFile * StdBIGFileSystem::openArchiveFile(const Char *filename) {
 	Int archiveFileSize = 0;
 	Int numLittleFiles = 0;
 
-	ArchiveFile *archiveFile = NEW StdBIGFile(filename, AsciiString::TheEmptyString);
-
 	DEBUG_LOG(("StdBIGFileSystem::openArchiveFile - opening BIG file %s", filename));
 
 	if (fp == nullptr) {
@@ -129,6 +127,8 @@ ArchiveFile * StdBIGFileSystem::openArchiveFile(const Char *filename) {
 	fp->seek(0x10, File::START);
 	// read in each directory listing.
 	ArchivedFileInfo *fileInfo = NEW ArchivedFileInfo;
+	// TheSuperHackers @fix CryoTheRenegade 24/08/2026 Allocate after validation so failed opens and invalid BIG identifiers cannot leak the archive object.
+	ArchiveFile *archiveFile = NEW StdBIGFile(filename, AsciiString::TheEmptyString);
 
 	for (Int i = 0; i < numLittleFiles; ++i) {
 		Int filesize = 0;


### PR DESCRIPTION
Clang-tidy found that `StdBIGFileSystem::openArchiveFile` allocated the archive object before checking whether the file opened or whether the BIG identifier was valid. Those two early-return paths leaked the object.

This matches the existing `Win32BIGFileSystem` allocation order.