### PR TITLE
ci(vcpkg): Disable vcpkg metrics to stop random link failures

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -39,6 +39,9 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,${{ github.event.pull_request.head.repo.fork && 'read' || 'readwrite' }}"
       VCPKG_NUGET_REPOSITORY: "https://github.com/${{ github.repository }}.git"
       VCPKG_FEATURE_FLAGS: manifests,versions,binarycaching
+      # Metrics make every vcpkg run open its own exe exclusively to copy itself into
+      # TEMP for the telemetry upload, which randomly blocks the next vcpkg launch.
+      VCPKG_DISABLE_METRICS: "1"
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
* Fixes #3243

vcpkg copies its own exe into TEMP on every run to upload telemetry, and it holds the running exe open with no sharing while it does that. The toolchain runs one `vcpkg z-applocal` per executable and Ninja folds that into the link edge, so the link phase launches about 21 vcpkg at once and one of them randomly fails to start. The failure comes from the shell, not from vcpkg or CMake, which is why nothing in the log names a file.

Now the jobs set VCPKG_DISABLE_METRICS, so no run copies itself and nothing holds the exe. I measured it on Windows with the toolset and vcpkg build CI uses: 32 launch failures in 2400 with metrics on, 0 in 2400 with it off. App-local deployment is untouched, so the artifacts are the same.

Todo:
- [x] Measure with metrics on and off on Windows
- [x] Confirm the six win32-vcpkg jobs pass here
