### PR TITLE
bugfix(particlesys): Delay particle system destruction to prevent orphaning slaved finite-lifetime particle systems

### DIFF
--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -2125,9 +2125,15 @@ Bool ParticleSystem::update( Int localPlayerIndex  )
 	// If we have been "destroyed", wait for all of our particles to die off,
 	// then destroy ourselves (return false).
 	//
+	// TheSuperHackers @bugfix Mauller 30/08/2026 Delay destruction to prevent finite-lifetime slave particle systems being orphaned.
+	// Orphaned particle systems lack positional data, render at the world origin and do not complete their full lifecycle.
 	if (m_isDestroyed && !m_systemParticlesHead)
-		return false;
+	{
+		if (m_slaveSystem && !m_slaveSystem->isSystemForever())
+			return true;
 
+		return false;
+	}
 
 	// monitor particle system lifetime
 	if (m_isForever == false)
@@ -2142,7 +2148,12 @@ Bool ParticleSystem::update( Int localPlayerIndex  )
 
 		// check if time is up
 		if (m_systemLifetimeLeft == 0)
-			return false;
+		{
+			if (m_slaveSystem && !m_slaveSystem->isSystemForever())
+				m_isDestroyed = true;
+			else
+				return false;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Alternative to: #3071

Closes: #3071 
Closed: #2645

This PR alters the lifetime handling of linked particle systems. Preventing a master particle system destroying itself before any slaved particle systems have been destroyed.

The result of a slave system losing its master are the following:
- Positional data is lost as this comes from the master system, so slave system particles render at the origin.
- The slave systems `m_isDestroyed` variable gets set which cuts the systems lifetime short.

The above occurs due to the random nature of particle lifetimes. And when a master particle system destroys itself,
the destructor clears the master of the slave system and calls `destroy()` which sets the slave systems `m_isDestroyed`.

With this fix a master particle system checks if it has a finite-lifetime slaved particle system and will not destroy itself till the slaved particle system has been destroyed.
This allows the slaved particle system to fully run the course of its lifetime and render properly.

EDIT - This only applies to finite lifetime particle systems now, it has been tweaked to destroy infinite lifetime systems like it did prior to this change.