### PR TITLE
ci(release): Fix weekly release workflow permissions

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -3,6 +3,7 @@ name: Weekly Release
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
* Fixes the startup failure in https://github.com/TheSuperHackers/GeneralsGameCode/actions/runs/33876554672

Adds `packages: write` to the Weekly Release workflow permissions.

The reusable toolchain workflow began requesting this permission when the vcpkg binary cache moved to GitHub Packages, but the Weekly Release caller was not updated. Because explicitly omitted permissions default to `none`, GitHub rejected the caller before any jobs could start.

This restores the caller or callee permission contract and allows scheduled and manually dispatched weekly releases, including releases run from forks, to start normally.