### PR TITLE
feat(client): Add SelectionCircle option drawing a ring under selected objects

### DIFF
--- a/Core/GameEngine/Include/Common/OptionPreferences.h
+++ b/Core/GameEngine/Include/Common/OptionPreferences.h
@@ -76,6 +76,7 @@ public:
 	Real getScrollFactor();
 	Bool getDrawScrollAnchor();
 	Bool getMoveScrollAnchor();
+	Bool getSelectionCircleEnabled() const;
 	Bool getCursorCaptureEnabledInWindowedGame() const;
 	Bool getCursorCaptureEnabledInWindowedMenu() const;
 	Bool getCursorCaptureEnabledInFullscreenGame() const;

--- a/Core/GameEngine/Source/Common/OptionPreferences.cpp
+++ b/Core/GameEngine/Source/Common/OptionPreferences.cpp
@@ -216,6 +216,20 @@ Bool OptionPreferences::getRightMouseScrollWithAlternateMouseEnabled() const
 	return FALSE;
 }
 
+// TheSuperHackers @feature Options.ini: SelectionCircle = Yes draws a green ring on the ground
+// under every selected object, so the current selection reads at a glance.
+Bool OptionPreferences::getSelectionCircleEnabled() const
+{
+	OptionPreferences::const_iterator it = find("SelectionCircle");
+	if (it == end())
+		return FALSE;
+
+	if (stricmp(it->second.str(), "yes") == 0) {
+		return TRUE;
+	}
+	return FALSE;
+}
+
 Bool OptionPreferences::getRetaliationModeEnabled()
 {
 	OptionPreferences::const_iterator it = find("Retaliation");

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
@@ -363,6 +363,9 @@ public:
 
 	virtual void setFullyObscuredByShroud(Bool fullyObscured) override;
 	virtual void setTerrainDecal(TerrainDecalType type) override;
+	// TheSuperHackers @feature Selection ring, kept in its own slot so it does not evict the
+	// horde or chem suit decal while a unit is selected.
+	virtual void setSelectionDecal(Bool enable, Real radius) override;
 
 	virtual Bool isVisible() const override;
 	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
@@ -501,6 +504,8 @@ private:
 	RenderObjClass*								m_renderObject;										///< W3D Render object for this drawable
 	Shadow*												m_shadow;													///< Updates/Renders shadows of this object
 	Shadow*												m_terrainDecal;
+	// TheSuperHackers @feature Selection ring decal, independent of m_terrainDecal.
+	Shadow*												m_selectionDecal;
 	TerrainTracksRenderObjClass*	m_trackRenderObject;							///< This is rendered under object
 	ParticleSystemIDVec						m_particleSystemIDs;							///< The ID numbers of the particle systems currently running.
 	std::vector<ModelConditionInfo::HideShowSubObjInfo>		m_subObjectVec;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
@@ -504,8 +504,12 @@ private:
 	RenderObjClass*								m_renderObject;										///< W3D Render object for this drawable
 	Shadow*												m_shadow;													///< Updates/Renders shadows of this object
 	Shadow*												m_terrainDecal;
-	// TheSuperHackers @feature Selection ring decal, independent of m_terrainDecal.
+	// TheSuperHackers @feature Selection ring decal, independent of m_terrainDecal. The wanted
+	// state is remembered separately so the ring survives render object rebuilds - a damage
+	// state or upgrade swaps the model while the object stays selected.
 	Shadow*												m_selectionDecal;
+	Bool													m_selectionDecalWanted;
+	Real													m_selectionDecalRadius;
 	TerrainTracksRenderObjClass*	m_trackRenderObject;							///< This is rendered under object
 	ParticleSystemIDVec						m_particleSystemIDs;							///< The ID numbers of the particle systems currently running.
 	std::vector<ModelConditionInfo::HideShowSubObjInfo>		m_subObjectVec;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -1734,6 +1734,8 @@ W3DModelDraw::W3DModelDraw(Thing *thing, const ModuleData* moduleData) : DrawMod
 	m_terrainDecal = nullptr;
 	// TheSuperHackers @feature no selection ring until one is asked for
 	m_selectionDecal = nullptr;
+	m_selectionDecalWanted = FALSE;
+	m_selectionDecalRadius = 0.0f;
 	m_trackRenderObject = nullptr;
 	m_whichAnimInCurState = -1;
 	m_nextState = nullptr;
@@ -1837,6 +1839,10 @@ void W3DModelDraw::setHidden(Bool hidden)
 
 	if (m_terrainDecal)
 		m_terrainDecal->enableShadowRender(!hidden);
+
+	// TheSuperHackers @fix the ring must not keep rendering under a hidden drawable
+	if (m_selectionDecal)
+		m_selectionDecal->enableShadowRender(!hidden);
 
 	if (m_trackRenderObject && hidden)
 	{	const Coord3D* pos = getDrawable()->getPosition();
@@ -1951,6 +1957,9 @@ void W3DModelDraw::setFullyObscuredByShroud(Bool fullyObscured)
 			m_shadow->enableShadowInvisible(m_fullyObscuredByShroud);
 		if (m_terrainDecal)
 			m_terrainDecal->enableShadowInvisible(m_fullyObscuredByShroud);
+		// TheSuperHackers @fix the ring must not expose a fully shrouded unit
+		if (m_selectionDecal)
+			m_selectionDecal->enableShadowInvisible(m_fullyObscuredByShroud);
 
 		doStartOrStopParticleSys();
 	}
@@ -2735,6 +2744,10 @@ Bool W3DModelDraw::updateBonesForClientParticleSystems()
 //-------------------------------------------------------------------------------------------------
 void W3DModelDraw::setSelectionDecal(Bool enable, Real radius)
 {
+	// remembered so the ring can be recreated after a model swap tears the render object down
+	m_selectionDecalWanted = enable;
+	m_selectionDecalRadius = radius;
+
 	if (m_selectionDecal)
 	{
 		m_selectionDecal->release();
@@ -2769,13 +2782,6 @@ void W3DModelDraw::setTerrainDecal(TerrainDecalType type)
 {
 	if (m_terrainDecal)
 		m_terrainDecal->release();
-
-	// TheSuperHackers @feature drop the selection ring too
-	if (m_selectionDecal)
-	{
-		m_selectionDecal->release();
-		m_selectionDecal = nullptr;
-	}
 
 	m_terrainDecal = nullptr;
 
@@ -3137,6 +3143,11 @@ void W3DModelDraw::setModelState(const ModelConditionInfo* newState)
 				m_shadow->enableShadowRender(m_shadowEnabled);
 			}
 		}
+
+		// TheSuperHackers @fix The selection ring was bound to the render object that was just
+		// torn down; the object is still selected, so put the ring back on the new one.
+		if (m_selectionDecalWanted)
+			setSelectionDecal(TRUE, m_selectionDecalRadius);
 
 		if( m_renderObject )
 		{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -1732,6 +1732,8 @@ W3DModelDraw::W3DModelDraw(Thing *thing, const ModuleData* moduleData) : DrawMod
 	m_shadow = nullptr;
 	m_shadowEnabled = TRUE;
 	m_terrainDecal = nullptr;
+	// TheSuperHackers @feature no selection ring until one is asked for
+	m_selectionDecal = nullptr;
 	m_trackRenderObject = nullptr;
 	m_whichAnimInCurState = -1;
 	m_nextState = nullptr;
@@ -2720,10 +2722,60 @@ Bool W3DModelDraw::updateBonesForClientParticleSystems()
 
 
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @feature Selection ring decal.
+//-------------------------------------------------------------------------------------------------
+/** Put a green ring on the ground under this object, or take it away.
+	*
+	* Uses the projected shadow system rather than screen space lines, so the ring is genuinely
+	* projected onto the terrain and the model draws over it. It lives in its own slot rather than
+	* sharing m_terrainDecal, so selecting a horde unit does not evict its horde ring.
+	*
+	* Expects a PlainRingSelection.tga in the mod's assets. The engine appends the extension, and
+	* the art is tinted green at runtime, so a plain white or greyscale ring works. */
+//-------------------------------------------------------------------------------------------------
+void W3DModelDraw::setSelectionDecal(Bool enable, Real radius)
+{
+	if (m_selectionDecal)
+	{
+		m_selectionDecal->release();
+		m_selectionDecal = nullptr;
+	}
+
+	if (!enable || m_renderObject == nullptr || TheProjectedShadowManager == nullptr)
+		return;
+
+	Shadow::ShadowTypeInfo decalInfo;
+	decalInfo.allowUpdates = FALSE;		//the ring never needs regenerating
+	decalInfo.allowWorldAlign = TRUE;	//wrap it around terrain and world objects
+	decalInfo.m_type = SHADOW_ALPHA_DECAL;
+	strlcpy(decalInfo.m_ShadowName, "PlainRingSelection", ARRAY_SIZE(decalInfo.m_ShadowName));
+	decalInfo.m_sizeX = radius * 2.0f;
+	decalInfo.m_sizeY = radius * 2.0f;
+	decalInfo.m_offsetX = 0.0f;
+	decalInfo.m_offsetY = 0.0f;
+
+	m_selectionDecal = TheProjectedShadowManager->addDecal(m_renderObject, &decalInfo);
+	if (m_selectionDecal)
+	{
+		m_selectionDecal->enableShadowInvisible(m_fullyObscuredByShroud);
+		m_selectionDecal->enableShadowRender(TRUE);
+		//the art is a plain ring, so tint it to the selection green
+		m_selectionDecal->setColor(GameMakeColor(0, 255, 0, 255));
+	}
+}
+
+//-------------------------------------------------------------------------------------------------
 void W3DModelDraw::setTerrainDecal(TerrainDecalType type)
 {
 	if (m_terrainDecal)
 		m_terrainDecal->release();
+
+	// TheSuperHackers @feature drop the selection ring too
+	if (m_selectionDecal)
+	{
+		m_selectionDecal->release();
+		m_selectionDecal = nullptr;
+	}
 
 	m_terrainDecal = nullptr;
 
@@ -2789,6 +2841,14 @@ void W3DModelDraw::nukeCurrentRender(Matrix3D* xform)
 	if(m_terrainDecal)
 		m_terrainDecal->release();
 	m_terrainDecal = nullptr;
+
+	// TheSuperHackers @fix The selection ring is bound to the render object about to be torn down
+	// here, exactly like the shadow and the terrain decal above, so it has to go with them. Left
+	// behind it stayed registered with the projected shadow manager while the render object it
+	// points at was freed, and the next renderShadows walked that dangling entry into the driver.
+	if (m_selectionDecal)
+		m_selectionDecal->release();
+	m_selectionDecal = nullptr;
 
 	// remove existing render object from the scene
 	if (m_renderObject)

--- a/Generals/Code/GameEngine/Include/Common/DrawModule.h
+++ b/Generals/Code/GameEngine/Include/Common/DrawModule.h
@@ -82,6 +82,9 @@ public:
 	virtual void setTerrainDecal(TerrainDecalType type) {};
 	virtual void setTerrainDecalSize(Real x, Real y) {};
 	virtual void setTerrainDecalOpacity(Real o) {};
+	// TheSuperHackers @feature Selection ring decal, in its own slot so it does not evict the
+	// horde or chem suit decal while a unit is selected.
+	virtual void setSelectionDecal(Bool enable, Real radius) {};
 
 	virtual void setFullyObscuredByShroud(Bool fullyObscured) = 0;
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/DrawModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/DrawModule.h
@@ -82,6 +82,9 @@ public:
 	virtual void setTerrainDecal(TerrainDecalType type) {};
 	virtual void setTerrainDecalSize(Real x, Real y) {};
 	virtual void setTerrainDecalOpacity(Real o) {};
+	// TheSuperHackers @feature Selection ring decal, in its own slot so it does not evict the
+	// horde or chem suit decal while a unit is selected.
+	virtual void setSelectionDecal(Bool enable, Real radius) {};
 
 	virtual void setFullyObscuredByShroud(Bool fullyObscured) = 0;
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -142,6 +142,8 @@ public:
 	Bool m_useAlternateMouse;
 	Bool m_useRightMouseScrollWithAlternateMouse; // TheSuperHackers @feature User option for RMB scroll in Alternate Mouse mode.
 	Bool m_clientRetaliationModeEnabled;
+	// TheSuperHackers @feature Draw a green hexagon ring under selected objects.
+	Bool m_selectionCircleEnabled;
 	Bool m_doubleClickAttackMove;
 	Bool m_rightMouseAlwaysScrolls;
 	Int m_jpegQuality; // TheSuperHackers @feature Quality for JPEG screenshots.

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
@@ -396,6 +396,9 @@ public:
 
 	/// Return true if drawable has been marked as "selected"
 	Bool isSelected() const {	return m_selected; }
+	// TheSuperHackers @feature Green selection ring decal (Options.ini: SelectionCircle).
+	// Client only -- never xfer'd, never read by game logic.
+	void updateSelectionDecal( void );
 	void onSelected();														///< Work unrelated to selection that must happen at time of selection
 	void onUnselected();													///< Work unrelated to selection that must happen at time of unselection
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1062,6 +1062,7 @@ GlobalData::GlobalData()
 	m_useRightMouseScrollWithAlternateMouse = TRUE;
 #endif
 	m_clientRetaliationModeEnabled = TRUE; //On by default.
+	m_selectionCircleEnabled = FALSE;
 	m_doubleClickAttackMove = FALSE;
 
 }
@@ -1206,6 +1207,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_useRightMouseScrollWithAlternateMouse = optionPref.getRightMouseScrollWithAlternateMouseEnabled();
 	TheWritableGlobalData->m_clientRetaliationModeEnabled = optionPref.getRetaliationModeEnabled();
 	TheWritableGlobalData->m_doubleClickAttackMove = optionPref.getDoubleClickAttackMoveEnabled();
+	TheWritableGlobalData->m_selectionCircleEnabled = optionPref.getSelectionCircleEnabled();
 	TheWritableGlobalData->m_jpegQuality = optionPref.getJpegQuality();
 	TheWritableGlobalData->m_keyboardScrollFactor = optionPref.getScrollFactor();
 	TheWritableGlobalData->m_drawScrollAnchor = optionPref.getDrawScrollAnchor();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -4204,6 +4204,9 @@ void Drawable::reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* old
 //-------------------------------------------------------------------------------------------------
 void Drawable::reactToGeometryChange()
 {
+	// TheSuperHackers @fix resize the selection ring along with the geometry it is derived from
+	updateSelectionDecal();
+
 	for (DrawModule** dm = getDrawModules(); *dm; ++dm)
 	{
 		(*dm)->reactToGeometryChange();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -979,8 +979,50 @@ void Drawable::colorTint( const RGBColor* color )
 //-------------------------------------------------------------------------------------------------
 /** Gathering point for all things besides actual selection that must happen on selection */
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @feature Selection ring decal.
+//-------------------------------------------------------------------------------------------------
+/** Show or hide the green selection ring, following the SelectionCircle option.
+	*
+	* Only the first draw module gets one, matching how terrain decals avoid stacking. */
+//-------------------------------------------------------------------------------------------------
+void Drawable::updateSelectionDecal( void )
+{
+	Bool wanted = TheGlobalData && TheGlobalData->m_selectionCircleEnabled && isSelected();
+
+	const Object *obj = getObject();
+	if( obj == nullptr || obj->isEffectivelyDead() || obj->isKindOf( KINDOF_IGNORED_IN_GUI ) )
+		wanted = FALSE;
+
+	Real radius = 0.0f;
+	if( wanted )
+	{
+		// The bounding circle encloses the whole model, so it reads as too big drawn at full
+		// size. How much too big depends on the shape: a building fills its circle, a soldier
+		// barely occupies the middle of one, so scale per kind.
+		Real scale;
+		if( obj->isKindOf( KINDOF_STRUCTURE ) )
+			scale = 1.0f;
+		else if( obj->isKindOf( KINDOF_INFANTRY ) )
+			scale = 0.7f;
+		else
+			scale = 0.85f;	// vehicles, aircraft and everything else
+
+		radius = getDrawableGeometryInfo().getBoundingCircleRadius() * scale;
+		if( radius < 1.0f )
+			radius = 1.0f;
+	}
+
+	for( DrawModule **dm = getDrawModules(); *dm; ++dm )
+	{
+		(*dm)->setSelectionDecal( wanted, radius );
+		break;	// first draw module only, so rings do not stack
+	}
+}
+
 void Drawable::onSelected()
 {
+	// TheSuperHackers @feature put the selection ring up straight away rather than waiting a frame
+	updateSelectionDecal();
 
 	flashAsSelected();//much simpler
 
@@ -1001,7 +1043,8 @@ void Drawable::onSelected()
 //-------------------------------------------------------------------------------------------------
 void Drawable::onUnselected()
 {
-	// nothing
+	// TheSuperHackers @feature take the selection ring down
+	updateSelectionDecal();
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds an opt-in client option drawing a green ring on the ground under every selected object, so the current selection reads at a glance. Defaults off; retail behavior unless set in Options.ini.

**SelectionCircle** (`= Yes`) — the ring is a projected decal through the shadow system rather than screen-space lines, so it wraps the terrain and the model genuinely occludes it. It lives in its own decal slot (selecting a horde unit does not evict its horde ring) and is released alongside the shadow and terrain decal when the render object is torn down — left behind it would dangle in the projected shadow manager and crash the next `renderShadows`. Sized from the bounding circle, scaled per kind: a building fills its circle, a soldier barely occupies the middle of one.

**Asset dependency, up front:** the decal expects a `PlainRingSelection.tga` in the game's assets — the engine appends the extension and tints the art green at runtime, so a plain white or greyscale ring works. This repo ships no such texture; the Contra mod provides its own. With the option on but no texture present, no ring renders. Happy to contribute the texture through whatever channel fits your asset pipeline, or the name can be pointed at an existing decal.

The drawing lives in the shared W3D model draw code with a default no-op in both titles' draw-module interface; the option currently drives it from Zero Hour's Drawable only. A Generals replica can follow after review.

This option ships in the Contra mod's engine fork and has been played there; this PR is the port onto current main, collapsing the fork's five ring commits into their final state with the teardown fix folded in. Code was written with LLM assistance and human-reviewed, adapted and playtested by the author.

Prepared for **Squash and Merge**.
