### PR TITLE
chore: Accept both path slashes for clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -87,8 +87,10 @@ Checks: >
 # Treat warnings as errors for CI/CD
 WarningsAsErrors: false
 
-# Header filter to include project headers
-HeaderFilterRegex: '(Core|Generals|GeneralsMD|Dependencies)/.*\.(h|hpp)$'
+# Header filter to include project headers.
+# Accept both / and \ so Windows diagnostics (Core\Include\Common/Foo.h) are not dropped.
+HeaderFilterRegex: '[/\\](Core|GeneralsMD|Generals|Dependencies)[/\\].*\.(h|hpp)$'
+ExcludeHeaderFilterRegex: '[/\\](MaxSDK|_deps)[/\\]'
 
 # Check options for specific rules
 CheckOptions:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -88,9 +88,10 @@ Checks: >
 WarningsAsErrors: false
 
 # Header filter to include project headers.
-# Accept both / and \ so Windows diagnostics (Core\Include\Common/Foo.h) are not dropped.
-HeaderFilterRegex: '[/\\](Core|GeneralsMD|Generals|Dependencies)[/\\].*\.(h|hpp)$'
-ExcludeHeaderFilterRegex: '[/\\](MaxSDK|_deps)[/\\]'
+# Match relative paths (Core/Foo.h, Core\Foo.h) and absolute ones (.../Core/Foo.h).
+# Accept both / and \ so Windows diagnostics are not dropped.
+HeaderFilterRegex: '(^|[/\\])(Core|GeneralsMD|Generals|Dependencies)[/\\].*\.(h|hpp)$'
+ExcludeHeaderFilterRegex: '(^|[/\\])(MaxSDK|_deps)[/\\]'
 
 # Check options for specific rules
 CheckOptions:


### PR DESCRIPTION
The old clang tidy config file ignored / file paths, so when running to check for diagnostics, it failed to find any headers on Windows (i.e Core\Include\Common/Foo.h).
This fixes that and adds an ExcludeHeader regex for the MaxSDK and and _deps so we aren't chasing our tails for stuff outside of the repo.