### PR TITLE
refactor(particlesys): Parse IsGroundAligned as an enum instead of a boolean

### DIFF
--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -431,7 +431,13 @@ public:
 	m_emissionVolume;														///< the dimensions of the emission volume
 
 	Bool m_isEmissionVolumeHollow;							///< if true, only create particles at boundary of volume
-	Bool m_particleAlignment;											///< if true, align with the ground. if false, then do the normal billboarding.
+	enum ParticleAlignmentType
+	{
+		PARTICLE_ALIGNMENT_BILLBOARD = 0,
+		PARTICLE_ALIGNMENT_XYPLANAR,
+		PARTICLE_ALIGNMENT_TYPE_COUNT
+	};
+	ParticleAlignmentType m_particleAlignment;
 	Bool m_isEmitAboveGroundOnly;								///< if true, only emit particles when the system is above ground.
 	Bool m_isParticleUpTowardsEmitter;					///< if true, align the up direction to be towards the emitter.
 
@@ -494,6 +500,12 @@ static const char *const ParticlePriorityNames[] =
 	"NONE", "WEAPON_EXPLOSION","SCORCHMARK","DUST_TRAIL","BUILDUP","DEBRIS_TRAIL","UNIT_DAMAGE_FX","DEATH_EXPLOSION","SEMI_CONSTANT","CONSTANT","WEAPON_TRAIL","AREA_EFFECT","CRITICAL", "ALWAYS_RENDER", nullptr
 };
 static_assert(ARRAY_SIZE(ParticlePriorityNames) == NUM_PARTICLE_PRIORITIES + 1, "Incorrect array size");
+
+static const char *const GroundAlignmentTypeNames[] =
+{
+	"No", "Yes", nullptr
+};
+static_assert(ARRAY_SIZE(GroundAlignmentTypeNames) == ParticleSystemInfo::PARTICLE_ALIGNMENT_TYPE_COUNT + 1, "Incorrect array size");
 
 static const char *const WindMotionNames[] =
 {
@@ -614,7 +626,7 @@ public:
 	Bool isUsingVolumeParticles() const { return m_particleType == VOLUME_PARTICLE; }
 	UnsignedInt getVolumeParticleDepth() const { return m_volumeParticleDepth; }
 
-	Bool shouldBillboard() const { return !m_particleAlignment; }
+	Bool shouldBillboard() const { return m_particleAlignment == PARTICLE_ALIGNMENT_BILLBOARD; }
 
 	ParticleShaderType getShaderType() const { return m_shaderType; }
 

--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -431,7 +431,7 @@ public:
 	m_emissionVolume;														///< the dimensions of the emission volume
 
 	Bool m_isEmissionVolumeHollow;							///< if true, only create particles at boundary of volume
-	Bool m_isGroundAligned;											///< if true, align with the ground. if false, then do the normal billboarding.
+	Bool m_particleAlignment;											///< if true, align with the ground. if false, then do the normal billboarding.
 	Bool m_isEmitAboveGroundOnly;								///< if true, only emit particles when the system is above ground.
 	Bool m_isParticleUpTowardsEmitter;					///< if true, align the up direction to be towards the emitter.
 
@@ -614,7 +614,7 @@ public:
 	Bool isUsingVolumeParticles() const { return m_particleType == VOLUME_PARTICLE; }
 	UnsignedInt getVolumeParticleDepth() const { return m_volumeParticleDepth; }
 
-	Bool shouldBillboard() const { return !m_isGroundAligned; }
+	Bool shouldBillboard() const { return !m_particleAlignment; }
 
 	ParticleShaderType getShaderType() const { return m_shaderType; }
 

--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -437,7 +437,7 @@ public:
 		PARTICLE_ALIGNMENT_XYPLANAR,
 		PARTICLE_ALIGNMENT_TYPE_COUNT
 	};
-	ParticleAlignmentType m_particleAlignment;
+	ParticleAlignmentType m_particleAlignment;		///< align particles toward the camera or with the XY plane.
 	Bool m_isEmitAboveGroundOnly;								///< if true, only emit particles when the system is above ground.
 	Bool m_isParticleUpTowardsEmitter;					///< if true, align the up direction to be towards the emitter.
 

--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -431,7 +431,8 @@ public:
 	m_emissionVolume;														///< the dimensions of the emission volume
 
 	Bool m_isEmissionVolumeHollow;							///< if true, only create particles at boundary of volume
-	enum ParticleAlignmentType
+
+	enum ParticleAlignmentType CPP_11(: Int)
 	{
 		PARTICLE_ALIGNMENT_BILLBOARD = 0,
 		PARTICLE_ALIGNMENT_XYPLANAR,

--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -752,7 +752,7 @@ void Particle::loadPostProcess()
 ParticleSystemInfo::ParticleSystemInfo()
 {
 	m_priority = PARTICLE_PRIORITY_LOWEST;
-	m_isGroundAligned = false;
+	m_particleAlignment = false;
 	m_isEmitAboveGroundOnly = false;
 	m_isParticleUpTowardsEmitter = false;
 
@@ -1002,7 +1002,7 @@ void ParticleSystemInfo::xfer( Xfer *xfer )
 	xfer->xferBool( &m_isEmissionVolumeHollow );
 
 	// is ground aligned
-	xfer->xferBool( &m_isGroundAligned );
+	xfer->xferBool( &m_particleAlignment );
 
 	// emit above ground only
 	xfer->xferBool( &m_isEmitAboveGroundOnly );
@@ -1168,7 +1168,7 @@ ParticleSystem::ParticleSystem( const ParticleSystemTemplate *sysTemplate,
 	m_emissionVolume = sysTemplate->m_emissionVolume;
 
 	m_isEmissionVolumeHollow = sysTemplate->m_isEmissionVolumeHollow;
-	m_isGroundAligned = sysTemplate->m_isGroundAligned;
+	m_particleAlignment = sysTemplate->m_particleAlignment;
 	m_isEmitAboveGroundOnly = sysTemplate->m_isEmitAboveGroundOnly;
 	m_isParticleUpTowardsEmitter = sysTemplate->m_isParticleUpTowardsEmitter;
 
@@ -1749,7 +1749,7 @@ Particle *ParticleSystem::createParticle( const ParticleInfo *info,
 				 TheGameLODManager->isParticleSkipped()) )
 			return nullptr;
 
-		if ( getParticleCount() > 0 && priority == AREA_EFFECT && m_isGroundAligned && TheParticleSystemManager->getFieldParticleCount() > (UnsignedInt)TheGlobalData->m_maxFieldParticleCount )
+		if ( getParticleCount() > 0 && priority == AREA_EFFECT && m_particleAlignment && TheParticleSystemManager->getFieldParticleCount() > (UnsignedInt)TheGlobalData->m_maxFieldParticleCount )
 			return nullptr;
 
 		// ALWAYS_RENDER particles are exempt from all count limits, and are always created, regardless of LOD issues.
@@ -2756,7 +2756,7 @@ const FieldParse ParticleSystemTemplate::m_fieldParseTable[] =
 	{ "VolCylinderLength",			INI::parseReal,																nullptr,		offsetof( ParticleSystemTemplate, m_emissionVolume.cylinder.length ) },
 
 	{ "IsHollow",								INI::parseBool,																nullptr,		offsetof( ParticleSystemTemplate, m_isEmissionVolumeHollow ) },
-	{ "IsGroundAligned",				INI::parseBool,																nullptr,		offsetof( ParticleSystemTemplate, m_isGroundAligned ) },
+	{ "IsGroundAligned",				INI::parseBool,																nullptr,		offsetof( ParticleSystemTemplate, m_particleAlignment ) },
 	{ "IsEmitAboveGroundOnly",	INI::parseBool,																nullptr,		offsetof( ParticleSystemTemplate, m_isEmitAboveGroundOnly) },
 	{ "IsParticleUpTowardsEmitter",	INI::parseBool,																nullptr,		offsetof( ParticleSystemTemplate, m_isParticleUpTowardsEmitter) },
 

--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -752,7 +752,7 @@ void Particle::loadPostProcess()
 ParticleSystemInfo::ParticleSystemInfo()
 {
 	m_priority = PARTICLE_PRIORITY_LOWEST;
-	m_particleAlignment = false;
+	m_particleAlignment = PARTICLE_ALIGNMENT_BILLBOARD;
 	m_isEmitAboveGroundOnly = false;
 	m_isParticleUpTowardsEmitter = false;
 
@@ -815,7 +815,11 @@ void ParticleSystemInfo::xfer( Xfer *xfer )
 	Int i;
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -1001,8 +1005,20 @@ void ParticleSystemInfo::xfer( Xfer *xfer )
 	// is emission volume hollow
 	xfer->xferBool( &m_isEmissionVolumeHollow );
 
-	// is ground aligned
-	xfer->xferBool( &m_particleAlignment );
+	// TheSuperHackers @refactor stephanmeesters 07/09/2026
+	// Replace the original ground-alignment boolean with an enum to support additional particle alignments.
+	// Preserve save compatibility by mapping all non-billboard alignments to ground-aligned particles.
+	if (version <= 1)
+	{
+		Bool groundAligned = m_particleAlignment > PARTICLE_ALIGNMENT_BILLBOARD;
+		xfer->xferBool( &groundAligned );
+		if (xfer->getXferMode() == XFER_LOAD)
+			m_particleAlignment = groundAligned ? PARTICLE_ALIGNMENT_XYPLANAR : PARTICLE_ALIGNMENT_BILLBOARD;
+	}
+	else
+	{
+		xfer->xferUser( &m_particleAlignment, sizeof( ParticleAlignmentType ) );
+	}
 
 	// emit above ground only
 	xfer->xferBool( &m_isEmitAboveGroundOnly );
@@ -1749,7 +1765,7 @@ Particle *ParticleSystem::createParticle( const ParticleInfo *info,
 				 TheGameLODManager->isParticleSkipped()) )
 			return nullptr;
 
-		if ( getParticleCount() > 0 && priority == AREA_EFFECT && m_particleAlignment && TheParticleSystemManager->getFieldParticleCount() > (UnsignedInt)TheGlobalData->m_maxFieldParticleCount )
+		if ( getParticleCount() > 0 && priority == AREA_EFFECT && !shouldBillboard() && TheParticleSystemManager->getFieldParticleCount() > (UnsignedInt)TheGlobalData->m_maxFieldParticleCount )
 			return nullptr;
 
 		// ALWAYS_RENDER particles are exempt from all count limits, and are always created, regardless of LOD issues.
@@ -2756,7 +2772,7 @@ const FieldParse ParticleSystemTemplate::m_fieldParseTable[] =
 	{ "VolCylinderLength",			INI::parseReal,																nullptr,		offsetof( ParticleSystemTemplate, m_emissionVolume.cylinder.length ) },
 
 	{ "IsHollow",								INI::parseBool,																nullptr,		offsetof( ParticleSystemTemplate, m_isEmissionVolumeHollow ) },
-	{ "IsGroundAligned",				INI::parseBool,																nullptr,		offsetof( ParticleSystemTemplate, m_particleAlignment ) },
+	{ "IsGroundAligned",				INI::parseIndexList,		GroundAlignmentTypeNames,		offsetof( ParticleSystemTemplate, m_particleAlignment ) },
 	{ "IsEmitAboveGroundOnly",	INI::parseBool,																nullptr,		offsetof( ParticleSystemTemplate, m_isEmitAboveGroundOnly) },
 	{ "IsParticleUpTowardsEmitter",	INI::parseBool,																nullptr,		offsetof( ParticleSystemTemplate, m_isParticleUpTowardsEmitter) },
 

--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -808,7 +808,9 @@ void ParticleSystemInfo::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version
+	* 2: TheSuperHackers @refactor Serialize particle alignment as an enum instead of a boolean.
+	*/
 // ------------------------------------------------------------------------------------------------
 void ParticleSystemInfo::xfer( Xfer *xfer )
 {
@@ -1005,11 +1007,10 @@ void ParticleSystemInfo::xfer( Xfer *xfer )
 	// is emission volume hollow
 	xfer->xferBool( &m_isEmissionVolumeHollow );
 
-	// TheSuperHackers @refactor stephanmeesters 07/09/2026
-	// Replace the original ground-alignment boolean with an enum to support additional particle alignments.
-	// Preserve save compatibility by mapping all non-billboard alignments to ground-aligned particles.
+	// particle alignment
 	if (version <= 1)
 	{
+		// TheSuperHackers @info Preserve save compatibility by mapping all non-billboard alignments to ground-aligned particles.
 		Bool groundAligned = m_particleAlignment > PARTICLE_ALIGNMENT_BILLBOARD;
 		xfer->xferBool( &groundAligned );
 		if (xfer->getXferMode() == XFER_LOAD)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
@@ -247,7 +247,7 @@ void W3DParticleSystemManager::doParticles(RenderInfoClass &rinfo)
 			pos = p->getPosition();
 			psize = p->getSize();
 
-			m_fieldParticleCount += ( sys->getPriority() == AREA_EFFECT && sys->m_particleAlignment != FALSE );
+			m_fieldParticleCount += ( sys->getPriority() == AREA_EFFECT && !sys->shouldBillboard() );
 
 			//@todo lorenzen sez: use pointer arithmetic for these arrays
 			personalities[pointCount] = p->getPersonality();

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
@@ -247,7 +247,7 @@ void W3DParticleSystemManager::doParticles(RenderInfoClass &rinfo)
 			pos = p->getPosition();
 			psize = p->getSize();
 
-			m_fieldParticleCount += ( sys->getPriority() == AREA_EFFECT && sys->m_isGroundAligned != FALSE );
+			m_fieldParticleCount += ( sys->getPriority() == AREA_EFFECT && sys->m_particleAlignment != FALSE );
 
 			//@todo lorenzen sez: use pointer arithmetic for these arrays
 			personalities[pointCount] = p->getPersonality();

--- a/Core/Tools/ParticleEditor/ParticleEditorDialog.cpp
+++ b/Core/Tools/ParticleEditor/ParticleEditorDialog.cpp
@@ -1092,7 +1092,7 @@ void DebugWindowDialog::getSwitchFromSystem( IN SwitchType switchType, OUT Bool&
 	{
 		case ST_HOLLOW: switchVal = m_particleSystem->m_isEmissionVolumeHollow; break;
 		case ST_ONESHOT: switchVal = m_particleSystem->m_isOneShot; break;
-		case ST_ALIGNXY: switchVal = m_particleSystem->m_isGroundAligned; break;
+		case ST_ALIGNXY: switchVal = m_particleSystem->m_particleAlignment; break;
 		case ST_EMITABOVEGROUNDONLY: switchVal = m_particleSystem->m_isEmitAboveGroundOnly; break;
 		case ST_PARTICLEUPTOWARDSEMITTER: switchVal = m_particleSystem->m_isParticleUpTowardsEmitter; break;
 	};
@@ -1108,7 +1108,7 @@ void DebugWindowDialog::updateSwitchToSystem( IN SwitchType switchType, IN const
 	{
 		case ST_HOLLOW: m_particleSystem->m_isEmissionVolumeHollow = switchVal; break;
 		case ST_ONESHOT: m_particleSystem->m_isOneShot = switchVal; break;
-		case ST_ALIGNXY: m_particleSystem->m_isGroundAligned = switchVal; break;
+		case ST_ALIGNXY: m_particleSystem->m_particleAlignment = switchVal; break;
 		case ST_EMITABOVEGROUNDONLY: m_particleSystem->m_isEmitAboveGroundOnly = switchVal; break;
 		case ST_PARTICLEUPTOWARDSEMITTER: m_particleSystem->m_isParticleUpTowardsEmitter = switchVal; break;
 	};

--- a/Core/Tools/ParticleEditor/ParticleEditorDialog.cpp
+++ b/Core/Tools/ParticleEditor/ParticleEditorDialog.cpp
@@ -1092,7 +1092,7 @@ void DebugWindowDialog::getSwitchFromSystem( IN SwitchType switchType, OUT Bool&
 	{
 		case ST_HOLLOW: switchVal = m_particleSystem->m_isEmissionVolumeHollow; break;
 		case ST_ONESHOT: switchVal = m_particleSystem->m_isOneShot; break;
-		case ST_ALIGNXY: switchVal = m_particleSystem->m_particleAlignment; break;
+		case ST_ALIGNXY: switchVal = m_particleSystem->m_particleAlignment == ParticleSystemInfo::PARTICLE_ALIGNMENT_XYPLANAR; break;
 		case ST_EMITABOVEGROUNDONLY: switchVal = m_particleSystem->m_isEmitAboveGroundOnly; break;
 		case ST_PARTICLEUPTOWARDSEMITTER: switchVal = m_particleSystem->m_isParticleUpTowardsEmitter; break;
 	};
@@ -1108,7 +1108,7 @@ void DebugWindowDialog::updateSwitchToSystem( IN SwitchType switchType, IN const
 	{
 		case ST_HOLLOW: m_particleSystem->m_isEmissionVolumeHollow = switchVal; break;
 		case ST_ONESHOT: m_particleSystem->m_isOneShot = switchVal; break;
-		case ST_ALIGNXY: m_particleSystem->m_particleAlignment = switchVal; break;
+		case ST_ALIGNXY: m_particleSystem->m_particleAlignment = switchVal ? ParticleSystemInfo::PARTICLE_ALIGNMENT_XYPLANAR : ParticleSystemInfo::PARTICLE_ALIGNMENT_BILLBOARD; break;
 		case ST_EMITABOVEGROUNDONLY: m_particleSystem->m_isEmitAboveGroundOnly = switchVal; break;
 		case ST_PARTICLEUPTOWARDSEMITTER: m_particleSystem->m_isParticleUpTowardsEmitter = switchVal; break;
 	};

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -9375,7 +9375,7 @@ void _writeSingleParticleSystem( File *out, ParticleSystemTemplate *templ )
 	}
 
 	thisEntry.append(SEP_HEAD).append(F_ISHOLLOW).append(EQ_WITH_SPACES).append((templ->m_isEmissionVolumeHollow ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
-	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append((templ->m_particleAlignment ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
+	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append(GroundAlignmentTypeNames[templ->m_particleAlignment]).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISEMITABOVEGROUNDONLY).append(EQ_WITH_SPACES).append((templ->m_isEmitAboveGroundOnly ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISPARTICLEUPTOWARDSEMITTER).append(EQ_WITH_SPACES).append((templ->m_isParticleUpTowardsEmitter ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -9375,7 +9375,7 @@ void _writeSingleParticleSystem( File *out, ParticleSystemTemplate *templ )
 	}
 
 	thisEntry.append(SEP_HEAD).append(F_ISHOLLOW).append(EQ_WITH_SPACES).append((templ->m_isEmissionVolumeHollow ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
-	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append((templ->m_isGroundAligned ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
+	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append((templ->m_particleAlignment ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISEMITABOVEGROUNDONLY).append(EQ_WITH_SPACES).append((templ->m_isEmitAboveGroundOnly ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISPARTICLEUPTOWARDSEMITTER).append(EQ_WITH_SPACES).append((templ->m_isParticleUpTowardsEmitter ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -9073,7 +9073,7 @@ static const std::string F_VOLSPHERERAD	=	"VolSphereRadius";
 static const std::string F_VOLCYLRAD =		"VolCylinderRadius";
 static const std::string F_VOLCYLLEN =		"VolCylinderLength";
 static const std::string F_ISHOLLOW =			"IsHollow";
-static const std::string F_ISXYPLANAR =		"IsGroundAligned";
+static const std::string F_PARTICLEALIGNMENT =		"IsGroundAligned";
 static const std::string F_ISEMITABOVEGROUNDONLY
 																			=		"IsEmitAboveGroundOnly";
 static const std::string F_ISPARTICLEUPTOWARDSEMITTER
@@ -9375,7 +9375,7 @@ void _writeSingleParticleSystem( File *out, ParticleSystemTemplate *templ )
 	}
 
 	thisEntry.append(SEP_HEAD).append(F_ISHOLLOW).append(EQ_WITH_SPACES).append((templ->m_isEmissionVolumeHollow ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
-	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append(GroundAlignmentTypeNames[templ->m_particleAlignment]).append(SEP_EOL);
+	thisEntry.append(SEP_HEAD).append(F_PARTICLEALIGNMENT).append(EQ_WITH_SPACES).append(GroundAlignmentTypeNames[templ->m_particleAlignment]).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISEMITABOVEGROUNDONLY).append(EQ_WITH_SPACES).append((templ->m_isEmitAboveGroundOnly ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISPARTICLEUPTOWARDSEMITTER).append(EQ_WITH_SPACES).append((templ->m_isParticleUpTowardsEmitter ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -10078,7 +10078,7 @@ void _writeSingleParticleSystem( File *out, ParticleSystemTemplate *templ )
 	}
 
 	thisEntry.append(SEP_HEAD).append(F_ISHOLLOW).append(EQ_WITH_SPACES).append((templ->m_isEmissionVolumeHollow ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
-	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append((templ->m_particleAlignment ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
+	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append(GroundAlignmentTypeNames[templ->m_particleAlignment]).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISEMITABOVEGROUNDONLY).append(EQ_WITH_SPACES).append((templ->m_isEmitAboveGroundOnly ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISPARTICLEUPTOWARDSEMITTER).append(EQ_WITH_SPACES).append((templ->m_isParticleUpTowardsEmitter ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -10078,7 +10078,7 @@ void _writeSingleParticleSystem( File *out, ParticleSystemTemplate *templ )
 	}
 
 	thisEntry.append(SEP_HEAD).append(F_ISHOLLOW).append(EQ_WITH_SPACES).append((templ->m_isEmissionVolumeHollow ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
-	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append((templ->m_isGroundAligned ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
+	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append((templ->m_particleAlignment ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISEMITABOVEGROUNDONLY).append(EQ_WITH_SPACES).append((templ->m_isEmitAboveGroundOnly ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISPARTICLEUPTOWARDSEMITTER).append(EQ_WITH_SPACES).append((templ->m_isParticleUpTowardsEmitter ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -9776,7 +9776,7 @@ static const std::string F_VOLSPHERERAD	=	"VolSphereRadius";
 static const std::string F_VOLCYLRAD =		"VolCylinderRadius";
 static const std::string F_VOLCYLLEN =		"VolCylinderLength";
 static const std::string F_ISHOLLOW =			"IsHollow";
-static const std::string F_ISXYPLANAR =		"IsGroundAligned";
+static const std::string F_PARTICLEALIGNMENT =		"IsGroundAligned";
 static const std::string F_ISEMITABOVEGROUNDONLY
 																			=		"IsEmitAboveGroundOnly";
 static const std::string F_ISPARTICLEUPTOWARDSEMITTER
@@ -10078,7 +10078,7 @@ void _writeSingleParticleSystem( File *out, ParticleSystemTemplate *templ )
 	}
 
 	thisEntry.append(SEP_HEAD).append(F_ISHOLLOW).append(EQ_WITH_SPACES).append((templ->m_isEmissionVolumeHollow ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
-	thisEntry.append(SEP_HEAD).append(F_ISXYPLANAR).append(EQ_WITH_SPACES).append(GroundAlignmentTypeNames[templ->m_particleAlignment]).append(SEP_EOL);
+	thisEntry.append(SEP_HEAD).append(F_PARTICLEALIGNMENT).append(EQ_WITH_SPACES).append(GroundAlignmentTypeNames[templ->m_particleAlignment]).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISEMITABOVEGROUNDONLY).append(EQ_WITH_SPACES).append((templ->m_isEmitAboveGroundOnly ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 	thisEntry.append(SEP_HEAD).append(F_ISPARTICLEUPTOWARDSEMITTER).append(EQ_WITH_SPACES).append((templ->m_isParticleUpTowardsEmitter ? STR_TRUE : STR_FALSE)).append(SEP_EOL);
 


### PR DESCRIPTION
- In preparation for #3245

Parse the INI value `IsGroundAligned` as enum values `No` and `Yes` instead of boolean. This will make it possible to set `IsGroundAligned = CONFORMING` in the INI later.

- Rename `m_isGroundAligned` to `m_particleAlignment`.
- Rename `F_ISXYPLANAR` to `F_PARTICLEALIGNMENT`
- Introduce enum type in place of the boolean type.
- Update the `ParticleSystemInfo` xfer version to handle the new enum save.

## Todo
- [x] Test new save