### PR TITLE
fix(gameaudio): Remove the has3DSensitiveStreamsPlaying volume hack

### DIFF
--- a/Core/GameEngine/Include/Common/GameAudio.h
+++ b/Core/GameEngine/Include/Common/GameAudio.h
@@ -244,8 +244,6 @@ class AudioManager : public SubsystemInterface
 		// on zoom.
 		virtual void set3DVolumeAdjustment( Real volumeAdjustment );
 
-    virtual Bool has3DSensitiveStreamsPlaying() const = 0;
-
  		virtual void *getHandleForBink() = 0;
  		virtual void releaseHandleForBink() = 0;
 

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -769,8 +769,7 @@ void AudioManager::set3DVolumeAdjustment( Real volumeAdjustment )
 	if (m_sound3DVolume > 1.0f)
 		m_sound3DVolume = 1.0f;
 
-  if ( ! has3DSensitiveStreamsPlaying() )
-  	m_volumeHasChanged = TRUE;
+	m_volumeHasChanged = TRUE;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -708,7 +708,12 @@ void AudioManager::setVolume( Real volume, AudioAffect whichToAffect )
 			m_scriptMusicVolume = volume;
 		}
 
-		m_musicVolume = m_scriptMusicVolume * m_systemMusicVolume;
+		const Real newVolume = m_scriptMusicVolume * m_systemMusicVolume;
+		if (m_musicVolume != newVolume)
+		{
+			m_musicVolume = newVolume;
+			m_volumeHasChanged = true;
+		}
 	}
 
 	if (whichToAffect & AudioAffect_Sound) {
@@ -718,7 +723,12 @@ void AudioManager::setVolume( Real volume, AudioAffect whichToAffect )
 			m_scriptSoundVolume = volume;
 		}
 
-		m_soundVolume = m_scriptSoundVolume * m_systemSoundVolume;
+		const Real newVolume = m_scriptSoundVolume * m_systemSoundVolume;
+		if (m_soundVolume != newVolume)
+		{
+			m_soundVolume = newVolume;
+			m_volumeHasChanged = true;
+		}
 	}
 
 	if (whichToAffect & AudioAffect_Sound3D) {
@@ -727,7 +737,13 @@ void AudioManager::setVolume( Real volume, AudioAffect whichToAffect )
 		} else {
 			m_scriptSound3DVolume = volume;
 		}
-		m_sound3DVolume = m_scriptSound3DVolume * m_systemSound3DVolume;
+
+		const Real newVolume = m_scriptSound3DVolume * m_systemSound3DVolume;
+		if (m_sound3DVolume != newVolume)
+		{
+			m_sound3DVolume = newVolume;
+			m_volumeHasChanged = true;
+		}
 	}
 
 	if (whichToAffect & AudioAffect_Speech) {
@@ -736,10 +752,14 @@ void AudioManager::setVolume( Real volume, AudioAffect whichToAffect )
 		} else {
 			m_scriptSpeechVolume = volume;
 		}
-		m_speechVolume = m_scriptSpeechVolume * m_systemSpeechVolume;
-	}
 
-	m_volumeHasChanged = true;
+		const Real newVolume = m_scriptSpeechVolume * m_systemSpeechVolume;
+		if (m_speechVolume != newVolume)
+		{
+			m_speechVolume = newVolume;
+			m_volumeHasChanged = true;
+		}
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -760,16 +780,13 @@ Real AudioManager::getVolume( AudioAffect whichToGet )
 //-------------------------------------------------------------------------------------------------
 void AudioManager::set3DVolumeAdjustment( Real volumeAdjustment )
 {
-	m_sound3DVolume = volumeAdjustment * m_scriptSound3DVolume * m_systemSound3DVolume;
+	const Real newVolume = clamp(0.0f, volumeAdjustment * m_scriptSound3DVolume * m_systemSound3DVolume, 1.0f);
 
-	// clamp
-	if (m_sound3DVolume < 0.0f)
-		m_sound3DVolume = 0.0f;
-
-	if (m_sound3DVolume > 1.0f)
-		m_sound3DVolume = 1.0f;
-
-	m_volumeHasChanged = TRUE;
+	if (m_sound3DVolume != newVolume)
+	{
+		m_sound3DVolume = newVolume;
+		m_volumeHasChanged = true;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -229,10 +229,6 @@ class MilesAudioManager : public AudioManager
 
 		virtual void closeAnySamplesUsingFile( const void *fileToClose ) override;
 
-
-    virtual Bool has3DSensitiveStreamsPlaying() const override;
-
-
 	protected:
 		// 3-D functions
 		virtual void setDeviceListenerPosition() override;
@@ -382,7 +378,6 @@ class MilesAudioManagerDummy : public MilesAudioManager
 	virtual void adjustVolumeOfPlayingAudio(AsciiString eventName, Real newVolume) override {}
 	virtual void removePlayingAudio(AsciiString eventName) override {}
 	virtual void removeAllDisabledAudio() override {}
-	virtual Bool has3DSensitiveStreamsPlaying() const override { return false; }
 	virtual void* getHandleForBink() override { return nullptr; }
 	virtual void releaseHandleForBink() override {}
 	virtual void friend_forcePlayAudioEventRTS(const AudioEventRTS* eventToPlay) override {}

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -2294,41 +2294,6 @@ void MilesAudioManager::processPlayingList()
 	}
 }
 
-//Patch for a rare bug (only on about 5% of in-studio machines suffer, and not all the time) .
-//The actual mechanics of this problem are still elusive as of the date of this comment. 8/21/03
-//but the cause is clear. Some cinematics do a radical change in the microphone position, which
-//calls for a radical 3DSoundVolume adjustment. If this happens while a stereo stream is *ENDING*,
-//low-level code gets caught in a tight loop. (Hangs) on some machines.
-//To prevent this condition, we just suppress the updating of 3DSoundVolume while one of these
-//is on the list. Since the music tracks play continuously, they never *END* during these cinematics.
-//so we filter them out as, *NOT SENSITIVE*... we do want to update 3DSoundVolume during music,
-//which is almost all of the time.
-
-Bool MilesAudioManager::has3DSensitiveStreamsPlaying() const
-{
-  if ( m_playingStreams.empty() )
-    return FALSE;
-
-	for ( std::list< PlayingAudio* >::const_iterator it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it )
-  {
-		const PlayingAudio *playing = (*it);
-
-    if ( playing->m_audioEventRTS->getAudioEventInfo()->m_soundType != AT_Music )
-    {
-      return TRUE;
-    }
-
-    if ( playing->m_audioEventRTS->getEventName().startsWith("Game_") == FALSE )
-    {
-      return TRUE;
-    }
-  }
-
-  return FALSE;
-
-}
-
-
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::processFadingList()
 {


### PR DESCRIPTION
**Merge with Rebase**

This change has 2 commits.

The first is removing the has3DSensitiveStreamsPlaying hack. It existed to workaround a hang on volume change. We aim to fix application hanging and not rely on the hack from here on.

The second is committing to sound volume change only if the volume has really changed, not merely calling the volume change function. This may or may not avoid unnecessary sound volume updates.

## TODO

- [x] Add pull ids to commits