### PR TITLE
bugfix(meshmatdesc): Fix mesh material color processing

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -693,9 +693,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 		bool emissive_used=false;
 		bool opacity_used=false;
 
-		Vector3 mtl_diffuse;
-		Vector3 mtl_ambient;
-		Vector3 mtl_emissive;
+		Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
+		Vector3 mtl_ambient(0.0f,0.0f,0.0f);
+		Vector3 mtl_emissive(0.0f,0.0f,0.0f);
 		float mtl_opacity = 1.0f;
 
 		VertexMaterialClass * prev_mtl = nullptr;
@@ -714,6 +714,11 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		for (int vidx=0; vidx<VertexCount; vidx++) {
 			mtl = Peek_Material(vidx,pass);
+			// TheSuperHackers @bugfix Cryo 01/09/2026 A material array can contain null entries.
+			if (mtl == nullptr) {
+				continue;
+			}
+
 			if (mtl != prev_mtl) {
 				prev_mtl = mtl;
 				mtl->Get_Diffuse(&mtl_diffuse);
@@ -770,6 +775,11 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 			for (int vidx=0; vidx<VertexCount; vidx++) {
 
 				mtl = Peek_Material(vidx,pass);
+				// TheSuperHackers @bugfix Cryo 01/09/2026 Do not apply material colors through a null entry.
+				if (mtl == nullptr) {
+					continue;
+				}
+
 				if (mtl != prev_mtl) {
 					prev_mtl = mtl;
 					mtl->Get_Diffuse(&mtl_diffuse);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -680,71 +680,35 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		if (!ColorArray[0] && !ColorArray[1]) continue;	// If no color arrays, we don't have a problem
 
-		Vector3 single_diffuse(0.0f,0.0f,0.0f);
-		Vector3 single_ambient(0.0f,0.0f,0.0f);
-		Vector3 single_emissive(0.0f,0.0f,0.0f);
-		float single_opacity=1.0f;
-		bool single_diffuse_used=true;
-		bool single_ambient_used=true;
-		bool single_emissive_used=true;
-		bool single_opacity_used=true;
+		// Aggregate color usage across valid materials; no first-material baseline is needed.
 		bool diffuse_used=false;
 		bool ambient_used=false;
 		bool emissive_used=false;
-		bool opacity_used=false;
 
-		Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
-		Vector3 mtl_ambient(0.0f,0.0f,0.0f);
-		Vector3 mtl_emissive(0.0f,0.0f,0.0f);
-		float mtl_opacity = 1.0f;
-
-		VertexMaterialClass * prev_mtl = nullptr;
-		VertexMaterialClass * mtl = Peek_Material(0, pass);
-		if (mtl) {
-			mtl->Get_Diffuse(&single_diffuse);
-			single_opacity = mtl->Get_Opacity();
-			mtl->Get_Ambient(&single_ambient);
-			mtl->Get_Emissive(&single_emissive);
-
-			if (single_diffuse.X || single_diffuse.Y || single_diffuse.Z) diffuse_used=true;
-			if (single_ambient.X || single_ambient.Y || single_ambient.Z) ambient_used=true;
-			if (single_emissive.X || single_emissive.Y || single_emissive.Z) emissive_used=true;
-			if (single_opacity!=1.0f) opacity_used=true;
-		}
-
-		for (int vidx=0; vidx<VertexCount; vidx++) {
-			mtl = Peek_Material(vidx,pass);
+		VertexMaterialClass* prev_mtl = nullptr;
+		for (int vidx=0; vidx<VertexCount; vidx++)
+		{
+			VertexMaterialClass* mtl = Peek_Material(vidx,pass);
 			// TheSuperHackers @bugfix Cryo 01/09/2026 A material array can contain null entries.
-			if (mtl == nullptr) {
+			if (mtl == nullptr)
+			{
 				continue;
 			}
 
-			if (mtl != prev_mtl) {
+			if (mtl != prev_mtl)
+			{
 				prev_mtl = mtl;
+				Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
+				Vector3 mtl_ambient(0.0f,0.0f,0.0f);
+				Vector3 mtl_emissive(0.0f,0.0f,0.0f);
 				mtl->Get_Diffuse(&mtl_diffuse);
-				mtl_opacity = mtl->Get_Opacity();
 				mtl->Get_Ambient(&mtl_ambient);
 				mtl->Get_Emissive(&mtl_emissive);
-			}
 
-			if (mtl_diffuse.X!=single_diffuse.X || mtl_diffuse.Y!=single_diffuse.Y || mtl_diffuse.Z!=single_diffuse.Z) {
-				single_diffuse_used=false;
+				diffuse_used = diffuse_used || mtl_diffuse.X || mtl_diffuse.Y || mtl_diffuse.Z;
+				ambient_used = ambient_used || mtl_ambient.X || mtl_ambient.Y || mtl_ambient.Z;
+				emissive_used = emissive_used || mtl_emissive.X || mtl_emissive.Y || mtl_emissive.Z;
 			}
-			if (mtl_ambient.X!=single_ambient.X || mtl_ambient.Y!=single_ambient.Y || mtl_ambient.Z!=single_ambient.Z) {
-				single_ambient_used=false;
-			}
-			if (mtl_emissive.X!=single_emissive.X || mtl_emissive.Y!=single_emissive.Y || mtl_emissive.Z!=single_emissive.Z) {
-				single_emissive_used=false;
-			}
-			if (mtl_opacity!=single_opacity) {
-				single_opacity_used=false;
-			}
-
-			if (mtl_diffuse.X || mtl_diffuse.Y || mtl_diffuse.Z) diffuse_used=true;
-			if (mtl_ambient.X || mtl_ambient.Y || mtl_ambient.Z) ambient_used=true;
-			if (mtl_emissive.X || mtl_emissive.Y || mtl_emissive.Z) emissive_used=true;
-			if (mtl_opacity!=1.0f) opacity_used=true;
-
 		}
 
 		// If both DCG and DIG arrays are submitted, multiply them together to DCG channel
@@ -766,7 +730,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		if ((DCGSource[pass] != VertexMaterialClass::MATERIAL) && (ColorArray[0] != nullptr)) {
 			unsigned * diffuse_array = ColorArray[0]->Get_Array();
-			Vector3 mtl_diffuse;
+			Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
+			Vector3 mtl_ambient(0.0f,0.0f,0.0f);
+			Vector3 mtl_emissive(0.0f,0.0f,0.0f);
 			float mtl_opacity = 1.0f;
 
 			VertexMaterialClass * prev_mtl = nullptr;
@@ -783,6 +749,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				if (mtl != prev_mtl) {
 					prev_mtl = mtl;
 					mtl->Get_Diffuse(&mtl_diffuse);
+					// TheSuperHackers @bugfix Cryo 10/09/2026 Use this vertex's material colors, not the last analyzed material.
+					mtl->Get_Ambient(&mtl_ambient);
+					mtl->Get_Emissive(&mtl_emissive);
 					mtl_opacity = mtl->Get_Opacity();
 				}
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -708,6 +708,11 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				diffuse_used = diffuse_used || mtl_diffuse.X || mtl_diffuse.Y || mtl_diffuse.Z;
 				ambient_used = ambient_used || mtl_ambient.X || mtl_ambient.Y || mtl_ambient.Z;
 				emissive_used = emissive_used || mtl_emissive.X || mtl_emissive.Y || mtl_emissive.Z;
+
+				if (diffuse_used && ambient_used && emissive_used)
+				{
+					break;
+				}
 			}
 		}
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -639,6 +639,8 @@ void MeshMatDescClass::Install_UV_Array(int pass,int stage,Vector2 * uvs,int cou
 }
 
 
+// TheSuperHackers @bugfix Cryo 10/09/2026 Skip null materials to prevent crashes and
+// use each vertex's material colors to avoid incorrect ambient/emissive vertex colors.
 void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * parent)
 {
 	/*
@@ -680,7 +682,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		if (!ColorArray[0] && !ColorArray[1]) continue;	// If no color arrays, we don't have a problem
 
-		// Aggregate color usage across valid materials; no first-material baseline is needed.
 		bool diffuse_used=false;
 		bool ambient_used=false;
 		bool emissive_used=false;
@@ -689,7 +690,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 		for (int vidx=0; vidx<VertexCount; vidx++)
 		{
 			VertexMaterialClass* mtl = Peek_Material(vidx,pass);
-			// TheSuperHackers @bugfix Cryo 01/09/2026 A material array can contain null entries.
 			if (mtl == nullptr)
 			{
 				continue;
@@ -698,9 +698,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 			if (mtl != prev_mtl)
 			{
 				prev_mtl = mtl;
-				Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
-				Vector3 mtl_ambient(0.0f,0.0f,0.0f);
-				Vector3 mtl_emissive(0.0f,0.0f,0.0f);
+				Vector3 mtl_diffuse;
+				Vector3 mtl_ambient;
+				Vector3 mtl_emissive;
 				mtl->Get_Diffuse(&mtl_diffuse);
 				mtl->Get_Ambient(&mtl_ambient);
 				mtl->Get_Emissive(&mtl_emissive);
@@ -730,10 +730,10 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		if ((DCGSource[pass] != VertexMaterialClass::MATERIAL) && (ColorArray[0] != nullptr)) {
 			unsigned * diffuse_array = ColorArray[0]->Get_Array();
-			Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
-			Vector3 mtl_ambient(0.0f,0.0f,0.0f);
-			Vector3 mtl_emissive(0.0f,0.0f,0.0f);
-			float mtl_opacity = 1.0f;
+			Vector3 mtl_diffuse;
+			Vector3 mtl_ambient;
+			Vector3 mtl_emissive;
+			float mtl_opacity;
 
 			VertexMaterialClass * prev_mtl = nullptr;
 			VertexMaterialClass * mtl = Peek_Material(0,pass);
@@ -741,7 +741,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 			for (int vidx=0; vidx<VertexCount; vidx++) {
 
 				mtl = Peek_Material(vidx,pass);
-				// TheSuperHackers @bugfix Cryo 01/09/2026 Do not apply material colors through a null entry.
 				if (mtl == nullptr) {
 					continue;
 				}
@@ -749,7 +748,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				if (mtl != prev_mtl) {
 					prev_mtl = mtl;
 					mtl->Get_Diffuse(&mtl_diffuse);
-					// TheSuperHackers @bugfix Cryo 10/09/2026 Use this vertex's material colors, not the last analyzed material.
 					mtl->Get_Ambient(&mtl_ambient);
 					mtl->Get_Emissive(&mtl_emissive);
 					mtl_opacity = mtl->Get_Opacity();

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -695,9 +695,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 		bool emissive_used=false;
 		bool opacity_used=false;
 
-		Vector3 mtl_diffuse;
-		Vector3 mtl_ambient;
-		Vector3 mtl_emissive;
+		Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
+		Vector3 mtl_ambient(0.0f,0.0f,0.0f);
+		Vector3 mtl_emissive(0.0f,0.0f,0.0f);
 		float mtl_opacity = 1.0f;
 
 		VertexMaterialClass * prev_mtl = nullptr;
@@ -716,6 +716,11 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		for (int vidx=0; vidx<VertexCount; vidx++) {
 			mtl = Peek_Material(vidx,pass);
+			// TheSuperHackers @bugfix Cryo 01/09/2026 A material array can contain null entries.
+			if (mtl == nullptr) {
+				continue;
+			}
+
 			if (mtl != prev_mtl) {
 				prev_mtl = mtl;
 				mtl->Get_Diffuse(&mtl_diffuse);
@@ -772,6 +777,11 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 			for (int vidx=0; vidx<VertexCount; vidx++) {
 
 				mtl = Peek_Material(vidx,pass);
+				// TheSuperHackers @bugfix Cryo 01/09/2026 Do not apply material colors through a null entry.
+				if (mtl == nullptr) {
+					continue;
+				}
+
 				if (mtl != prev_mtl) {
 					prev_mtl = mtl;
 					mtl->Get_Diffuse(&mtl_diffuse);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -901,9 +901,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 			bool ambient_used=false;
 			bool emissive_used=false;
 
-			Vector3 mtl_diffuse;
-			Vector3 mtl_ambient;
-			Vector3 mtl_emissive;
+			Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
+			Vector3 mtl_ambient(0.0f,0.0f,0.0f);
+			Vector3 mtl_emissive(0.0f,0.0f,0.0f);
 
 			VertexMaterialClass * prev_mtl = nullptr;
 			VertexMaterialClass * mtl = Peek_Material(0, pass);
@@ -919,6 +919,12 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 			for (int vidx=0; vidx<VertexCount; vidx++) {
 				mtl = Peek_Material(vidx,pass);
+				// TheSuperHackers @bugfix Cryo 09/09/2026 Skip null materials in the final lighting analysis too.
+				if (mtl == nullptr)
+				{
+					continue;
+				}
+
 				if (mtl != prev_mtl) {
 					prev_mtl = mtl;
 					mtl->Get_Diffuse(&mtl_diffuse);
@@ -936,6 +942,12 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				VertexMaterialClass * mtl = Peek_Material(0,pass);
 				for (int vidx=0; vidx<VertexCount; vidx++) {
 					mtl = Peek_Material(vidx,pass);
+					// TheSuperHackers @bugfix Cryo 09/09/2026 Apply lighting only to existing materials.
+					if (mtl == nullptr)
+					{
+						continue;
+					}
+
 					if (mtl != prev_mtl) {
 						prev_mtl = mtl;
 						// If only emissive is used apply emissive to color channel, set diffuse source to color 1, and turn off lighting

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -640,6 +640,8 @@ void MeshMatDescClass::Install_UV_Array(int pass,int stage,Vector2 * uvs,int cou
 }
 
 
+// TheSuperHackers @bugfix Cryo 10/09/2026 Skip null materials to prevent crashes and
+// use each vertex's material colors to avoid incorrect ambient/emissive vertex colors.
 void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * parent)
 {
 	/*
@@ -682,7 +684,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		if (!ColorArray[0] && !ColorArray[1]) continue;	// If no color arrays, we don't have a problem
 
-		// Aggregate color usage across valid materials; no first-material baseline is needed.
 		bool diffuse_used=false;
 		bool ambient_used=false;
 		bool emissive_used=false;
@@ -691,7 +692,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 		for (int vidx=0; vidx<VertexCount; vidx++)
 		{
 			VertexMaterialClass* mtl = Peek_Material(vidx,pass);
-			// TheSuperHackers @bugfix Cryo 01/09/2026 A material array can contain null entries.
 			if (mtl == nullptr)
 			{
 				continue;
@@ -700,9 +700,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 			if (mtl != prev_mtl)
 			{
 				prev_mtl = mtl;
-				Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
-				Vector3 mtl_ambient(0.0f,0.0f,0.0f);
-				Vector3 mtl_emissive(0.0f,0.0f,0.0f);
+				Vector3 mtl_diffuse;
+				Vector3 mtl_ambient;
+				Vector3 mtl_emissive;
 				mtl->Get_Diffuse(&mtl_diffuse);
 				mtl->Get_Ambient(&mtl_ambient);
 				mtl->Get_Emissive(&mtl_emissive);
@@ -732,10 +732,10 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		if ((DCGSource[pass] != VertexMaterialClass::MATERIAL) && (ColorArray[0] != nullptr)) {
 			unsigned * diffuse_array = ColorArray[0]->Get_Array();
-			Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
-			Vector3 mtl_ambient(0.0f,0.0f,0.0f);
-			Vector3 mtl_emissive(0.0f,0.0f,0.0f);
-			float mtl_opacity = 1.0f;
+			Vector3 mtl_diffuse;
+			Vector3 mtl_ambient;
+			Vector3 mtl_emissive;
+			float mtl_opacity;
 
 			VertexMaterialClass * prev_mtl = nullptr;
 			VertexMaterialClass * mtl = Peek_Material(0,pass);
@@ -743,7 +743,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 			for (int vidx=0; vidx<VertexCount; vidx++) {
 
 				mtl = Peek_Material(vidx,pass);
-				// TheSuperHackers @bugfix Cryo 01/09/2026 Do not apply material colors through a null entry.
 				if (mtl == nullptr) {
 					continue;
 				}
@@ -751,7 +750,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				if (mtl != prev_mtl) {
 					prev_mtl = mtl;
 					mtl->Get_Diffuse(&mtl_diffuse);
-					// TheSuperHackers @bugfix Cryo 10/09/2026 Use this vertex's material colors, not the last analyzed material.
 					mtl->Get_Ambient(&mtl_ambient);
 					mtl->Get_Emissive(&mtl_emissive);
 					mtl_opacity = mtl->Get_Opacity();
@@ -863,7 +861,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 		}
 		// Set lighting to false if requested in all passes...
 		else if (set_lighting_to_false) {
-			// Aggregate color usage across valid materials; no first-material baseline is needed.
 			bool diffuse_used=false;
 			bool ambient_used=false;
 			bool emissive_used=false;
@@ -872,7 +869,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 			for (int vidx=0; vidx<VertexCount; vidx++)
 			{
 				VertexMaterialClass* mtl = Peek_Material(vidx,pass);
-				// TheSuperHackers @bugfix Cryo 09/09/2026 Skip null materials in the final lighting analysis too.
 				if (mtl == nullptr)
 				{
 					continue;
@@ -881,9 +877,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				if (mtl != prev_mtl)
 				{
 					prev_mtl = mtl;
-					Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
-					Vector3 mtl_ambient(0.0f,0.0f,0.0f);
-					Vector3 mtl_emissive(0.0f,0.0f,0.0f);
+					Vector3 mtl_diffuse;
+					Vector3 mtl_ambient;
+					Vector3 mtl_emissive;
 					mtl->Get_Diffuse(&mtl_diffuse);
 					mtl->Get_Ambient(&mtl_ambient);
 					mtl->Get_Emissive(&mtl_emissive);
@@ -899,7 +895,6 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				VertexMaterialClass * mtl = Peek_Material(0,pass);
 				for (int vidx=0; vidx<VertexCount; vidx++) {
 					mtl = Peek_Material(vidx,pass);
-					// TheSuperHackers @bugfix Cryo 09/09/2026 Apply lighting only to existing materials.
 					if (mtl == nullptr)
 					{
 						continue;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -682,71 +682,35 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		if (!ColorArray[0] && !ColorArray[1]) continue;	// If no color arrays, we don't have a problem
 
-		Vector3 single_diffuse(0.0f,0.0f,0.0f);
-		Vector3 single_ambient(0.0f,0.0f,0.0f);
-		Vector3 single_emissive(0.0f,0.0f,0.0f);
-		float single_opacity=1.0f;
-		bool single_diffuse_used=true;
-		bool single_ambient_used=true;
-		bool single_emissive_used=true;
-		bool single_opacity_used=true;
+		// Aggregate color usage across valid materials; no first-material baseline is needed.
 		bool diffuse_used=false;
 		bool ambient_used=false;
 		bool emissive_used=false;
-		bool opacity_used=false;
 
-		Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
-		Vector3 mtl_ambient(0.0f,0.0f,0.0f);
-		Vector3 mtl_emissive(0.0f,0.0f,0.0f);
-		float mtl_opacity = 1.0f;
-
-		VertexMaterialClass * prev_mtl = nullptr;
-		VertexMaterialClass * mtl = Peek_Material(0, pass);
-		if (mtl) {
-			mtl->Get_Diffuse(&single_diffuse);
-			single_opacity = mtl->Get_Opacity();
-			mtl->Get_Ambient(&single_ambient);
-			mtl->Get_Emissive(&single_emissive);
-
-			if (single_diffuse.X || single_diffuse.Y || single_diffuse.Z) diffuse_used=true;
-			if (single_ambient.X || single_ambient.Y || single_ambient.Z) ambient_used=true;
-			if (single_emissive.X || single_emissive.Y || single_emissive.Z) emissive_used=true;
-			if (single_opacity!=1.0f) opacity_used=true;
-		}
-
-		for (int vidx=0; vidx<VertexCount; vidx++) {
-			mtl = Peek_Material(vidx,pass);
+		VertexMaterialClass* prev_mtl = nullptr;
+		for (int vidx=0; vidx<VertexCount; vidx++)
+		{
+			VertexMaterialClass* mtl = Peek_Material(vidx,pass);
 			// TheSuperHackers @bugfix Cryo 01/09/2026 A material array can contain null entries.
-			if (mtl == nullptr) {
+			if (mtl == nullptr)
+			{
 				continue;
 			}
 
-			if (mtl != prev_mtl) {
+			if (mtl != prev_mtl)
+			{
 				prev_mtl = mtl;
+				Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
+				Vector3 mtl_ambient(0.0f,0.0f,0.0f);
+				Vector3 mtl_emissive(0.0f,0.0f,0.0f);
 				mtl->Get_Diffuse(&mtl_diffuse);
-				mtl_opacity = mtl->Get_Opacity();
 				mtl->Get_Ambient(&mtl_ambient);
 				mtl->Get_Emissive(&mtl_emissive);
-			}
 
-			if (mtl_diffuse.X!=single_diffuse.X || mtl_diffuse.Y!=single_diffuse.Y || mtl_diffuse.Z!=single_diffuse.Z) {
-				single_diffuse_used=false;
+				diffuse_used = diffuse_used || mtl_diffuse.X || mtl_diffuse.Y || mtl_diffuse.Z;
+				ambient_used = ambient_used || mtl_ambient.X || mtl_ambient.Y || mtl_ambient.Z;
+				emissive_used = emissive_used || mtl_emissive.X || mtl_emissive.Y || mtl_emissive.Z;
 			}
-			if (mtl_ambient.X!=single_ambient.X || mtl_ambient.Y!=single_ambient.Y || mtl_ambient.Z!=single_ambient.Z) {
-				single_ambient_used=false;
-			}
-			if (mtl_emissive.X!=single_emissive.X || mtl_emissive.Y!=single_emissive.Y || mtl_emissive.Z!=single_emissive.Z) {
-				single_emissive_used=false;
-			}
-			if (mtl_opacity!=single_opacity) {
-				single_opacity_used=false;
-			}
-
-			if (mtl_diffuse.X || mtl_diffuse.Y || mtl_diffuse.Z) diffuse_used=true;
-			if (mtl_ambient.X || mtl_ambient.Y || mtl_ambient.Z) ambient_used=true;
-			if (mtl_emissive.X || mtl_emissive.Y || mtl_emissive.Z) emissive_used=true;
-			if (mtl_opacity!=1.0f) opacity_used=true;
-
 		}
 
 		// If both DCG and DIG arrays are submitted, multiply them together to DCG channel
@@ -768,7 +732,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		if ((DCGSource[pass] != VertexMaterialClass::MATERIAL) && (ColorArray[0] != nullptr)) {
 			unsigned * diffuse_array = ColorArray[0]->Get_Array();
-			Vector3 mtl_diffuse;
+			Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
+			Vector3 mtl_ambient(0.0f,0.0f,0.0f);
+			Vector3 mtl_emissive(0.0f,0.0f,0.0f);
 			float mtl_opacity = 1.0f;
 
 			VertexMaterialClass * prev_mtl = nullptr;
@@ -785,6 +751,9 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				if (mtl != prev_mtl) {
 					prev_mtl = mtl;
 					mtl->Get_Diffuse(&mtl_diffuse);
+					// TheSuperHackers @bugfix Cryo 10/09/2026 Use this vertex's material colors, not the last analyzed material.
+					mtl->Get_Ambient(&mtl_ambient);
+					mtl->Get_Emissive(&mtl_emissive);
 					mtl_opacity = mtl->Get_Opacity();
 				}
 
@@ -894,47 +863,35 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 		}
 		// Set lighting to false if requested in all passes...
 		else if (set_lighting_to_false) {
-			Vector3 single_diffuse(0.0f,0.0f,0.0f);
-			Vector3 single_ambient(0.0f,0.0f,0.0f);
-			Vector3 single_emissive(0.0f,0.0f,0.0f);
+			// Aggregate color usage across valid materials; no first-material baseline is needed.
 			bool diffuse_used=false;
 			bool ambient_used=false;
 			bool emissive_used=false;
 
-			Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
-			Vector3 mtl_ambient(0.0f,0.0f,0.0f);
-			Vector3 mtl_emissive(0.0f,0.0f,0.0f);
-
-			VertexMaterialClass * prev_mtl = nullptr;
-			VertexMaterialClass * mtl = Peek_Material(0, pass);
-			if (mtl) {
-				mtl->Get_Diffuse(&single_diffuse);
-				mtl->Get_Ambient(&single_ambient);
-				mtl->Get_Emissive(&single_emissive);
-
-				if (single_diffuse.X || single_diffuse.Y || single_diffuse.Z) diffuse_used=true;
-				if (single_ambient.X || single_ambient.Y || single_ambient.Z) ambient_used=true;
-				if (single_emissive.X || single_emissive.Y || single_emissive.Z) emissive_used=true;
-			}
-
-			for (int vidx=0; vidx<VertexCount; vidx++) {
-				mtl = Peek_Material(vidx,pass);
+			VertexMaterialClass* prev_mtl = nullptr;
+			for (int vidx=0; vidx<VertexCount; vidx++)
+			{
+				VertexMaterialClass* mtl = Peek_Material(vidx,pass);
 				// TheSuperHackers @bugfix Cryo 09/09/2026 Skip null materials in the final lighting analysis too.
 				if (mtl == nullptr)
 				{
 					continue;
 				}
 
-				if (mtl != prev_mtl) {
+				if (mtl != prev_mtl)
+				{
 					prev_mtl = mtl;
+					Vector3 mtl_diffuse(0.0f,0.0f,0.0f);
+					Vector3 mtl_ambient(0.0f,0.0f,0.0f);
+					Vector3 mtl_emissive(0.0f,0.0f,0.0f);
 					mtl->Get_Diffuse(&mtl_diffuse);
 					mtl->Get_Ambient(&mtl_ambient);
 					mtl->Get_Emissive(&mtl_emissive);
-				}
 
-				if (mtl_diffuse.X || mtl_diffuse.Y || mtl_diffuse.Z) diffuse_used=true;
-				if (mtl_ambient.X || mtl_ambient.Y || mtl_ambient.Z) ambient_used=true;
-				if (mtl_emissive.X || mtl_emissive.Y || mtl_emissive.Z) emissive_used=true;
+					diffuse_used = diffuse_used || mtl_diffuse.X || mtl_diffuse.Y || mtl_diffuse.Z;
+					ambient_used = ambient_used || mtl_ambient.X || mtl_ambient.Y || mtl_ambient.Z;
+					emissive_used = emissive_used || mtl_emissive.X || mtl_emissive.Y || mtl_emissive.Z;
+				}
 			}
 
 			if ((DCGSource[pass] != VertexMaterialClass::MATERIAL) && (ColorArray[0] != nullptr)) {

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -710,6 +710,11 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				diffuse_used = diffuse_used || mtl_diffuse.X || mtl_diffuse.Y || mtl_diffuse.Z;
 				ambient_used = ambient_used || mtl_ambient.X || mtl_ambient.Y || mtl_ambient.Z;
 				emissive_used = emissive_used || mtl_emissive.X || mtl_emissive.Y || mtl_emissive.Z;
+
+				if (diffuse_used && ambient_used && emissive_used)
+				{
+					break;
+				}
 			}
 		}
 
@@ -887,6 +892,11 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 					diffuse_used = diffuse_used || mtl_diffuse.X || mtl_diffuse.Y || mtl_diffuse.Z;
 					ambient_used = ambient_used || mtl_ambient.X || mtl_ambient.Y || mtl_ambient.Z;
 					emissive_used = emissive_used || mtl_emissive.X || mtl_emissive.Y || mtl_emissive.Z;
+
+					if (diffuse_used && ambient_used && emissive_used)
+					{
+						break;
+					}
 				}
 			}
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.cpp
@@ -890,22 +890,23 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				}
 			}
 
-			if ((DCGSource[pass] != VertexMaterialClass::MATERIAL) && (ColorArray[0] != nullptr)) {
-				VertexMaterialClass * prev_mtl = nullptr;
-				VertexMaterialClass * mtl = Peek_Material(0,pass);
-				for (int vidx=0; vidx<VertexCount; vidx++) {
-					mtl = Peek_Material(vidx,pass);
+			// Turn off lighting only for emissive-only materials using vertex colors.
+			if (!diffuse_used && !ambient_used && emissive_used &&
+				(DCGSource[pass] != VertexMaterialClass::MATERIAL) && (ColorArray[0] != nullptr))
+			{
+				VertexMaterialClass* prev_mtl = nullptr;
+				for (int vidx=0; vidx<VertexCount; vidx++)
+				{
+					VertexMaterialClass* mtl = Peek_Material(vidx,pass);
 					if (mtl == nullptr)
 					{
 						continue;
 					}
 
-					if (mtl != prev_mtl) {
+					if (mtl != prev_mtl)
+					{
 						prev_mtl = mtl;
-						// If only emissive is used apply emissive to color channel, set diffuse source to color 1, and turn off lighting
-						if (!diffuse_used && !ambient_used && emissive_used) {
-							mtl->Set_Lighting(false);
-						}
+						mtl->Set_Lighting(false);
 					}
 				}
 			}


### PR DESCRIPTION
Prevents crashes on null mesh materials and incorrect vertex colors caused by reusing another material's ambient or emissive color. Skips null entries, applies each vertex's own material colors, and removes unused first-material baseline calculations in Generals and Zero Hour.

For example, with white input vertex colors and two ambient-only materials, green followed by red, the old code applies the last material's red color to both vertices:

| Vertex material | Before | After |
| --- | --- | --- |
| Green | 🟥 Red | 🟩 Green |
| Red | 🟥 Red | 🟥 Red |

This RGB example was reproduced in the CPU regression test. Emissive-only materials have the same problem.
