### PR TITLE
ci(release): Protect weekly-release against commit-subject injection

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,9 +1,7 @@
 name: Weekly Release
 
 permissions:
-  contents: write
-  pull-requests: write
-  packages: write
+  contents: read
 
 on:
   workflow_dispatch:
@@ -62,6 +60,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - id: check
         run: |
           if [ "${{ github.event.inputs.force_changed }}" = "true" ]; then
@@ -128,12 +127,15 @@ jobs:
     name: Create Release
     needs: [build-generals, build-generalsmd, get-date]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Collect commits since last release
         id: changelog
@@ -176,19 +178,20 @@ jobs:
           zip -jr generalszh-weekly-${{ needs.get-date.outputs.date }}.zip generalsmd-vc6-artifacts/*
 
       - name: Generate release notes
-        id: release_body
+        env:
+          BUILD_NOTES: ${{ github.event.inputs.build_notes }}
+          KNOWN_ISSUES: ${{ github.event.inputs.known_issues }}
+          CHANGELOG_COMMITS: ${{ steps.changelog.outputs.commits }}
         run: |
-          BODY=""
-          if [ "${{ github.event.inputs.build_notes }}" != "" ]; then
-            BODY="${BODY}### Build notes\n${{ github.event.inputs.build_notes }}\n"
-          fi
-          if [ "${{ github.event.inputs.known_issues }}" != "" ]; then
-            BODY="${BODY}### Known issues\n${{ github.event.inputs.known_issues }}\n"
-          fi
-          BODY="${BODY}### Changelog\n${{ steps.changelog.outputs.commits }}"
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$BODY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            if [ -n "$BUILD_NOTES" ]; then
+              printf '### Build notes\n%s\n' "$BUILD_NOTES"
+            fi
+            if [ -n "$KNOWN_ISSUES" ]; then
+              printf '### Known issues\n%s\n' "$KNOWN_ISSUES"
+            fi
+            printf '### Changelog\n%s\n' "$CHANGELOG_COMMITS"
+          } > release-notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
@@ -196,7 +199,7 @@ jobs:
           tag_name: weekly-${{ needs.get-date.outputs.date }}
           name: weekly-${{ needs.get-date.outputs.date }}
           prerelease: ${{ github.event.inputs.pre-release == 'true' }}
-          body: ${{ steps.release_body.outputs.body }}
+          body_path: release-notes.md
           files: |
             generals-weekly-${{ needs.get-date.outputs.date }}.zip
             generalszh-weekly-${{ needs.get-date.outputs.date }}.zip
@@ -209,3 +212,4 @@ jobs:
           rm -rf generals-vc6-artifacts generalsmd-vc6-artifacts
           rm -f generals-weekly-${{ needs.get-date.outputs.date }}.zip
           rm -f generalszh-weekly-${{ needs.get-date.outputs.date }}.zip
+          rm -f release-notes.md


### PR DESCRIPTION
The weekly release job builds the release notes by pasting the commit list and the workflow inputs straight into a bash `run:` block. GitHub fills in `${{ ... }}` before bash runs, so a commit message with something like `$(...)` in it would actually run when the notes are generated. That happens after the release zips are built and before they are uploaded, so it could tamper with them.

Commit 548f4e3 also added `packages: write` at the workflow level, which the release job picked up even though it does not publish packages.

- The release notes are now written with `printf` from env vars into a file, and the release action reads that file with `body_path`. Nothing untrusted goes into a shell command anymore.
- Dropped the workflow level `packages: write` and `pull-requests: write`. Nothing here needs them. The release job asks for `contents: write` on its own.
- Added `persist-credentials: false` on the two checkouts that only read git history.