### PR TITLE
fix(heightmapedit): Fix undefined behaviors in WorldHeightMapEdit::remapTextures, WorldHeightMapEdit::findBoundaryNear

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -323,7 +323,7 @@ WorldHeightMapEdit::WorldHeightMapEdit(ChunkInputStream *pStrm):
 Bool WorldHeightMapEdit::remapTextures()
 {
 	Int i;
-	Bool anyChanges;
+	Bool anyChanges = false;
 	for (i=0; i<m_numTextureClasses; i++) {
 		TerrainModal modalTerrainDlg(m_textureClasses[i].name, this);
 		if (IDOK==modalTerrainDlg.DoModal()) {
@@ -3394,6 +3394,7 @@ void WorldHeightMapEdit::findBoundaryNear(Coord3D *pt, float okDistance, Int *ou
 
 	if (!pt) {
 		(*outNdx) = -1;
+		return;
 	}
 
 	int numBoundaries = m_boundaries.size();

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -324,7 +324,7 @@ WorldHeightMapEdit::WorldHeightMapEdit(ChunkInputStream *pStrm):
 Bool WorldHeightMapEdit::remapTextures()
 {
 	Int i;
-	Bool anyChanges;
+	Bool anyChanges = false;
 	for (i=0; i<m_numTextureClasses; i++) {
 		TerrainModal modalTerrainDlg(m_textureClasses[i].name, this);
 		if (IDOK==modalTerrainDlg.DoModal()) {
@@ -3366,6 +3366,7 @@ void WorldHeightMapEdit::findBoundaryNear(Coord3D *pt, float okDistance, Int *ou
 
 	if (!pt) {
 		(*outNdx) = -1;
+		return;
 	}
 
 	int numBoundaries = m_boundaries.size();


### PR DESCRIPTION
Initialize `anyChanges` to `false` so `remapTextures()` returns a defined value when no texture classes change.
Return from `findBoundaryNear()` after handling a null point to prevent a null dereference.
Found with clang-tidy