### PR TITLE
bugfix(milesaudiomanager): Fix premature 2d and 3d sound cancellations from MilesAudioManager::stopAudioEvent()

### DIFF
--- a/Core/GameEngine/Include/Common/AudioRequest.h
+++ b/Core/GameEngine/Include/Common/AudioRequest.h
@@ -52,10 +52,12 @@ public:
 		, m_pendingEvent(nullptr)
 		, m_handleToInteractOn(AHSV_Error)
 		, m_requiresCheckForSample(false)
+		, m_requestStop(false)
 	{}
 
 	RequestType m_request;
 	RefCountPtr<DynamicAudioEventRTS> m_pendingEvent;
 	AudioHandle m_handleToInteractOn;
 	Bool m_requiresCheckForSample;
+	Bool m_requestStop; // Let the audio play and finish but stop looping if it is looping
 };

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -69,6 +69,7 @@ struct PlayingAudio
 	Short m_framesFaded;
 	Bool m_fade;
 	volatile Bool m_rerequestOnNextUpdate;
+	volatile Bool m_requestStop; // Let the audio finish but stop looping if it is looping
 
 	PlayingAudio()
 		: m_sample(nullptr)
@@ -79,6 +80,7 @@ struct PlayingAudio
 		, m_framesFaded(0)
 		, m_fade(false)
 		, m_rerequestOnNextUpdate(false)
+		, m_requestStop(false)
 	{}
 
 	static_assert(sizeof(m_status) == sizeof(long), "Must be size of long, because it is used with Interlocked functions");

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -237,7 +237,7 @@ class MilesAudioManager : public AudioManager
 		Real getEffectiveVolume(AudioEventRTS *event) const;
 
 		// Looping functions
-		Bool startNextLoop( PlayingAudio *looping );
+		Bool startNextLoop( PlayingAudio *playing );
 
 		void playStream( AudioEventRTS *event, HSTREAM stream );
 		// Returns the file handle for attachment to the PlayingAudio structure
@@ -259,9 +259,9 @@ class MilesAudioManager : public AudioManager
 		void closeFile( void *fileRead );
 
 		PlayingAudio *allocatePlayingAudio();
-		void releaseMilesHandles( PlayingAudio *release );
-		void releasePlayingAudio( PlayingAudio *release );
-		void stopPlayingAudio( PlayingAudio *release );
+		void releaseMilesHandles( PlayingAudio *playing );
+		void releasePlayingAudio( PlayingAudio *playing );
+		void stopPlayingAudio( PlayingAudio *playing );
 		void rerequestPlayingAudio( PlayingAudio *playing );
 		void rerequestPlayingAudioWhenSignalled( PlayingAudio *playing );
 		void fadePlayingAudio( PlayingAudio *playing );

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -83,6 +83,16 @@ struct PlayingAudio
 		, m_requestStop(false)
 	{}
 
+	Bool isPlaying() const
+	{
+		return m_status == PS_Playing;
+	}
+
+	Bool isPlayingOrRequested() const
+	{
+		return m_status == PS_Playing || m_rerequestOnNextUpdate;
+	}
+
 	static_assert(sizeof(m_status) == sizeof(long), "Must be size of long, because it is used with Interlocked functions");
 };
 

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -1911,15 +1911,16 @@ Bool MilesAudioManager::isObjectPlayingVoice( UnsignedInt objID ) const
 //-------------------------------------------------------------------------------------------------
 AudioEventRTS* MilesAudioManager::findLowestPrioritySound( AudioEventRTS *event )
 {
-	AudioPriority priority = event->getAudioEventInfo()->m_priority;
+	const AudioPriority priority = event->getAudioEventInfo()->m_priority;
 	if( priority == AP_LOWEST )
 	{
 		//If the event we pass in is the lowest priority, don't bother checking because
 		//there is nothing lower priority than lowest.
 		return nullptr;
 	}
+
 	AudioEventRTS *lowestPriorityEvent = nullptr;
-	AudioPriority lowestPriority;
+	AudioPriority lowestPriority = priority;
 
 	std::list<PlayingAudio *>::const_iterator it;
 	if( event->isPositionalAudio() )
@@ -1928,17 +1929,14 @@ AudioEventRTS* MilesAudioManager::findLowestPrioritySound( AudioEventRTS *event 
 		for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 		{
 			AudioEventRTS *itEvent = (*it)->m_audioEventRTS.Peek();
-			AudioPriority itPriority = itEvent->getAudioEventInfo()->m_priority;
-			if( itPriority < priority )
+			const AudioPriority itPriority = itEvent->getAudioEventInfo()->m_priority;
+			if( itPriority < lowestPriority )
 			{
-				if( !lowestPriorityEvent || lowestPriority > itPriority )
+				lowestPriorityEvent = itEvent;
+				lowestPriority = itPriority;
+				if( lowestPriority == AP_LOWEST )
 				{
-					lowestPriorityEvent = itEvent;
-					lowestPriority = itPriority;
-					if( lowestPriority == AP_LOWEST )
-					{
-						return lowestPriorityEvent;
-					}
+					return lowestPriorityEvent;
 				}
 			}
 		}
@@ -1949,17 +1947,14 @@ AudioEventRTS* MilesAudioManager::findLowestPrioritySound( AudioEventRTS *event 
 		for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 		{
 			AudioEventRTS *itEvent = (*it)->m_audioEventRTS.Peek();
-			AudioPriority itPriority = itEvent->getAudioEventInfo()->m_priority;
-			if( itPriority < priority )
+			const AudioPriority itPriority = itEvent->getAudioEventInfo()->m_priority;
+			if( itPriority < lowestPriority )
 			{
-				if( !lowestPriorityEvent || lowestPriority > itPriority )
+				lowestPriorityEvent = itEvent;
+				lowestPriority = itPriority;
+				if( lowestPriority == AP_LOWEST )
 				{
-					lowestPriorityEvent = itEvent;
-					lowestPriority = itPriority;
-					if( lowestPriority == AP_LOWEST )
-					{
-						return lowestPriorityEvent;
-					}
+					return lowestPriorityEvent;
 				}
 			}
 		}

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -1478,8 +1478,12 @@ void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt
 	}
 
 	playing->m_audioEventRTS->advanceNextPlayPortion();
-	if (playing->m_audioEventRTS->getNextPlayPortion() != PP_Done) {
-		if (playing->m_type == PAT_Sample) {
+
+	switch (playing->m_type)
+	{
+	case PAT_Sample:
+	{
+		if (playing->m_audioEventRTS->getNextPlayPortion() != PP_Done) {
 			closeFile(playing->m_file);	// close it so as not to leak it.
 			playing->m_file = playSample(playing->m_audioEventRTS.Peek(), playing->m_sample);
 
@@ -1488,7 +1492,12 @@ void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt
 			if (playing->m_file) {
 				return;
 			}
-		} else if (playing->m_type == PAT_3DSample) {
+		}
+		break;
+	}
+	case PAT_3DSample:
+	{
+		if (playing->m_audioEventRTS->getNextPlayPortion() != PP_Done) {
 			closeFile(playing->m_file);	// close it so as not to leak it.
 			playing->m_file = playSample3D(playing->m_audioEventRTS.Peek(), playing->m_3DSample);
 
@@ -1498,13 +1507,16 @@ void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt
 				return;
 			}
 		}
+		break;
 	}
-
-	if (playing->m_type == PAT_Stream) {
+	case PAT_Stream:
+	{
 		if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
 			playStream(playing->m_audioEventRTS.Peek(), playing->m_stream);
 			return;
 		}
+		break;
+	}
 	}
 
 	// it will be cleaned up on the next frame update

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -634,7 +634,7 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 	AudioHandle handleToKill = event->getHandleToKill();
 
 	AsciiString fileToPlay = event->getFilename();
-	PlayingAudio *audio = allocatePlayingAudio();
+	PlayingAudio *newPlaying = allocatePlayingAudio();
 	switch(info->m_soundType)
 	{
 		case AT_Music:
@@ -671,9 +671,9 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 			}
 
 			// Put this on here, so that the audio event RTS will be cleaned up regardless.
-			audio->m_audioEventRTS = req->m_pendingEvent;
-			audio->m_stream = stream;
-			audio->m_type = PAT_Stream;
+			newPlaying->m_audioEventRTS = req->m_pendingEvent;
+			newPlaying->m_stream = stream;
+			newPlaying->m_type = PAT_Stream;
 
 			if (stream) {
 				if ((info->m_soundType == AT_Streaming) && event->getUninterruptible()) {
@@ -683,8 +683,8 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 				playStream(event, stream);
 
 				CriticalSectionClass::LockClass lock(m_playingStreamsCS);
-				m_playingStreams.push_back(audio);
-				audio = nullptr;
+				m_playingStreams.push_back(newPlaying);
+				newPlaying = nullptr;
 			}
 			break;
 		}
@@ -738,16 +738,16 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 					sample3D = nullptr;
 				}
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = req->m_pendingEvent;
-				audio->m_3DSample = sample3D;
-				audio->m_file = nullptr;
-				audio->m_type = PAT_3DSample;
+				newPlaying->m_audioEventRTS = req->m_pendingEvent;
+				newPlaying->m_3DSample = sample3D;
+				newPlaying->m_file = nullptr;
+				newPlaying->m_type = PAT_3DSample;
 
 				if (sample3D) {
-					audio->m_file = playSample3D(event, sample3D);
+					newPlaying->m_file = playSample3D(event, sample3D);
 				}
 
-				if( !audio->m_file )
+				if( !newPlaying->m_file )
 				{
 					#ifdef INTENSIVE_AUDIO_DEBUG
 						DEBUG_LOG((" Killed (no handles available)"));
@@ -756,8 +756,8 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 				else
 				{
 					CriticalSectionClass::LockClass lock(m_playing3DSoundsCS);
-					m_playing3DSounds.push_back(audio);
-					audio = nullptr;
+					m_playing3DSounds.push_back(newPlaying);
+					newPlaying = nullptr;
 					#ifdef INTENSIVE_AUDIO_DEBUG
 						DEBUG_LOG((" Playing."));
 					#endif
@@ -804,23 +804,23 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 				}
 
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = req->m_pendingEvent;
-				audio->m_sample = sample;
-				audio->m_file = nullptr;
-				audio->m_type = PAT_Sample;
+				newPlaying->m_audioEventRTS = req->m_pendingEvent;
+				newPlaying->m_sample = sample;
+				newPlaying->m_file = nullptr;
+				newPlaying->m_type = PAT_Sample;
 
 				if (sample) {
-					audio->m_file = playSample(event, sample);
+					newPlaying->m_file = playSample(event, sample);
 				}
 
-				if (!audio->m_file) {
+				if (!newPlaying->m_file) {
 					#ifdef INTENSIVE_AUDIO_DEBUG
 						DEBUG_LOG((" Killed (no handles available)"));
 					#endif
 				} else {
 					CriticalSectionClass::LockClass lock(m_playingSoundsCS);
-					m_playingSounds.push_back(audio);
-					audio = nullptr;
+					m_playingSounds.push_back(newPlaying);
+					newPlaying = nullptr;
 					#ifdef INTENSIVE_AUDIO_DEBUG
 						DEBUG_LOG((" Playing."));
 					#endif
@@ -832,9 +832,9 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 
 	// If we were able to successfully play audio, then we set it to null above. (And it will be freed
 	// later. However, if audio is non-null at this point, then it must be freed.
-	if (audio) {
-		stopPlayingAudio(audio);
-		releasePlayingAudio(audio);
+	if (newPlaying) {
+		stopPlayingAudio(newPlaying);
+		releasePlayingAudio(newPlaying);
 	}
 }
 
@@ -849,17 +849,17 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 	if ( handle == AHSV_StopTheMusic || handle == AHSV_StopTheMusicFade ) {
 		// for music, find and stop the currently playing music stream(s).
 		for ( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it ) {
-			PlayingAudio *audio = (*it);
+			PlayingAudio *playing = (*it);
 
-			if( audio->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music )
+			if( playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music )
 			{
 				if( handle == AHSV_StopTheMusicFade )
 				{
-					fadePlayingAudio(audio);
+					fadePlayingAudio(playing);
 				}
 				else
 				{
-					stopPlayingAudio(audio);
+					stopPlayingAudio(playing);
 				}
 			}
 		}
@@ -867,31 +867,31 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 	}
 
 	for ( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it ) {
-		PlayingAudio *audio = (*it);
+		PlayingAudio *playing = (*it);
 
-		if (audio->m_audioEventRTS->getPlayingHandle() == handle) {
-			stopPlayingAudio(audio);
+		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
+			stopPlayingAudio(playing);
 			break;
 		}
 	}
 
 	for ( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it ) {
-		PlayingAudio *audio = (*it);
+		PlayingAudio *playing = (*it);
 
-		if (audio->m_audioEventRTS->getPlayingHandle() == handle) {
-			stopPlayingAudio(audio);
+		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
+			stopPlayingAudio(playing);
 			break;
 		}
 	}
 
 	for ( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it ) {
-		PlayingAudio *audio = (*it);
+		PlayingAudio *playing = (*it);
 
-		if (audio->m_audioEventRTS->getPlayingHandle() == handle) {
+		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
 		#ifdef INTENSIVE_AUDIO_DEBUG
-			DEBUG_LOG((" (%s)", audio->m_audioEventRTS->getEventName()));
+			DEBUG_LOG((" (%s)", playing->m_audioEventRTS->getEventName()));
 		#endif
-			stopPlayingAudio(audio);
+			stopPlayingAudio(playing);
 			break;
 		}
 	}
@@ -917,11 +917,11 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 	std::list<PlayingAudio *>::iterator it;
 	for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); it++ )
 	{
-		PlayingAudio *audio = (*it);
+		PlayingAudio *playing = (*it);
 
-		if( audio->m_audioEventRTS->getPlayingHandle() == audioEvent )
+		if( playing->m_audioEventRTS->getPlayingHandle() == audioEvent )
 		{
-			stopPlayingAudio(audio);
+			stopPlayingAudio(playing);
 			return;
 		}
 	}
@@ -929,11 +929,11 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 	//Look for matching 2D sound to kill
 	for( it = m_playingSounds.begin(); it != m_playingSounds.end(); it++ )
 	{
-		PlayingAudio *audio = (*it);
+		PlayingAudio *playing = (*it);
 
-		if( audio->m_audioEventRTS->getPlayingHandle() == audioEvent )
+		if( playing->m_audioEventRTS->getPlayingHandle() == audioEvent )
 		{
-			stopPlayingAudio(audio);
+			stopPlayingAudio(playing);
 			return;
 		}
 	}
@@ -941,11 +941,11 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 	//Look for matching steaming sound to kill
 	for( it = m_playingStreams.begin(); it != m_playingStreams.end(); it++ )
 	{
-		PlayingAudio *audio = (*it);
+		PlayingAudio *playing = (*it);
 
-		if( audio->m_audioEventRTS->getPlayingHandle() == audioEvent )
+		if( playing->m_audioEventRTS->getPlayingHandle() == audioEvent )
 		{
-			stopPlayingAudio(audio);
+			stopPlayingAudio(playing);
 			return;
 		}
 	}
@@ -978,68 +978,68 @@ PlayingAudio *MilesAudioManager::allocatePlayingAudio()
 
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::releaseMilesHandles( PlayingAudio *release )
+void MilesAudioManager::releaseMilesHandles( PlayingAudio *playing )
 {
-	switch (release->m_type)
+	switch (playing->m_type)
 	{
 		case PAT_Sample:
 		{
-			if (release->m_sample) {
-				AIL_register_EOS_callback(release->m_sample, nullptr);
-				AIL_stop_sample(release->m_sample);
-				m_availableSamples.push_back(release->m_sample);
-				release->m_sample = nullptr;
+			if (playing->m_sample) {
+				AIL_register_EOS_callback(playing->m_sample, nullptr);
+				AIL_stop_sample(playing->m_sample);
+				m_availableSamples.push_back(playing->m_sample);
+				playing->m_sample = nullptr;
 			}
 			break;
 		}
 		case PAT_3DSample:
 		{
-			if (release->m_3DSample) {
-				AIL_register_3D_EOS_callback(release->m_3DSample, nullptr);
-				AIL_stop_3D_sample(release->m_3DSample);
-				m_available3DSamples.push_back(release->m_3DSample);
-				release->m_3DSample = nullptr;
+			if (playing->m_3DSample) {
+				AIL_register_3D_EOS_callback(playing->m_3DSample, nullptr);
+				AIL_stop_3D_sample(playing->m_3DSample);
+				m_available3DSamples.push_back(playing->m_3DSample);
+				playing->m_3DSample = nullptr;
 			}
 			break;
 		}
 		case PAT_Stream:
 		{
-			if (release->m_stream) {
-				AIL_register_stream_callback(release->m_stream, nullptr);
-				AIL_close_stream(release->m_stream);
-				release->m_stream = nullptr;
+			if (playing->m_stream) {
+				AIL_register_stream_callback(playing->m_stream, nullptr);
+				AIL_close_stream(playing->m_stream);
+				playing->m_stream = nullptr;
 			}
 			break;
 		}
 	}
-	release->m_type = PAT_INVALID;
+	playing->m_type = PAT_INVALID;
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::releasePlayingAudio( PlayingAudio *release )
+void MilesAudioManager::releasePlayingAudio( PlayingAudio *playing )
 {
-	DEBUG_ASSERTCRASH(release->m_status == PS_Stopped, ("PlayingAudio must be stopped by now"));
-	DEBUG_ASSERTCRASH(release->m_type == PAT_INVALID, ("PlayingAudio must be invalidated by now"));
+	DEBUG_ASSERTCRASH(playing->m_status == PS_Stopped, ("PlayingAudio must be stopped by now"));
+	DEBUG_ASSERTCRASH(playing->m_type == PAT_INVALID, ("PlayingAudio must be invalidated by now"));
 
-	if (release->m_file) {
-		closeFile(release->m_file);
-		release->m_file = nullptr;
+	if (playing->m_file) {
+		closeFile(playing->m_file);
+		playing->m_file = nullptr;
 	}
 
-	delete release;
+	delete playing;
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::stopPlayingAudio( PlayingAudio *release )
+void MilesAudioManager::stopPlayingAudio( PlayingAudio *playing )
 {
 	// Advance from Playing to Stopping
-	InterlockedCompareExchange(reinterpret_cast<volatile long*>(&release->m_status), PS_Stopping, PS_Playing);
+	InterlockedCompareExchange(reinterpret_cast<volatile long*>(&playing->m_status), PS_Stopping, PS_Playing);
 	// Advance from Stopping to Stopped
-	const long prevStatus = InterlockedCompareExchange(reinterpret_cast<volatile long*>(&release->m_status), PS_Stopped, PS_Stopping);
+	const long prevStatus = InterlockedCompareExchange(reinterpret_cast<volatile long*>(&playing->m_status), PS_Stopped, PS_Stopping);
 	if (prevStatus != PS_Stopping) {
 		return;
 	}
-	releaseMilesHandles(release);
+	releaseMilesHandles(playing);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1224,23 +1224,23 @@ H3DSAMPLE MilesAudioManager::getAvailable3DSample( AudioEventRTS *event )
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::adjustPlayingVolume( PlayingAudio *audio )
+void MilesAudioManager::adjustPlayingVolume( PlayingAudio *playing )
 {
 	Real pan;
-	if (audio->m_type == PAT_Sample) {
-		AIL_sample_volume_pan(audio->m_sample, nullptr, &pan);
-		AIL_set_sample_volume_pan(audio->m_sample, getEffectiveVolume(audio->m_audioEventRTS.Peek()), pan);
+	if (playing->m_type == PAT_Sample) {
+		AIL_sample_volume_pan(playing->m_sample, nullptr, &pan);
+		AIL_set_sample_volume_pan(playing->m_sample, getEffectiveVolume(playing->m_audioEventRTS.Peek()), pan);
 
-	} else if (audio->m_type == PAT_3DSample) {
-		AIL_set_3D_sample_volume(audio->m_3DSample, getEffectiveVolume(audio->m_audioEventRTS.Peek()));
+	} else if (playing->m_type == PAT_3DSample) {
+		AIL_set_3D_sample_volume(playing->m_3DSample, getEffectiveVolume(playing->m_audioEventRTS.Peek()));
 
-	} else if (audio->m_type == PAT_Stream) {
-		AIL_stream_volume_pan(audio->m_stream, nullptr, &pan);
-		if (audio->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music ) {
-			AIL_set_stream_volume_pan(audio->m_stream, getEffectiveVolume(audio->m_audioEventRTS.Peek()), pan);
+	} else if (playing->m_type == PAT_Stream) {
+		AIL_stream_volume_pan(playing->m_stream, nullptr, &pan);
+		if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music ) {
+			AIL_set_stream_volume_pan(playing->m_stream, getEffectiveVolume(playing->m_audioEventRTS.Peek()), pan);
 
 		} else {
-			AIL_set_stream_volume_pan(audio->m_stream, getEffectiveVolume(audio->m_audioEventRTS.Peek()), pan);
+			AIL_set_stream_volume_pan(playing->m_stream, getEffectiveVolume(playing->m_audioEventRTS.Peek()), pan);
 
 		}
 	}
@@ -2590,32 +2590,32 @@ Real MilesAudioManager::getEffectiveVolume(AudioEventRTS *event) const
 }
 
 //-------------------------------------------------------------------------------------------------
-Bool MilesAudioManager::startNextLoop( PlayingAudio *looping )
+Bool MilesAudioManager::startNextLoop( PlayingAudio *playing )
 {
-	closeFile(looping->m_file);
-	looping->m_file = nullptr;
+	closeFile(playing->m_file);
+	playing->m_file = nullptr;
 
-	if (looping->m_status != PS_Playing) {
+	if (playing->m_status != PS_Playing) {
 		return false;
 	}
 
-	if (looping->m_audioEventRTS->hasMoreLoops()) {
+	if (playing->m_audioEventRTS->hasMoreLoops()) {
 		// generate a new filename, and test to see whether we can play with it now
-		looping->m_audioEventRTS->generateFilename();
+		playing->m_audioEventRTS->generateFilename();
 
-		if (looping->m_audioEventRTS->getDelay() > MSEC_PER_LOGICFRAME_REAL) {
-			looping->m_rerequestOnNextUpdate = true;
-			InterlockedCompareExchange(reinterpret_cast<volatile long*>(&looping->m_status), PS_Stopping, PS_Playing);
+		if (playing->m_audioEventRTS->getDelay() > MSEC_PER_LOGICFRAME_REAL) {
+			playing->m_rerequestOnNextUpdate = true;
+			InterlockedCompareExchange(reinterpret_cast<volatile long*>(&playing->m_status), PS_Stopping, PS_Playing);
 			return true;
 		}
 
-		if (looping->m_type == PAT_3DSample) {
-			looping->m_file = playSample3D(looping->m_audioEventRTS.Peek(), looping->m_3DSample);
+		if (playing->m_type == PAT_3DSample) {
+			playing->m_file = playSample3D(playing->m_audioEventRTS.Peek(), playing->m_3DSample);
 		} else {
-			looping->m_file = playSample(looping->m_audioEventRTS.Peek(), looping->m_sample);
+			playing->m_file = playSample(playing->m_audioEventRTS.Peek(), playing->m_sample);
 		}
 
-		return looping->m_file != nullptr;
+		return playing->m_file != nullptr;
 	}
 	return false;
 }
@@ -2807,19 +2807,19 @@ void MilesAudioManager::processRequest( AudioRequest *req )
 void *MilesAudioManager::getHandleForBink()
 {
 	if (m_binkHandle == nullptr) {
-		PlayingAudio *aud = allocatePlayingAudio();
-		aud->m_audioEventRTS.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS)("BinkHandle"));
-		getInfoForAudioEvent(aud->m_audioEventRTS.Peek());
-		aud->m_sample = getAvailable2DSample(aud->m_audioEventRTS.Peek());
-		aud->m_type = PAT_Sample;
+		PlayingAudio *playing = allocatePlayingAudio();
+		playing->m_audioEventRTS.Assign_No_Add_Ref(newInstance(DynamicAudioEventRTS)("BinkHandle"));
+		getInfoForAudioEvent(playing->m_audioEventRTS.Peek());
+		playing->m_sample = getAvailable2DSample(playing->m_audioEventRTS.Peek());
+		playing->m_type = PAT_Sample;
 
-		if (!aud->m_sample) {
-			stopPlayingAudio(aud);
-			releasePlayingAudio(aud);
+		if (!playing->m_sample) {
+			stopPlayingAudio(playing);
+			releasePlayingAudio(playing);
 			return nullptr;
 		}
 
-		m_binkHandle = aud;
+		m_binkHandle = playing;
 	}
 
 	AILLPDIRECTSOUND lpDS;

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -635,6 +635,8 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 
 	AsciiString fileToPlay = event->getFilename();
 	PlayingAudio *newPlaying = allocatePlayingAudio();
+	newPlaying->m_requestStop = req->m_requestStop;
+
 	switch(info->m_soundType)
 	{
 		case AT_Music:
@@ -866,12 +868,34 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 		return;
 	}
 
+	// Look for it in the request list.
+	{
+		std::list<AudioRequest*>::iterator it;
+		for( it = m_audioRequests.begin(); it != m_audioRequests.end(); it++ )
+		{
+			AudioRequest *req = (*it);
+			if( req->m_pendingEvent && req->m_pendingEvent->getPlayingHandle() == handle )
+			{
+				if (req->m_pendingEvent->getAudioEventInfo()->m_soundType == AT_SoundEffect)
+				{
+					req->m_requestStop = true;
+				}
+				else
+				{
+					deleteInstance(req);
+					m_audioRequests.erase(it);
+				}
+				return;
+			}
+		}
+	}
+
 	for ( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it ) {
 		PlayingAudio *playing = (*it);
 
 		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
 			stopPlayingAudio(playing);
-			break;
+			return;
 		}
 	}
 
@@ -879,8 +903,8 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 		PlayingAudio *playing = (*it);
 
 		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
-			stopPlayingAudio(playing);
-			break;
+			playing->m_requestStop = true;
+			return;
 		}
 	}
 
@@ -891,8 +915,8 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 		#ifdef INTENSIVE_AUDIO_DEBUG
 			DEBUG_LOG((" (%s)", playing->m_audioEventRTS->getEventName()));
 		#endif
-			stopPlayingAudio(playing);
-			break;
+			playing->m_requestStop = true;
+			return;
 		}
 	}
 }
@@ -908,7 +932,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 		if( req->m_pendingEvent && req->m_pendingEvent->getPlayingHandle() == audioEvent )
 		{
 			deleteInstance(req);
-			ait = m_audioRequests.erase(ait);
+			m_audioRequests.erase(ait);
 			return;
 		}
 	}
@@ -1048,6 +1072,7 @@ void MilesAudioManager::rerequestPlayingAudio( PlayingAudio *playing )
 	AudioRequest *req = allocateAudioRequest();
 	req->m_pendingEvent = playing->m_audioEventRTS;
 	req->m_requiresCheckForSample = true;
+	req->m_requestStop = playing->m_requestStop;
 	appendAudioRequest(req);
 }
 
@@ -2603,6 +2628,10 @@ Bool MilesAudioManager::startNextLoop( PlayingAudio *playing )
 	playing->m_file = nullptr;
 
 	if (playing->m_status != PS_Playing) {
+		return false;
+	}
+
+	if (playing->m_requestStop) {
 		return false;
 	}
 

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -519,6 +519,9 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound)) {
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
+			if (!playing->isPlaying()) {
+				continue;
+			}
 			DEBUG_ASSERTCRASH(playing->m_sample, ("Sample is not expected to be null"));
 			AIL_stop_sample(playing->m_sample);
 		}
@@ -527,7 +530,10 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound3D)) {
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
-			DEBUG_ASSERTCRASH(playing->m_sample, ("3D Sample is not expected to be null"));
+			if (!playing->isPlaying()) {
+				continue;
+			}
+			DEBUG_ASSERTCRASH(playing->m_3DSample, ("3D Sample is not expected to be null"));
 			AIL_stop_3D_sample(playing->m_3DSample);
 		}
 	}
@@ -535,6 +541,9 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Speech | AudioAffect_Music)) {
 		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 			playing = *it;
+			if (!playing->isPlaying()) {
+				continue;
+			}
 			if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
 				if (!BitIsSet(which, AudioAffect_Music)) {
 					continue;
@@ -544,7 +553,7 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 					continue;
 				}
 			}
-			DEBUG_ASSERTCRASH(playing->m_sample, ("Stream is not expected to be null"));
+			DEBUG_ASSERTCRASH(playing->m_stream, ("Stream is not expected to be null"));
 			AIL_pause_stream(playing->m_stream, 1);
 		}
 	}
@@ -576,6 +585,9 @@ void MilesAudioManager::resumeAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound)) {
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
+			if (!playing->isPlaying()) {
+				continue;
+			}
 			DEBUG_ASSERTCRASH(playing->m_sample, ("Sample is not expected to be null"));
 			AIL_resume_sample(playing->m_sample);
 		}
@@ -584,6 +596,9 @@ void MilesAudioManager::resumeAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound3D)) {
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
+			if (!playing->isPlaying()) {
+				continue;
+			}
 			DEBUG_ASSERTCRASH(playing->m_3DSample, ("3D Sample is not expected to be null"));
 			AIL_resume_3D_sample(playing->m_3DSample);
 		}
@@ -592,6 +607,9 @@ void MilesAudioManager::resumeAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Speech | AudioAffect_Music)) {
 		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 			playing = *it;
+			if (!playing->isPlaying()) {
+				continue;
+			}
 			if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
 				if (!BitIsSet(which, AudioAffect_Music)) {
 					continue;
@@ -1064,6 +1082,7 @@ void MilesAudioManager::stopPlayingAudio( PlayingAudio *playing )
 		return;
 	}
 	releaseMilesHandles(playing);
+	playing->m_rerequestOnNextUpdate = false;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1098,7 +1117,7 @@ PlayingAudio *MilesAudioManager::findActiveMusic( const AsciiString* trackName )
 	PlayingAudio *playing;
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 		playing = *it;
-		if (playing->m_status != PS_Playing) {
+		if (!playing->isPlaying()) {
 			continue;
 		}
 		if (playing->m_fade) {
@@ -1442,6 +1461,9 @@ Bool MilesAudioManager::isCurrentlyPlaying( AudioHandle handle )
 
 	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 		playing = *it;
+		if (!playing->isPlayingOrRequested()) {
+			continue;
+		}
 		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
 			return true;
 		}
@@ -1449,6 +1471,9 @@ Bool MilesAudioManager::isCurrentlyPlaying( AudioHandle handle )
 
 	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 		playing = *it;
+		if (!playing->isPlayingOrRequested()) {
+			continue;
+		}
 		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
 			return true;
 		}
@@ -1456,6 +1481,9 @@ Bool MilesAudioManager::isCurrentlyPlaying( AudioHandle handle )
 
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 		playing = *it;
+		if (!playing->isPlayingOrRequested()) {
+			continue;
+		}
 		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
 			return true;
 		}
@@ -1822,6 +1850,9 @@ Bool MilesAudioManager::doesViolateLimit( AudioEventRTS *event ) const
 	if (!event->isPositionalAudio()) {
 		// 2-D
 		for ( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it ) {
+			if (!(*it)->isPlayingOrRequested()) {
+				continue;
+			}
 			if ((*it)->m_audioEventRTS->getEventName() == event->getEventName()) {
 				if (totalCount == 0) {
 					// This is the oldest audio of this type playing.
@@ -1833,6 +1864,9 @@ Bool MilesAudioManager::doesViolateLimit( AudioEventRTS *event ) const
 	} else {
 		// 3-D
 		for ( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it ) {
+			if (!(*it)->isPlayingOrRequested()) {
+				continue;
+			}
 			if ((*it)->m_audioEventRTS->getEventName() == event->getEventName()) {
 				if (totalCount == 0) {
 					// This is the oldest audio of this type playing.
@@ -1892,6 +1926,9 @@ Bool MilesAudioManager::isPlayingAlready( AudioEventRTS *event ) const
 	if (!event->isPositionalAudio()) {
 		// 2-D
 		for ( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it ) {
+			if (!(*it)->isPlaying()) {
+				continue;
+			}
 			if ((*it)->m_audioEventRTS->getEventName() == event->getEventName()) {
 				return true;
 			}
@@ -1899,6 +1936,9 @@ Bool MilesAudioManager::isPlayingAlready( AudioEventRTS *event ) const
 	} else {
 		// 3-D
 		for ( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it ) {
+			if (!(*it)->isPlaying()) {
+				continue;
+			}
 			if ((*it)->m_audioEventRTS->getEventName() == event->getEventName()) {
 				return true;
 			}
@@ -1918,6 +1958,9 @@ Bool MilesAudioManager::isObjectPlayingVoice( UnsignedInt objID ) const
 	std::list<PlayingAudio *>::const_iterator it;
 		// 2-D
 	for ( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it ) {
+		if (!(*it)->isPlaying()) {
+			continue;
+		}
 		if ((*it)->m_audioEventRTS->getObjectID() == objID && (*it)->m_audioEventRTS->getAudioEventInfo()->m_type & ST_VOICE) {
 			return true;
 		}
@@ -1925,6 +1968,9 @@ Bool MilesAudioManager::isObjectPlayingVoice( UnsignedInt objID ) const
 
 	// 3-D
 	for ( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it ) {
+		if (!(*it)->isPlaying()) {
+			continue;
+		}
 		if ((*it)->m_audioEventRTS->getObjectID() == objID && (*it)->m_audioEventRTS->getAudioEventInfo()->m_type & ST_VOICE) {
 			return true;
 		}
@@ -1953,6 +1999,9 @@ AudioEventRTS* MilesAudioManager::findLowestPrioritySound( AudioEventRTS *event 
 		//3D
 		for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 		{
+			if (!(*it)->isPlaying()) {
+				continue;
+			}
 			AudioEventRTS *itEvent = (*it)->m_audioEventRTS.Peek();
 			const AudioPriority itPriority = itEvent->getAudioEventInfo()->m_priority;
 			if( itPriority < lowestPriority )
@@ -1971,6 +2020,9 @@ AudioEventRTS* MilesAudioManager::findLowestPrioritySound( AudioEventRTS *event 
 		//2D
 		for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 		{
+			if (!(*it)->isPlaying()) {
+				continue;
+			}
 			AudioEventRTS *itEvent = (*it)->m_audioEventRTS.Peek();
 			const AudioPriority itPriority = itEvent->getAudioEventInfo()->m_priority;
 			if( itPriority < lowestPriority )
@@ -2003,6 +2055,9 @@ Bool MilesAudioManager::isPlayingLowerPriority( AudioEventRTS *event ) const
 	if (!event->isPositionalAudio()) {
 		// 2-D
 		for ( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it ) {
+			if (!(*it)->isPlaying()) {
+				continue;
+			}
 			if ((*it)->m_audioEventRTS->getAudioEventInfo()->m_priority < priority) {
 				//event->setHandleToKill((*it)->m_audioEventRTS->getPlayingHandle());
 				return true;
@@ -2011,6 +2066,9 @@ Bool MilesAudioManager::isPlayingLowerPriority( AudioEventRTS *event ) const
 	} else {
 		// 3-D
 		for ( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it ) {
+			if (!(*it)->isPlaying()) {
+				continue;
+			}
 			if ((*it)->m_audioEventRTS->getAudioEventInfo()->m_priority < priority) {
 				//event->setHandleToKill((*it)->m_audioEventRTS->getPlayingHandle());
 				return true;
@@ -2035,9 +2093,13 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 			for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 			{
 				PlayingAudio *playing = (*it);
+				if (!playing->isPlaying())
+				{
+					continue;
+				}
 				if( playing->m_audioEventRTS.Peek() == lowestPriorityEvent )
 				{
-					//Release this 3D sound channel immediately because we are going to play another sound in it's place.
+					// Stop this 3D sound channel immediately because we are going to play another sound in it's place.
 					stopPlayingAudio(playing);
 					return TRUE;
 				}
@@ -2048,9 +2110,13 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 			for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 			{
 				PlayingAudio *playing = (*it);
+				if (!playing->isPlaying())
+				{
+					continue;
+				}
 				if( playing->m_audioEventRTS.Peek() == lowestPriorityEvent )
 				{
-					//Release this sound channel immediately because we are going to play another sound in it's place.
+					// Stop this sound channel immediately because we are going to play another sound in it's place.
 					stopPlayingAudio(playing);
 					return TRUE;
 				}
@@ -2070,6 +2136,9 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 	PlayingAudio *playing = nullptr;
 	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 		playing = *it;
+		if (!playing->isPlaying()) {
+			continue;
+		}
 		AudioEventRTS *itEvent = playing->m_audioEventRTS.Peek();
 
 		if (itEvent->getEventName() == eventName) {
@@ -2082,6 +2151,9 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 
 	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 		playing = *it;
+		if (!playing->isPlaying()) {
+			continue;
+		}
 		AudioEventRTS *itEvent = playing->m_audioEventRTS.Peek();
 
 		if (itEvent->getEventName() == eventName) {
@@ -2093,6 +2165,9 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 		playing = *it;
+		if (!playing->isPlaying()) {
+			continue;
+		}
 		AudioEventRTS *itEvent = playing->m_audioEventRTS.Peek();
 
 		if (itEvent->getEventName() == eventName) {
@@ -2627,7 +2702,7 @@ Bool MilesAudioManager::startNextLoop( PlayingAudio *playing )
 	closeFile(playing->m_file);
 	playing->m_file = nullptr;
 
-	if (playing->m_status != PS_Playing) {
+	if (!playing->isPlaying()) {
 		return false;
 	}
 


### PR DESCRIPTION
**Merge with Rebase**

* Fixes #3232
* Follow up for #2718

This change has 5 commits.

1: MilesAudioManager now uses consistent variable names for PlayingAudio pointers. Previously was a mix of `audio`, `aud`, `release`, `playing`, `looping`. For ease of understanding the code.

2: Simplifies function MilesAudioManager::notifyOfAudioCompletion(). For ease of understanding the code.

3: Simplifies function MilesAudioManager::findLowestPrioritySound(). For ease of understanding the code.

4: Fixes premature 2d and 3d sound cancellations from MilesAudioManager::stopAudioEvent(). Fixes #3232

5: No longer uses stopped audio in queries and updates to prevent 1 frame gaps when a stopping audio is about to be released.

## AI Use

All code changes were applied by hand and Claude Opus was used for several review rounds.

## TODO

- [x] Add pull id to commit titles