### PR TITLE
bugfix(skirmish): Prevent mismatch in replay playback by restoring slot setup before replay creation

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/GameInfo.h
+++ b/Core/GameEngine/Include/GameNetwork/GameInfo.h
@@ -301,6 +301,8 @@ public:
 		for (Int i = 0; i< MAX_SLOTS; ++i)
 			setSlotPointer(i, &m_skirmishSlot[i]);
 	}
+
+	void handleOriginalSetups();
 };
 
 extern SkirmishGameInfo *TheSkirmishGameInfo;

--- a/Core/GameEngine/Source/GameNetwork/GameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameInfo.cpp
@@ -1645,4 +1645,24 @@ void SkirmishGameInfo::loadPostProcess()
 {
 }
 
+void SkirmishGameInfo::handleOriginalSetups()
+{
+	// TheSuperHackers @fix Caball009 19/03/2026 Random color, position and faction are based on the logical seed. For improved determinism,
+	// restarted games now set the original values so that the games start with the exact same logical seed values as the first time.
 
+	for (size_t i = 0; i < ARRAY_SIZE(m_skirmishSlot); ++i)
+	{
+		GameSlot& slot = m_skirmishSlot[i];
+
+		if (slot.hasSavedOriginalSetup())
+		{
+			slot.setColor(slot.getOriginalColor());
+			slot.setStartPos(slot.getOriginalStartPos());
+			slot.setPlayerTemplate(slot.getOriginalPlayerTemplate());
+		}
+		else
+		{
+			slot.saveOriginalSetup();
+		}
+	}
+}

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -618,6 +618,8 @@ void RecorderClass::startRecording(GameDifficulty diff, Int originalGameMode, In
 	{
     if(TheSkirmishGameInfo)
     {
+			TheSkirmishGameInfo->handleOriginalSetups();
+
 			TheSkirmishGameInfo->setCRCInterval(REPLAY_CRC_INTERVAL);
       theSlotList = GameInfoToAsciiString(TheSkirmishGameInfo);
       DEBUG_LOG(("GameInfo String: %s",theSlotList.str()));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1283,28 +1283,18 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 	Bool isSkirmishOrSkirmishReplay = FALSE;
 	if (TheGameInfo)
 	{
+		if (!loadingSaveGame && m_gameMode == GAME_SKIRMISH)
+		{
+			TheSkirmishGameInfo->handleOriginalSetups();
+		}
+
 		for (Int i=0; i<MAX_SLOTS; ++i)
 		{
-			GameSlot *slot = TheGameInfo->getSlot(i);
-			if (!loadingSaveGame) {
-				if (slot->hasSavedOriginalSetup())
-				{
-					DEBUG_ASSERTCRASH(m_gameMode == GAME_SKIRMISH, ("Expected GAME_SKIRMISH but got %s", toString(m_gameMode)));
-
-					// TheSuperHackers @fix Caball009 19/03/2026 Random color, position and faction are based on the logical seed. For improved determinism,
-					// restarted games now set the original values so that the games start with the exact same logical seed values as the first time.
-					slot->setColor(slot->getOriginalColor());
-					slot->setStartPos(slot->getOriginalStartPos());
-					slot->setPlayerTemplate(slot->getOriginalPlayerTemplate());
-				}
-				else
-				{
-					slot->saveOriginalSetup();
-				}
-			}
+			GameSlot* slot = TheGameInfo->getSlot(i);
 			if (slot->isAI())
 			{
 				isSkirmishOrSkirmishReplay = TRUE;
+				break;
 			}
 		}
 	} else {


### PR DESCRIPTION
* Follow up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2373

https://github.com/TheSuperHackers/GeneralsGameCode/pull/2373 broke replays of restarted skirmish games again, making them mismatch 100% of the time. This PR fixes that.

The issue is that restoring the original slot data (color, position and faction) in `GameLogic::tryStartNewGame` happens too late because the `RecorderClass` update runs first. So for restarted games, a new replay is created with incorrect data. That's why I refactored the code, extracted it to a separate function and call it from both places.

## TODO:
- [ ] Replicate to Generals.

