### PR TITLE
bugfix(update): Resolve mismatch in Generals caused by updating AssistedTargetingUpdate for the initial frame

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -69,7 +69,10 @@ AssistedTargetingUpdate::AssistedTargetingUpdate( Thing *thing, const ModuleData
 
 	m_laserFromAssisted = TheThingFactory->findTemplate(d->m_laserFromAssistedName);
 	m_laserToTarget = TheThingFactory->findTemplate(d->m_laserToTargetName);
+#if RTS_GENERALS
+	// TheSuperHackers @info Zero Hour needs the update to run once to avoid mismatches with retail.
 	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -69,7 +69,7 @@ AssistedTargetingUpdate::AssistedTargetingUpdate( Thing *thing, const ModuleData
 
 	m_laserFromAssisted = TheThingFactory->findTemplate(d->m_laserFromAssistedName);
 	m_laserToTarget = TheThingFactory->findTemplate(d->m_laserToTargetName);
-#if RTS_GENERALS
+#if RTS_GENERALS || !RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @info Zero Hour needs the update to run once to avoid mismatches with retail.
 	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -65,8 +65,11 @@ void AssistedTargetingUpdateModuleData::buildFieldParse(MultiIniFieldParse& p)
 //-------------------------------------------------------------------------------------------------
 AssistedTargetingUpdate::AssistedTargetingUpdate( Thing *thing, const ModuleData* moduleData ) : UpdateModule( thing, moduleData )
 {
-	m_laserFromAssisted = nullptr;
-	m_laserToTarget = nullptr;
+	const AssistedTargetingUpdateModuleData* d = getAssistedTargetingUpdateModuleData();
+
+	m_laserFromAssisted = TheThingFactory->findTemplate(d->m_laserFromAssistedName);
+	m_laserToTarget = TheThingFactory->findTemplate(d->m_laserToTargetName);
+	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -138,11 +141,6 @@ void AssistedTargetingUpdate::makeFeedbackLaser( const ThingTemplate *laserTempl
 //-------------------------------------------------------------------------------------------------
 UpdateSleepTime AssistedTargetingUpdate::update()
 {
-	const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
-
-	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
-	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
-
 	return UPDATE_SLEEP_FOREVER;
 }
 
@@ -180,11 +178,6 @@ void AssistedTargetingUpdate::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void AssistedTargetingUpdate::loadPostProcess()
 {
-	const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
-
-	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
-	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
-
 	// extend base class
 	UpdateModule::loadPostProcess();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -69,7 +69,7 @@ AssistedTargetingUpdate::AssistedTargetingUpdate( Thing *thing, const ModuleData
 
 	m_laserFromAssisted = TheThingFactory->findTemplate(d->m_laserFromAssistedName);
 	m_laserToTarget = TheThingFactory->findTemplate(d->m_laserToTargetName);
-#if RTS_GENERALS
+#if RTS_GENERALS || !RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @info Zero Hour needs the update to run once to avoid mismatches with retail.
 	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AssistedTargetingUpdate.cpp
@@ -65,8 +65,14 @@ void AssistedTargetingUpdateModuleData::buildFieldParse(MultiIniFieldParse& p)
 //-------------------------------------------------------------------------------------------------
 AssistedTargetingUpdate::AssistedTargetingUpdate( Thing *thing, const ModuleData* moduleData ) : UpdateModule( thing, moduleData )
 {
-	m_laserFromAssisted = nullptr;
-	m_laserToTarget = nullptr;
+	const AssistedTargetingUpdateModuleData* d = getAssistedTargetingUpdateModuleData();
+
+	m_laserFromAssisted = TheThingFactory->findTemplate(d->m_laserFromAssistedName);
+	m_laserToTarget = TheThingFactory->findTemplate(d->m_laserToTargetName);
+#if RTS_GENERALS
+	// TheSuperHackers @info Zero Hour needs the update to run once to avoid mismatches with retail.
+	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -138,11 +144,6 @@ void AssistedTargetingUpdate::makeFeedbackLaser( const ThingTemplate *laserTempl
 //-------------------------------------------------------------------------------------------------
 UpdateSleepTime AssistedTargetingUpdate::update()
 {
-	const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
-
-	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
-	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
-
 	return UPDATE_SLEEP_FOREVER;
 }
 
@@ -180,11 +181,6 @@ void AssistedTargetingUpdate::xfer( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void AssistedTargetingUpdate::loadPostProcess()
 {
-	const AssistedTargetingUpdateModuleData *d = getAssistedTargetingUpdateModuleData();
-
-	m_laserFromAssisted = TheThingFactory->findTemplate( d->m_laserFromAssistedName );
-	m_laserToTarget = TheThingFactory->findTemplate( d->m_laserToTargetName );
-
 	// extend base class
 	UpdateModule::loadPostProcess();
 }


### PR DESCRIPTION
* Fixes #3171

This change is a follow-up to #2809 and fixes a mismatch in Generals that was caused by unifying the `AssistedTargetingUpdate` module's setup with Zero Hour, which allowed the module's update logic to run for one frame.