### PR TITLE
fix(audio): Copy SoundSceneObjClass state safely

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWAudio/SoundSceneObj.cpp
+++ b/Core/Libraries/Source/WWVegas/WWAudio/SoundSceneObj.cpp
@@ -93,6 +93,7 @@ SoundSceneObjClass::SoundSceneObjClass ()
 		m_PhysWrapper (nullptr),
 		m_pCallback (nullptr),
 		m_AttachedObject (nullptr),
+		m_AttachedBone (-1),
 		m_UserData (0),
 		m_UserObj (nullptr),
 		m_ID (SOUND_OBJ_DEFAULT_ID),
@@ -110,18 +111,22 @@ SoundSceneObjClass::SoundSceneObjClass ()
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////
 SoundSceneObjClass::SoundSceneObjClass (const SoundSceneObjClass &src)
-	:	m_Scene (nullptr),
+	:	m_Scene (src.m_Scene),
 		m_PhysWrapper (nullptr),
-		m_pCallback (nullptr),
+		m_pCallback (src.m_pCallback),
 		m_AttachedObject (nullptr),
+		m_AttachedBone (src.m_AttachedBone),
 		m_UserData (0),
 		m_UserObj (nullptr),
 		m_ID (SOUND_OBJ_DEFAULT_ID),
-		m_RegisteredEvents (AudioCallbackClass::EVENT_NONE)
+		m_RegisteredEvents (src.m_RegisteredEvents)
 {
 	m_ID = m_NextAvailableID ++;
 
-	(*this) = src;
+	// TheSuperHackers @bugfix Cryo 01/09/2026 Copy the attachment without invoking virtual positioning
+	// before the derived sound object has been constructed.
+	REF_PTR_SET (m_AttachedObject, src.m_AttachedObject);
+	PersistClass::operator= ((const PersistClass &)src);
 	Register_Sound_Object (this);
 }
 


### PR DESCRIPTION
Prevents a pure virtual call and possible crash when copying an attached sound object. The copy constructor now preserves attachment state without positioning the object before construction finishes.

Found by clang-tidy