### PR TITLE
tweak(gamestate): Support loading save files from absolute paths

### DIFF
--- a/Core/GameEngine/Source/Common/CommandLine.cpp
+++ b/Core/GameEngine/Source/Common/CommandLine.cpp
@@ -727,8 +727,10 @@ Int parseLoadSave(char *args[], int num)
 		TheWritableGlobalData->m_shellMapOn = FALSE;
 		TheWritableGlobalData->m_playIntro = FALSE;
 		TheWritableGlobalData->m_playSizzle = FALSE;
+
+		return 2;
 	}
-	return 2;
+	return 1;
 }
 
 //=============================================================================

--- a/Core/Libraries/Include/Lib/PathUtil.h
+++ b/Core/Libraries/Include/Lib/PathUtil.h
@@ -23,6 +23,38 @@
 #include "BaseType.h"
 #include <string.h>
 
+inline bool isPathSeparator(char ch)
+{
+#ifdef _WIN32
+	return ch == '\\' || ch == '/';
+#else
+	return ch == '/';
+#endif
+}
+
+inline bool isAbsolutePath(const char* path)
+{
+	if (path == nullptr)
+	{
+		return false;
+	}
+
+	if (isPathSeparator(path[0]))
+	{
+		return true;
+	}
+
+#ifdef _WIN32
+	const bool hasDriveLetter = (path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z');
+	if (hasDriveLetter && path[1] == ':' && isPathSeparator(path[2]))
+	{
+		return true;
+	}
+#endif
+
+	return false;
+}
+
 inline const char* getExtension(const char* path)
 {
 	const char* lastDot = strrchr(path, '.');

--- a/Generals/Code/GameEngine/Include/Common/GameState.h
+++ b/Generals/Code/GameEngine/Include/Common/GameState.h
@@ -191,6 +191,7 @@ public:
 
 	AsciiString getSaveDirectory() const;
 	AsciiString getFilePathInSaveDirectory(const AsciiString& leaf) const;
+	AsciiString getSaveGamePathForRead(const AsciiString& filenameOrPath) const;
 	Bool isInSaveDirectory(const AsciiString& path) const;
 
 	AsciiString realMapPathToPortableMapPath(const AsciiString& in) const;

--- a/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -48,6 +48,7 @@
 #include "GameClient/GameClient.h"
 #include "GameClient/GameText.h"
 #include "GameClient/MapUtil.h"
+#include "GameClient/MessageBox.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/ParticleSys.h"
 #include "GameClient/TerrainVisual.h"
@@ -57,6 +58,7 @@
 #include "GameLogic/ScriptEngine.h"
 #include "GameLogic/SidesList.h"
 #include "GameLogic/TerrainLogic.h"
+#include "Lib/PathUtil.h"
 
 
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
@@ -656,8 +658,7 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 	//
 	TheGameStateMap->clearScratchPadMaps();
 
-	// construct path to file
-	AsciiString filepath = getFilePathInSaveDirectory(gameInfo.filename);
+	AsciiString filepath = getSaveGamePathForRead(gameInfo.filename);
 
 	// open the save file
 	XferLoad xferLoad;
@@ -740,6 +741,15 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 
 }
 
+//-------------------------------------------------------------------------------------------------
+static void showQueuedSaveGameLoadFailure( void )
+{
+	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:SaveGameLoadFailedTitle", L"CANNOT LOAD SAVE");
+	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:SaveGameLoadFailed", L"The saved game file could not be opened or is invalid.");
+
+	MessageBoxOk(title, body, nullptr);
+}
+
 // ------------------------------------------------------------------------------------------------
 /** Load the save game requested on startup, after the shell has been initialized */
 // ------------------------------------------------------------------------------------------------
@@ -752,24 +762,30 @@ void GameState::loadQueuedSaveGame()
 
 	TheWritableGlobalData->m_loadSaveGame.clear();
 
+	if( gameInfo.filename.endsWithNoCase( SAVE_GAME_EXTENSION ) == FALSE )
+	{
+		DEBUG_LOG(("Save game '%s' is not a save game file", gameInfo.filename.str()));
+		showQueuedSaveGameLoadFailure();
+		return;
+	}
+
 	// getSaveGameInfoFromFile throws when the file is missing, so check before reading it
 	if( doesSaveGameExist( gameInfo.filename ) == FALSE )
 	{
 		DEBUG_LOG(("Save game '%s' was not found", gameInfo.filename.str()));
-		TheGameEngine->setQuitting( TRUE );
+		showQueuedSaveGameLoadFailure();
 		return;
 	}
 
 	// getSaveGameInfoFromFile throws on a malformed file instead of returning a SaveCode
 	try
 	{
-		AsciiString filepath = getFilePathInSaveDirectory( gameInfo.filename );
-		getSaveGameInfoFromFile( filepath, &gameInfo.saveGameInfo );
+		getSaveGameInfoFromFile( gameInfo.filename, &gameInfo.saveGameInfo );
 	}
 	catch( ... )
 	{
 		DEBUG_LOG(("Save game '%s' could not be read", gameInfo.filename.str()));
-		TheGameEngine->setQuitting( TRUE );
+		showQueuedSaveGameLoadFailure();
 		return;
 	}
 
@@ -800,6 +816,17 @@ AsciiString GameState::getFilePathInSaveDirectory(const AsciiString& leaf) const
 	AsciiString tmp = getSaveDirectory();
 	tmp.concat(leaf);
 	return tmp;
+}
+
+//-------------------------------------------------------------------------------------------------
+AsciiString GameState::getSaveGamePathForRead(const AsciiString& filenameOrPath) const
+{
+	if (isAbsolutePath(filenameOrPath.str()))
+	{
+		return filenameOrPath;
+	}
+
+	return getFilePathInSaveDirectory(filenameOrPath);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -959,8 +986,7 @@ AsciiString GameState::portableMapPathToRealMapPath(const AsciiString& in) const
 Bool GameState::doesSaveGameExist( AsciiString filename )
 {
 
-	// construct full path to file
-	AsciiString filepath = getFilePathInSaveDirectory(filename);
+	AsciiString filepath = getSaveGamePathForRead(filename);
 
 	// open file
 	XferLoad xfer;
@@ -1004,6 +1030,8 @@ void GameState::getSaveGameInfoFromFile( AsciiString filename, SaveGameInfo *sav
 		return;
 
 	}
+
+	filename = getSaveGamePathForRead( filename );
 
 	// open file for partial loading
 	XferLoad xferLoad;

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameState.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameState.h
@@ -191,6 +191,7 @@ public:
 
 	AsciiString getSaveDirectory() const;
 	AsciiString getFilePathInSaveDirectory(const AsciiString& leaf) const;
+	AsciiString getSaveGamePathForRead(const AsciiString& filenameOrPath) const;
 	Bool isInSaveDirectory(const AsciiString& path) const;
 
 	AsciiString realMapPathToPortableMapPath(const AsciiString& in) const;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -48,6 +48,7 @@
 #include "GameClient/GameClient.h"
 #include "GameClient/GameText.h"
 #include "GameClient/MapUtil.h"
+#include "GameClient/MessageBox.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/ParticleSys.h"
 #include "GameClient/TerrainVisual.h"
@@ -57,6 +58,7 @@
 #include "GameLogic/ScriptEngine.h"
 #include "GameLogic/SidesList.h"
 #include "GameLogic/TerrainLogic.h"
+#include "Lib/PathUtil.h"
 
 
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
@@ -656,8 +658,7 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 	//
 	TheGameStateMap->clearScratchPadMaps();
 
-	// construct path to file
-	AsciiString filepath = getFilePathInSaveDirectory(gameInfo.filename);
+	AsciiString filepath = getSaveGamePathForRead(gameInfo.filename);
 
 	// open the save file
 	XferLoad xferLoad;
@@ -740,6 +741,15 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 
 }
 
+//-------------------------------------------------------------------------------------------------
+static void showQueuedSaveGameLoadFailure( void )
+{
+	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:SaveGameLoadFailedTitle", L"CANNOT LOAD SAVE");
+	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:SaveGameLoadFailed", L"The saved game file could not be opened or is invalid.");
+
+	MessageBoxOk(title, body, nullptr);
+}
+
 // ------------------------------------------------------------------------------------------------
 /** Load the save game requested on startup, after the shell has been initialized */
 // ------------------------------------------------------------------------------------------------
@@ -752,24 +762,30 @@ void GameState::loadQueuedSaveGame()
 
 	TheWritableGlobalData->m_loadSaveGame.clear();
 
+	if( gameInfo.filename.endsWithNoCase( SAVE_GAME_EXTENSION ) == FALSE )
+	{
+		DEBUG_LOG(("Save game '%s' is not a save game file", gameInfo.filename.str()));
+		showQueuedSaveGameLoadFailure();
+		return;
+	}
+
 	// getSaveGameInfoFromFile throws when the file is missing, so check before reading it
 	if( doesSaveGameExist( gameInfo.filename ) == FALSE )
 	{
 		DEBUG_LOG(("Save game '%s' was not found", gameInfo.filename.str()));
-		TheGameEngine->setQuitting( TRUE );
+		showQueuedSaveGameLoadFailure();
 		return;
 	}
 
 	// getSaveGameInfoFromFile throws on a malformed file instead of returning a SaveCode
 	try
 	{
-		AsciiString filepath = getFilePathInSaveDirectory( gameInfo.filename );
-		getSaveGameInfoFromFile( filepath, &gameInfo.saveGameInfo );
+		getSaveGameInfoFromFile( gameInfo.filename, &gameInfo.saveGameInfo );
 	}
 	catch( ... )
 	{
 		DEBUG_LOG(("Save game '%s' could not be read", gameInfo.filename.str()));
-		TheGameEngine->setQuitting( TRUE );
+		showQueuedSaveGameLoadFailure();
 		return;
 	}
 
@@ -800,6 +816,17 @@ AsciiString GameState::getFilePathInSaveDirectory(const AsciiString& leaf) const
 	AsciiString tmp = getSaveDirectory();
 	tmp.concat(leaf);
 	return tmp;
+}
+
+//-------------------------------------------------------------------------------------------------
+AsciiString GameState::getSaveGamePathForRead(const AsciiString& filenameOrPath) const
+{
+	if (isAbsolutePath(filenameOrPath.str()))
+	{
+		return filenameOrPath;
+	}
+
+	return getFilePathInSaveDirectory(filenameOrPath);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -959,8 +986,7 @@ AsciiString GameState::portableMapPathToRealMapPath(const AsciiString& in) const
 Bool GameState::doesSaveGameExist( AsciiString filename )
 {
 
-	// construct full path to file
-	AsciiString filepath = getFilePathInSaveDirectory(filename);
+	AsciiString filepath = getSaveGamePathForRead(filename);
 
 	// open file
 	XferLoad xfer;
@@ -1004,6 +1030,8 @@ void GameState::getSaveGameInfoFromFile( AsciiString filename, SaveGameInfo *sav
 		return;
 
 	}
+
+	filename = getSaveGamePathForRead( filename );
 
 	// open file for partial loading
 	XferLoad xferLoad;


### PR DESCRIPTION
* Closes #3078

`-loadsave` normally resolves its argument inside the managed user Save directory, so a file anywhere else has to be copied there before it can be opened. That prevents an operating-system file handler from launching the game directly for a selected `.sav`.

Now absolute paths are opened in place while relative names continue to resolve from the Save directory. `isAbsolutePath(const char*)` in `PathUtil.h` recognizes a drive root (`C:\` or `C:/`), a current-drive or UNC root (a leading separator), or a POSIX root. `GameState::getSaveGamePathForRead` preserves absolute paths and resolves relative names through the managed directory. Save writes and the save menu are unchanged.

`parseLoadSave` now returns 2 only when it consumes an argument and 1 otherwise. Previously it returned 2 unconditionally, so `-loadsave` without an argument could consume the following token.

Queued save validation runs after the shell is initialized. A wrong extension, missing file, or unreadable file now shows a visible error dialog, and dismissing it leaves the user on the main menu.

Paths containing spaces work when quoted, which is the form an operating-system file handler supplies. `nextParam` is quote-aware, so a token beginning with `"` ends at the matching quote rather than at whitespace.

Verified with a bogus path as a control so a successful launch is distinguishable from a successful load:

| case | result |
| --- | --- |
| Invalid save extension | shows the load-error dialog; OK returns to the main menu |
| Missing absolute save path | shows the load-error dialog; OK returns to the main menu |
| Unreadable save file | shows the load-error dialog; OK returns to the main menu |
| Save from an absolute path outside the user directory | loads |
| Save from an absolute path containing spaces (quoted) | loads |
| Relative save filename | loads from the managed directory |
| Save from a UNC path (`\\localhost\C$\...`) | loads |
| Save from a POSIX absolute path containing spaces | loads |

Todo:
- [x] Both games build (`z_generals` and `g_generals`)
- [x] Absolute path classification covers drive roots, UNC and current-drive roots, and POSIX roots
- [x] Save paths outside the user data directory
- [x] Paths containing spaces
- [x] Invalid, missing, and unreadable saves show a visible error
- [x] Windows drive paths and UNC paths
- [x] Relative save filenames still resolve from the managed directory
- [x] Replicate to Generals
