### PR TITLE
bugfix(gamewindow): Remove destroyed windows from the modal stack and prevent duplicate modals for the same window

### DIFF
--- a/Core/GameEngine/Include/GameClient/GameWindowManager.h
+++ b/Core/GameEngine/Include/GameClient/GameWindowManager.h
@@ -278,8 +278,7 @@ public:
 	virtual GameWindow *winGetCapture();  ///< current mouse capture settings
 
 	virtual Int winSetModal( GameWindow *window );  ///< put at top of modal stack
-	virtual Int winUnsetModal( GameWindow *window );  /**< take window off modal stack, if window is
-																										not at top of stack and error will occur */
+	virtual Int winUnsetModal( GameWindow *window );  ///< take window off the modal stack from anywhere in the stack
 
 	//---------------------------------------------------------------------------
 	/////////////////////////////////////////////////////////////////////////////

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -103,9 +103,6 @@ void GameWindowManager::processDestroyList()
 		if( m_keyboardFocus == doDestroy )
 			winSetFocus( nullptr );
 
-		if( (m_modalHead != nullptr) && (doDestroy == m_modalHead->window) )
-			winUnsetModal( m_modalHead->window );
-
 		if( m_currMouseRgn == doDestroy )
 			m_currMouseRgn = nullptr;
 
@@ -1422,8 +1419,7 @@ Int GameWindowManager::winDestroy( GameWindow *window )
 	if( m_keyboardFocus == window )
 		winSetFocus( nullptr );
 
-	if( (m_modalHead != nullptr) && (window == m_modalHead->window) )
-		winUnsetModal( m_modalHead->window );
+	winUnsetModal( window );
 
 	if( m_currMouseRgn == window )
 		m_currMouseRgn = nullptr;
@@ -1525,33 +1521,41 @@ Int GameWindowManager::winSetModal( GameWindow *window )
 }
 
 //-------------------------------------------------------------------------------------------------
-/** pops window off of the modal stack.  If this window is not the top
-	* of the modal stack an error will occur. */
+/** takes the window off the modal stack from anywhere in the stack */
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @bugfix arcticdolphin 07/09/2026 Remove the window from anywhere in the modal stack, not just the top, so a destroyed window cannot leave a dangling entry behind.
 Int GameWindowManager::winUnsetModal( GameWindow *window )
 {
-	ModalWindow *next;
-
 	if( window == nullptr )
 		return WIN_ERR_INVALID_WINDOW;
 
-	// verify entry is at top of list
-	if( (m_modalHead == nullptr) || (m_modalHead->window != window) )
+	ModalWindow *previous = nullptr;
+	ModalWindow *modal = m_modalHead;
+	Bool found = FALSE;
+
+	while( modal != nullptr )
 	{
+		ModalWindow *next = modal->next;
 
-		// return error if not
-		DEBUG_LOG(( "WinUnsetModal: Invalid window attempting to unset modal (%d)",
-								window->winGetWindowId() ));
-		return WIN_ERR_GENERAL_FAILURE;
+		if( modal->window == window )
+		{
+			if( previous != nullptr )
+				previous->next = next;
+			else
+				m_modalHead = next;
 
+			deleteInstance(modal);
+			found = TRUE;
+		}
+		else
+		{
+			previous = modal;
+		}
+
+		modal = next;
 	}
 
-	// remove from top of list
-	next = m_modalHead->next;
-	deleteInstance(m_modalHead);
-	m_modalHead = next;
-
-	return WIN_ERR_OK;
+	return found ? WIN_ERR_OK : WIN_ERR_GENERAL_FAILURE;
 
 }
 

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -1503,6 +1503,24 @@ Int GameWindowManager::winSetModal( GameWindow *window )
 		DEBUG_LOG(( "WinSetModal: Non Root window attempted to go modal." ));
 		return WIN_ERR_INVALID_PARAMETER;			// return error if not
 	}
+
+	// TheSuperHackers @bugfix arcticdolphin 08/09/2026 If already modal, move to the top instead of duplicating.
+	ModalWindow *previous = nullptr;
+	for( ModalWindow *existing = m_modalHead; existing != nullptr; previous = existing, existing = existing->next )
+	{
+		if( existing->window != window )
+			continue;
+
+		if( previous != nullptr )
+		{
+			previous->next = existing->next;
+			existing->next = m_modalHead;
+			m_modalHead = existing;
+		}
+
+		return WIN_ERR_OK;
+	}
+
 	// Allocate new Modal Window Entry
 	modal = newInstance(ModalWindow);
 	if( modal == nullptr )
@@ -1531,31 +1549,25 @@ Int GameWindowManager::winUnsetModal( GameWindow *window )
 
 	ModalWindow *previous = nullptr;
 	ModalWindow *modal = m_modalHead;
-	Bool found = FALSE;
 
 	while( modal != nullptr )
 	{
-		ModalWindow *next = modal->next;
-
 		if( modal->window == window )
 		{
 			if( previous != nullptr )
-				previous->next = next;
+				previous->next = modal->next;
 			else
-				m_modalHead = next;
+				m_modalHead = modal->next;
 
 			deleteInstance(modal);
-			found = TRUE;
-		}
-		else
-		{
-			previous = modal;
+			return WIN_ERR_OK;
 		}
 
-		modal = next;
+		previous = modal;
+		modal = modal->next;
 	}
 
-	return found ? WIN_ERR_OK : WIN_ERR_GENERAL_FAILURE;
+	return WIN_ERR_GENERAL_FAILURE;
 
 }
 

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -96,21 +96,12 @@ void GameWindowManager::processDestroyList()
 
 		next = doDestroy->m_next;
 
-		// Check to see if this window is "special"
-		if( m_mouseCaptor == doDestroy )
-			winRelease( doDestroy );
-
-		if( m_keyboardFocus == doDestroy )
-			winSetFocus( nullptr );
-
-		if( m_currMouseRgn == doDestroy )
-			m_currMouseRgn = nullptr;
-
-		if( m_grabWindow == doDestroy )
-			m_grabWindow = nullptr;
-
 		// send the destroy message to the window we're about to kill
 		winSendSystemMsg( doDestroy, GWM_DESTROY, 0, 0 );
+
+		DEBUG_ASSERTCRASH( m_mouseCaptor != doDestroy && m_keyboardFocus != doDestroy
+			&& m_currMouseRgn != doDestroy && m_grabWindow != doDestroy,
+			("processDestroyList: manager still points at a window being destroyed") );
 
 		DEBUG_ASSERTCRASH(doDestroy->winGetUserData() == nullptr, ("Win user data is expected to be deleted now"));
 


### PR DESCRIPTION
A destroyed window could stay buried in the modal stack. The game could later use that dead pointer and crash.

This removes destroyed windows from the whole stack. `winSetModal` also promotes an already-modal window to the top instead of adding a duplicate entry. Hidden windows keep the old behavior so they can still be shown again.

Closes #3223 