### PR TITLE
bugfix(tunnel): Restore retail compatibility after changes to TunnelTracker::onTunnelDestroyed() and TunnelContain::onCapture()

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/TunnelTracker.h
+++ b/Generals/Code/GameEngine/Include/Common/TunnelTracker.h
@@ -66,7 +66,11 @@ public:
 	void healObjects();	///< heal all objects within the tunnel
 #endif
 
+#if RETAIL_COMPATIBLE_CRC
 	UnsignedInt friend_getTunnelCount() const {return m_tunnelCount;}///< TunnelContains are allowed to ask if they are the last one ahead of deletion time
+#else
+	UnsignedInt friend_getTunnelCount() const { return m_tunnelIDs.size(); }///< TunnelContains are allowed to ask if they are the last one ahead of deletion time
+#endif
 
 	const std::list< ObjectID > *getContainerList() const {return &m_tunnelIDs;}
 
@@ -87,7 +91,9 @@ private:
 	std::list< ObjectID > m_xferContainList;///< for loading of m_containList during post processing
 	Int m_containListSize;									///< size of the contain list
 	UnsignedInt m_heroUnitsContained;				///< cached hero count
+#if RETAIL_COMPATIBLE_CRC
 	UnsignedInt m_tunnelCount;							///< How many tunnels have registered so we know when we should kill our contain list
+#endif
 	UnsignedInt m_framesForFullHeal;				///< How many frames it takes to fully heal a unit
 	Bool m_needsFullHealTimeUpdate;					///< Set to true when needing to recalc full heal time to batch the operation
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
@@ -94,7 +94,9 @@ public:
 	virtual void onContaining( Object *obj ) override;		///< object now contains 'obj'
 	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 	virtual void onSelling() override;///< Container is being sold.  Tunnel responds by kicking people out if this is the last tunnel.
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	virtual void onCapture( Player *oldOwner, Player *newOwner ) override; // Need to change who we are registered with.
+#endif
 
 	virtual void orderAllPassengersToExit( CommandSourceType commandSource ) override; ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
 

--- a/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -231,18 +231,14 @@ void TunnelTracker::onTunnelCreated( const Object *newTunnel )
 // ------------------------------------------------------------------------
 void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 {
-	{
-		std::list<ObjectID>::iterator it = std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), deadTunnel->getID());
-		if (it == m_tunnelIDs.end())
-		{
-			DEBUG_CRASH(("TunnelTracker::onTunnelDestroyed - Attempting to remove object '%s' that has never been tracked as a tunnel", deadTunnel->getName().str()));
-			return;
-		}
+	DEBUG_ASSERTCRASH(static_cast<Int>(m_tunnelCount) > 0 && m_tunnelCount == m_tunnelIDs.size(),
+		("TunnelTracker::onTunnelDestroyed - Tunnel count is unexpected"));
+	DEBUG_ASSERTCRASH(std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), deadTunnel->getID()) != m_tunnelIDs.end(),
+		("TunnelTracker::onTunnelDestroyed - Attempting to remove object '%s' that has never been tracked as a tunnel", deadTunnel->getName().str()));
 
-		m_tunnelCount--;
-		m_tunnelIDs.erase(it);
-		m_needsFullHealTimeUpdate = true;
-	}
+	m_tunnelCount--;
+	m_tunnelIDs.remove( deadTunnel->getID() );
+	m_needsFullHealTimeUpdate = true;
 
 	if( m_tunnelCount == 0 )
 	{
@@ -253,7 +249,11 @@ void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 	}
 	else
 	{
-		Object *validTunnel = TheGameLogic->findObjectByID( m_tunnelIDs.front() );
+		// TheSuperHackers @bugfix Caball009 01/09/2026 Check if container is empty before accessing it.
+		// The tunnel count may diverge from the container size, because of bugs that cannot be fixed with
+		// retail compatibility enabled. Expected retail behavior: empty container access results in a nullptr.
+		Object *tunnel = m_tunnelIDs.empty() ? nullptr : TheGameLogic->findObjectByID( m_tunnelIDs.front() );
+
 		// Otherwise, make sure nobody inside remembers the dead tunnel as the one they entered
 		// (scripts need to use so there must be something valid here)
 		for(ContainedItemsList::iterator it = m_containList.begin(); it != m_containList.end(); )
@@ -261,7 +261,7 @@ void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 			Object* obj = *it;
 			++it;
 			if( obj->getContainedBy() == deadTunnel )
-				obj->onContainedBy( validTunnel );
+				obj->onContainedBy( tunnel );
 		}
 	}
 }

--- a/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -50,7 +50,9 @@
 // ------------------------------------------------------------------------
 TunnelTracker::TunnelTracker()
 {
+#if RETAIL_COMPATIBLE_CRC
 	m_tunnelCount = 0;
+#endif
 	m_containListSize = 0;
 	m_heroUnitsContained = 0;
 	m_curNemesisID = INVALID_ID;
@@ -223,7 +225,12 @@ Bool TunnelTracker::isInContainer( Object *obj )
 // ------------------------------------------------------------------------
 void TunnelTracker::onTunnelCreated( const Object *newTunnel )
 {
+	DEBUG_ASSERTCRASH(std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), newTunnel->getID()) == m_tunnelIDs.end(),
+		("TunnelTracker::onTunnelCreated - New tunnel was already added; this shouldn't happen"));
+
+#if RETAIL_COMPATIBLE_CRC
 	m_tunnelCount++;
+#endif
 	m_tunnelIDs.push_back( newTunnel->getID() );
 	m_needsFullHealTimeUpdate = true;
 }
@@ -231,14 +238,19 @@ void TunnelTracker::onTunnelCreated( const Object *newTunnel )
 // ------------------------------------------------------------------------
 void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 {
-	DEBUG_ASSERTCRASH(static_cast<Int>(m_tunnelCount) > 0 && m_tunnelCount == m_tunnelIDs.size(),
+#if RETAIL_COMPATIBLE_CRC
+
+	DEBUG_ASSERTLOG(static_cast<Int>(m_tunnelCount) > 0 && m_tunnelCount == m_tunnelIDs.size(),
 		("TunnelTracker::onTunnelDestroyed - Tunnel count is unexpected"));
-	DEBUG_ASSERTCRASH(std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), deadTunnel->getID()) != m_tunnelIDs.end(),
+
+	const size_t oldSize = m_tunnelIDs.size();
+	m_tunnelIDs.remove(deadTunnel->getID());
+
+	(void)oldSize;
+	DEBUG_ASSERTLOG(oldSize != m_tunnelIDs.size(),
 		("TunnelTracker::onTunnelDestroyed - Attempting to remove object '%s' that has never been tracked as a tunnel", deadTunnel->getName().str()));
 
 	m_tunnelCount--;
-	m_tunnelIDs.remove( deadTunnel->getID() );
-	m_needsFullHealTimeUpdate = true;
 
 	if( m_tunnelCount == 0 )
 	{
@@ -264,6 +276,45 @@ void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 				obj->onContainedBy( tunnel );
 		}
 	}
+
+#else
+
+	const std::list<ObjectID>::iterator it = std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), deadTunnel->getID());
+	if (it != m_tunnelIDs.end())
+	{
+		m_tunnelIDs.erase(it);
+
+		m_needsFullHealTimeUpdate = true;
+	}
+	else
+	{
+		DEBUG_CRASH(("TunnelTracker::onTunnelDestroyed - Attempting to remove object '%s' that has never been tracked as a tunnel",
+			deadTunnel->getName().str()));
+	}
+
+	if( m_tunnelIDs.empty() )
+	{
+		// Kill everyone in our contain list.  Cave in!
+		iterateContained( destroyObject, nullptr, FALSE );
+		m_containList.clear();
+		m_containListSize = 0;
+	}
+	else
+	{
+		Object *validTunnel = TheGameLogic->findObjectByID( m_tunnelIDs.front() );
+
+		// Otherwise, make sure nobody inside remembers the dead tunnel as the one they entered
+		// (scripts need to use so there must be something valid here)
+		for(ContainedItemsList::iterator it = m_containList.begin(); it != m_containList.end(); )
+		{
+			Object* obj = *it;
+			++it;
+			if( obj->getContainedBy() == deadTunnel )
+				obj->onContainedBy( validTunnel );
+		}
+	}
+
+#endif // RETAIL_COMPATIBLE_CRC
 }
 
 // ------------------------------------------------------------------------
@@ -378,13 +429,19 @@ void TunnelTracker::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version
+	* 2: TheSuperHackers @tweak Removed m_tunnelCount (should always be equal to m_tunnelIDs.size())
+	*/
 // ------------------------------------------------------------------------------------------------
 void TunnelTracker::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -423,8 +480,25 @@ void TunnelTracker::xfer( Xfer *xfer )
 		m_needsFullHealTimeUpdate = true;
 	}
 
-	// tunnel count
-	xfer->xferUnsignedInt( &m_tunnelCount );
+#if RETAIL_COMPATIBLE_CRC
+	if (version <= 1)
+	{
+		xfer->xferUnsignedInt(&m_tunnelCount);
+	}
+	else
+	{
+		if (xfer->getXferMode() == XFER_LOAD)
+		{
+			m_tunnelCount = m_tunnelIDs.size();
+		}
+	}
+#else
+	if (version <= 1)
+	{
+		UnsignedInt tunnelCount = m_tunnelIDs.size();
+		xfer->xferUnsignedInt(&tunnelCount);
+	}
+#endif
 
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -400,6 +400,7 @@ void TunnelContain::onBuildComplete()
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 void TunnelContain::onCapture( Player *oldOwner, Player *newOwner )
 {
 	if( m_isCurrentlyRegistered )
@@ -421,6 +422,7 @@ void TunnelContain::onCapture( Player *oldOwner, Player *newOwner )
 	// extend base class
 	OpenContain::onCapture( oldOwner, newOwner );
 }
+#endif
 
 //-------------------------------------------------------------------------------------------------
 void TunnelContain::orderAllPassengersToExit( CommandSourceType commandSource )

--- a/GeneralsMD/Code/GameEngine/Include/Common/TunnelTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/TunnelTracker.h
@@ -66,7 +66,11 @@ public:
 	void healObjects();	///< heal all objects within the tunnel
 #endif
 
+#if RETAIL_COMPATIBLE_CRC
 	UnsignedInt friend_getTunnelCount() const {return m_tunnelCount;}///< TunnelContains are allowed to ask if they are the last one ahead of deletion time
+#else
+	UnsignedInt friend_getTunnelCount() const { return m_tunnelIDs.size(); }///< TunnelContains are allowed to ask if they are the last one ahead of deletion time
+#endif
 
 	const std::list< ObjectID > *getContainerList() const {return &m_tunnelIDs;}
 
@@ -87,7 +91,9 @@ private:
 	std::list< ObjectID > m_xferContainList;///< for loading of m_containList during post processing
 	Int m_containListSize;									///< size of the contain list
 	UnsignedInt m_heroUnitsContained;				///< cached hero count
+#if RETAIL_COMPATIBLE_CRC
 	UnsignedInt m_tunnelCount;							///< How many tunnels have registered so we know when we should kill our contain list
+#endif
 	UnsignedInt m_framesForFullHeal;				///< How many frames it takes to fully heal a unit
 	Bool m_needsFullHealTimeUpdate;					///< Set to true when needing to recalc full heal time to batch the operation
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
@@ -97,7 +97,9 @@ public:
 	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
 	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 	virtual void onSelling() override;///< Container is being sold.  Tunnel responds by kicking people out if this is the last tunnel.
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 	virtual void onCapture( Player *oldOwner, Player *newOwner ) override; // Need to change who we are registered with.
+#endif
 
 	virtual void orderAllPassengersToExit( CommandSourceType commandSource, Bool instantly ) override; ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
 	virtual void orderAllPassengersToIdle( CommandSourceType commandSource ) override; ///< Just like it sounds

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -50,7 +50,9 @@
 // ------------------------------------------------------------------------
 TunnelTracker::TunnelTracker()
 {
+#if RETAIL_COMPATIBLE_CRC
 	m_tunnelCount = 0;
+#endif
 	m_containListSize = 0;
 	m_heroUnitsContained = 0;
 	m_curNemesisID = INVALID_ID;
@@ -224,7 +226,12 @@ Bool TunnelTracker::isInContainer( Object *obj )
 // ------------------------------------------------------------------------
 void TunnelTracker::onTunnelCreated( const Object *newTunnel )
 {
+	DEBUG_ASSERTCRASH(std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), newTunnel->getID()) == m_tunnelIDs.end(),
+		("TunnelTracker::onTunnelCreated - New tunnel was already added; this shouldn't happen"));
+
+#if RETAIL_COMPATIBLE_CRC
 	m_tunnelCount++;
+#endif
 	m_tunnelIDs.push_back( newTunnel->getID() );
 	m_needsFullHealTimeUpdate = true;
 }
@@ -232,14 +239,19 @@ void TunnelTracker::onTunnelCreated( const Object *newTunnel )
 // ------------------------------------------------------------------------
 void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 {
-	DEBUG_ASSERTCRASH(static_cast<Int>(m_tunnelCount) > 0 && m_tunnelCount == m_tunnelIDs.size(),
+#if RETAIL_COMPATIBLE_CRC
+
+	DEBUG_ASSERTLOG(static_cast<Int>(m_tunnelCount) > 0 && m_tunnelCount == m_tunnelIDs.size(),
 		("TunnelTracker::onTunnelDestroyed - Tunnel count is unexpected"));
-	DEBUG_ASSERTCRASH(std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), deadTunnel->getID()) != m_tunnelIDs.end(),
+
+	const size_t oldSize = m_tunnelIDs.size();
+	m_tunnelIDs.remove(deadTunnel->getID());
+
+	(void)oldSize;
+	DEBUG_ASSERTLOG(oldSize != m_tunnelIDs.size(),
 		("TunnelTracker::onTunnelDestroyed - Attempting to remove object '%s' that has never been tracked as a tunnel", deadTunnel->getName().str()));
 
 	m_tunnelCount--;
-	m_tunnelIDs.remove( deadTunnel->getID() );
-	m_needsFullHealTimeUpdate = true;
 
 	if( m_tunnelCount == 0 )
 	{
@@ -265,6 +277,45 @@ void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 				obj->onContainedBy( tunnel );
 		}
 	}
+
+#else
+
+	const std::list<ObjectID>::iterator it = std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), deadTunnel->getID());
+	if (it != m_tunnelIDs.end())
+	{
+		m_tunnelIDs.erase(it);
+
+		m_needsFullHealTimeUpdate = true;
+	}
+	else
+	{
+		DEBUG_CRASH(("TunnelTracker::onTunnelDestroyed - Attempting to remove object '%s' that has never been tracked as a tunnel",
+			deadTunnel->getName().str()));
+	}
+
+	if( m_tunnelIDs.empty() )
+	{
+		// Kill everyone in our contain list.  Cave in!
+		iterateContained( destroyObject, nullptr, FALSE );
+		m_containList.clear();
+		m_containListSize = 0;
+	}
+	else
+	{
+		Object *validTunnel = TheGameLogic->findObjectByID( m_tunnelIDs.front() );
+
+		// Otherwise, make sure nobody inside remembers the dead tunnel as the one they entered
+		// (scripts need to use so there must be something valid here)
+		for(ContainedItemsList::iterator it = m_containList.begin(); it != m_containList.end(); )
+		{
+			Object* obj = *it;
+			++it;
+			if( obj->getContainedBy() == deadTunnel )
+				obj->onContainedBy( validTunnel );
+		}
+	}
+
+#endif // RETAIL_COMPATIBLE_CRC
 }
 
 // ------------------------------------------------------------------------
@@ -379,13 +430,19 @@ void TunnelTracker::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version
+	* 2: TheSuperHackers @tweak Removed m_tunnelCount (should always be equal to m_tunnelIDs.size())
+	*/
 // ------------------------------------------------------------------------------------------------
 void TunnelTracker::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -424,8 +481,25 @@ void TunnelTracker::xfer( Xfer *xfer )
 		m_needsFullHealTimeUpdate = true;
 	}
 
-	// tunnel count
-	xfer->xferUnsignedInt( &m_tunnelCount );
+#if RETAIL_COMPATIBLE_CRC
+	if (version <= 1)
+	{
+		xfer->xferUnsignedInt(&m_tunnelCount);
+	}
+	else
+	{
+		if (xfer->getXferMode() == XFER_LOAD)
+		{
+			m_tunnelCount = m_tunnelIDs.size();
+		}
+	}
+#else
+	if (version <= 1)
+	{
+		UnsignedInt tunnelCount = m_tunnelIDs.size();
+		xfer->xferUnsignedInt(&tunnelCount);
+	}
+#endif
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -232,18 +232,14 @@ void TunnelTracker::onTunnelCreated( const Object *newTunnel )
 // ------------------------------------------------------------------------
 void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 {
-	{
-		std::list<ObjectID>::iterator it = std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), deadTunnel->getID());
-		if (it == m_tunnelIDs.end())
-		{
-			DEBUG_CRASH(("TunnelTracker::onTunnelDestroyed - Attempting to remove object '%s' that has never been tracked as a tunnel", deadTunnel->getName().str()));
-			return;
-		}
+	DEBUG_ASSERTCRASH(static_cast<Int>(m_tunnelCount) > 0 && m_tunnelCount == m_tunnelIDs.size(),
+		("TunnelTracker::onTunnelDestroyed - Tunnel count is unexpected"));
+	DEBUG_ASSERTCRASH(std::find(m_tunnelIDs.begin(), m_tunnelIDs.end(), deadTunnel->getID()) != m_tunnelIDs.end(),
+		("TunnelTracker::onTunnelDestroyed - Attempting to remove object '%s' that has never been tracked as a tunnel", deadTunnel->getName().str()));
 
-		m_tunnelCount--;
-		m_tunnelIDs.erase(it);
-		m_needsFullHealTimeUpdate = true;
-	}
+	m_tunnelCount--;
+	m_tunnelIDs.remove( deadTunnel->getID() );
+	m_needsFullHealTimeUpdate = true;
 
 	if( m_tunnelCount == 0 )
 	{
@@ -254,7 +250,11 @@ void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 	}
 	else
 	{
-		Object *validTunnel = TheGameLogic->findObjectByID( m_tunnelIDs.front() );
+		// TheSuperHackers @bugfix Caball009 01/09/2026 Check if container is empty before accessing it.
+		// The tunnel count may diverge from the container size, because of bugs that cannot be fixed with
+		// retail compatibility enabled. Expected retail behavior: empty container access results in a nullptr.
+		Object *tunnel = m_tunnelIDs.empty() ? nullptr : TheGameLogic->findObjectByID( m_tunnelIDs.front() );
+
 		// Otherwise, make sure nobody inside remembers the dead tunnel as the one they entered
 		// (scripts need to use so there must be something valid here)
 		for(ContainedItemsList::iterator it = m_containList.begin(); it != m_containList.end(); )
@@ -262,7 +262,7 @@ void TunnelTracker::onTunnelDestroyed( const Object *deadTunnel )
 			Object* obj = *it;
 			++it;
 			if( obj->getContainedBy() == deadTunnel )
-				obj->onContainedBy( validTunnel );
+				obj->onContainedBy( tunnel );
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -502,6 +502,7 @@ void TunnelContain::onBuildComplete()
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
+#if !(RTS_GENERALS && RETAIL_COMPATIBLE_CRC)
 void TunnelContain::onCapture( Player *oldOwner, Player *newOwner )
 {
 	if( m_isCurrentlyRegistered )
@@ -523,6 +524,7 @@ void TunnelContain::onCapture( Player *oldOwner, Player *newOwner )
 	// extend base class
 	OpenContain::onCapture( oldOwner, newOwner );
 }
+#endif
 
 //-------------------------------------------------------------------------------------------------
 void TunnelContain::orderAllPassengersToExit( CommandSourceType commandSource, Bool instantly )


### PR DESCRIPTION
* Closes https://github.com/TheSuperHackers/GeneralsGameCode/issues/2496
* Follow-up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/1958

This PR makes 3 changes (one commit for each):
1. - Restore retail compatibility: adding `TunnelContain::onCapture` to Generals is not retail compatible so this needs to be behind the `RETAIL_COMPATIBLE_CRC` macro.
2. - Restore retail compatibility: the early return in `TunnelTracker::onTunnelDestroyed` is not retail compatible so this had to be changed.
    - Fix a potential crash. A side effect of the early return is that the members of the contain list (`m_containList`) hold on to a pointer to their container. This can lead to use-after-free bugs and crashes. The early return is removed.
3. - Add non-retail code to `TunnelTracker::onTunnelDestroyed` that only relies on `m_tunnelIDs` and doesn't use `m_tunnelCount`. It's also removed from `TunnelTracker::xfer`.

The `m_tunnelCount` integer underflow cannot be fixed with retail compatibility enabled, but the code should be well-defined and safe now.

See commits for cleaner diffs; third commit partially changes code from second commit.

---

```cpp
Object *validTunnel = TheGameLogic->findObjectByID( m_tunnelIDs.front() );
```
I'm not entirely familiar with the STLPort implementation of `std::list<T>`, but accessing the front element of an empty `std::list` appears to result reliably in `T{}` for trivial types; `INVALID_ID` in this context. As a result, all contained objects have their container pointer updated to `nullptr`, neatly avoiding the use-after-free bugs and resulting crash.

---

### Crash reproduction with the current main branch (VC6 / VS22, RETAIL_COMPATIBLE_CRC == 1), using Zero Hour GLA campaign mission 3:
<details>
<summary>Video and call stack</summary>

https://github.com/user-attachments/assets/106195f0-e149-4e18-a10e-8f7a9649484a

```
generalszh.exe!AIUpdateInterface::getNextMoodTarget(bool calledByAI, bool calledDuringIdle) Line 4557
generalszh.exe!AIIdleState::update() Line 1443
generalszh.exe!StateMachine::updateStateMachine() Line 439
generalszh.exe!AIStateMachine::updateStateMachine() Line 884
generalszh.exe!AIUpdateInterface::update() Line 1015
generalszh.exe!GameLogic::update() Line 3873
generalszh.exe!SubsystemInterface::UPDATE() Line 131
generalszh.exe!GameEngine::update() Line 921
generalszh.exe!Win32GameEngine::update() Line 91
generalszh.exe!GameEngine::execute() Line 983
generalszh.exe!GameMain() Line 55
generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 929
```

</details>

## TODO:
- [x] Replicate last commit to Generals.
- [x] Update PR description to include the changes after the second commit.