### PR TITLE
refactor: Fix unnecessary copy initializations

### DIFF
--- a/Core/GameEngine/Source/Common/ReplaySimulation.cpp
+++ b/Core/GameEngine/Source/Common/ReplaySimulation.cpp
@@ -77,7 +77,7 @@ int ReplaySimulation::simulateReplaysInThisProcess(const std::vector<AsciiString
 	DWORD totalStartTimeMillis = GetTickCount();
 	for (size_t i = 0; i < filenames.size(); i++)
 	{
-		AsciiString filename = filenames[i];
+		const AsciiString &filename = filenames[i];
 		printf("Simulating Replay \"%s\"\n", filename.str());
 		fflush(stdout);
 		DWORD startTimeMillis = GetTickCount();

--- a/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -302,7 +302,7 @@ void ControlBar::populatePurchaseScience( Player* player )
 
 			setControlCommand( m_sciencePurchaseWindowsRank3[ i ], commandButton );
 			ScienceType	st = SCIENCE_INVALID;
-			ScienceVec sv = commandButton->getScienceVec();
+			const ScienceVec &sv = commandButton->getScienceVec();
 			if (! sv.empty())
 			{
 				st = sv[ 0 ];

--- a/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Core/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1176,7 +1176,7 @@ GameMessageDisposition SelectionTranslator::onMetaSelectTeam(MAYBE_UNUSED const 
 				Squad *selectedSquad = player->getHotkeySquad(group);
 				if (selectedSquad != nullptr)
 				{
-					VecObjectPtr objlist = selectedSquad->getLiveObjects();
+					const VecObjectPtr& objlist = selectedSquad->getLiveObjects();
 					Int numObjs = objlist.size();
 					if (numObjs > 0)
 					{
@@ -1201,7 +1201,7 @@ GameMessageDisposition SelectionTranslator::onMetaSelectTeam(MAYBE_UNUSED const 
 				Squad *selectedSquad = player->getHotkeySquad(group);
 				if (selectedSquad != nullptr)
 				{
-					VecObjectPtr objlist = selectedSquad->getLiveObjects();
+					const VecObjectPtr& objlist = selectedSquad->getLiveObjects();
 					Int numObjs = objlist.size();
 					for (Int i = 0; i < numObjs; ++i)
 					{
@@ -1244,7 +1244,7 @@ GameMessageDisposition SelectionTranslator::onMetaAddTeam(MAYBE_UNUSED const Gam
 				Squad *selectedSquad = player->getHotkeySquad(group);
 				if (selectedSquad != nullptr)
 				{
-					VecObjectPtr objlist = selectedSquad->getLiveObjects();
+					const VecObjectPtr& objlist = selectedSquad->getLiveObjects();
 					Int numObjs = objlist.size();
 					if (numObjs > 0)
 					{
@@ -1275,7 +1275,7 @@ GameMessageDisposition SelectionTranslator::onMetaAddTeam(MAYBE_UNUSED const Gam
 				Squad *selectedSquad = player->getHotkeySquad(group);
 				if (selectedSquad != nullptr)
 				{
-					VecObjectPtr objlist = selectedSquad->getLiveObjects();
+					const VecObjectPtr& objlist = selectedSquad->getLiveObjects();
 					Int numObjs = objlist.size();
 
 					// TheSuperHackers @bugfix skyaero 22/07/2025 Can't select other units if you have a structure selected. So deselect the structure to prevent group force attack exploit.
@@ -1311,7 +1311,7 @@ GameMessageDisposition SelectionTranslator::onMetaViewTeam(MAYBE_UNUSED const Ga
 			Squad *selectedSquad = player->getHotkeySquad(group);
 			if (selectedSquad != nullptr)
 			{
-				VecObjectPtr objlist = selectedSquad->getLiveObjects();
+				const VecObjectPtr& objlist = selectedSquad->getLiveObjects();
 				Int numObjs = objlist.size();
 				if (numObjs > 0)
 				{

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LadderDefs.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LadderDefs.cpp
@@ -183,7 +183,7 @@ static LadderInfo *parseLadder(AsciiString raw)
 					AsciiStringList validFactions = lad->validFactions;
 					for (AsciiStringListIterator it = validFactions.begin(); it != validFactions.end(); ++it)
 					{
-						AsciiString faction = *it;
+						const AsciiString &faction = *it;
 						AsciiString marker;
 						marker.format("INI:Faction%s", faction.str());
 						DEBUG_LOG(("Faction %s has marker %s corresponding to str %ls", faction.str(), marker.str(), TheGameText->fetch(marker).str()));
@@ -196,7 +196,7 @@ static LadderInfo *parseLadder(AsciiString raw)
 					std::list<AsciiString> qmMaps = TheGameSpyConfig->getQMMaps();
 					for (std::list<AsciiString>::const_iterator it = qmMaps.begin(); it != qmMaps.end(); ++it)
 					{
-						AsciiString mapName = *it;
+						const AsciiString &mapName = *it;
 
 						// check sizes on the maps before allowing them
 						const MapMetaData *md = TheMapCache->findMap(mapName);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -2619,7 +2619,7 @@ void W3DModelDraw::recalcBonesForClientParticleSystems()
 							tmp.Scale(getDrawable()->getScale());
 							m_renderObject->Set_Transform(tmp);					// set to identity transform
 
-							const Matrix3D boneTransform = m_renderObject->Get_Bone_Transform(boneIndex);
+							const Matrix3D& boneTransform = m_renderObject->Get_Bone_Transform(boneIndex);
 							Vector3 vpos = boneTransform.Get_Translation();
 							rotation = boneTransform.Get_Z_Rotation();
 
@@ -2690,7 +2690,7 @@ Bool W3DModelDraw::updateBonesForClientParticleSystems()
 			Int boneIndex = (*it).boneIndex;
 			if ( (sys != nullptr) && (boneIndex != 0)  )
 			{
-    		const Matrix3D boneTransform = m_renderObject->Get_Bone_Transform(boneIndex);// just a little worried about state changes
+    		const Matrix3D& boneTransform = m_renderObject->Get_Bone_Transform(boneIndex);// just a little worried about state changes
 
         Vector3 vpos = boneTransform.Get_Translation();
 
@@ -3516,7 +3516,7 @@ Bool W3DModelDraw::clientOnly_getRenderObjBoundBox(OBBoxClass * boundbox) const
 	AABoxClass aabox;
 	m_renderObject->Get_Obj_Space_Bounding_Box(aabox);
 
-	Matrix3D tm = m_renderObject->Get_Transform();
+	const Matrix3D& tm = m_renderObject->Get_Transform();
 
 	// build an OBB for this AAB,transform
 	OBBoxClass box0(aabox.Center,aabox.Extent);
@@ -3720,7 +3720,7 @@ Bool W3DModelDraw::handleWeaponFireFX(WeaponSlotType wslot, Int specificBarrelTo
 			if( ! m_renderObject->Is_Hidden() || (logicObject == nullptr) )
 			{
 				// I can ask the drawable's bone position if I am not hidden (if I have no object I have no choice)
-				Matrix3D mtx = m_renderObject->Get_Bone_Transform(info.m_fxBone);
+				const Matrix3D& mtx = m_renderObject->Get_Bone_Transform(info.m_fxBone);
 				Coord3D pos;
 				pos.x = mtx.Get_X_Translation();
 				pos.y = mtx.Get_Y_Translation();

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
@@ -468,7 +468,6 @@ void FlatHeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 		W3DShaderManager::updateCloud();
 	}
 
-	const Matrix3D& tm = Transform;
 	// If there are trees, tell them to draw at the transparent time to draw.
 	if (m_treeBuffer) {
 		m_treeBuffer->setIsTerrain();
@@ -494,8 +493,7 @@ void FlatHeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 	DX8Wrapper::Set_Texture(1,nullptr);
 	ShaderClass::Invalidate();
 
-	//	tm.Scale(ObjSpaceExtent);
-	DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
+	DX8Wrapper::Set_Transform(D3DTS_WORLD,Transform);
 
 
 	DX8Wrapper::Set_Material(m_vertexMaterialClass);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
@@ -468,7 +468,7 @@ void FlatHeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 		W3DShaderManager::updateCloud();
 	}
 
-	Matrix3D tm(Transform);
+	const Matrix3D& tm = Transform;
 	// If there are trees, tell them to draw at the transparent time to draw.
 	if (m_treeBuffer) {
 		m_treeBuffer->setIsTerrain();

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1884,7 +1884,7 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 		W3DShaderManager::updateCloud();
 	}
 
-	Matrix3D tm(Transform);
+	const Matrix3D& tm = Transform;
 #if 0 // There is some weirdness sometimes with the dx8 static buffers.
 			// This usually fixes terrain flashing.  jba.
 	static Int delay = 1;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1884,7 +1884,6 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 		W3DShaderManager::updateCloud();
 	}
 
-	const Matrix3D& tm = Transform;
 #if 0 // There is some weirdness sometimes with the dx8 static buffers.
 			// This usually fixes terrain flashing.  jba.
 	static Int delay = 1;
@@ -1926,8 +1925,7 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 	DX8Wrapper::Set_Texture(1,nullptr);
 	ShaderClass::Invalidate();
 
-	//	tm.Scale(ObjSpaceExtent);
-	DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
+	DX8Wrapper::Set_Transform(D3DTS_WORLD,Transform);
 
 	//Apply the shader and material
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -991,7 +991,7 @@ void W3DTerrainVisual::addFactionBib(Object *factionBuilding, Bool highlight, Re
 		pos.set(0,0,0);
 		Real exitWidth = factionBuilding->getTemplate()->getFactoryExitWidth();
 		Real extraWidth = factionBuilding->getTemplate()->getFactoryExtraBibWidth() + extra;
-		const GeometryInfo info = factionBuilding->getGeometryInfo();
+		const GeometryInfo &info = factionBuilding->getGeometryInfo();
 		Real sizeX = info.getMajorRadius();
 		Real sizeY = info.getMinorRadius();
 		if (info.getGeomType() != GEOMETRY_BOX) {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -1296,7 +1296,6 @@ Int W3DTreeBuffer::addTreeType(const W3DTreeDrawModuleData *data)
 	Int numVertex = m_treeTypes[m_numTreeTypes].m_mesh->Peek_Model()->Get_Vertex_Count();
 	Vector3 *pVert = m_treeTypes[m_numTreeTypes].m_mesh->Peek_Model()->Get_Vertex_Array();
 
-	const Matrix3D xfm = m_treeTypes[m_numTreeTypes].m_mesh->Get_Transform();
 	SphereClass bounds(pVert, numVertex);
 	bounds.Center += offset;
 	m_treeTypes[m_numTreeTypes].m_bounds = bounds;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -299,7 +299,7 @@ void W3DTreeBuffer::cull(const CameraClass * camera)
 	Int curTree;
 
 	// Calculate the vector direction that the camera is looking at.
-	Matrix3D camera_matrix = camera->Get_Transform();
+	const Matrix3D &camera_matrix = camera->Get_Transform();
 	float zmod = -1;
 	float x = zmod * camera_matrix[0][2] ;
 	float y = zmod * camera_matrix[1][2] ;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -1280,7 +1280,7 @@ Int W3DTreeBuffer::addTreeType(const W3DTreeDrawModuleData *data)
 	if (robj->Class_ID() == RenderObjClass::CLASSID_HLOD) {
 		RenderObjClass *hlod = robj;
 		robj = hlod->Get_Sub_Object(0);
-		const Matrix3D xfm = robj->Get_Bone_Transform(0);
+		const Matrix3D& xfm = robj->Get_Bone_Transform(0);
 		xfm.Get_Translation(&offset);
 		REF_PTR_RELEASE(hlod);
 	}

--- a/Core/Libraries/Source/WWVegas/WW3D2/intersec.inl
+++ b/Core/Libraries/Source/WWVegas/WW3D2/intersec.inl
@@ -87,7 +87,7 @@ inline void IntersectionClass::Get_Screen_Ray(float screen_x, float screen_y, co
 	CameraClass *camera = Layer.Camera;
 
 	// determine the ray corresponding to the camera and distance to projection plane
-	Matrix3D camera_matrix = camera->Get_Transform();
+	const Matrix3D& camera_matrix = camera->Get_Transform();
 	Vector3 camera_location  = camera->Get_Position();
 
 	// the projected ray has the same origin as the camera

--- a/Core/Libraries/Source/WWVegas/WW3D2/rendobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/rendobj.cpp
@@ -322,7 +322,7 @@ float RenderObjClass::Get_Screen_Size(CameraClass &camera)
 	// accurate (perhaps by using the object-space bounding-box)
 	Vector3 cam = camera.Get_Position();
 
-	ViewportClass viewport = camera.Get_Viewport();
+	const ViewportClass &viewport = camera.Get_Viewport();
 	Vector2 vpr_min, vpr_max;
 	camera.Get_View_Plane(vpr_min, vpr_max);
 	float width_factor = viewport.Width() / (vpr_max.X - vpr_min.X);

--- a/Core/Libraries/Source/WWVegas/WW3D2/rendobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/rendobj.cpp
@@ -1277,7 +1277,7 @@ void RenderObjPersistFactoryClass::Save(ChunkSaveClass & csave,PersistClass * ob
 {
 	RenderObjClass * robj = (RenderObjClass *)obj;
 	const char * name = robj->Get_Name();
-	Matrix3D tm = robj->Get_Transform();
+	const Matrix3D& tm = robj->Get_Transform();
 
 	csave.Begin_Chunk(RENDOBJFACTORY_CHUNKID_VARIABLES);
 	WRITE_MICRO_CHUNK(csave,RENDOBJFACTORY_VARIABLE_OBJPOINTER,robj);

--- a/Core/Libraries/Source/WWVegas/WW3D2/ringobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/ringobj.cpp
@@ -690,8 +690,6 @@ void RingRenderObjClass::Render(RenderInfoClass & rinfo)
 		// Process texture reductions:
 //		if (RingTexture) RingTexture->Process_Reduction();
 
-		Matrix3D temp = Transform;
-
 		// Do Time Based Animation
 		animate ();
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/shattersystem.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/shattersystem.cpp
@@ -920,7 +920,7 @@ void ShatterSystem::Shatter_Mesh(MeshClass * mesh,const Vector3 & point,const Ve
 	/*
 	** Object-space to world-space transform
 	*/
-	Matrix3D Mobj_to_world = mesh->Get_Transform();
+	const Matrix3D& Mobj_to_world = mesh->Get_Transform();
 
 	/*
 	** World-space to shatter-space transform

--- a/Core/Libraries/Source/WWVegas/WW3D2/texproject.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texproject.cpp
@@ -931,9 +931,8 @@ bool TexProjectClass::Compute_Perspective_Projection
 	** Calculate the axis-aligned bounding box of the model in the camera's coordinate system.
 	*/
 	AABoxClass box = obj_box;
-	Matrix3D obj_to_world = tm;
 	Matrix3D obj_to_texture;
-	Matrix3D::Multiply(texture_tm_inv,obj_to_world,&obj_to_texture);
+	Matrix3D::Multiply(texture_tm_inv,tm,&obj_to_texture);
 	box.Transform(obj_to_texture);
 
 	/*
@@ -1060,9 +1059,8 @@ bool TexProjectClass::Compute_Ortho_Projection
 	** Calculate the axis-aligned bounding box of the model in the camera's coordinate system.
 	*/
 	AABoxClass box = obj_box;
-	Matrix3D obj_to_world = tm;
 	Matrix3D obj_to_texture;
-	Matrix3D::Multiply(texture_tm_inv,obj_to_world,&obj_to_texture);
+	Matrix3D::Multiply(texture_tm_inv,tm,&obj_to_texture);
 	box.Transform(obj_to_texture);
 
 	/*

--- a/Core/Libraries/Source/WWVegas/WWAudio/Sound3D.cpp
+++ b/Core/Libraries/Source/WWVegas/WWAudio/Sound3D.cpp
@@ -353,9 +353,8 @@ Sound3DClass::Set_Position (const Vector3 &position)
 			//
 			//	Transform the sound's position into 'listener-space'
 			//
-			Vector3 sound_pos	= position;
 			Vector3 listener_space_pos;
-			Matrix3D::Inverse_Transform_Vector (m_ListenerTransform, sound_pos, &listener_space_pos);
+			Matrix3D::Inverse_Transform_Vector (m_ListenerTransform, position, &listener_space_pos);
 
 			//
 			//	Update the object's position inside of Miles

--- a/Core/Tools/W3DView/W3DViewDoc.cpp
+++ b/Core/Tools/W3DView/W3DViewDoc.cpp
@@ -1506,7 +1506,7 @@ CW3DViewDoc::SaveSettings
                                          stringValue,
                                          (LPCTSTR)stringCompleteFilename);
 
-				Matrix3D transform = m_pCSceneLight->Get_Transform ();
+				const Matrix3D& transform = m_pCSceneLight->Get_Transform ();
 				Quaternion orientation = ::Build_Quaternion (transform);
 
             // Write the x-position out to the file
@@ -2379,7 +2379,7 @@ CW3DViewDoc::Make_Movie ()
 				if (index != -1) {
 
 					// Convert the bone's transform into a camera transform
-					Matrix3D	transform = m_pCRenderObj->Get_Bone_Transform (index);
+					const Matrix3D& transform = m_pCRenderObj->Get_Bone_Transform (index);
 					Matrix3D cam_transform (Vector3 (0, -1, 0), Vector3 (0, 0, 1), Vector3 (-1, 0, 0), Vector3 (0, 0, 0));
 #ifdef ALLOW_TEMPORARIES
 					Matrix3D new_transform = transform * cam_transform;

--- a/Core/Tools/W3DView/W3DViewDoc.cpp
+++ b/Core/Tools/W3DView/W3DViewDoc.cpp
@@ -2719,7 +2719,7 @@ CW3DViewDoc::Copy_Assets_To_Dir (LPCTSTR directory)
 			//
 			//	Determine the source and destination filenames
 			//
-			StringClass filename		= dependency_list[counter];
+			const StringClass &filename		= dependency_list[counter];
 			CString src_filename		= src_path + CString (filename);
 			CString dest_filename	= dest_path + CString (filename);
 

--- a/Core/Tools/textureCompress/textureCompress.cpp
+++ b/Core/Tools/textureCompress/textureCompress.cpp
@@ -472,7 +472,7 @@ static void scanDir( const std::string& sourceDirName, const std::string& target
 		FileInfoSet::iterator fit = sourceFiles->find(f);
 		if (fit != sourceFiles->end())
 		{
-			FileInfo sf = *fit;
+			const FileInfo &sf = *fit;
 			if (f.modTime < sf.modTime)
 			{
 				/**
@@ -563,7 +563,7 @@ static void scanDir( const std::string& sourceDirName, const std::string& target
 			FileInfoSet::iterator fit = cacheFiles->find(f);
 			if (fit != cacheFiles->end())
 			{
-				FileInfo cf = *fit;
+				const FileInfo &cf = *fit;
 				if (cf.modTime < f.modTime)
 				{
 					origFilesToCompress.insert(fname);

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -3541,7 +3541,7 @@ void Player::processSelectTeamGameMessage(Int hotkeyNum) {
 
 	m_currentSelection->clearSquad();
 
-	VecObjectPtr objectList = m_squads[hotkeyNum]->getLiveObjects();
+	const VecObjectPtr& objectList = m_squads[hotkeyNum]->getLiveObjects();
 	Int numObjs = objectList.size();
 
 	for (Int i = 0; i < numObjs; ++i) {
@@ -3566,7 +3566,7 @@ void Player::processAddTeamGameMessage(Int hotkeyNum) {
 		m_currentSelection = newInstance( Squad );
 	}
 
-	VecObjectPtr objectList = m_squads[hotkeyNum]->getLiveObjects();
+	const VecObjectPtr& objectList = m_squads[hotkeyNum]->getLiveObjects();
 	Int numObjs = objectList.size();
 
 	for (Int i = 0; i < numObjs; ++i) {

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -698,7 +698,7 @@ void PopulateOldBuddyMessages()
 	BuddyMessageList *messages = TheGameSpyInfo->getBuddyMessages();
 	for (BuddyMessageList::iterator mIt = messages->begin(); mIt != messages->end(); ++mIt)
 	{
-		BuddyMessage message = *mIt;
+		const BuddyMessage &message = *mIt;
 		insertChat(message);
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -592,7 +592,7 @@ static void populateQuickMatchMapSelectListbox( QuickMatchPreferences& pref )
 	GadgetListBoxReset(listboxMapSelect);
 	for (std::list<AsciiString>::const_iterator it = maps.begin(); it != maps.end(); ++it)
 	{
-		AsciiString theMap = *it;
+		const AsciiString &theMap = *it;
 		const MapMetaData *md = TheMapCache->findMap(theMap);
 		if (md && md->m_numPlayers >= numPlayers)
 		{
@@ -1670,7 +1670,7 @@ WindowMsgHandledType WOLQuickMatchMenuSystem( GameWindow *window, UnsignedInt ms
 						if (cit != ladderInfo->validFactions.end())
 						{
 							Int numPlayerTemplates = ThePlayerTemplateStore->getPlayerTemplateCount();
-							AsciiString sideStr = *cit;
+							const AsciiString &sideStr = *cit;
 							DEBUG_LOG(("Chose %s as our side... finding", sideStr.str()));
 							for (Int c=0; c<numPlayerTemplates; ++c)
 							{

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5781,7 +5781,7 @@ Object *AIAttackSquadState::chooseVictim()
 		case DIFFICULTY_EASY:
 		{
 			// pick a random unit
-			VecObjectPtr objects = victimSquad->getLiveObjects();
+			const VecObjectPtr& objects = victimSquad->getLiveObjects();
 			Int numUnits = objects.size();
 			if (numUnits == 0)
 			{
@@ -5809,7 +5809,7 @@ Object *AIAttackSquadState::chooseVictim()
 		case DIFFICULTY_HARD:
 		{
 			// everyone picks the same unit
-			VecObjectPtr objects = victimSquad->getLiveObjects();
+			const VecObjectPtr& objects = victimSquad->getLiveObjects();
 			if (!objects.empty())
 			{
 				return objects[0];

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -610,7 +610,7 @@ void ScriptActions::doCreateReinforcements(const AsciiString& team, const AsciiS
 
 		PartitionSolver partition(vecOfUnits, vecOfTransports, PREFER_FAST_SOLUTION);
 		partition.solve();
-		SolutionVec solution = partition.getSolution();
+		const SolutionVec& solution = partition.getSolution();
 		for (size_t i = 0; i < solution.size(); ++i) {
 			Object *unit = TheGameLogic->findObjectByID(solution[i].first);
 			Object *trans = TheGameLogic->findObjectByID(solution[i].second);
@@ -1463,7 +1463,7 @@ void ScriptActions::doLoadAllTransports(const AsciiString& teamName)
 
 	PartitionSolver partition(vecOfUnits, vecOfTransports, PREFER_FAST_SOLUTION);
 	partition.solve();
-	SolutionVec solution = partition.getSolution();
+	const SolutionVec& solution = partition.getSolution();
 	for (size_t i = 0; i < solution.size(); ++i) {
 		Object *unit = TheGameLogic->findObjectByID(solution[i].first);
 		Object *trans = TheGameLogic->findObjectByID(solution[i].second);

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -199,7 +199,7 @@ void ScriptConditions::objectTypesFromParam(Parameter *pTypeParm, ObjectTypes *o
 		return;
 	}
 
-	AsciiString str = pTypeParm->getString();
+	const AsciiString &str = pTypeParm->getString();
 
 	if (str.isEmpty()) {
 		return;
@@ -355,7 +355,7 @@ Bool ScriptConditions::evaluateNamedUnitTotallyDead(Parameter *pUnitParm)
 //-------------------------------------------------------------------------------------------------
 Bool ScriptConditions::evaluateHasUnits(Parameter *pTeamParm)
 {
-	AsciiString desiredTeamName = pTeamParm->getString();
+	const AsciiString &desiredTeamName = pTeamParm->getString();
 	// If they are calling a <this team> condition, do it.
 	if (desiredTeamName == THIS_TEAM) {
 		Team *theTeam = TheScriptEngine->getTeamNamed( desiredTeamName );
@@ -396,7 +396,6 @@ Bool ScriptConditions::evaluateTeamInsideAreaPartially(Parameter *pTeamParm, Par
 	Team *theTeam = TheScriptEngine->getTeamNamed( pTeamParm->getString() );
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// is being considered for the condition.  jba. :)
-	AsciiString triggerName = pTriggerAreaParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerAreaParm->getString());
 
 	if (pTrig == nullptr) return false;
@@ -418,7 +417,6 @@ Bool ScriptConditions::evaluateNamedInsideArea(Parameter *pUnitParm, Parameter *
 		return false;
 	}
 
-	AsciiString triggerName = pTriggerAreaParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerAreaParm->getString());
 	if (pTrig == nullptr) return false;
 	if (theObj) {
@@ -435,7 +433,6 @@ Bool ScriptConditions::evaluateNamedInsideArea(Parameter *pUnitParm, Parameter *
 //-------------------------------------------------------------------------------------------------
 Bool ScriptConditions::evaluatePlayerHasUnitTypeInArea(Condition *pCondition, Parameter *pPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm, Parameter *pTypeParm, Parameter *pTriggerParm )
 {
-	AsciiString triggerName = pTriggerParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerParm->getString());
 	if (pTrig == nullptr) return false;
 
@@ -527,7 +524,6 @@ Bool ScriptConditions::evaluatePlayerHasUnitTypeInArea(Condition *pCondition, Pa
 //-------------------------------------------------------------------------------------------------
 Bool ScriptConditions::evaluatePlayerHasUnitKindInArea(Condition *pCondition, Parameter *pPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm, Parameter *pKindParm, Parameter *pTriggerParm )
 {
-	AsciiString triggerName = pTriggerParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerParm->getString());
 	if (pTrig == nullptr) return false;
 
@@ -611,7 +607,7 @@ Bool ScriptConditions::evaluateTeamStateIs(Parameter *pTeamParm, Parameter *pSta
 	Team *theTeam = TheScriptEngine->getTeamNamed( pTeamParm->getString() );
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// is being considered for the condition.  jba. :)
-	AsciiString stateName = pStateParm->getString();
+	const AsciiString &stateName = pStateParm->getString();
 	if (theTeam) {
 		return (theTeam->getState() == stateName);
 	}
@@ -627,7 +623,7 @@ Bool ScriptConditions::evaluateTeamStateIsNot(Parameter *pTeamParm, Parameter *p
 	Team *theTeam = TheScriptEngine->getTeamNamed( pTeamParm->getString() );
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// is being considered for the condition.  jba. :)
-	AsciiString stateName = pStateParm->getString();
+	const AsciiString &stateName = pStateParm->getString();
 	if (theTeam) {
 		return (!(theTeam->getState() == stateName));
 	}
@@ -651,7 +647,6 @@ Bool ScriptConditions::evaluateTeamInsideAreaEntirely(Parameter *pTeamParm, Para
 	Team *theTeam = TheScriptEngine->getTeamNamed( pTeamParm->getString() );
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// is being considered for the condition.  jba. :)
-	AsciiString triggerName = pTriggerParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerParm->getString());
 
 	if (pTrig == nullptr)
@@ -1290,7 +1285,7 @@ Bool ScriptConditions::evaluateNamedReachedWaypointsEnd(Parameter *pUnitParm, Pa
 
 	if (!targetWay) return false;
 
-	AsciiString	pathName = pWaypointPathParm->getString();
+	const AsciiString &pathName = pWaypointPathParm->getString();
 
 	if (targetWay->getPathLabel1() == pathName) return true;
 	if (targetWay->getPathLabel2() == pathName) return true;
@@ -1309,7 +1304,7 @@ Bool ScriptConditions::evaluateTeamReachedWaypointsEnd(Parameter *pTeamParm, Par
 		return false;
 	}
 
-	AsciiString	pathName = pWaypointPathParm->getString();
+	const AsciiString &pathName = pWaypointPathParm->getString();
 	Bool anyAtEnd = false;
 	Bool anyNotAtEnd = false;
 	// Note - This returns true if any of the team completed the path.  This is as the current
@@ -2019,7 +2014,6 @@ Bool ScriptConditions::evaluateSkirmishValueInArea(Condition *pCondition, Parame
 		return false;
 	}
 
-	AsciiString triggerName = pTriggerParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerParm->getString());
 
 	if (!pTrig) {
@@ -2574,7 +2568,7 @@ Bool ScriptConditions::evaluateSkirmishPlayerHasDiscoveredPlayer(Parameter *pSki
 //-------------------------------------------------------------------------------------------------
 Bool ScriptConditions::evaluateMusicHasCompleted(Parameter *pMusicParm, Parameter *pIntParm)
 {
-	AsciiString str = pMusicParm->getString();
+	const AsciiString &str = pMusicParm->getString();
 	return TheAudio->hasMusicTrackCompleted(str, pIntParm->getInt());
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -6661,7 +6661,7 @@ Bool ScriptEngine::isSpecialPowerTriggered( Int playerIndex, const AsciiString& 
 
 	for (ListAsciiStringObjectIDIt findIt = specialList->begin(); findIt != specialList->end(); ++findIt)
 	{
-		AsciiStringObjectIDPair pair = *findIt;
+		const AsciiStringObjectIDPair &pair = *findIt;
 		if (pair.first == completedPower && (sourceObj == INVALID_ID || sourceObj == pair.second))
 		{
 			if (removeFromList) {
@@ -6686,7 +6686,7 @@ Bool ScriptEngine::isSpecialPowerMidway( Int playerIndex, const AsciiString& com
 
 	for (ListAsciiStringObjectIDIt findIt = specialList->begin(); findIt != specialList->end(); ++findIt)
 	{
-		AsciiStringObjectIDPair pair = *findIt;
+		const AsciiStringObjectIDPair &pair = *findIt;
 		if (pair.first == completedPower && (sourceObj == INVALID_ID || sourceObj == pair.second))
 		{
 			if (removeFromList) {
@@ -6711,7 +6711,7 @@ Bool ScriptEngine::isSpecialPowerComplete( Int playerIndex, const AsciiString& c
 
 	for (ListAsciiStringObjectIDIt findIt = specialList->begin(); findIt != specialList->end(); ++findIt)
 	{
-		AsciiStringObjectIDPair pair = *findIt;
+		const AsciiStringObjectIDPair &pair = *findIt;
 		if (pair.first == completedPower && (sourceObj == INVALID_ID || sourceObj == pair.second))
 		{
 			if (removeFromList) {
@@ -6736,7 +6736,7 @@ Bool ScriptEngine::isUpgradeComplete( Int playerIndex, const AsciiString& upgrad
 
 	for (ListAsciiStringObjectIDIt findIt = specialList->begin(); findIt != specialList->end(); ++findIt)
 	{
-		AsciiStringObjectIDPair pair = *findIt;
+		const AsciiStringObjectIDPair &pair = *findIt;
 		if (pair.first == upgrade && (sourceObj == INVALID_ID || sourceObj == pair.second))
 		{
 			if (removeFromList) {
@@ -6853,7 +6853,7 @@ void ScriptEngine::adjustToppleDirection( Object *object, Coord2D *direction)
 //-------------------------------------------------------------------------------------------------
 void ScriptEngine::adjustToppleDirection( Object *object, Coord3D *direction)
 {
-	AsciiString objName = object->getName();
+	const AsciiString &objName = object->getName();
 	if (objName.isEmpty() || !direction) {
 		return;
 	}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBridgeBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBridgeBuffer.cpp
@@ -255,7 +255,7 @@ Bool W3DBridge::load(BodyDamageType curDamageState)
 	Int i;
 	for (i=0; i<pObj->Get_Num_Sub_Objects(); i++) {
 		RenderObjClass *pSub = pObj->Get_Sub_Object(i);
-		Matrix3D mtx = pSub->Get_Transform();
+		const Matrix3D& mtx = pSub->Get_Transform();
 		if (0==strnicmp(left, pSub->Get_Name(), strlen(left))) {
 			m_leftMtx = mtx;
 			strlcpy(left, pSub->Get_Name(), ARRAY_SIZE(left));

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
@@ -221,8 +221,7 @@ void W3DDebugIcons::Render(RenderInfoClass & rinfo)
 	DX8Wrapper::Set_Texture(0, nullptr);
 	DX8Wrapper::Apply_Render_State_Changes();
 
-	const Matrix3D& tm = Transform;
-	DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
+	DX8Wrapper::Set_Transform(D3DTS_WORLD,Transform);
 
 	Int numRect = m_numDebugIcons;
 	static Real offset = 30;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
@@ -221,7 +221,7 @@ void W3DDebugIcons::Render(RenderInfoClass & rinfo)
 	DX8Wrapper::Set_Texture(0, nullptr);
 	DX8Wrapper::Apply_Render_State_Changes();
 
-	Matrix3D tm(Transform);
+	const Matrix3D& tm = Transform;
 	DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
 
 	Int numRect = m_numDebugIcons;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DInGameUI.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DInGameUI.cpp
@@ -246,7 +246,7 @@ void DebugHintObject::Render(RenderInfoClass & rinfo)
 		DX8Wrapper::Set_Index_Buffer(m_indexBuffer,0);
 		DX8Wrapper::Set_Vertex_Buffer(m_vertexBufferTile);
 
-		Matrix3D tm(Transform);
+		Matrix3D tm = Transform;
 		Vector3 vec(m_myLoc.x, m_myLoc.y, m_myLoc.z);
 		tm.Set_Translation(vec);
 		DX8Wrapper::Set_Transform(D3DTS_WORLD, tm);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/camera.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/camera.cpp
@@ -618,7 +618,7 @@ void CameraClass::Update_Frustum() const
    float znear,zfar;
 	float znear_dist,zfar_dist;
 
-   Matrix3D cam_mat = Get_Transform();
+   const Matrix3D& cam_mat = Get_Transform();
    Get_View_Plane(vpmin, vpmax); // Normalized view plane at a depth of 1.0
    Get_Clip_Planes(znear_dist, zfar_dist);
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -1412,7 +1412,7 @@ void DazzlePersistFactoryClass::Save(ChunkSaveClass & csave,PersistClass * obj)	
 	DazzleRenderObjClass * robj = (DazzleRenderObjClass *)obj;
 	unsigned int dazzle_type = robj->Get_Dazzle_Type();
 	const char * dazzle_type_name = DazzleRenderObjClass::Get_Type_Name(dazzle_type);
-	Matrix3D tm = robj->Get_Transform();
+	const Matrix3D& tm = robj->Get_Transform();
 
 	csave.Begin_Chunk(DAZZLEFACTORY_CHUNKID_VARIABLES);
 	WRITE_MICRO_CHUNK(csave,DAZZLEFACTORY_VARIABLE_OBJPOINTER,robj);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
@@ -2057,7 +2057,7 @@ bool HLodClass::Get_Proxy (int index, ProxyClass &proxy) const
 		//	Lookup the proxy's transform
 		//
 		HTree->Base_Update(Get_Transform());
-		Matrix3D transform = HTree->Get_Transform((*ProxyArray)[index].Get_Bone_Index());
+		const Matrix3D& transform = HTree->Get_Transform((*ProxyArray)[index].Get_Bone_Index());
 		Set_Hierarchy_Valid(false);
 
 		//

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/light.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/light.cpp
@@ -525,7 +525,7 @@ bool LightClass::Save (ChunkSaveClass &csave)
 	Save_W3D(csave);
 	csave.End_Chunk();
 
-	Matrix3D tm = Get_Transform();
+	const Matrix3D& tm = Get_Transform();
 	csave.Begin_Chunk(LIGHT_CHUNK_VARIABLES);
 	WRITE_MICRO_CHUNK(csave,LIGHT_VARIABLE_TRANSFORM,tm);
 	csave.End_Chunk();

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.cpp
@@ -336,9 +336,6 @@ void MeshModelClass::compose_deformed_vertex_buffer(
 	for (vi = 0; vi < vertex_count;) {
 		const Matrix3D & tm = htree->Get_Transform(bonelink[vi]);
 
-		// Make a copy so we can set the translation to zero
-		Matrix3D mytm=tm;
-
 		int idx=bonelink[vi];
 		int cnt;
 		for (cnt = vi; cnt < vertex_count; cnt++) {
@@ -348,7 +345,7 @@ void MeshModelClass::compose_deformed_vertex_buffer(
 		}
 
 		for (int pidx=0;pidx<cnt-vi;++pidx) {
-			const Matrix3D& A=mytm;
+			const Matrix3D& A=tm;
 			VertexFormatXYZNDUV2* out=verts+vi+pidx;
 			const Vector3& v=*(src_vert+vi+pidx);
 			out->x = (A[0][0] * v.X + A[0][1] * v.Y + A[0][2] * v.Z + A[0][3]);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_buf.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_buf.cpp
@@ -997,7 +997,7 @@ void ParticleBufferClass::Prepare_LOD(CameraClass &camera)
 	// treat them as all being the maximum size and being in the center of the bounding sphere).
 
 	Vector3 cam = camera.Get_Position();
-	ViewportClass viewport = camera.Get_Viewport();
+	const ViewportClass &viewport = camera.Get_Viewport();
 	Vector2 vpr_min, vpr_max;
 	camera.Get_View_Plane(vpr_min, vpr_max);
 	float width_factor = viewport.Width() / (vpr_max.X - vpr_min.X);

--- a/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -1687,7 +1687,7 @@ void DrawObject::Render(RenderInfoClass & rinfo)
 			Bool isTree = false;
 
 			Vector3 vec(loc.x, loc.y, loc.z);
-			Matrix3D tm(Transform);
+			Matrix3D tm = Transform;
 			Matrix3x3 rot(true);
 			rot.Rotate_Z(pMapObj->getAngle());
 
@@ -1749,7 +1749,7 @@ void DrawObject::Render(RenderInfoClass & rinfo)
 					count++;
 
 					Vector3 vec(loc.x, loc.y, loc.z);
-					Matrix3D tm(Transform);
+					Matrix3D tm = Transform;
 					tm.Set_Translation(vec);
 
 					int polyCount = NUM_TRI;
@@ -1804,7 +1804,7 @@ void DrawObject::Render(RenderInfoClass & rinfo)
 			count++;
 // ok to here.
 			Vector3 vec(loc.x, loc.y, loc.z);
-			Matrix3D tmXX(Transform);
+			Matrix3D tmXX = Transform;
 			Matrix3x3 rot(true);
 			rot.Rotate_Z(pBuild->getAngle());
 

--- a/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -1758,8 +1758,7 @@ void DrawObject::Render(RenderInfoClass & rinfo)
 					DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
 					DX8Wrapper::Draw_Triangles(	0,polyCount, 0,	(m_numTriangles*3));
 				}
-				const Matrix3D& tmReset = Transform;
-				DX8Wrapper::Set_Transform(D3DTS_WORLD,tmReset);
+				DX8Wrapper::Set_Transform(D3DTS_WORLD,Transform);
 				DX8Wrapper::Set_Vertex_Buffer(m_vertexBufferTile1);
 				updatePolygonVB(pTrig, polySelected, polySelected && PolygonTool::isSelectedOpen());
  				DX8Wrapper::Set_Vertex_Buffer(m_vertexFeedback);
@@ -1801,12 +1800,9 @@ void DrawObject::Render(RenderInfoClass & rinfo)
 			count++;
 // ok to here.
 			Vector3 vec(loc.x, loc.y, loc.z);
-			Matrix3D tmXX = Transform;
 			Matrix3x3 rot(true);
 			rot.Rotate_Z(pBuild->getAngle());
-
-			tmXX.Set_Translation(vec);
-			tmXX.Set_Rotation(rot);
+			Matrix3D tmXX(rot, vec);
 			int polyCountA = NUM_TRI;
 			if (!pBuild->isSelected()) {
 				polyCountA -= NUM_ARROW_TRI+NUM_SELECT_TRI;
@@ -1823,8 +1819,7 @@ void DrawObject::Render(RenderInfoClass & rinfo)
 	DX8Wrapper::Set_Vertex_Buffer(nullptr);	//release reference to vertex buffer
 	DX8Wrapper::Set_Index_Buffer(nullptr,0);	//release reference to vertex buffer
 
-	const Matrix3D& tmReset = Transform;
-	DX8Wrapper::Set_Transform(D3DTS_WORLD,tmReset);
+	DX8Wrapper::Set_Transform(D3DTS_WORLD,Transform);
 
 	if (m_drawWaypoints) {
 		updateWaypointVB();

--- a/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -1761,7 +1761,7 @@ void DrawObject::Render(RenderInfoClass & rinfo)
 					DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
 					DX8Wrapper::Draw_Triangles(	0,polyCount, 0,	(m_numTriangles*3));
 				}
-				Matrix3D tmReset(Transform);
+				const Matrix3D& tmReset = Transform;
 				DX8Wrapper::Set_Transform(D3DTS_WORLD,tmReset);
 				DX8Wrapper::Set_Vertex_Buffer(m_vertexBufferTile1);
 				updatePolygonVB(pTrig, polySelected, polySelected && PolygonTool::isSelectedOpen());
@@ -1826,7 +1826,7 @@ void DrawObject::Render(RenderInfoClass & rinfo)
 	DX8Wrapper::Set_Vertex_Buffer(nullptr);	//release reference to vertex buffer
 	DX8Wrapper::Set_Index_Buffer(nullptr,0);	//release reference to vertex buffer
 
-	Matrix3D tmReset(Transform);
+	const Matrix3D& tmReset = Transform;
 	DX8Wrapper::Set_Transform(D3DTS_WORLD,tmReset);
 
 	if (m_drawWaypoints) {

--- a/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -1687,12 +1687,9 @@ void DrawObject::Render(RenderInfoClass & rinfo)
 			Bool isTree = false;
 
 			Vector3 vec(loc.x, loc.y, loc.z);
-			Matrix3D tm = Transform;
 			Matrix3x3 rot(true);
 			rot.Rotate_Z(pMapObj->getAngle());
-
-			tm.Set_Translation(vec);
-			tm.Set_Rotation(rot);
+			Matrix3D tm(rot, vec);
 			int polyCount = NUM_TRI;
 			if (!pMapObj->isSelected()) {
 				polyCount -= NUM_ARROW_TRI+NUM_SELECT_TRI;

--- a/Generals/Code/Tools/WorldBuilder/src/EditObjectParameter.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/EditObjectParameter.cpp
@@ -118,7 +118,7 @@ void EditObjectParameter::addObject( const ThingTemplate *thingTemplate  )
 			parent = findOrAdd( parent, "TEST" );
 
 		// first sort by Side, either create or find the tree item with matching side name
-		AsciiString side = thingTemplate->getDefaultOwningSide();
+		const AsciiString &side = thingTemplate->getDefaultOwningSide();
 		DEBUG_ASSERTCRASH(!side.isEmpty(), ("null default side in template") );
 		parent = findOrAdd( parent, side.str());
 

--- a/Generals/Code/Tools/WorldBuilder/src/EditParameter.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/EditParameter.cpp
@@ -789,7 +789,7 @@ Bool EditParameter::loadUpgrades(CComboBox *pCombo, AsciiString match)
 
 	for (int i = 0; i < numUpgrades; ++i) {
 
-		AsciiString upgradeName = upgradeNames[i];
+		const AsciiString &upgradeName = upgradeNames[i];
 		if (pCombo) {
 			pCombo->AddString(upgradeName.str());
 		}

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
@@ -1004,7 +1004,7 @@ void ScriptDialog::markWaypoint(MapObject *pObj)
 void ScriptDialog::scanParmForWaypointsAndTeams(Parameter *pParm, Bool doUnits, Bool doWaypoints, Bool doTriggers)
 {
 	if (pParm->getParameterType() == Parameter::WAYPOINT && doWaypoints) {
-		AsciiString waypointName  = pParm->getString();
+		const AsciiString &waypointName  = pParm->getString();
 		MapObject *pObj;
 		for (pObj = MapObject::getFirstMapObject(); pObj; pObj = pObj->getNext()) {
 			if (pObj->isWaypoint() && pObj->getWaypointName()==waypointName) {
@@ -1013,7 +1013,7 @@ void ScriptDialog::scanParmForWaypointsAndTeams(Parameter *pParm, Bool doUnits, 
 		}
 	}
 	if (pParm->getParameterType() == Parameter::WAYPOINT_PATH && doWaypoints) {
-		AsciiString waypointPathLabel = pParm->getString();
+		const AsciiString &waypointPathLabel = pParm->getString();
 		MapObject *pObj;
 		for (pObj = MapObject::getFirstMapObject(); pObj; pObj = pObj->getNext()) {
 			if (pObj->isWaypoint() ) {
@@ -1031,7 +1031,7 @@ void ScriptDialog::scanParmForWaypointsAndTeams(Parameter *pParm, Bool doUnits, 
 		}
 	}
 	if (pParm->getParameterType() == Parameter::TEAM) {
-		AsciiString teamName  = pParm->getString();
+		const AsciiString &teamName  = pParm->getString();
 		TeamsInfo * pInfo = m_sides.findTeamInfo(teamName);
 		if (pInfo) {
 			pInfo->getDict()->setBool(TheKey_exportWithScript, true);
@@ -1048,7 +1048,7 @@ void ScriptDialog::scanParmForWaypointsAndTeams(Parameter *pParm, Bool doUnits, 
 		}
 	}
 	if (pParm->getParameterType() == Parameter::UNIT) {
-		AsciiString unitName  = pParm->getString();
+		const AsciiString &unitName  = pParm->getString();
 		if (doUnits) {
 			MapObject *pObj;
 			for (pObj = MapObject::getFirstMapObject(); pObj; pObj = pObj->getNext()) {

--- a/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -1633,7 +1633,7 @@ Bool WbView3d::viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain)
 	float logY = (Real)curPt.y / (Real)client.Height();
 	Vector3 intersection(0,0,0);
 	// determine the ray corresponding to the camera and distance to projection plane
-	Matrix3D camera_matrix = m_camera->Get_Transform();
+	const Matrix3D& camera_matrix = m_camera->Get_Transform();
 
 	Vector3 camera_location  = m_camera->Get_Position();
 
@@ -1761,7 +1761,7 @@ Bool WbView3d::viewToDocCoordZ(CPoint curPt, Coord3D *newPt, Real theZ)
 	float logY = (Real)curPt.y / (Real)client.Height();
 	Vector3 intersection(0,0,0);
 	// determine the ray corresponding to the camera and distance to projection plane
-	Matrix3D camera_matrix = m_camera->Get_Transform();
+	const Matrix3D& camera_matrix = m_camera->Get_Transform();
 
 	Vector3 camera_location  = m_camera->Get_Position();
 
@@ -1816,7 +1816,7 @@ void WbView3d::updateHysteresis()
 	float logY = (Real)curPt.y / (Real)client.Height();
 	Vector3 intersection(0,0,0);
 	// determine the ray corresponding to the camera and distance to projection plane
-	Matrix3D camera_matrix = m_camera->Get_Transform();
+	const Matrix3D& camera_matrix = m_camera->Get_Transform();
 
 	Vector3 camera_location  = m_camera->Get_Position();
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -3735,7 +3735,7 @@ void Player::processSelectTeamGameMessage(Int hotkeyNum) {
 
 	m_currentSelection->clearSquad();
 
-	VecObjectPtr objectList = m_squads[hotkeyNum]->getLiveObjects();
+	const VecObjectPtr& objectList = m_squads[hotkeyNum]->getLiveObjects();
 	Int numObjs = objectList.size();
 
 	for (Int i = 0; i < numObjs; ++i)
@@ -3767,7 +3767,7 @@ void Player::processAddTeamGameMessage(Int hotkeyNum) {
 		m_currentSelection = newInstance( Squad );
 	}
 
-	VecObjectPtr objectList = m_squads[hotkeyNum]->getLiveObjects();
+	const VecObjectPtr& objectList = m_squads[hotkeyNum]->getLiveObjects();
 	Int numObjs = objectList.size();
 
 	for (Int i = 0; i < numObjs; ++i) {

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/Module.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/Module.cpp
@@ -269,7 +269,7 @@ Bool UpgradeMuxData::isTriggeredBy(const std::string &upgrade) const
 	std::vector<AsciiString>::const_iterator it;
 	for( it = m_triggerUpgradeNames.begin(); it != m_triggerUpgradeNames.end();	++it)
 	{
-		AsciiString trigger = *it;
+		const AsciiString &trigger = *it;
 		if (stricmp(trigger.str(), upgrade.c_str()) == 0)
 		{
 			return TRUE;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -699,7 +699,7 @@ void PopulateOldBuddyMessages()
 	BuddyMessageList *messages = TheGameSpyInfo->getBuddyMessages();
 	for (BuddyMessageList::iterator mIt = messages->begin(); mIt != messages->end(); ++mIt)
 	{
-		BuddyMessage message = *mIt;
+		const BuddyMessage &message = *mIt;
 		insertChat(message);
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -584,7 +584,7 @@ static void populateQuickMatchMapSelectListbox( QuickMatchPreferences& pref )
 	GadgetListBoxReset(listboxMapSelect);
 	for (std::list<AsciiString>::const_iterator it = maps.begin(); it != maps.end(); ++it)
 	{
-		AsciiString theMap = *it;
+		const AsciiString &theMap = *it;
 		const MapMetaData *md = TheMapCache->findMap(theMap);
 		if (md && md->m_numPlayers >= numPlayers)
 		{
@@ -1719,7 +1719,7 @@ WindowMsgHandledType WOLQuickMatchMenuSystem( GameWindow *window, UnsignedInt ms
 						if (cit != ladderInfo->validFactions.end())
 						{
 							Int numPlayerTemplates = ThePlayerTemplateStore->getPlayerTemplateCount();
-							AsciiString sideStr = *cit;
+							const AsciiString &sideStr = *cit;
 							DEBUG_LOG(("Chose %s as our side... finding", sideStr.str()));
 							for (Int c=0; c<numPlayerTemplates; ++c)
 							{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5993,7 +5993,7 @@ Object *AIAttackSquadState::chooseVictim()
 		case DIFFICULTY_EASY:
 		{
 			// pick a random unit
-			VecObjectPtr objects = victimSquad->getLiveObjects();
+			const VecObjectPtr& objects = victimSquad->getLiveObjects();
 			Int numUnits = objects.size();
 			if (numUnits == 0)
 			{
@@ -6021,7 +6021,7 @@ Object *AIAttackSquadState::chooseVictim()
 		case DIFFICULTY_HARD:
 		{
 			// everyone picks the same unit
-			VecObjectPtr objects = victimSquad->getLiveObjects();
+			const VecObjectPtr& objects = victimSquad->getLiveObjects();
 			if (!objects.empty())
 			{
 				return objects[0];

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/OCLUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/OCLUpdate.cpp
@@ -209,7 +209,7 @@ UpdateSleepTime OCLUpdate::update()
 			// Loop through the list of faction ocls to find the matching faction that triggers the specific ocls
 			for (OCLUpdateModuleData::FactionOCLList::const_iterator it = data->m_factionOCL.begin(); it != data->m_factionOCL.end(); ++it)
 			{
-				OCLUpdateModuleData::FactionOCLInfo info = *it;
+				const OCLUpdateModuleData::FactionOCLInfo &info = *it;
 				if (playerFactionName == info.m_factionName)
 				{
 					ObjectCreationList::create( info.m_ocl, getObject(), &creationCoord, getObject()->getPosition(), getObject()->getOrientation() );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -637,7 +637,7 @@ void ScriptActions::doCreateReinforcements(const AsciiString& team, const AsciiS
 
 		PartitionSolver partition(vecOfUnits, vecOfTransports, PREFER_FAST_SOLUTION);
 		partition.solve();
-		SolutionVec solution = partition.getSolution();
+		const SolutionVec& solution = partition.getSolution();
 		for (size_t i = 0; i < solution.size(); ++i) {
 			Object *unit = TheGameLogic->findObjectByID(solution[i].first);
 			Object *trans = TheGameLogic->findObjectByID(solution[i].second);
@@ -1511,7 +1511,7 @@ void ScriptActions::doLoadAllTransports(const AsciiString& teamName)
 
 	PartitionSolver partition(vecOfUnits, vecOfTransports, PREFER_FAST_SOLUTION);
 	partition.solve();
-	SolutionVec solution = partition.getSolution();
+	const SolutionVec& solution = partition.getSolution();
 	for (size_t i = 0; i < solution.size(); ++i) {
 		Object *unit = TheGameLogic->findObjectByID(solution[i].first);
 		Object *trans = TheGameLogic->findObjectByID(solution[i].second);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -199,7 +199,7 @@ void ScriptConditions::objectTypesFromParam(Parameter *pTypeParm, ObjectTypes *o
 		return;
 	}
 
-	AsciiString str = pTypeParm->getString();
+	const AsciiString &str = pTypeParm->getString();
 
 	if (str.isEmpty()) {
 		return;
@@ -355,7 +355,7 @@ Bool ScriptConditions::evaluateNamedUnitTotallyDead(Parameter *pUnitParm)
 //-------------------------------------------------------------------------------------------------
 Bool ScriptConditions::evaluateHasUnits(Parameter *pTeamParm)
 {
-	AsciiString desiredTeamName = pTeamParm->getString();
+	const AsciiString &desiredTeamName = pTeamParm->getString();
 	// If they are calling a <this team> condition, do it.
 	if (desiredTeamName == THIS_TEAM) {
 		Team *theTeam = TheScriptEngine->getTeamNamed( desiredTeamName );
@@ -396,7 +396,6 @@ Bool ScriptConditions::evaluateTeamInsideAreaPartially(Parameter *pTeamParm, Par
 	Team *theTeam = TheScriptEngine->getTeamNamed( pTeamParm->getString() );
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// is being considered for the condition.  jba. :)
-	AsciiString triggerName = pTriggerAreaParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerAreaParm->getString());
 
 	if (pTrig == nullptr) return false;
@@ -418,7 +417,6 @@ Bool ScriptConditions::evaluateNamedInsideArea(Parameter *pUnitParm, Parameter *
 		return false;
 	}
 
-	AsciiString triggerName = pTriggerAreaParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerAreaParm->getString());
 	if (pTrig == nullptr) return false;
 	if (theObj) {
@@ -435,7 +433,6 @@ Bool ScriptConditions::evaluateNamedInsideArea(Parameter *pUnitParm, Parameter *
 //-------------------------------------------------------------------------------------------------
 Bool ScriptConditions::evaluatePlayerHasUnitTypeInArea(Condition *pCondition, Parameter *pPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm, Parameter *pTypeParm, Parameter *pTriggerParm )
 {
-	AsciiString triggerName = pTriggerParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerParm->getString());
 	if (pTrig == nullptr) return false;
 
@@ -528,7 +525,6 @@ Bool ScriptConditions::evaluatePlayerHasUnitTypeInArea(Condition *pCondition, Pa
 //-------------------------------------------------------------------------------------------------
 Bool ScriptConditions::evaluatePlayerHasUnitKindInArea(Condition *pCondition, Parameter *pPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm, Parameter *pKindParm, Parameter *pTriggerParm )
 {
-	AsciiString triggerName = pTriggerParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerParm->getString());
 	if (pTrig == nullptr) return false;
 
@@ -612,7 +608,7 @@ Bool ScriptConditions::evaluateTeamStateIs(Parameter *pTeamParm, Parameter *pSta
 	Team *theTeam = TheScriptEngine->getTeamNamed( pTeamParm->getString() );
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// is being considered for the condition.  jba. :)
-	AsciiString stateName = pStateParm->getString();
+	const AsciiString &stateName = pStateParm->getString();
 	if (theTeam) {
 		return (theTeam->getState() == stateName);
 	}
@@ -628,7 +624,7 @@ Bool ScriptConditions::evaluateTeamStateIsNot(Parameter *pTeamParm, Parameter *p
 	Team *theTeam = TheScriptEngine->getTeamNamed( pTeamParm->getString() );
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// is being considered for the condition.  jba. :)
-	AsciiString stateName = pStateParm->getString();
+	const AsciiString &stateName = pStateParm->getString();
 	if (theTeam) {
 		return (!(theTeam->getState() == stateName));
 	}
@@ -652,7 +648,6 @@ Bool ScriptConditions::evaluateTeamInsideAreaEntirely(Parameter *pTeamParm, Para
 	Team *theTeam = TheScriptEngine->getTeamNamed( pTeamParm->getString() );
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// is being considered for the condition.  jba. :)
-	AsciiString triggerName = pTriggerParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerParm->getString());
 
 	if (pTrig == nullptr)
@@ -1333,7 +1328,7 @@ Bool ScriptConditions::evaluateNamedReachedWaypointsEnd(Parameter *pUnitParm, Pa
 
 	if (!targetWay) return false;
 
-	AsciiString	pathName = pWaypointPathParm->getString();
+	const AsciiString &pathName = pWaypointPathParm->getString();
 
 	if (targetWay->getPathLabel1() == pathName) return true;
 	if (targetWay->getPathLabel2() == pathName) return true;
@@ -1352,7 +1347,7 @@ Bool ScriptConditions::evaluateTeamReachedWaypointsEnd(Parameter *pTeamParm, Par
 		return false;
 	}
 
-	AsciiString	pathName = pWaypointPathParm->getString();
+	const AsciiString &pathName = pWaypointPathParm->getString();
 	Bool anyAtEnd = false;
 	Bool anyNotAtEnd = false;
 	// Note - This returns true if any of the team completed the path.  This is as the current
@@ -2112,7 +2107,6 @@ Bool ScriptConditions::evaluateSkirmishValueInArea(Condition *pCondition, Parame
 		return false;
 	}
 
-	AsciiString triggerName = pTriggerParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerParm->getString());
 
 	if (!pTrig) {
@@ -2491,7 +2485,6 @@ Bool ScriptConditions::evaluateSkirmishNamedAreaExists(Parameter *, Parameter *p
 //-------------------------------------------------------------------------------------------------
 Bool ScriptConditions::evaluateSkirmishPlayerHasUnitsInArea(Condition *pCondition, Parameter *pSkirmishPlayerParm, Parameter *pTriggerParm )
 {
-	AsciiString triggerName = pTriggerParm->getString();
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(pTriggerParm->getString());
 	if (pTrig == nullptr) return false;
 
@@ -2683,7 +2676,7 @@ Bool ScriptConditions::evaluateSkirmishPlayerHasDiscoveredPlayer(Parameter *pSki
 //-------------------------------------------------------------------------------------------------
 Bool ScriptConditions::evaluateMusicHasCompleted(Parameter *pMusicParm, Parameter *pIntParm)
 {
-	AsciiString str = pMusicParm->getString();
+	const AsciiString &str = pMusicParm->getString();
 	return TheAudio->hasMusicTrackCompleted(str, pIntParm->getInt());
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -7362,7 +7362,7 @@ Bool ScriptEngine::isSpecialPowerTriggered( Int playerIndex, const AsciiString& 
 
 	for (ListAsciiStringObjectIDIt findIt = specialList->begin(); findIt != specialList->end(); ++findIt)
 	{
-		AsciiStringObjectIDPair pair = *findIt;
+		const AsciiStringObjectIDPair &pair = *findIt;
 		if (pair.first == completedPower && (sourceObj == INVALID_ID || sourceObj == pair.second))
 		{
 			if (removeFromList) {
@@ -7387,7 +7387,7 @@ Bool ScriptEngine::isSpecialPowerMidway( Int playerIndex, const AsciiString& com
 
 	for (ListAsciiStringObjectIDIt findIt = specialList->begin(); findIt != specialList->end(); ++findIt)
 	{
-		AsciiStringObjectIDPair pair = *findIt;
+		const AsciiStringObjectIDPair &pair = *findIt;
 		if (pair.first == completedPower && (sourceObj == INVALID_ID || sourceObj == pair.second))
 		{
 			if (removeFromList) {
@@ -7412,7 +7412,7 @@ Bool ScriptEngine::isSpecialPowerComplete( Int playerIndex, const AsciiString& c
 
 	for (ListAsciiStringObjectIDIt findIt = specialList->begin(); findIt != specialList->end(); ++findIt)
 	{
-		AsciiStringObjectIDPair pair = *findIt;
+		const AsciiStringObjectIDPair &pair = *findIt;
 		if (pair.first == completedPower && (sourceObj == INVALID_ID || sourceObj == pair.second))
 		{
 			if (removeFromList) {
@@ -7437,7 +7437,7 @@ Bool ScriptEngine::isUpgradeComplete( Int playerIndex, const AsciiString& upgrad
 
 	for (ListAsciiStringObjectIDIt findIt = specialList->begin(); findIt != specialList->end(); ++findIt)
 	{
-		AsciiStringObjectIDPair pair = *findIt;
+		const AsciiStringObjectIDPair &pair = *findIt;
 		if (pair.first == upgrade && (sourceObj == INVALID_ID || sourceObj == pair.second))
 		{
 			if (removeFromList) {
@@ -7554,7 +7554,7 @@ void ScriptEngine::adjustToppleDirection( Object *object, Coord2D *direction)
 //-------------------------------------------------------------------------------------------------
 void ScriptEngine::adjustToppleDirection( Object *object, Coord3D *direction)
 {
-	AsciiString objName = object->getName();
+	const AsciiString &objName = object->getName();
 	if (objName.isEmpty() || !direction) {
 		return;
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBridgeBuffer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBridgeBuffer.cpp
@@ -255,7 +255,7 @@ Bool W3DBridge::load(BodyDamageType curDamageState)
 	Int i;
 	for (i=0; i<pObj->Get_Num_Sub_Objects(); i++) {
 		RenderObjClass *pSub = pObj->Get_Sub_Object(i);
-		Matrix3D mtx = pSub->Get_Transform();
+		const Matrix3D& mtx = pSub->Get_Transform();
 		if (0==strnicmp(left, pSub->Get_Name(), strlen(left))) {
 			m_leftMtx = mtx;
 			strlcpy(left, pSub->Get_Name(), ARRAY_SIZE(left));

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
@@ -221,8 +221,7 @@ void W3DDebugIcons::Render(RenderInfoClass & rinfo)
 	DX8Wrapper::Set_Texture(0, nullptr);
 	DX8Wrapper::Apply_Render_State_Changes();
 
-	const Matrix3D& tm = Transform;
-	DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
+	DX8Wrapper::Set_Transform(D3DTS_WORLD,Transform);
 
 	Int numRect = m_numDebugIcons;
 	static Real offset = 30;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
@@ -221,7 +221,7 @@ void W3DDebugIcons::Render(RenderInfoClass & rinfo)
 	DX8Wrapper::Set_Texture(0, nullptr);
 	DX8Wrapper::Apply_Render_State_Changes();
 
-	Matrix3D tm(Transform);
+	const Matrix3D& tm = Transform;
 	DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
 
 	Int numRect = m_numDebugIcons;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DInGameUI.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DInGameUI.cpp
@@ -246,7 +246,7 @@ void DebugHintObject::Render(RenderInfoClass & rinfo)
 		DX8Wrapper::Set_Index_Buffer(m_indexBuffer,0);
 		DX8Wrapper::Set_Vertex_Buffer(m_vertexBufferTile);
 
-		Matrix3D tm(Transform);
+		Matrix3D tm = Transform;
 		Vector3 vec(m_myLoc.x, m_myLoc.y, m_myLoc.z);
 		tm.Set_Translation(vec);
 		DX8Wrapper::Set_Transform(D3DTS_WORLD, tm);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/camera.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/camera.cpp
@@ -618,7 +618,7 @@ void CameraClass::Update_Frustum() const
    float znear,zfar;
 	float znear_dist,zfar_dist;
 
-   Matrix3D cam_mat = Get_Transform();
+   const Matrix3D& cam_mat = Get_Transform();
    Get_View_Plane(vpmin, vpmax); // Normalized view plane at a depth of 1.0
    Get_Clip_Planes(znear_dist, zfar_dist);
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -948,7 +948,7 @@ void DazzleRenderObjClass::Render(RenderInfoClass & rinfo)
 			DX8Wrapper::Get_Transform(D3DTS_PROJECTION,projection_transform);
 			Vector3 camera_loc(rinfo.Camera.Get_Position());
 			Vector3 camera_dir(-view_transform[2][0],-view_transform[2][1],-view_transform[2][2]);
-//			Matrix3D cam(rinfo.Camera.Get_Transform());
+//			const Matrix3D& cam = rinfo.Camera.Get_Transform();
 //			Vector3 camera_dir(-cam[2][0],-cam[2][1],-cam[2][2]);
 //			camera_dir.Normalize();
 
@@ -1515,7 +1515,7 @@ void DazzlePersistFactoryClass::Save(ChunkSaveClass & csave,PersistClass * obj)	
 	DazzleRenderObjClass * robj = (DazzleRenderObjClass *)obj;
 	unsigned int dazzle_type = robj->Get_Dazzle_Type();
 	const char * dazzle_type_name = DazzleRenderObjClass::Get_Type_Name(dazzle_type);
-	Matrix3D tm = robj->Get_Transform();
+	const Matrix3D& tm = robj->Get_Transform();
 
 	csave.Begin_Chunk(DAZZLEFACTORY_CHUNKID_VARIABLES);
 	WRITE_MICRO_CHUNK(csave,DAZZLEFACTORY_VARIABLE_OBJPOINTER,robj);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
@@ -2057,7 +2057,7 @@ bool HLodClass::Get_Proxy (int index, ProxyClass &proxy) const
 		//	Lookup the proxy's transform
 		//
 		HTree->Base_Update(Get_Transform());
-		Matrix3D transform = HTree->Get_Transform((*ProxyArray)[index].Get_Bone_Index());
+		const Matrix3D& transform = HTree->Get_Transform((*ProxyArray)[index].Get_Bone_Index());
 		Set_Hierarchy_Valid(false);
 
 		//

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/light.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/light.cpp
@@ -525,7 +525,7 @@ bool LightClass::Save (ChunkSaveClass &csave)
 	Save_W3D(csave);
 	csave.End_Chunk();
 
-	Matrix3D tm = Get_Transform();
+	const Matrix3D& tm = Get_Transform();
 	csave.Begin_Chunk(LIGHT_CHUNK_VARIABLES);
 	WRITE_MICRO_CHUNK(csave,LIGHT_VARIABLE_TRANSFORM,tm);
 	csave.End_Chunk();

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/part_buf.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/part_buf.cpp
@@ -1285,7 +1285,7 @@ void ParticleBufferClass::Prepare_LOD(CameraClass &camera)
 	// treat them as all being the maximum size and being in the center of the bounding sphere).
 
 	Vector3 cam = camera.Get_Position();
-	ViewportClass viewport = camera.Get_Viewport();
+	const ViewportClass &viewport = camera.Get_Viewport();
 	Vector2 vpr_min, vpr_max;
 	camera.Get_View_Plane(vpr_min, vpr_max);
 	float width_factor = viewport.Width() / (vpr_max.X - vpr_min.X);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -2205,12 +2205,9 @@ if (pMapObj->isSelected()) {
 			Bool isTree = false;
 
 			Vector3 vec(loc.x, loc.y, loc.z);
-			Matrix3D tm = Transform;
 			Matrix3x3 rot(true);
 			rot.Rotate_Z(pMapObj->getAngle());
-
-			tm.Set_Translation(vec);
-			tm.Set_Rotation(rot);
+			Matrix3D tm(rot, vec);
 			int polyCount = NUM_TRI;
 			if (!pMapObj->isSelected()) {
 				polyCount -= NUM_ARROW_TRI+NUM_SELECT_TRI;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -2277,7 +2277,7 @@ if (pMapObj->isSelected()) {
 					DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
 					DX8Wrapper::Draw_Triangles(	0,polyCount, 0,	(m_numTriangles*3));
 				}
-				Matrix3D tmReset(Transform);
+				const Matrix3D& tmReset = Transform;
 				DX8Wrapper::Set_Transform(D3DTS_WORLD,tmReset);
 				DX8Wrapper::Set_Vertex_Buffer(m_vertexBufferTile1);
 				updatePolygonVB(pTrig, polySelected, polySelected && PolygonTool::isSelectedOpen());
@@ -2339,7 +2339,7 @@ if (pMapObj->isSelected()) {
 
 	DX8Wrapper::Set_Index_Buffer(m_indexBuffer,0);
  	DX8Wrapper::Set_Vertex_Buffer(m_vertexBufferWater);
-	Matrix3D tmReset(Transform);
+	const Matrix3D& tmReset = Transform;
 	DX8Wrapper::Set_Transform(D3DTS_WORLD,tmReset);
 
 	if (m_drawWaypoints) {

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -2274,8 +2274,7 @@ if (pMapObj->isSelected()) {
 					DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
 					DX8Wrapper::Draw_Triangles(	0,polyCount, 0,	(m_numTriangles*3));
 				}
-				const Matrix3D& tmReset = Transform;
-				DX8Wrapper::Set_Transform(D3DTS_WORLD,tmReset);
+				DX8Wrapper::Set_Transform(D3DTS_WORLD,Transform);
 				DX8Wrapper::Set_Vertex_Buffer(m_vertexBufferTile1);
 				updatePolygonVB(pTrig, polySelected, polySelected && PolygonTool::isSelectedOpen());
  				DX8Wrapper::Set_Vertex_Buffer(m_vertexFeedback);
@@ -2315,12 +2314,9 @@ if (pMapObj->isSelected()) {
 			count++;
 // ok to here.
 			Vector3 vec(loc.x, loc.y, loc.z);
-			Matrix3D tmXX = Transform;
 			Matrix3x3 rot(true);
 			rot.Rotate_Z(pBuild->getAngle());
-
-			tmXX.Set_Translation(vec);
-			tmXX.Set_Rotation(rot);
+			Matrix3D tmXX(rot, vec);
 			int polyCountA = NUM_TRI;
 			if (!pBuild->isSelected()) {
 				polyCountA -= NUM_ARROW_TRI+NUM_SELECT_TRI;
@@ -2336,8 +2332,7 @@ if (pMapObj->isSelected()) {
 
 	DX8Wrapper::Set_Index_Buffer(m_indexBuffer,0);
  	DX8Wrapper::Set_Vertex_Buffer(m_vertexBufferWater);
-	const Matrix3D& tmReset = Transform;
-	DX8Wrapper::Set_Transform(D3DTS_WORLD,tmReset);
+	DX8Wrapper::Set_Transform(D3DTS_WORLD,Transform);
 
 	if (m_drawWaypoints) {
 		updateWaypointVB();

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -2205,7 +2205,7 @@ if (pMapObj->isSelected()) {
 			Bool isTree = false;
 
 			Vector3 vec(loc.x, loc.y, loc.z);
-			Matrix3D tm(Transform);
+			Matrix3D tm = Transform;
 			Matrix3x3 rot(true);
 			rot.Rotate_Z(pMapObj->getAngle());
 
@@ -2265,7 +2265,7 @@ if (pMapObj->isSelected()) {
 					count++;
 
 					Vector3 vec(loc.x, loc.y, loc.z);
-					Matrix3D tm(Transform);
+					Matrix3D tm = Transform;
 					tm.Set_Translation(vec);
 
 					int polyCount = NUM_TRI;
@@ -2318,7 +2318,7 @@ if (pMapObj->isSelected()) {
 			count++;
 // ok to here.
 			Vector3 vec(loc.x, loc.y, loc.z);
-			Matrix3D tmXX(Transform);
+			Matrix3D tmXX = Transform;
 			Matrix3x3 rot(true);
 			rot.Rotate_Z(pBuild->getAngle());
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/EditObjectParameter.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/EditObjectParameter.cpp
@@ -118,7 +118,7 @@ void EditObjectParameter::addObject( const ThingTemplate *thingTemplate  )
 			parent = findOrAdd( parent, "TEST" );
 
 		// first sort by Side, either create or find the tree item with matching side name
-		AsciiString side = thingTemplate->getDefaultOwningSide();
+		const AsciiString &side = thingTemplate->getDefaultOwningSide();
 		DEBUG_ASSERTCRASH(!side.isEmpty(), ("null default side in template") );
 		parent = findOrAdd( parent, side.str());
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/EditParameter.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/EditParameter.cpp
@@ -819,7 +819,7 @@ Bool EditParameter::loadUpgrades(CComboBox *pCombo, AsciiString match)
 
 	for (int i = 0; i < numUpgrades; ++i) {
 
-		AsciiString upgradeName = upgradeNames[i];
+		const AsciiString &upgradeName = upgradeNames[i];
 		if (pCombo) {
 			pCombo->AddString(upgradeName.str());
 		}

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
@@ -1156,7 +1156,7 @@ void ScriptDialog::markWaypoint(MapObject *pObj)
 void ScriptDialog::scanParmForWaypointsAndTeams(Parameter *pParm, Bool doUnits, Bool doWaypoints, Bool doTriggers)
 {
 	if (pParm->getParameterType() == Parameter::WAYPOINT && doWaypoints) {
-		AsciiString waypointName  = pParm->getString();
+		const AsciiString &waypointName  = pParm->getString();
 		MapObject *pObj;
 		for (pObj = MapObject::getFirstMapObject(); pObj; pObj = pObj->getNext()) {
 			if (pObj->isWaypoint() && pObj->getWaypointName()==waypointName) {
@@ -1165,7 +1165,7 @@ void ScriptDialog::scanParmForWaypointsAndTeams(Parameter *pParm, Bool doUnits, 
 		}
 	}
 	if (pParm->getParameterType() == Parameter::WAYPOINT_PATH && doWaypoints) {
-		AsciiString waypointPathLabel = pParm->getString();
+		const AsciiString &waypointPathLabel = pParm->getString();
 		MapObject *pObj;
 		for (pObj = MapObject::getFirstMapObject(); pObj; pObj = pObj->getNext()) {
 			if (pObj->isWaypoint() ) {
@@ -1183,7 +1183,7 @@ void ScriptDialog::scanParmForWaypointsAndTeams(Parameter *pParm, Bool doUnits, 
 		}
 	}
 	if (pParm->getParameterType() == Parameter::TEAM) {
-		AsciiString teamName  = pParm->getString();
+		const AsciiString &teamName  = pParm->getString();
 		TeamsInfo * pInfo = m_sides.findTeamInfo(teamName);
 		if (pInfo) {
 			pInfo->getDict()->setBool(TheKey_exportWithScript, true);
@@ -1200,7 +1200,7 @@ void ScriptDialog::scanParmForWaypointsAndTeams(Parameter *pParm, Bool doUnits, 
 		}
 	}
 	if (pParm->getParameterType() == Parameter::UNIT) {
-		AsciiString unitName  = pParm->getString();
+		const AsciiString &unitName  = pParm->getString();
 		if (doUnits) {
 			MapObject *pObj;
 			for (pObj = MapObject::getFirstMapObject(); pObj; pObj = pObj->getNext()) {

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -1714,7 +1714,7 @@ Bool WbView3d::viewToDocCoords(CPoint curPt, Coord3D *newPt, Bool constrain)
 	float logY = (Real)curPt.y / (Real)client.Height();
 	Vector3 intersection(0,0,0);
 	// determine the ray corresponding to the camera and distance to projection plane
-	Matrix3D camera_matrix = m_camera->Get_Transform();
+	const Matrix3D& camera_matrix = m_camera->Get_Transform();
 
 	Vector3 camera_location  = m_camera->Get_Position();
 
@@ -1842,7 +1842,7 @@ Bool WbView3d::viewToDocCoordZ(CPoint curPt, Coord3D *newPt, Real theZ)
 	float logY = (Real)curPt.y / (Real)client.Height();
 	Vector3 intersection(0,0,0);
 	// determine the ray corresponding to the camera and distance to projection plane
-	Matrix3D camera_matrix = m_camera->Get_Transform();
+	const Matrix3D& camera_matrix = m_camera->Get_Transform();
 
 	Vector3 camera_location  = m_camera->Get_Position();
 
@@ -1897,7 +1897,7 @@ void WbView3d::updateHysteresis()
 	float logY = (Real)curPt.y / (Real)client.Height();
 	Vector3 intersection(0,0,0);
 	// determine the ray corresponding to the camera and distance to projection plane
-	Matrix3D camera_matrix = m_camera->Get_Transform();
+	const Matrix3D& camera_matrix = m_camera->Get_Transform();
 
 	Vector3 camera_location  = m_camera->Get_Position();
 


### PR DESCRIPTION
- Fix all 73 `performance-unnecessary-copy-initialization` findings across 29 files from clang-tidy.
- Bind const-only locals to const references.
- Remove unused copies and one-use aliases.
---
@Caball009  Added their fixes as well, now up to 121 findings across 61 files