### PR TITLE
perf(gamememory): Remove unnecessary overhead from GameMemory allocator function overloads

### DIFF
--- a/Core/GameEngine/Include/Common/GameMemory.h
+++ b/Core/GameEngine/Include/Common/GameMemory.h
@@ -852,9 +852,11 @@ extern void userMemoryAdjustPoolSize(const char *poolName, Int& initialAllocatio
 
 	extern void * __cdecl operator new		(size_t size);
 	extern void __cdecl operator delete		(void *p);
+	extern void __cdecl operator delete		(void *p, size_t);
 
 	extern void * __cdecl operator new[]	(size_t size);
 	extern void __cdecl operator delete[]	(void *p);
+	extern void __cdecl operator delete[]	(void *p, size_t);
 
 	// additional overloads to account for VC/MFC funky versions
 	extern void* __cdecl operator new(size_t nSize, const char *, int);

--- a/Core/GameEngine/Include/Common/GameMemory.h
+++ b/Core/GameEngine/Include/Common/GameMemory.h
@@ -448,7 +448,7 @@ public:
 #endif
 
 	/// free the bytes. (assumes allocated by this dma.)
-	void freeBytes(void* pMem);
+	void freeBytes(void* pMem) noexcept;
 
 	/**
 		return the actual number of bytes that would be allocated

--- a/Core/GameEngine/Include/Common/GameMemoryNull.h
+++ b/Core/GameEngine/Include/Common/GameMemoryNull.h
@@ -151,9 +151,11 @@ extern DynamicMemoryAllocator *TheDynamicMemoryAllocator;
 
 extern void * __cdecl operator new(size_t size);
 extern void __cdecl operator delete(void *p);
+extern void __cdecl operator delete(void *p, size_t);
 
 extern void * __cdecl operator new[](size_t size);
 extern void __cdecl operator delete[](void *p);
+extern void __cdecl operator delete[](void *p, size_t);
 
 // additional overloads to account for VC/MFC funky versions
 extern void* __cdecl operator new(size_t size, const char *, int);

--- a/Core/GameEngine/Include/Common/GameMemoryNull.h
+++ b/Core/GameEngine/Include/Common/GameMemoryNull.h
@@ -45,7 +45,7 @@ public:
 #endif
 
 	/// free the bytes. (assumes allocated by this dma.)
-	void freeBytes(void* pMem);
+	void freeBytes(void* pMem) noexcept;
 
 	/**
 		return the actual number of bytes that would be allocated

--- a/Core/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemory.cpp
@@ -2277,7 +2277,7 @@ void *DynamicMemoryAllocator::allocateBytesImplementation(Int numBytes DECLARE_L
 /**
 	free a chunk-o-bytes allocated by this dma. it's ok to pass null.
 */
-void DynamicMemoryAllocator::freeBytes(void* pBlockPtr)
+void DynamicMemoryAllocator::freeBytes(void* pBlockPtr) noexcept
 {
 	if (!pBlockPtr)
 		return;
@@ -3295,7 +3295,6 @@ void* STLSpecialAlloc::allocate(size_t __n)
 void STLSpecialAlloc::deallocate(void* __p, size_t)
 {
 	LINK_TESTER_INCREMENT();
-	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator new"));
 	TheDynamicMemoryAllocator->freeBytes(__p);
 }
@@ -3333,7 +3332,6 @@ void operator delete(void *p)
 	LINK_TESTER_INCREMENT();
 	if (p == nullptr)
 		return;
-	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
 }
@@ -3343,7 +3341,6 @@ void operator delete(void *p, size_t)
 	LINK_TESTER_INCREMENT();
 	if (p == nullptr)
 		return;
-	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
 }
@@ -3357,7 +3354,6 @@ void operator delete[](void *p)
 	LINK_TESTER_INCREMENT();
 	if (p == nullptr)
 		return;
-	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
 }
@@ -3367,7 +3363,6 @@ void operator delete[](void *p, size_t)
 	LINK_TESTER_INCREMENT();
 	if (p == nullptr)
 		return;
-	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
 }
@@ -3397,7 +3392,6 @@ void operator delete(void * p, const char *, int)
 	LINK_TESTER_INCREMENT();
 	if (p == nullptr)
 		return;
-	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
 }
@@ -3427,7 +3421,6 @@ void operator delete[](void * p, const char *, int)
 	LINK_TESTER_INCREMENT();
 	if (p == nullptr)
 		return;
-	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
 }
@@ -3450,7 +3443,6 @@ void  free(void * p)
 	LINK_TESTER_INCREMENT();
 	if (p == nullptr)
 		return;
-	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager"));
 	TheDynamicMemoryAllocator->freeBytes(p);
 }

--- a/Core/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemory.cpp
@@ -3326,6 +3326,8 @@ void *operator new[](size_t size)
 void operator delete(void *p)
 {
 	LINK_TESTER_INCREMENT();
+	if (p == nullptr)
+		return;
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
@@ -3338,6 +3340,8 @@ void operator delete(void *p)
 void operator delete[](void *p)
 {
 	LINK_TESTER_INCREMENT();
+	if (p == nullptr)
+		return;
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
@@ -3366,6 +3370,8 @@ void* operator new(size_t size, const char * fname, int)
 void operator delete(void * p, const char *, int)
 {
 	LINK_TESTER_INCREMENT();
+	if (p == nullptr)
+		return;
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
@@ -3394,6 +3400,8 @@ void* operator new[](size_t size, const char * fname, int)
 void operator delete[](void * p, const char *, int)
 {
 	LINK_TESTER_INCREMENT();
+	if (p == nullptr)
+		return;
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
@@ -3415,6 +3423,8 @@ void *calloc(size_t a, size_t b)
 void  free(void * p)
 {
 	LINK_TESTER_INCREMENT();
+	if (p == nullptr)
+		return;
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager"));
 	TheDynamicMemoryAllocator->freeBytes(p);

--- a/Core/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemory.cpp
@@ -3338,11 +3338,31 @@ void operator delete(void *p)
 	TheDynamicMemoryAllocator->freeBytes(p);
 }
 
+void operator delete(void *p, size_t)
+{
+	LINK_TESTER_INCREMENT();
+	if (p == nullptr)
+		return;
+	preMainInitMemoryManager();
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
+	TheDynamicMemoryAllocator->freeBytes(p);
+}
+
 //-----------------------------------------------------------------------------
 /**
 	overload for global operator delete[]; send requests to TheDynamicMemoryAllocator.
 */
 void operator delete[](void *p)
+{
+	LINK_TESTER_INCREMENT();
+	if (p == nullptr)
+		return;
+	preMainInitMemoryManager();
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
+	TheDynamicMemoryAllocator->freeBytes(p);
+}
+
+void operator delete[](void *p, size_t)
 {
 	LINK_TESTER_INCREMENT();
 	if (p == nullptr)

--- a/Core/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemory.cpp
@@ -210,7 +210,12 @@ static void memset32(void* ptr, Int value, Int bytesToFill);
 static void doStackDumpOutput(const char* m);
 static void doStackDump(void **stacktrace, int size);
 #endif
-static void preMainInitMemoryManager();
+static NOINLINE void preMainInitMemoryManagerImpl();
+static inline void preMainInitMemoryManager()
+{
+	if (TheDynamicMemoryAllocator == nullptr)
+		preMainInitMemoryManagerImpl();
+}
 
 // ----------------------------------------------------------------------------
 // PRIVATE FUNCTIONS
@@ -3501,11 +3506,13 @@ Bool isMemoryManagerOfficiallyInited()
 	This is only called if memory is allocated prior to the normal call to initMemoryManager
 	(generally via a static C++ ctor).
 */
-static void preMainInitMemoryManager()
+#if defined(_MSC_VER) && _MSC_VER < 1300
+#pragma auto_inline(off)
+#endif
+static NOINLINE void preMainInitMemoryManagerImpl()
 {
 	if (TheMemoryPoolFactory == nullptr)
 	{
-
 		Int numSubPools;
 		const PoolInitRec *pParms;
 		userMemoryManagerGetDmaParms(&numSubPools, &pParms);
@@ -3520,6 +3527,9 @@ static void preMainInitMemoryManager()
 		DEBUG_LOG(("*** Initialized the Memory Manager prior to main!"));
 	}
 }
+#if defined(_MSC_VER) && _MSC_VER < 1300
+#pragma auto_inline(on)
+#endif
 
 //-----------------------------------------------------------------------------
 /**

--- a/Core/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemory.cpp
@@ -3236,12 +3236,51 @@ void MemoryPoolFactory::debugMemoryReport(Int flags, Int startCheckpoint, Int en
 // GLOBAL FUNCTIONS
 //-----------------------------------------------------------------------------
 
+#ifdef DEBUG_CRASHING
 static int theLinkTester = 0;
+void verifyLinkTester()
+{
+	char* linktest;
+
+	theLinkTester = 0;
+
+	linktest = new char;
+	delete linktest;
+
+	linktest = new char[8];
+	delete [] linktest;
+
+	linktest = new char('\0');
+	delete linktest;
+
+#ifdef MEMORYPOOL_OVERRIDE_MALLOC
+	linktest = (char*)malloc(1);
+	free(linktest);
+
+	linktest = (char*)calloc(1,1);
+	free(linktest);
+#endif
+
+#ifdef MEMORYPOOL_OVERRIDE_MALLOC
+	if (theLinkTester != 10)
+#else
+	if (theLinkTester != 6)
+#endif
+	{
+		DEBUG_CRASH(("Wrong operator new/delete linked in! Fix this..."));
+	}
+}
+#define VERIFY_LINK_TESTER() verifyLinkTester()
+#define LINK_TESTER_INCREMENT() ++theLinkTester
+#else
+#define VERIFY_LINK_TESTER()
+#define LINK_TESTER_INCREMENT()
+#endif
 
 //-----------------------------------------------------------------------------
 void* STLSpecialAlloc::allocate(size_t __n)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator new"));
 	return TheDynamicMemoryAllocator->allocateBytes(__n, "STL_");
@@ -3250,7 +3289,7 @@ void* STLSpecialAlloc::allocate(size_t __n)
 //-----------------------------------------------------------------------------
 void STLSpecialAlloc::deallocate(void* __p, size_t)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator new"));
 	TheDynamicMemoryAllocator->freeBytes(__p);
@@ -3262,7 +3301,7 @@ void STLSpecialAlloc::deallocate(void* __p, size_t)
 */
 void *operator new(size_t size)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator new"));
 	return TheDynamicMemoryAllocator->allocateBytes(size, "global operator new");
@@ -3274,7 +3313,7 @@ void *operator new(size_t size)
 */
 void *operator new[](size_t size)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator new"));
 	return TheDynamicMemoryAllocator->allocateBytes(size, "global operator new[]");
@@ -3286,7 +3325,7 @@ void *operator new[](size_t size)
 */
 void operator delete(void *p)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
@@ -3298,7 +3337,7 @@ void operator delete(void *p)
 */
 void operator delete[](void *p)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
@@ -3310,7 +3349,7 @@ void operator delete[](void *p)
 */
 void* operator new(size_t size, const char * fname, int)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator new"));
 #ifdef MEMORYPOOL_DEBUG
@@ -3326,7 +3365,7 @@ void* operator new(size_t size, const char * fname, int)
 */
 void operator delete(void * p, const char *, int)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
@@ -3338,7 +3377,7 @@ void operator delete(void * p, const char *, int)
 */
 void* operator new[](size_t size, const char * fname, int)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator new"));
 #ifdef MEMORYPOOL_DEBUG
@@ -3354,7 +3393,7 @@ void* operator new[](size_t size, const char * fname, int)
 */
 void operator delete[](void * p, const char *, int)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager before calling global operator delete"));
 	TheDynamicMemoryAllocator->freeBytes(p);
@@ -3364,7 +3403,7 @@ void operator delete[](void * p, const char *, int)
 #ifdef MEMORYPOOL_OVERRIDE_MALLOC
 void *calloc(size_t a, size_t b)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager"));
 	return TheDynamicMemoryAllocator->allocateBytes(a * b, "calloc");
@@ -3375,7 +3414,7 @@ void *calloc(size_t a, size_t b)
 #ifdef MEMORYPOOL_OVERRIDE_MALLOC
 void  free(void * p)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager"));
 	TheDynamicMemoryAllocator->freeBytes(p);
@@ -3386,7 +3425,7 @@ void  free(void * p)
 #ifdef MEMORYPOOL_OVERRIDE_MALLOC
 void *malloc(size_t a)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != nullptr, ("must init memory manager"));
 	return TheDynamicMemoryAllocator->allocateBytesDoNotZero(a, "malloc");
@@ -3434,35 +3473,7 @@ void initMemoryManager()
 		}
 	}
 
-	char* linktest;
-
-	theLinkTester = 0;
-
-	linktest = new char;
-	delete linktest;
-
-	linktest = new char[8];
-	delete [] linktest;
-
-	linktest = new char('\0');
-	delete linktest;
-
-#ifdef MEMORYPOOL_OVERRIDE_MALLOC
-	linktest = (char*)malloc(1);
-	free(linktest);
-
-	linktest = (char*)calloc(1,1);
-	free(linktest);
-#endif
-
-#ifdef MEMORYPOOL_OVERRIDE_MALLOC
-	if (theLinkTester != 10)
-#else
-	if (theLinkTester != 6)
-#endif
-	{
-		DEBUG_CRASH(("Wrong operator new/delete linked in! Fix this..."));
-	}
+	VERIFY_LINK_TESTER();
 
 	theMainInitFlag = true;
 
@@ -3548,7 +3559,7 @@ void shutdownMemoryManager()
 //-----------------------------------------------------------------------------
 void* createW3DMemPool(const char *poolName, int allocationSize)
 {
-	++theLinkTester;
+	LINK_TESTER_INCREMENT();
 	preMainInitMemoryManager();
 	MemoryPool* pool = TheMemoryPoolFactory->createMemoryPool(poolName, allocationSize, 0, 0);
 	DEBUG_ASSERTCRASH(pool && pool->getAllocationSize() == allocationSize, ("bad w3d pool"));

--- a/Core/GameEngine/Source/Common/System/GameMemoryNull.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemoryNull.cpp
@@ -65,7 +65,7 @@ void *DynamicMemoryAllocator::allocateBytesImplementation(Int numBytes)
 /**
 	free a chunk-o-bytes allocated by this dma. it's ok to pass null.
 */
-void DynamicMemoryAllocator::freeBytes(void* pBlockPtr)
+void DynamicMemoryAllocator::freeBytes(void* pBlockPtr) noexcept
 {
 	free(pBlockPtr);
 }

--- a/Core/GameEngine/Source/Common/System/GameMemoryNull.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemoryNull.cpp
@@ -158,7 +158,7 @@ void shutdownMemoryManager()
 
 #ifndef DISABLE_GAMEMEMORY_NEW_OPERATORS
 
-extern void * __cdecl operator new(size_t size)
+void * __cdecl operator new(size_t size)
 {
 	void *p = malloc(size);
 	if (p == nullptr)
@@ -167,17 +167,17 @@ extern void * __cdecl operator new(size_t size)
 	return p;
 }
 
-extern void __cdecl operator delete(void *p)
+void __cdecl operator delete(void *p)
 {
 	free(p);
 }
 
-extern void __cdecl operator delete(void *p, size_t)
+void __cdecl operator delete(void *p, size_t)
 {
 	free(p);
 }
 
-extern void * __cdecl operator new[](size_t size)
+void * __cdecl operator new[](size_t size)
 {
 	void *p = malloc(size);
 	if (p == nullptr)
@@ -186,18 +186,18 @@ extern void * __cdecl operator new[](size_t size)
 	return p;
 }
 
-extern void __cdecl operator delete[](void *p)
+void __cdecl operator delete[](void *p)
 {
 	free(p);
 }
 
-extern void __cdecl operator delete[](void *p, size_t)
+void __cdecl operator delete[](void *p, size_t)
 {
 	free(p);
 }
 
 // additional overloads to account for VC/MFC funky versions
-extern void* __cdecl operator new(size_t size, const char *, int)
+void* __cdecl operator new(size_t size, const char *, int)
 {
 	void *p = malloc(size);
 	if (p == nullptr)
@@ -206,12 +206,12 @@ extern void* __cdecl operator new(size_t size, const char *, int)
 	return p;
 }
 
-extern void __cdecl operator delete(void *p, const char *, int)
+void __cdecl operator delete(void *p, const char *, int)
 {
 	free(p);
 }
 
-extern void* __cdecl operator new[](size_t size, const char *, int)
+void* __cdecl operator new[](size_t size, const char *, int)
 {
 	void *p = malloc(size);
 	if (p == nullptr)
@@ -220,7 +220,7 @@ extern void* __cdecl operator new[](size_t size, const char *, int)
 	return p;
 }
 
-extern void __cdecl operator delete[](void *p, const char *, int)
+void __cdecl operator delete[](void *p, const char *, int)
 {
 	free(p);
 }

--- a/Core/GameEngine/Source/Common/System/GameMemoryNull.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemoryNull.cpp
@@ -172,6 +172,11 @@ extern void __cdecl operator delete(void *p)
 	free(p);
 }
 
+extern void __cdecl operator delete(void *p, size_t)
+{
+	free(p);
+}
+
 extern void * __cdecl operator new[](size_t size)
 {
 	void *p = malloc(size);
@@ -182,6 +187,11 @@ extern void * __cdecl operator new[](size_t size)
 }
 
 extern void __cdecl operator delete[](void *p)
+{
+	free(p);
+}
+
+extern void __cdecl operator delete[](void *p, size_t)
 {
 	free(p);
 }

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -83,9 +83,11 @@
 
 	extern void * __cdecl operator new		(size_t size);
 	extern void __cdecl operator delete		(void *p);
+	extern void __cdecl operator delete		(void *p, size_t);
 
 	extern void * __cdecl operator new[]	(size_t size);
 	extern void __cdecl operator delete[]	(void *p);
+	extern void __cdecl operator delete[]	(void *p, size_t);
 
 	// additional overloads to account for VC/MFC funky versions
 	extern void* __cdecl operator new			(size_t nSize, const char *, int);

--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -56,6 +56,14 @@
 #define IUNKNOWN_NOEXCEPT
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER >= 1300
+#define NOINLINE __declspec(noinline)
+#elif defined(__GNUC__) || defined(__clang__)
+#define NOINLINE __attribute__((noinline))
+#else
+#define NOINLINE
+#endif
+
 #ifdef __cplusplus
 namespace stl
 {


### PR DESCRIPTION
**Merge with Rebase**

This change provides a number of small optimizations to the GameMemory to reduce computation overhead in its various new, delete, malloc, free overrides.

1. The memory link tester is now compiled out in Release
2. Delete and free functions are now exited early when called with nullptr
3. The preMainInitMemoryManager function is now inlined for the hot paths (verified in assembler)
4. Adds delete overloads that carry the size_t argument so that it does not need to trampoline to the other delete overloads
5. Remove superfluous extern keywords in GameMemoryNull.cpp
6. Remove unnecessary preMainInitMemoryManager calls and make freeBytes noexcept to get rid of EH frame in delete functions which removes a number of unnecessary instructions (Claude says operator delete is down from 68 bytes to 24 bytes)

Performance impact was not measured, because it will likely be very small, but allocators are very hot functions so it will be good to make them cheaper.

## AI use

All code changes were applied by hand, but assisted by Claude Opus 5 for ideas and verification.

## TODO

- [x] Add pull id to commit titles