### PR TITLE
refactor(basetype): Add utility functions to Region and Coord types

### DIFF
--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -197,7 +197,7 @@ public:
 	void setPosition( const Coord3D &pos ) { m_pos = pos; }
 	void setPosition2D( const Coord2D &pos ) { m_pos.x = pos.x; m_pos.y = pos.y; }
 	const Coord3D &getPosition() const { return m_pos; } ///< Returns position camera is looking at
-	Coord2D getPosition2D() const { return m_pos.xy(); } ///< Returns position camera is looking at
+	Coord2D getPosition2D() const { return m_pos.getXY(); } ///< Returns position camera is looking at
 
 	virtual Coord3D get3DCameraPosition() const { Coord3D c={0,0,0}; return c; } ///< Returns the actual camera position
 	virtual Coord3D get3DCameraDirection() const { Coord3D c={0,0,0}; return c; } ///< Returns the actual camera view direction

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -197,7 +197,7 @@ public:
 	void setPosition( const Coord3D &pos ) { m_pos = pos; }
 	void setPosition2D( const Coord2D &pos ) { m_pos.x = pos.x; m_pos.y = pos.y; }
 	const Coord3D &getPosition() const { return m_pos; } ///< Returns position camera is looking at
-	Coord2D getPosition2D() const { return m_pos.getXY(); } ///< Returns position camera is looking at
+	Coord2D getPosition2D() const { return m_pos.asCoord2D(); } ///< Returns position camera is looking at
 
 	virtual Coord3D get3DCameraPosition() const { Coord3D c={0,0,0}; return c; } ///< Returns the actual camera position
 	virtual Coord3D get3DCameraDirection() const { Coord3D c={0,0,0}; return c; } ///< Returns the actual camera view direction

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -197,7 +197,7 @@ public:
 	void setPosition( const Coord3D &pos ) { m_pos = pos; }
 	void setPosition2D( const Coord2D &pos ) { m_pos.x = pos.x; m_pos.y = pos.y; }
 	const Coord3D &getPosition() const { return m_pos; } ///< Returns position camera is looking at
-	Coord2D getPosition2D() const { Coord2D c = { m_pos.x, m_pos.y }; return c; } ///< Returns position camera is looking at
+	Coord2D getPosition2D() const { return m_pos.xy(); } ///< Returns position camera is looking at
 
 	virtual Coord3D get3DCameraPosition() const { Coord3D c={0,0,0}; return c; } ///< Returns the actual camera position
 	virtual Coord3D get3DCameraDirection() const { Coord3D c={0,0,0}; return c; } ///< Returns the actual camera view direction

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindow.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindow.cpp
@@ -180,9 +180,11 @@ void GameWindow::unlinkFromTransitionWindows()
 //=============================================================================
 void GameWindow::normalizeWindowRegion()
 {
-	const ICoord2D lo = m_region.lo;
-	m_region.lo.min(m_region.hi);
-	m_region.hi.max(lo);
+	if( m_region.lo.x > m_region.hi.x )
+		std::swap( m_region.lo.x, m_region.hi.x );
+
+	if( m_region.lo.y > m_region.hi.y )
+		std::swap( m_region.lo.y, m_region.hi.y );
 }
 
 // GameWindow::findFirstLeaf ==================================================

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindow.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindow.cpp
@@ -180,26 +180,9 @@ void GameWindow::unlinkFromTransitionWindows()
 //=============================================================================
 void GameWindow::normalizeWindowRegion()
 {
-	Int temp;
-
-	if( m_region.lo.x > m_region.hi.x)
-	{
-
-		temp = m_region.lo.x;
-		m_region.lo.x = m_region.hi.x;
-		m_region.hi.x = temp;
-
-	}
-
-	if( m_region.lo.y > m_region.hi.y )
-	{
-
-		temp = m_region.lo.y;
-		m_region.lo.y = m_region.hi.y;
-		m_region.hi.y = temp;
-
-	}
-
+	const ICoord2D lo = m_region.lo;
+	m_region.lo.min(m_region.hi);
+	m_region.hi.max(lo);
 }
 
 // GameWindow::findFirstLeaf ==================================================

--- a/Core/GameEngine/Source/GameClient/Line2D.cpp
+++ b/Core/GameEngine/Source/GameClient/Line2D.cpp
@@ -289,17 +289,12 @@ Bool PointInsideRect3D(const Coord3D *bl, const Coord3D *tl, const Coord3D *br, 
 											 const Coord3D *inputPoint)
 {
 	Coord2D bl2d, tl2d, br2d, tr2d, pt;
-	bl2d.x = bl->x;
-	bl2d.y = bl->y;
-	tl2d.x = tl->x;
-	tl2d.y = tl->y;
-	br2d.x = br->x;
-	br2d.y = br->y;
-	tr2d.x = tr->x;
-	tr2d.y = tr->y;
+	bl2d = bl->xy();
+	tl2d = tl->xy();
+	br2d = br->xy();
+	tr2d = tr->xy();
 
-	pt.x = inputPoint->x;
-	pt.y = inputPoint->y;
+	pt = inputPoint->xy();
 
 	return PointInsideRect2D(&bl2d, &br2d, &tl2d, &tr2d, &pt);
 }
@@ -322,14 +317,11 @@ Bool PointInsideArea2D( const Coord3D *ptToTest, const Coord3D *area, Int numPoi
 {
 	int numIntersections = 0;
 	Coord2D pt2D, area2D1, area2D2;
-	pt2D.x = ptToTest->x;
-	pt2D.y = ptToTest->y;
+	pt2D = ptToTest->xy();
 
 	for (int i = 0; i < numPointsInArea; ++i) {
-		area2D1.x = area[i].x;
-		area2D1.y = area[i].y;
-		area2D2.x = area[(i + 1) % numPointsInArea].x;
-		area2D2.y = area[(i + 1) % numPointsInArea].y;
+		area2D1 = area[i].xy();
+		area2D2 = area[(i + 1) % numPointsInArea].xy();
 		if (IntersectLine2D(&pt2D, &reallyFarPoint, &area2D1, &area2D2)) {
 			++numIntersections;
 		}

--- a/Core/GameEngine/Source/GameClient/Line2D.cpp
+++ b/Core/GameEngine/Source/GameClient/Line2D.cpp
@@ -289,12 +289,12 @@ Bool PointInsideRect3D(const Coord3D *bl, const Coord3D *tl, const Coord3D *br, 
 											 const Coord3D *inputPoint)
 {
 	Coord2D bl2d, tl2d, br2d, tr2d, pt;
-	bl2d = bl->xy();
-	tl2d = tl->xy();
-	br2d = br->xy();
-	tr2d = tr->xy();
+	bl2d = bl->getXY();
+	tl2d = tl->getXY();
+	br2d = br->getXY();
+	tr2d = tr->getXY();
 
-	pt = inputPoint->xy();
+	pt = inputPoint->getXY();
 
 	return PointInsideRect2D(&bl2d, &br2d, &tl2d, &tr2d, &pt);
 }
@@ -317,11 +317,11 @@ Bool PointInsideArea2D( const Coord3D *ptToTest, const Coord3D *area, Int numPoi
 {
 	int numIntersections = 0;
 	Coord2D pt2D, area2D1, area2D2;
-	pt2D = ptToTest->xy();
+	pt2D = ptToTest->getXY();
 
 	for (int i = 0; i < numPointsInArea; ++i) {
-		area2D1 = area[i].xy();
-		area2D2 = area[(i + 1) % numPointsInArea].xy();
+		area2D1 = area[i].getXY();
+		area2D2 = area[(i + 1) % numPointsInArea].getXY();
 		if (IntersectLine2D(&pt2D, &reallyFarPoint, &area2D1, &area2D2)) {
 			++numIntersections;
 		}

--- a/Core/GameEngine/Source/GameClient/Line2D.cpp
+++ b/Core/GameEngine/Source/GameClient/Line2D.cpp
@@ -289,12 +289,12 @@ Bool PointInsideRect3D(const Coord3D *bl, const Coord3D *tl, const Coord3D *br, 
 											 const Coord3D *inputPoint)
 {
 	Coord2D bl2d, tl2d, br2d, tr2d, pt;
-	bl2d = bl->getXY();
-	tl2d = tl->getXY();
-	br2d = br->getXY();
-	tr2d = tr->getXY();
+	bl2d = bl->asCoord2D();
+	tl2d = tl->asCoord2D();
+	br2d = br->asCoord2D();
+	tr2d = tr->asCoord2D();
 
-	pt = inputPoint->getXY();
+	pt = inputPoint->asCoord2D();
 
 	return PointInsideRect2D(&bl2d, &br2d, &tl2d, &tr2d, &pt);
 }
@@ -317,11 +317,11 @@ Bool PointInsideArea2D( const Coord3D *ptToTest, const Coord3D *area, Int numPoi
 {
 	int numIntersections = 0;
 	Coord2D pt2D, area2D1, area2D2;
-	pt2D = ptToTest->getXY();
+	pt2D = ptToTest->asCoord2D();
 
 	for (int i = 0; i < numPointsInArea; ++i) {
-		area2D1 = area[i].getXY();
-		area2D2 = area[(i + 1) % numPointsInArea].getXY();
+		area2D1 = area[i].asCoord2D();
+		area2D2 = area[(i + 1) % numPointsInArea].asCoord2D();
 		if (IntersectLine2D(&pt2D, &reallyFarPoint, &area2D1, &area2D2)) {
 			++numIntersections;
 		}

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -3882,10 +3882,8 @@ void PathfindLayer::classifyLayerMapCell( Int i, Int j , PathfindCell *cell, Bri
 		// check against the end lines.
 
 		Region2D cellBounds;
-		cellBounds.lo.x = topLeftCorner.x;
-		cellBounds.lo.y = topLeftCorner.y;
-		cellBounds.hi.x = bottomRightCorner.x;
-		cellBounds.hi.y = bottomRightCorner.y;
+		cellBounds.lo = topLeftCorner.xy();
+		cellBounds.hi = bottomRightCorner.xy();
 
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 		if (m_bridge->isCellOnEnd(&cellBounds)) {
@@ -10443,10 +10441,8 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 
 		for( node = pathToAvoid->getFirstNode(); node && node->getNextOptimized(); node = node->getNextOptimized() )	{
 			Coord2D start, end;
-			start.x = node->getPosition()->x;
-			start.y = node->getPosition()->y;
-			end.x = node->getNextOptimized()->getPosition()->x;
-			end.y = node->getNextOptimized()->getPosition()->y;
+			start = node->getPosition()->xy();
+			end = node->getNextOptimized()->getPosition()->xy();
 			if (LineInRegion(&start, &end, &bounds)) {
 				overlap = true;
 				break;
@@ -10456,10 +10452,8 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 		if (!overlap && pathToAvoid2) {
 			for( node = pathToAvoid2->getFirstNode(); node && node->getNextOptimized(); node = node->getNextOptimized() )	{
 				Coord2D start, end;
-				start.x = node->getPosition()->x;
-				start.y = node->getPosition()->y;
-				end.x = node->getNextOptimized()->getPosition()->x;
-				end.y = node->getNextOptimized()->getPosition()->y;
+				start = node->getPosition()->xy();
+				end = node->getNextOptimized()->getPosition()->xy();
 				if (LineInRegion(&start, &end, &bounds)) {
 					overlap = true;
 					break;

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -3052,7 +3052,7 @@ void PathfindZoneManager::updateZonesForModify(PathfindCell **map, PathfindLayer
 			blockBounds.lo.y = globalBounds.lo.y + yBlock*ZONE_BLOCK_SIZE;
 			blockBounds.hi.x = blockBounds.lo.x + ZONE_BLOCK_SIZE - 1; // blockBounds are inclusive.
 			blockBounds.hi.y = blockBounds.lo.y + ZONE_BLOCK_SIZE - 1; // blockBounds are inclusive.
-			blockBounds.clipTo(bounds);
+			blockBounds.intersectWith(bounds);
 			if (blockBounds.lo.x>blockBounds.hi.x || blockBounds.lo.y>blockBounds.hi.y) {
 				continue;
 			}
@@ -3591,7 +3591,7 @@ void PathfindLayer::allocateCellsForWallLayer(const IRegion2D *extent, ObjectID 
 			bridgeBounds = objBounds;
 			first = false;
 		} else {
-			bridgeBounds.expandWith(objBounds);
+			bridgeBounds.uniteWith(objBounds);
 		}
 	}
 
@@ -4577,7 +4577,7 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 
 	Int i, j;
 
-	cellBounds.clipTo(m_extent);
+	cellBounds.intersectWith(m_extent);
 
 	if (!insert) {
 		for( j=cellBounds.lo.y; j<=cellBounds.hi.y; j++ )

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -2726,7 +2726,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 			bounds.lo.y = globalBounds.lo.y + yBlock*ZONE_BLOCK_SIZE;
 			bounds.hi.x = bounds.lo.x + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
 			bounds.hi.y = bounds.lo.y + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
-			bounds.hi.min(globalBounds.hi);
+			bounds.hi.minimize(globalBounds.hi);
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 			if (bounds.lo.x>bounds.hi.x || bounds.lo.y>bounds.hi.y) {
 				DEBUG_CRASH(("Incorrect bounds calculation. Logic error, fix me. jba."));
@@ -2823,7 +2823,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 			bounds.hi.x = bounds.lo.x + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
 			bounds.hi.y = bounds.lo.y + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
 
-			bounds.hi.min(globalBounds.hi);
+			bounds.hi.minimize(globalBounds.hi);
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 			if (bounds.lo.x>bounds.hi.x || bounds.lo.y>bounds.hi.y) {
 				DEBUG_CRASH(("Incorrect bounds calculation. Logic error, fix me. jba."));
@@ -3042,7 +3042,7 @@ void PathfindZoneManager::updateZonesForModify(PathfindCell **map, PathfindLayer
 	IRegion2D bounds = structureBounds;
 	bounds.hi.x++;
 	bounds.hi.y++;
-	bounds.hi.min(globalBounds.hi);
+	bounds.hi.minimize(globalBounds.hi);
 
 	Int xBlock, yBlock;
 	for (xBlock = 0; xBlock<m_zoneBlockExtent.x; xBlock++) {

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -3881,8 +3881,8 @@ void PathfindLayer::classifyLayerMapCell( Int i, Int j , PathfindCell *cell, Bri
 		// check against the end lines.
 
 		Region2D cellBounds;
-		cellBounds.lo = topLeftCorner.getXY();
-		cellBounds.hi = bottomRightCorner.getXY();
+		cellBounds.lo = topLeftCorner.asCoord2D();
+		cellBounds.hi = bottomRightCorner.asCoord2D();
 
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 		if (m_bridge->isCellOnEnd(&cellBounds)) {
@@ -10440,8 +10440,8 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 
 		for( node = pathToAvoid->getFirstNode(); node && node->getNextOptimized(); node = node->getNextOptimized() )	{
 			Coord2D start, end;
-			start = node->getPosition()->getXY();
-			end = node->getNextOptimized()->getPosition()->getXY();
+			start = node->getPosition()->asCoord2D();
+			end = node->getNextOptimized()->getPosition()->asCoord2D();
 			if (LineInRegion(&start, &end, &bounds)) {
 				overlap = true;
 				break;
@@ -10451,8 +10451,8 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 		if (!overlap && pathToAvoid2) {
 			for( node = pathToAvoid2->getFirstNode(); node && node->getNextOptimized(); node = node->getNextOptimized() )	{
 				Coord2D start, end;
-				start = node->getPosition()->getXY();
-				end = node->getNextOptimized()->getPosition()->getXY();
+				start = node->getPosition()->asCoord2D();
+				end = node->getNextOptimized()->getPosition()->asCoord2D();
 				if (LineInRegion(&start, &end, &bounds)) {
 					overlap = true;
 					break;

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -3052,7 +3052,7 @@ void PathfindZoneManager::updateZonesForModify(PathfindCell **map, PathfindLayer
 			blockBounds.lo.y = globalBounds.lo.y + yBlock*ZONE_BLOCK_SIZE;
 			blockBounds.hi.x = blockBounds.lo.x + ZONE_BLOCK_SIZE - 1; // blockBounds are inclusive.
 			blockBounds.hi.y = blockBounds.lo.y + ZONE_BLOCK_SIZE - 1; // blockBounds are inclusive.
-			blockBounds.intersect(bounds);
+			blockBounds.clipTo(bounds);
 			if (blockBounds.lo.x>blockBounds.hi.x || blockBounds.lo.y>blockBounds.hi.y) {
 				continue;
 			}
@@ -3591,7 +3591,7 @@ void PathfindLayer::allocateCellsForWallLayer(const IRegion2D *extent, ObjectID 
 			bridgeBounds = objBounds;
 			first = false;
 		} else {
-			bridgeBounds.unite(objBounds);
+			bridgeBounds.expandWith(objBounds);
 		}
 	}
 
@@ -4577,7 +4577,7 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 
 	Int i, j;
 
-	cellBounds.intersect(m_extent);
+	cellBounds.clipTo(m_extent);
 
 	if (!insert) {
 		for( j=cellBounds.lo.y; j<=cellBounds.hi.y; j++ )

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -2726,12 +2726,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 			bounds.lo.y = globalBounds.lo.y + yBlock*ZONE_BLOCK_SIZE;
 			bounds.hi.x = bounds.lo.x + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
 			bounds.hi.y = bounds.lo.y + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
-			if (bounds.hi.x > globalBounds.hi.x) {
-				bounds.hi.x = globalBounds.hi.x;
-			}
-			if (bounds.hi.y > globalBounds.hi.y) {
-				bounds.hi.y = globalBounds.hi.y;
-			}
+			bounds.hi.min(globalBounds.hi);
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 			if (bounds.lo.x>bounds.hi.x || bounds.lo.y>bounds.hi.y) {
 				DEBUG_CRASH(("Incorrect bounds calculation. Logic error, fix me. jba."));
@@ -2828,11 +2823,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 			bounds.hi.x = bounds.lo.x + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
 			bounds.hi.y = bounds.lo.y + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
 
-			if (bounds.hi.x > globalBounds.hi.x)
-				bounds.hi.x = globalBounds.hi.x;
-
-			if (bounds.hi.y > globalBounds.hi.y)
-				bounds.hi.y = globalBounds.hi.y;
+			bounds.hi.min(globalBounds.hi);
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 			if (bounds.lo.x>bounds.hi.x || bounds.lo.y>bounds.hi.y) {
 				DEBUG_CRASH(("Incorrect bounds calculation. Logic error, fix me. jba."));
@@ -3051,12 +3042,7 @@ void PathfindZoneManager::updateZonesForModify(PathfindCell **map, PathfindLayer
 	IRegion2D bounds = structureBounds;
 	bounds.hi.x++;
 	bounds.hi.y++;
-	if (bounds.hi.x > globalBounds.hi.x) {
-		bounds.hi.x = globalBounds.hi.x;
-	}
-	if (bounds.hi.y > globalBounds.hi.y) {
-		bounds.hi.y = globalBounds.hi.y;
-	}
+	bounds.hi.min(globalBounds.hi);
 
 	Int xBlock, yBlock;
 	for (xBlock = 0; xBlock<m_zoneBlockExtent.x; xBlock++) {
@@ -3066,18 +3052,7 @@ void PathfindZoneManager::updateZonesForModify(PathfindCell **map, PathfindLayer
 			blockBounds.lo.y = globalBounds.lo.y + yBlock*ZONE_BLOCK_SIZE;
 			blockBounds.hi.x = blockBounds.lo.x + ZONE_BLOCK_SIZE - 1; // blockBounds are inclusive.
 			blockBounds.hi.y = blockBounds.lo.y + ZONE_BLOCK_SIZE - 1; // blockBounds are inclusive.
-			if (blockBounds.hi.x > bounds.hi.x) {
-				blockBounds.hi.x = bounds.hi.x;
-			}
-			if (blockBounds.hi.y > bounds.hi.y) {
-				blockBounds.hi.y = bounds.hi.y;
-			}
-			if (blockBounds.lo.x < bounds.lo.x) {
-				blockBounds.lo.x = bounds.lo.x;
-			}
-			if (blockBounds.lo.y < bounds.lo.y) {
-				blockBounds.lo.y = bounds.lo.y;
-			}
+			blockBounds.intersect(bounds);
 			if (blockBounds.lo.x>blockBounds.hi.x || blockBounds.lo.y>blockBounds.hi.y) {
 				continue;
 			}
@@ -4607,21 +4582,7 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 
 	Int i, j;
 
-	if (cellBounds.lo.x < m_extent.lo.x) {
-		cellBounds.lo.x = m_extent.lo.x;
-	}
-	if (cellBounds.lo.y < m_extent.lo.y) {
-		cellBounds.lo.y = m_extent.lo.y;
-	}
-	if (cellBounds.lo.y < m_extent.lo.y) {
-		cellBounds.lo.y = m_extent.lo.y;
-	}
-	if (cellBounds.hi.x > m_extent.hi.x) {
-		cellBounds.hi.x = m_extent.hi.x;
-	}
-	if (cellBounds.hi.y > m_extent.hi.y) {
-		cellBounds.hi.y = m_extent.hi.y;
-	}
+	cellBounds.intersect(m_extent);
 
 	if (!insert) {
 		for( j=cellBounds.lo.y; j<=cellBounds.hi.y; j++ )

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -3591,8 +3591,7 @@ void PathfindLayer::allocateCellsForWallLayer(const IRegion2D *extent, ObjectID 
 			bridgeBounds = objBounds;
 			first = false;
 		} else {
-			bridgeBounds.lo.min(objBounds.lo);
-			bridgeBounds.hi.max(objBounds.hi);
+			bridgeBounds.unite(objBounds);
 		}
 	}
 

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -3591,10 +3591,8 @@ void PathfindLayer::allocateCellsForWallLayer(const IRegion2D *extent, ObjectID 
 			bridgeBounds = objBounds;
 			first = false;
 		} else {
-			if (bridgeBounds.lo.x>objBounds.lo.x) bridgeBounds.lo.x = objBounds.lo.x;
-			if (bridgeBounds.lo.y>objBounds.lo.y) bridgeBounds.lo.y = objBounds.lo.y;
-			if (bridgeBounds.hi.x<objBounds.hi.x) bridgeBounds.hi.x = objBounds.hi.x;
-			if (bridgeBounds.hi.y<objBounds.hi.y) bridgeBounds.hi.y = objBounds.hi.y;
+			bridgeBounds.lo.min(objBounds.lo);
+			bridgeBounds.hi.max(objBounds.hi);
 		}
 	}
 

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -3882,8 +3882,8 @@ void PathfindLayer::classifyLayerMapCell( Int i, Int j , PathfindCell *cell, Bri
 		// check against the end lines.
 
 		Region2D cellBounds;
-		cellBounds.lo = topLeftCorner.xy();
-		cellBounds.hi = bottomRightCorner.xy();
+		cellBounds.lo = topLeftCorner.getXY();
+		cellBounds.hi = bottomRightCorner.getXY();
 
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 		if (m_bridge->isCellOnEnd(&cellBounds)) {
@@ -10441,8 +10441,8 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 
 		for( node = pathToAvoid->getFirstNode(); node && node->getNextOptimized(); node = node->getNextOptimized() )	{
 			Coord2D start, end;
-			start = node->getPosition()->xy();
-			end = node->getNextOptimized()->getPosition()->xy();
+			start = node->getPosition()->getXY();
+			end = node->getNextOptimized()->getPosition()->getXY();
 			if (LineInRegion(&start, &end, &bounds)) {
 				overlap = true;
 				break;
@@ -10452,8 +10452,8 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 		if (!overlap && pathToAvoid2) {
 			for( node = pathToAvoid2->getFirstNode(); node && node->getNextOptimized(); node = node->getNextOptimized() )	{
 				Coord2D start, end;
-				start = node->getPosition()->xy();
-				end = node->getNextOptimized()->getPosition()->xy();
+				start = node->getPosition()->getXY();
+				end = node->getNextOptimized()->getPosition()->getXY();
 				if (LineInRegion(&start, &end, &bounds)) {
 					overlap = true;
 					break;

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -2726,7 +2726,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 			bounds.lo.y = globalBounds.lo.y + yBlock*ZONE_BLOCK_SIZE;
 			bounds.hi.x = bounds.lo.x + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
 			bounds.hi.y = bounds.lo.y + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
-			bounds.hi.minimize(globalBounds.hi);
+			bounds.hi.updateMin(globalBounds.hi);
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 			if (bounds.lo.x>bounds.hi.x || bounds.lo.y>bounds.hi.y) {
 				DEBUG_CRASH(("Incorrect bounds calculation. Logic error, fix me. jba."));
@@ -2823,7 +2823,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 			bounds.hi.x = bounds.lo.x + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
 			bounds.hi.y = bounds.lo.y + ZONE_BLOCK_SIZE - 1; // bounds are inclusive.
 
-			bounds.hi.minimize(globalBounds.hi);
+			bounds.hi.updateMin(globalBounds.hi);
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 			if (bounds.lo.x>bounds.hi.x || bounds.lo.y>bounds.hi.y) {
 				DEBUG_CRASH(("Incorrect bounds calculation. Logic error, fix me. jba."));
@@ -3042,7 +3042,7 @@ void PathfindZoneManager::updateZonesForModify(PathfindCell **map, PathfindLayer
 	IRegion2D bounds = structureBounds;
 	bounds.hi.x++;
 	bounds.hi.y++;
-	bounds.hi.minimize(globalBounds.hi);
+	bounds.hi.updateMin(globalBounds.hi);
 
 	Int xBlock, yBlock;
 	for (xBlock = 0; xBlock<m_zoneBlockExtent.x; xBlock++) {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -2625,7 +2625,7 @@ void W3DView::lookAt( const Coord3D *o )
 		}
 	}
 
-	setPosition2D(pos.getXY());
+	setPosition2D(pos.asCoord2D());
 
 	resetPivotToGround();
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -2625,8 +2625,7 @@ void W3DView::lookAt( const Coord3D *o )
 		}
 	}
 
-	Coord2D pos2D = { pos.x, pos.y };
-	setPosition2D(pos2D);
+	setPosition2D(pos.xy());
 
 	resetPivotToGround();
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -2625,7 +2625,7 @@ void W3DView::lookAt( const Coord3D *o )
 		}
 	}
 
-	setPosition2D(pos.xy());
+	setPosition2D(pos.getXY());
 
 	resetPivotToGround();
 

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -511,21 +511,21 @@ struct Region2D
 	Coord2D lo, hi;						// bounds of 2D rectangular region
 
 	// Keep only the overlapping portion of both regions.
-	void intersect( const Region2D &other )
+	void clipTo( const Region2D &other )
 	{
 		lo.maximize(other.lo);
 		hi.minimize(other.hi);
 	}
 
 	// Expand to include the other region.
-	void unite( const Region2D &other )
+	void expandWith( const Region2D &other )
 	{
 		lo.minimize(other.lo);
 		hi.maximize(other.hi);
 	}
 
 	// Expand to include the point.
-	void unite( const Coord2D &point )
+	void expandWith( const Coord2D &point )
 	{
 		lo.minimize(point);
 		hi.maximize(point);
@@ -552,21 +552,21 @@ struct IRegion2D
 	ICoord2D lo, hi;					// bounds of 2D rectangular region
 
 	// Keep only the overlapping portion of both regions.
-	void intersect( const IRegion2D &other )
+	void clipTo( const IRegion2D &other )
 	{
 		lo.maximize(other.lo);
 		hi.minimize(other.hi);
 	}
 
 	// Expand to include the other region.
-	void unite( const IRegion2D &other )
+	void expandWith( const IRegion2D &other )
 	{
 		lo.minimize(other.lo);
 		hi.maximize(other.hi);
 	}
 
 	// Expand to include the point.
-	void unite( const ICoord2D &point )
+	void expandWith( const ICoord2D &point )
 	{
 		lo.minimize(point);
 		hi.maximize(point);
@@ -831,21 +831,21 @@ struct Region3D
 	Coord3D lo, hi;						// axis-aligned bounding box
 
 	// Keep only the overlapping portion of both regions.
-	void intersect( const Region3D &other )
+	void clipTo( const Region3D &other )
 	{
 		lo.maximize(other.lo);
 		hi.minimize(other.hi);
 	}
 
 	// Expand to include the other region.
-	void unite( const Region3D &other )
+	void expandWith( const Region3D &other )
 	{
 		lo.minimize(other.lo);
 		hi.maximize(other.hi);
 	}
 
 	// Expand to include the point.
-	void unite( const Coord3D &point )
+	void expandWith( const Coord3D &point )
 	{
 		lo.minimize(point);
 		hi.maximize(point);
@@ -897,7 +897,7 @@ struct Region3D
 		hi = points[0];
 		for (Int i = 1; i < count; ++i)
 		{
-			unite(points[i]);
+			expandWith(points[i]);
 		}
 	}
 
@@ -920,21 +920,21 @@ struct IRegion3D
 	ICoord3D lo, hi;					// axis-aligned bounding box
 
 	// Keep only the overlapping portion of both regions.
-	void intersect( const IRegion3D &other )
+	void clipTo( const IRegion3D &other )
 	{
 		lo.maximize(other.lo);
 		hi.minimize(other.hi);
 	}
 
 	// Expand to include the other region.
-	void unite( const IRegion3D &other )
+	void expandWith( const IRegion3D &other )
 	{
 		lo.minimize(other.lo);
 		hi.maximize(other.hi);
 	}
 
 	// Expand to include the point.
-	void unite( const ICoord3D &point )
+	void expandWith( const ICoord3D &point )
 	{
 		lo.minimize(point);
 		hi.maximize(point);

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -517,7 +517,7 @@ struct Region2D
 		hi.min(other.hi);
 	}
 
-	// Expand to include both regions.
+	// Expand to include the other region.
 	void unite( const Region2D &other )
 	{
 		lo.min(other.lo);
@@ -558,7 +558,7 @@ struct IRegion2D
 		hi.min(other.hi);
 	}
 
-	// Expand to include both regions.
+	// Expand to include the other region.
 	void unite( const IRegion2D &other )
 	{
 		lo.min(other.lo);
@@ -837,7 +837,7 @@ struct Region3D
 		hi.min(other.hi);
 	}
 
-	// Expand to include both regions.
+	// Expand to include the other region.
 	void unite( const Region3D &other )
 	{
 		lo.min(other.lo);
@@ -926,7 +926,7 @@ struct IRegion3D
 		hi.min(other.hi);
 	}
 
-	// Expand to include both regions.
+	// Expand to include the other region.
 	void unite( const IRegion3D &other )
 	{
 		lo.min(other.lo);

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -593,7 +593,7 @@ struct Coord3D
 {
 	Real x, y, z;
 
-	Coord2D getXY() const
+	Coord2D asCoord2D() const
 	{
 		const Coord2D xy = { x, y };
 		return xy;

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -510,6 +510,7 @@ struct Region2D
 {
 	Coord2D lo, hi;						// bounds of 2D rectangular region
 
+	// Keep only the overlapping portion of both regions.
 	void intersect( const Region2D &other )
 	{
 		lo.max(other.lo);
@@ -536,6 +537,7 @@ struct IRegion2D
 {
 	ICoord2D lo, hi;					// bounds of 2D rectangular region
 
+	// Keep only the overlapping portion of both regions.
 	void intersect( const IRegion2D &other )
 	{
 		lo.max(other.lo);
@@ -788,6 +790,7 @@ struct Region3D
 {
 	Coord3D lo, hi;						// axis-aligned bounding box
 
+	// Keep only the overlapping portion of both regions.
 	void intersect( const Region3D &other )
 	{
 		lo.max(other.lo);
@@ -863,6 +866,7 @@ struct IRegion3D
 {
 	ICoord3D lo, hi;					// axis-aligned bounding box
 
+	// Keep only the overlapping portion of both regions.
 	void intersect( const IRegion3D &other )
 	{
 		lo.max(other.lo);

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -515,21 +515,21 @@ struct Region2D
 	Coord2D lo, hi;						// bounds of 2D rectangular region
 
 	// Keep only the overlapping portion of both regions.
-	void clipTo( const Region2D &other )
+	void intersectWith( const Region2D &other )
 	{
 		lo.updateMax(other.lo);
 		hi.updateMin(other.hi);
 	}
 
 	// Expand to include the other region.
-	void expandWith( const Region2D &other )
+	void uniteWith( const Region2D &other )
 	{
 		lo.updateMin(other.lo);
 		hi.updateMax(other.hi);
 	}
 
 	// Expand to include the point.
-	void expandWith( const Coord2D &point )
+	void uniteWith( const Coord2D &point )
 	{
 		lo.updateMin(point);
 		hi.updateMax(point);
@@ -556,21 +556,21 @@ struct IRegion2D
 	ICoord2D lo, hi;					// bounds of 2D rectangular region
 
 	// Keep only the overlapping portion of both regions.
-	void clipTo( const IRegion2D &other )
+	void intersectWith( const IRegion2D &other )
 	{
 		lo.updateMax(other.lo);
 		hi.updateMin(other.hi);
 	}
 
 	// Expand to include the other region.
-	void expandWith( const IRegion2D &other )
+	void uniteWith( const IRegion2D &other )
 	{
 		lo.updateMin(other.lo);
 		hi.updateMax(other.hi);
 	}
 
 	// Expand to include the point.
-	void expandWith( const ICoord2D &point )
+	void uniteWith( const ICoord2D &point )
 	{
 		lo.updateMin(point);
 		hi.updateMax(point);
@@ -843,21 +843,21 @@ struct Region3D
 	Coord3D lo, hi;						// axis-aligned bounding box
 
 	// Keep only the overlapping portion of both regions.
-	void clipTo( const Region3D &other )
+	void intersectWith( const Region3D &other )
 	{
 		lo.updateMax(other.lo);
 		hi.updateMin(other.hi);
 	}
 
 	// Expand to include the other region.
-	void expandWith( const Region3D &other )
+	void uniteWith( const Region3D &other )
 	{
 		lo.updateMin(other.lo);
 		hi.updateMax(other.hi);
 	}
 
 	// Expand to include the point.
-	void expandWith( const Coord3D &point )
+	void uniteWith( const Coord3D &point )
 	{
 		lo.updateMin(point);
 		hi.updateMax(point);
@@ -909,7 +909,7 @@ struct Region3D
 		hi = points[0];
 		for (Int i = 1; i < count; ++i)
 		{
-			expandWith(points[i]);
+			uniteWith(points[i]);
 		}
 	}
 
@@ -932,21 +932,21 @@ struct IRegion3D
 	ICoord3D lo, hi;					// axis-aligned bounding box
 
 	// Keep only the overlapping portion of both regions.
-	void clipTo( const IRegion3D &other )
+	void intersectWith( const IRegion3D &other )
 	{
 		lo.updateMax(other.lo);
 		hi.updateMin(other.hi);
 	}
 
 	// Expand to include the other region.
-	void expandWith( const IRegion3D &other )
+	void uniteWith( const IRegion3D &other )
 	{
 		lo.updateMin(other.lo);
 		hi.updateMax(other.hi);
 	}
 
 	// Expand to include the point.
-	void expandWith( const ICoord3D &point )
+	void uniteWith( const ICoord3D &point )
 	{
 		lo.updateMin(point);
 		hi.updateMax(point);

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -565,7 +565,7 @@ struct Coord3D
 {
 	Real x, y, z;
 
-	Coord2D xy() const
+	Coord2D getXY() const
 	{
 		const Coord2D xy = { x, y };
 		return xy;
@@ -703,7 +703,7 @@ struct ICoord3D
 {
 	Int x, y, z;
 
-	ICoord2D xy() const
+	ICoord2D getXY() const
 	{
 		const ICoord2D xy = { x, y };
 		return xy;

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -331,6 +331,22 @@ struct Coord2D
 		x = ax;
 		y = ay;
 	}
+
+	void min( const Coord2D &other )
+	{
+		if (x > other.x)
+			x = other.x;
+		if (y > other.y)
+			y = other.y;
+	}
+
+	void max( const Coord2D &other )
+	{
+		if (x < other.x)
+			x = other.x;
+		if (y < other.y)
+			y = other.y;
+	}
 };
 
 inline Coord2D operator+( const Coord2D &a, const Coord2D &b )
@@ -458,6 +474,22 @@ struct ICoord2D
 		x = ax;
 		y = ay;
 	}
+
+	void min( const ICoord2D &other )
+	{
+		if (x > other.x)
+			x = other.x;
+		if (y > other.y)
+			y = other.y;
+	}
+
+	void max( const ICoord2D &other )
+	{
+		if (x < other.x)
+			x = other.x;
+		if (y < other.y)
+			y = other.y;
+	}
 };
 
 inline ICoord2D operator+( const ICoord2D &a, const ICoord2D &b )
@@ -478,6 +510,12 @@ struct Region2D
 {
 	Coord2D lo, hi;						// bounds of 2D rectangular region
 
+	void intersect( const Region2D &other )
+	{
+		lo.max(other.lo);
+		hi.min(other.hi);
+	}
+
 	void zero()
 	{
 		lo.zero();
@@ -497,6 +535,12 @@ struct Region2D
 struct IRegion2D
 {
 	ICoord2D lo, hi;					// bounds of 2D rectangular region
+
+	void intersect( const IRegion2D &other )
+	{
+		lo.max(other.lo);
+		hi.min(other.hi);
+	}
 
 	void zero()
 	{
@@ -611,6 +655,26 @@ struct Coord3D
 						y == r.y &&
 						z == r.z);
 	}
+
+	void min( const Coord3D &other )
+	{
+		if (x > other.x)
+			x = other.x;
+		if (y > other.y)
+			y = other.y;
+		if (z > other.z)
+			z = other.z;
+	}
+
+	void max( const Coord3D &other )
+	{
+		if (x < other.x)
+			x = other.x;
+		if (y < other.y)
+			y = other.y;
+		if (z < other.z)
+			z = other.z;
+	}
 };
 
 inline Coord3D operator+( const Coord3D &a, const Coord3D &b )
@@ -683,6 +747,26 @@ struct ICoord3D
 		y = ay;
 		z = az;
 	}
+
+	void min( const ICoord3D &other )
+	{
+		if (x > other.x)
+			x = other.x;
+		if (y > other.y)
+			y = other.y;
+		if (z > other.z)
+			z = other.z;
+	}
+
+	void max( const ICoord3D &other )
+	{
+		if (x < other.x)
+			x = other.x;
+		if (y < other.y)
+			y = other.y;
+		if (z < other.z)
+			z = other.z;
+	}
 };
 
 inline ICoord3D operator+( const ICoord3D &a, const ICoord3D &b )
@@ -703,6 +787,12 @@ inline ICoord3D operator-( const ICoord3D &a, const ICoord3D &b )
 struct Region3D
 {
 	Coord3D lo, hi;						// axis-aligned bounding box
+
+	void intersect( const Region3D &other )
+	{
+		lo.max(other.lo);
+		hi.min(other.hi);
+	}
 
 	Real width() const { return hi.x - lo.x; }
 	Real height() const { return hi.y - lo.y; }
@@ -782,6 +872,12 @@ struct Region3D
 struct IRegion3D
 {
 	ICoord3D lo, hi;					// axis-aligned bounding box
+
+	void intersect( const IRegion3D &other )
+	{
+		lo.max(other.lo);
+		hi.min(other.hi);
+	}
 
 	void zero()
 	{

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -739,7 +739,7 @@ struct ICoord3D
 {
 	Int x, y, z;
 
-	ICoord2D getXY() const
+	ICoord2D asICoord2D() const
 	{
 		const ICoord2D xy = { x, y };
 		return xy;

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -332,7 +332,7 @@ struct Coord2D
 		y = ay;
 	}
 
-	void min( const Coord2D &other )
+	void minimize( const Coord2D &other )
 	{
 		if (x > other.x)
 			x = other.x;
@@ -340,7 +340,7 @@ struct Coord2D
 			y = other.y;
 	}
 
-	void max( const Coord2D &other )
+	void maximize( const Coord2D &other )
 	{
 		if (x < other.x)
 			x = other.x;
@@ -475,7 +475,7 @@ struct ICoord2D
 		y = ay;
 	}
 
-	void min( const ICoord2D &other )
+	void minimize( const ICoord2D &other )
 	{
 		if (x > other.x)
 			x = other.x;
@@ -483,7 +483,7 @@ struct ICoord2D
 			y = other.y;
 	}
 
-	void max( const ICoord2D &other )
+	void maximize( const ICoord2D &other )
 	{
 		if (x < other.x)
 			x = other.x;
@@ -513,22 +513,22 @@ struct Region2D
 	// Keep only the overlapping portion of both regions.
 	void intersect( const Region2D &other )
 	{
-		lo.max(other.lo);
-		hi.min(other.hi);
+		lo.maximize(other.lo);
+		hi.minimize(other.hi);
 	}
 
 	// Expand to include the other region.
 	void unite( const Region2D &other )
 	{
-		lo.min(other.lo);
-		hi.max(other.hi);
+		lo.minimize(other.lo);
+		hi.maximize(other.hi);
 	}
 
 	// Expand to include the point.
 	void unite( const Coord2D &point )
 	{
-		lo.min(point);
-		hi.max(point);
+		lo.minimize(point);
+		hi.maximize(point);
 	}
 
 	void zero()
@@ -554,22 +554,22 @@ struct IRegion2D
 	// Keep only the overlapping portion of both regions.
 	void intersect( const IRegion2D &other )
 	{
-		lo.max(other.lo);
-		hi.min(other.hi);
+		lo.maximize(other.lo);
+		hi.minimize(other.hi);
 	}
 
 	// Expand to include the other region.
 	void unite( const IRegion2D &other )
 	{
-		lo.min(other.lo);
-		hi.max(other.hi);
+		lo.minimize(other.lo);
+		hi.maximize(other.hi);
 	}
 
 	// Expand to include the point.
 	void unite( const ICoord2D &point )
 	{
-		lo.min(point);
-		hi.max(point);
+		lo.minimize(point);
+		hi.maximize(point);
 	}
 
 	void zero()
@@ -692,7 +692,7 @@ struct Coord3D
 						z == r.z);
 	}
 
-	void min( const Coord3D &other )
+	void minimize( const Coord3D &other )
 	{
 		if (x > other.x)
 			x = other.x;
@@ -702,7 +702,7 @@ struct Coord3D
 			z = other.z;
 	}
 
-	void max( const Coord3D &other )
+	void maximize( const Coord3D &other )
 	{
 		if (x < other.x)
 			x = other.x;
@@ -790,7 +790,7 @@ struct ICoord3D
 		z = az;
 	}
 
-	void min( const ICoord3D &other )
+	void minimize( const ICoord3D &other )
 	{
 		if (x > other.x)
 			x = other.x;
@@ -800,7 +800,7 @@ struct ICoord3D
 			z = other.z;
 	}
 
-	void max( const ICoord3D &other )
+	void maximize( const ICoord3D &other )
 	{
 		if (x < other.x)
 			x = other.x;
@@ -833,22 +833,22 @@ struct Region3D
 	// Keep only the overlapping portion of both regions.
 	void intersect( const Region3D &other )
 	{
-		lo.max(other.lo);
-		hi.min(other.hi);
+		lo.maximize(other.lo);
+		hi.minimize(other.hi);
 	}
 
 	// Expand to include the other region.
 	void unite( const Region3D &other )
 	{
-		lo.min(other.lo);
-		hi.max(other.hi);
+		lo.minimize(other.lo);
+		hi.maximize(other.hi);
 	}
 
 	// Expand to include the point.
 	void unite( const Coord3D &point )
 	{
-		lo.min(point);
-		hi.max(point);
+		lo.minimize(point);
+		hi.maximize(point);
 	}
 
 	Real width() const { return hi.x - lo.x; }
@@ -922,22 +922,22 @@ struct IRegion3D
 	// Keep only the overlapping portion of both regions.
 	void intersect( const IRegion3D &other )
 	{
-		lo.max(other.lo);
-		hi.min(other.hi);
+		lo.maximize(other.lo);
+		hi.minimize(other.hi);
 	}
 
 	// Expand to include the other region.
 	void unite( const IRegion3D &other )
 	{
-		lo.min(other.lo);
-		hi.max(other.hi);
+		lo.minimize(other.lo);
+		hi.maximize(other.hi);
 	}
 
 	// Expand to include the point.
 	void unite( const ICoord3D &point )
 	{
-		lo.min(point);
-		hi.max(point);
+		lo.minimize(point);
+		hi.maximize(point);
 	}
 
 	void zero()

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -517,6 +517,20 @@ struct Region2D
 		hi.min(other.hi);
 	}
 
+	// Expand to include both regions.
+	void unite( const Region2D &other )
+	{
+		lo.min(other.lo);
+		hi.max(other.hi);
+	}
+
+	// Expand to include the point.
+	void unite( const Coord2D &point )
+	{
+		lo.min(point);
+		hi.max(point);
+	}
+
 	void zero()
 	{
 		lo.zero();
@@ -542,6 +556,20 @@ struct IRegion2D
 	{
 		lo.max(other.lo);
 		hi.min(other.hi);
+	}
+
+	// Expand to include both regions.
+	void unite( const IRegion2D &other )
+	{
+		lo.min(other.lo);
+		hi.max(other.hi);
+	}
+
+	// Expand to include the point.
+	void unite( const ICoord2D &point )
+	{
+		lo.min(point);
+		hi.max(point);
 	}
 
 	void zero()
@@ -809,6 +837,20 @@ struct Region3D
 		hi.min(other.hi);
 	}
 
+	// Expand to include both regions.
+	void unite( const Region3D &other )
+	{
+		lo.min(other.lo);
+		hi.max(other.hi);
+	}
+
+	// Expand to include the point.
+	void unite( const Coord3D &point )
+	{
+		lo.min(point);
+		hi.max(point);
+	}
+
 	Real width() const { return hi.x - lo.x; }
 	Real height() const { return hi.y - lo.y; }
 	Real depth() const { return hi.z - lo.z; }
@@ -855,8 +897,7 @@ struct Region3D
 		hi = points[0];
 		for (Int i = 1; i < count; ++i)
 		{
-			lo.min(points[i]);
-			hi.max(points[i]);
+			unite(points[i]);
 		}
 	}
 
@@ -883,6 +924,20 @@ struct IRegion3D
 	{
 		lo.max(other.lo);
 		hi.min(other.hi);
+	}
+
+	// Expand to include both regions.
+	void unite( const IRegion3D &other )
+	{
+		lo.min(other.lo);
+		hi.max(other.hi);
+	}
+
+	// Expand to include the point.
+	void unite( const ICoord3D &point )
+	{
+		lo.min(point);
+		hi.max(point);
 	}
 
 	void zero()

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -336,6 +336,7 @@ struct Coord2D
 	{
 		if (x > other.x)
 			x = other.x;
+
 		if (y > other.y)
 			y = other.y;
 	}
@@ -344,6 +345,7 @@ struct Coord2D
 	{
 		if (x < other.x)
 			x = other.x;
+
 		if (y < other.y)
 			y = other.y;
 	}
@@ -479,6 +481,7 @@ struct ICoord2D
 	{
 		if (x > other.x)
 			x = other.x;
+
 		if (y > other.y)
 			y = other.y;
 	}
@@ -487,6 +490,7 @@ struct ICoord2D
 	{
 		if (x < other.x)
 			x = other.x;
+
 		if (y < other.y)
 			y = other.y;
 	}
@@ -696,8 +700,10 @@ struct Coord3D
 	{
 		if (x > other.x)
 			x = other.x;
+
 		if (y > other.y)
 			y = other.y;
+
 		if (z > other.z)
 			z = other.z;
 	}
@@ -706,8 +712,10 @@ struct Coord3D
 	{
 		if (x < other.x)
 			x = other.x;
+
 		if (y < other.y)
 			y = other.y;
+
 		if (z < other.z)
 			z = other.z;
 	}
@@ -794,8 +802,10 @@ struct ICoord3D
 	{
 		if (x > other.x)
 			x = other.x;
+
 		if (y > other.y)
 			y = other.y;
+
 		if (z > other.z)
 			z = other.z;
 	}
@@ -804,8 +814,10 @@ struct ICoord3D
 	{
 		if (x < other.x)
 			x = other.x;
+
 		if (y < other.y)
 			y = other.y;
+
 		if (z < other.z)
 			z = other.z;
 	}

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -840,18 +840,8 @@ struct Region3D
 		hi = points[0];
 		for (Int i = 1; i < count; ++i)
 		{
-			if (points[i].x < lo.x)
-				lo.x = points[i].x;
-			if (points[i].y < lo.y)
-				lo.y = points[i].y;
-			if (points[i].z < lo.z)
-				lo.z = points[i].z;
-			if (points[i].x > hi.x)
-				hi.x = points[i].x;
-			if (points[i].y > hi.y)
-				hi.y = points[i].y;
-			if (points[i].z > hi.z)
-				hi.z = points[i].z;
+			lo.min(points[i]);
+			hi.max(points[i]);
 		}
 	}
 

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -332,7 +332,7 @@ struct Coord2D
 		y = ay;
 	}
 
-	void minimize( const Coord2D &other )
+	void updateMin( const Coord2D &other )
 	{
 		if (x > other.x)
 			x = other.x;
@@ -341,7 +341,7 @@ struct Coord2D
 			y = other.y;
 	}
 
-	void maximize( const Coord2D &other )
+	void updateMax( const Coord2D &other )
 	{
 		if (x < other.x)
 			x = other.x;
@@ -477,7 +477,7 @@ struct ICoord2D
 		y = ay;
 	}
 
-	void minimize( const ICoord2D &other )
+	void updateMin( const ICoord2D &other )
 	{
 		if (x > other.x)
 			x = other.x;
@@ -486,7 +486,7 @@ struct ICoord2D
 			y = other.y;
 	}
 
-	void maximize( const ICoord2D &other )
+	void updateMax( const ICoord2D &other )
 	{
 		if (x < other.x)
 			x = other.x;
@@ -517,22 +517,22 @@ struct Region2D
 	// Keep only the overlapping portion of both regions.
 	void clipTo( const Region2D &other )
 	{
-		lo.maximize(other.lo);
-		hi.minimize(other.hi);
+		lo.updateMax(other.lo);
+		hi.updateMin(other.hi);
 	}
 
 	// Expand to include the other region.
 	void expandWith( const Region2D &other )
 	{
-		lo.minimize(other.lo);
-		hi.maximize(other.hi);
+		lo.updateMin(other.lo);
+		hi.updateMax(other.hi);
 	}
 
 	// Expand to include the point.
 	void expandWith( const Coord2D &point )
 	{
-		lo.minimize(point);
-		hi.maximize(point);
+		lo.updateMin(point);
+		hi.updateMax(point);
 	}
 
 	void zero()
@@ -558,22 +558,22 @@ struct IRegion2D
 	// Keep only the overlapping portion of both regions.
 	void clipTo( const IRegion2D &other )
 	{
-		lo.maximize(other.lo);
-		hi.minimize(other.hi);
+		lo.updateMax(other.lo);
+		hi.updateMin(other.hi);
 	}
 
 	// Expand to include the other region.
 	void expandWith( const IRegion2D &other )
 	{
-		lo.minimize(other.lo);
-		hi.maximize(other.hi);
+		lo.updateMin(other.lo);
+		hi.updateMax(other.hi);
 	}
 
 	// Expand to include the point.
 	void expandWith( const ICoord2D &point )
 	{
-		lo.minimize(point);
-		hi.maximize(point);
+		lo.updateMin(point);
+		hi.updateMax(point);
 	}
 
 	void zero()
@@ -696,7 +696,7 @@ struct Coord3D
 						z == r.z);
 	}
 
-	void minimize( const Coord3D &other )
+	void updateMin( const Coord3D &other )
 	{
 		if (x > other.x)
 			x = other.x;
@@ -708,7 +708,7 @@ struct Coord3D
 			z = other.z;
 	}
 
-	void maximize( const Coord3D &other )
+	void updateMax( const Coord3D &other )
 	{
 		if (x < other.x)
 			x = other.x;
@@ -798,7 +798,7 @@ struct ICoord3D
 		z = az;
 	}
 
-	void minimize( const ICoord3D &other )
+	void updateMin( const ICoord3D &other )
 	{
 		if (x > other.x)
 			x = other.x;
@@ -810,7 +810,7 @@ struct ICoord3D
 			z = other.z;
 	}
 
-	void maximize( const ICoord3D &other )
+	void updateMax( const ICoord3D &other )
 	{
 		if (x < other.x)
 			x = other.x;
@@ -845,22 +845,22 @@ struct Region3D
 	// Keep only the overlapping portion of both regions.
 	void clipTo( const Region3D &other )
 	{
-		lo.maximize(other.lo);
-		hi.minimize(other.hi);
+		lo.updateMax(other.lo);
+		hi.updateMin(other.hi);
 	}
 
 	// Expand to include the other region.
 	void expandWith( const Region3D &other )
 	{
-		lo.minimize(other.lo);
-		hi.maximize(other.hi);
+		lo.updateMin(other.lo);
+		hi.updateMax(other.hi);
 	}
 
 	// Expand to include the point.
 	void expandWith( const Coord3D &point )
 	{
-		lo.minimize(point);
-		hi.maximize(point);
+		lo.updateMin(point);
+		hi.updateMax(point);
 	}
 
 	Real width() const { return hi.x - lo.x; }
@@ -934,22 +934,22 @@ struct IRegion3D
 	// Keep only the overlapping portion of both regions.
 	void clipTo( const IRegion3D &other )
 	{
-		lo.maximize(other.lo);
-		hi.minimize(other.hi);
+		lo.updateMax(other.lo);
+		hi.updateMin(other.hi);
 	}
 
 	// Expand to include the other region.
 	void expandWith( const IRegion3D &other )
 	{
-		lo.minimize(other.lo);
-		hi.maximize(other.hi);
+		lo.updateMin(other.lo);
+		hi.updateMax(other.hi);
 	}
 
 	// Expand to include the point.
 	void expandWith( const ICoord3D &point )
 	{
-		lo.minimize(point);
-		hi.maximize(point);
+		lo.updateMin(point);
+		hi.updateMax(point);
 	}
 
 	void zero()

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -565,6 +565,12 @@ struct Coord3D
 {
 	Real x, y, z;
 
+	Coord2D xy() const
+	{
+		const Coord2D xy = { x, y };
+		return xy;
+	}
+
 	Real length() const { return (Real)sqrt( x*x + y*y + z*z ); }
 	Real lengthSqr() const { return ( x*x + y*y + z*z ); }
 
@@ -696,6 +702,12 @@ inline Coord3D operator-( const Coord3D &a, const Coord3D &b )
 struct ICoord3D
 {
 	Int x, y, z;
+
+	ICoord2D xy() const
+	{
+		const ICoord2D xy = { x, y };
+		return xy;
+	}
 
 	Int length() const { return (Int)sqrt( (double)(x*x + y*y + z*z) ); }
 	Int lengthSqr() const { return x*x + y*y + z*z; }

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3496,16 +3496,14 @@ void AIPlayer::getPlayerStructureBounds(Region2D *bounds, Int playerNdx )
 						objBounds.lo.y = objBounds.hi.y = pos.y;
 						firstObject = false;
 					}	else {
-						objBounds.lo.min(pos.getXY());
-						objBounds.hi.max(pos.getXY());
+						objBounds.unite(pos.getXY());
 					}
 					if (firstStructure) {
 						bounds->lo.x = bounds->hi.x = pos.x;
 						bounds->lo.y = bounds->hi.y = pos.y;
 						firstStructure = false;
 					}	else {
-						bounds->lo.min(pos.getXY());
-						bounds->hi.max(pos.getXY());
+						bounds->unite(pos.getXY());
 					}
 				}
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3496,14 +3496,14 @@ void AIPlayer::getPlayerStructureBounds(Region2D *bounds, Int playerNdx )
 						objBounds.lo.y = objBounds.hi.y = pos.y;
 						firstObject = false;
 					}	else {
-						objBounds.expandWith(pos.asCoord2D());
+						objBounds.uniteWith(pos.asCoord2D());
 					}
 					if (firstStructure) {
 						bounds->lo.x = bounds->hi.x = pos.x;
 						bounds->lo.y = bounds->hi.y = pos.y;
 						firstStructure = false;
 					}	else {
-						bounds->expandWith(pos.asCoord2D());
+						bounds->uniteWith(pos.asCoord2D());
 					}
 				}
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3496,16 +3496,16 @@ void AIPlayer::getPlayerStructureBounds(Region2D *bounds, Int playerNdx )
 						objBounds.lo.y = objBounds.hi.y = pos.y;
 						firstObject = false;
 					}	else {
-						objBounds.lo.min(pos.xy());
-						objBounds.hi.max(pos.xy());
+						objBounds.lo.min(pos.getXY());
+						objBounds.hi.max(pos.getXY());
 					}
 					if (firstStructure) {
 						bounds->lo.x = bounds->hi.x = pos.x;
 						bounds->lo.y = bounds->hi.y = pos.y;
 						firstStructure = false;
 					}	else {
-						bounds->lo.min(pos.xy());
-						bounds->hi.max(pos.xy());
+						bounds->lo.min(pos.getXY());
+						bounds->hi.max(pos.getXY());
 					}
 				}
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3496,14 +3496,14 @@ void AIPlayer::getPlayerStructureBounds(Region2D *bounds, Int playerNdx )
 						objBounds.lo.y = objBounds.hi.y = pos.y;
 						firstObject = false;
 					}	else {
-						objBounds.unite(pos.getXY());
+						objBounds.unite(pos.asCoord2D());
 					}
 					if (firstStructure) {
 						bounds->lo.x = bounds->hi.x = pos.x;
 						bounds->lo.y = bounds->hi.y = pos.y;
 						firstStructure = false;
 					}	else {
-						bounds->unite(pos.getXY());
+						bounds->unite(pos.asCoord2D());
 					}
 				}
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3496,14 +3496,14 @@ void AIPlayer::getPlayerStructureBounds(Region2D *bounds, Int playerNdx )
 						objBounds.lo.y = objBounds.hi.y = pos.y;
 						firstObject = false;
 					}	else {
-						objBounds.unite(pos.asCoord2D());
+						objBounds.expandWith(pos.asCoord2D());
 					}
 					if (firstStructure) {
 						bounds->lo.x = bounds->hi.x = pos.x;
 						bounds->lo.y = bounds->hi.y = pos.y;
 						firstStructure = false;
 					}	else {
-						bounds->unite(pos.asCoord2D());
+						bounds->expandWith(pos.asCoord2D());
 					}
 				}
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3496,20 +3496,16 @@ void AIPlayer::getPlayerStructureBounds(Region2D *bounds, Int playerNdx )
 						objBounds.lo.y = objBounds.hi.y = pos.y;
 						firstObject = false;
 					}	else {
-						if (objBounds.lo.x>pos.x) objBounds.lo.x = pos.x;
-						if (objBounds.lo.y>pos.y) objBounds.lo.y = pos.y;
-						if (objBounds.hi.x<pos.x) objBounds.hi.x = pos.x;
-						if (objBounds.hi.y<pos.y) objBounds.hi.y = pos.y;
+						objBounds.lo.min(pos.xy());
+						objBounds.hi.max(pos.xy());
 					}
 					if (firstStructure) {
 						bounds->lo.x = bounds->hi.x = pos.x;
 						bounds->lo.y = bounds->hi.y = pos.y;
 						firstStructure = false;
 					}	else {
-						if (bounds->lo.x>pos.x) bounds->lo.x = pos.x;
-						if (bounds->lo.y>pos.y) bounds->lo.y = pos.y;
-						if (bounds->hi.x<pos.x) bounds->hi.x = pos.x;
-						if (bounds->hi.y<pos.y) bounds->hi.y = pos.y;
+						bounds->lo.min(pos.xy());
+						bounds->hi.max(pos.xy());
 					}
 				}
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -261,8 +261,7 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.lo.min(m_points[i].getXY());
-		m_bounds.hi.max(m_points[i].getXY());
+		m_bounds.unite(m_points[i].getXY());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -261,10 +261,8 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		if (m_points[i].x < m_bounds.lo.x) m_bounds.lo.x = m_points[i].x;
-		if (m_points[i].y < m_bounds.lo.y) m_bounds.lo.y = m_points[i].y;
-		if (m_points[i].x > m_bounds.hi.x) m_bounds.hi.x = m_points[i].x;
-		if (m_points[i].y > m_bounds.hi.y) m_bounds.hi.y = m_points[i].y;
+		m_bounds.lo.min(m_points[i].xy());
+		m_bounds.hi.max(m_points[i].xy());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -261,7 +261,7 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.unite(m_points[i].getXY());
+		m_bounds.expandWith(m_points[i].getXY());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -261,7 +261,7 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.expandWith(m_points[i].getXY());
+		m_bounds.uniteWith(m_points[i].getXY());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -261,8 +261,8 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.lo.min(m_points[i].xy());
-		m_bounds.hi.max(m_points[i].xy());
+		m_bounds.lo.min(m_points[i].getXY());
+		m_bounds.hi.max(m_points[i].getXY());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -261,7 +261,7 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.uniteWith(m_points[i].getXY());
+		m_bounds.uniteWith(m_points[i].asICoord2D());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -223,12 +223,9 @@ m_bridgeInfo(theInfo)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.lo.min(m_bridgeInfo.fromRight.getXY());
-	m_bounds.hi.max(m_bridgeInfo.fromRight.getXY());
-	m_bounds.lo.min(m_bridgeInfo.toLeft.getXY());
-	m_bounds.hi.max(m_bridgeInfo.toLeft.getXY());
-	m_bounds.lo.min(m_bridgeInfo.toRight.getXY());
-	m_bounds.hi.max(m_bridgeInfo.toRight.getXY());
+	m_bounds.unite(m_bridgeInfo.fromRight.getXY());
+	m_bounds.unite(m_bridgeInfo.toLeft.getXY());
+	m_bounds.unite(m_bridgeInfo.toRight.getXY());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -352,12 +349,9 @@ Bridge::Bridge(Object *bridgeObj)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.lo.min(m_bridgeInfo.fromRight.getXY());
-	m_bounds.hi.max(m_bridgeInfo.fromRight.getXY());
-	m_bounds.lo.min(m_bridgeInfo.toLeft.getXY());
-	m_bounds.hi.max(m_bridgeInfo.toLeft.getXY());
-	m_bounds.lo.min(m_bridgeInfo.toRight.getXY());
-	m_bounds.hi.max(m_bridgeInfo.toRight.getXY());
+	m_bounds.unite(m_bridgeInfo.fromRight.getXY());
+	m_bounds.unite(m_bridgeInfo.toLeft.getXY());
+	m_bounds.unite(m_bridgeInfo.toRight.getXY());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -224,18 +224,12 @@ m_bridgeInfo(theInfo)
 	m_bounds.lo.x = m_bridgeInfo.fromLeft.x;
 	m_bounds.lo.y = m_bridgeInfo.fromLeft.y;
 	m_bounds.hi = m_bounds.lo;
-	if (m_bounds.lo.x > m_bridgeInfo.fromRight.x) m_bounds.lo.x = m_bridgeInfo.fromRight.x;
-	if (m_bounds.lo.y > m_bridgeInfo.fromRight.y) m_bounds.lo.y = m_bridgeInfo.fromRight.y;
-	if (m_bounds.hi.x < m_bridgeInfo.fromRight.x) m_bounds.hi.x = m_bridgeInfo.fromRight.x;
-	if (m_bounds.hi.y < m_bridgeInfo.fromRight.y) m_bounds.hi.y = m_bridgeInfo.fromRight.y;
-	if (m_bounds.lo.x > m_bridgeInfo.toLeft.x) m_bounds.lo.x = m_bridgeInfo.toLeft.x;
-	if (m_bounds.lo.y > m_bridgeInfo.toLeft.y) m_bounds.lo.y = m_bridgeInfo.toLeft.y;
-	if (m_bounds.hi.x < m_bridgeInfo.toLeft.x) m_bounds.hi.x = m_bridgeInfo.toLeft.x;
-	if (m_bounds.hi.y < m_bridgeInfo.toLeft.y) m_bounds.hi.y = m_bridgeInfo.toLeft.y;
-	if (m_bounds.lo.x > m_bridgeInfo.toRight.x) m_bounds.lo.x = m_bridgeInfo.toRight.x;
-	if (m_bounds.lo.y > m_bridgeInfo.toRight.y) m_bounds.lo.y = m_bridgeInfo.toRight.y;
-	if (m_bounds.hi.x < m_bridgeInfo.toRight.x) m_bounds.hi.x = m_bridgeInfo.toRight.x;
-	if (m_bounds.hi.y < m_bridgeInfo.toRight.y) m_bounds.hi.y = m_bridgeInfo.toRight.y;
+	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
+	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
+	m_bounds.lo.min(m_bridgeInfo.toLeft.xy());
+	m_bounds.hi.max(m_bridgeInfo.toLeft.xy());
+	m_bounds.lo.min(m_bridgeInfo.toRight.xy());
+	m_bounds.hi.max(m_bridgeInfo.toRight.xy());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -360,18 +354,12 @@ Bridge::Bridge(Object *bridgeObj)
 	m_bounds.lo.x = m_bridgeInfo.fromLeft.x;
 	m_bounds.lo.y = m_bridgeInfo.fromLeft.y;
 	m_bounds.hi = m_bounds.lo;
-	if (m_bounds.lo.x > m_bridgeInfo.fromRight.x) m_bounds.lo.x = m_bridgeInfo.fromRight.x;
-	if (m_bounds.lo.y > m_bridgeInfo.fromRight.y) m_bounds.lo.y = m_bridgeInfo.fromRight.y;
-	if (m_bounds.hi.x < m_bridgeInfo.fromRight.x) m_bounds.hi.x = m_bridgeInfo.fromRight.x;
-	if (m_bounds.hi.y < m_bridgeInfo.fromRight.y) m_bounds.hi.y = m_bridgeInfo.fromRight.y;
-	if (m_bounds.lo.x > m_bridgeInfo.toLeft.x) m_bounds.lo.x = m_bridgeInfo.toLeft.x;
-	if (m_bounds.lo.y > m_bridgeInfo.toLeft.y) m_bounds.lo.y = m_bridgeInfo.toLeft.y;
-	if (m_bounds.hi.x < m_bridgeInfo.toLeft.x) m_bounds.hi.x = m_bridgeInfo.toLeft.x;
-	if (m_bounds.hi.y < m_bridgeInfo.toLeft.y) m_bounds.hi.y = m_bridgeInfo.toLeft.y;
-	if (m_bounds.lo.x > m_bridgeInfo.toRight.x) m_bounds.lo.x = m_bridgeInfo.toRight.x;
-	if (m_bounds.lo.y > m_bridgeInfo.toRight.y) m_bounds.lo.y = m_bridgeInfo.toRight.y;
-	if (m_bounds.hi.x < m_bridgeInfo.toRight.x) m_bounds.hi.x = m_bridgeInfo.toRight.x;
-	if (m_bounds.hi.y < m_bridgeInfo.toRight.y) m_bounds.hi.y = m_bridgeInfo.toRight.y;
+	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
+	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
+	m_bounds.lo.min(m_bridgeInfo.toLeft.xy());
+	m_bounds.hi.max(m_bridgeInfo.toLeft.xy());
+	m_bounds.lo.min(m_bridgeInfo.toRight.xy());
+	m_bounds.hi.max(m_bridgeInfo.toRight.xy());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -221,14 +221,14 @@ m_bridgeInfo(theInfo)
 	m_templateName = bridgeTemplateName;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo = m_bridgeInfo.fromLeft.xy();
+	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
-	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
-	m_bounds.lo.min(m_bridgeInfo.toLeft.xy());
-	m_bounds.hi.max(m_bridgeInfo.toLeft.xy());
-	m_bounds.lo.min(m_bridgeInfo.toRight.xy());
-	m_bounds.hi.max(m_bridgeInfo.toRight.xy());
+	m_bounds.lo.min(m_bridgeInfo.fromRight.getXY());
+	m_bounds.hi.max(m_bridgeInfo.fromRight.getXY());
+	m_bounds.lo.min(m_bridgeInfo.toLeft.getXY());
+	m_bounds.hi.max(m_bridgeInfo.toLeft.getXY());
+	m_bounds.lo.min(m_bridgeInfo.toRight.getXY());
+	m_bounds.hi.max(m_bridgeInfo.toRight.getXY());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -350,14 +350,14 @@ Bridge::Bridge(Object *bridgeObj)
 	m_bridgeInfo.to.z = (m_bridgeInfo.toLeft.z + m_bridgeInfo.toRight.z)/2.0f;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo = m_bridgeInfo.fromLeft.xy();
+	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
-	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
-	m_bounds.lo.min(m_bridgeInfo.toLeft.xy());
-	m_bounds.hi.max(m_bridgeInfo.toLeft.xy());
-	m_bounds.lo.min(m_bridgeInfo.toRight.xy());
-	m_bounds.hi.max(m_bridgeInfo.toRight.xy());
+	m_bounds.lo.min(m_bridgeInfo.fromRight.getXY());
+	m_bounds.hi.max(m_bridgeInfo.fromRight.getXY());
+	m_bounds.lo.min(m_bridgeInfo.toLeft.getXY());
+	m_bounds.hi.max(m_bridgeInfo.toLeft.getXY());
+	m_bounds.lo.min(m_bridgeInfo.toRight.getXY());
+	m_bounds.hi.max(m_bridgeInfo.toRight.getXY());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -659,13 +659,13 @@ Bool Bridge::isCellOnEnd(const Region2D *cell)
 	if (PointInRegion2D(&toLeft, cell)) return false;
 	if (PointInRegion2D(&toRight, cell)) return false; */
 	Coord2D line1, line2;
-	line1 = fromLeft.xy();
-	line2 = fromRight.xy();
+	line1 = fromLeft.getXY();
+	line2 = fromRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = toLeft.xy();
-	line2 = toRight.xy();
+	line1 = toLeft.getXY();
+	line2 = toRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -703,13 +703,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.y += endVector.y;
 
 	Coord2D line1, line2;
-	line1 = fromLeft.xy();
-	line2 = toLeft.xy();
+	line1 = fromLeft.getXY();
+	line2 = toLeft.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = fromRight.xy();
-	line2 = toRight.xy();
+	line1 = fromRight.getXY();
+	line2 = toRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -725,13 +725,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.x += endVector.x;
 	toRight.y += endVector.y;
 
-	line1 = fromLeft.xy();
-	line2 = toLeft.xy();
+	line1 = fromLeft.getXY();
+	line2 = toLeft.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = fromRight.xy();
-	line2 = toRight.xy();
+	line1 = fromRight.getXY();
+	line2 = toRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -790,13 +790,13 @@ Bool Bridge::isCellEntryPoint(const Region2D *cell)
 	if (PointInRegion2D(&toRight, cell)) return false;
 	*/
 	Coord2D line1, line2;
-	line1 = fromLeft.xy();
-	line2 = fromRight.xy();
+	line1 = fromLeft.getXY();
+	line2 = fromRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = toLeft.xy();
-	line2 = toRight.xy();
+	line1 = toLeft.getXY();
+	line2 = toRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -1751,7 +1751,7 @@ Bool TerrainLogic::objectInteractsWithBridgeLayer(Object *obj, Int layer, Bool c
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo = obj->getPosition()->xy();
+			bounds.lo = obj->getPosition()->getXY();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;
@@ -1799,7 +1799,7 @@ Bool TerrainLogic::objectInteractsWithBridgeEnd(Object *obj, Int layer) const
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo = obj->getPosition()->xy();
+			bounds.lo = obj->getPosition()->getXY();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -223,9 +223,9 @@ m_bridgeInfo(theInfo)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.expandWith(m_bridgeInfo.fromRight.asCoord2D());
-	m_bounds.expandWith(m_bridgeInfo.toLeft.asCoord2D());
-	m_bounds.expandWith(m_bridgeInfo.toRight.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -349,9 +349,9 @@ Bridge::Bridge(Object *bridgeObj)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.expandWith(m_bridgeInfo.fromRight.asCoord2D());
-	m_bounds.expandWith(m_bridgeInfo.toLeft.asCoord2D());
-	m_bounds.expandWith(m_bridgeInfo.toRight.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -223,9 +223,9 @@ m_bridgeInfo(theInfo)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.unite(m_bridgeInfo.fromRight.asCoord2D());
-	m_bounds.unite(m_bridgeInfo.toLeft.asCoord2D());
-	m_bounds.unite(m_bridgeInfo.toRight.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -349,9 +349,9 @@ Bridge::Bridge(Object *bridgeObj)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.unite(m_bridgeInfo.fromRight.asCoord2D());
-	m_bounds.unite(m_bridgeInfo.toLeft.asCoord2D());
-	m_bounds.unite(m_bridgeInfo.toRight.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -221,11 +221,11 @@ m_bridgeInfo(theInfo)
 	m_templateName = bridgeTemplateName;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
+	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.unite(m_bridgeInfo.fromRight.getXY());
-	m_bounds.unite(m_bridgeInfo.toLeft.getXY());
-	m_bounds.unite(m_bridgeInfo.toRight.getXY());
+	m_bounds.unite(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.unite(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.unite(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -347,11 +347,11 @@ Bridge::Bridge(Object *bridgeObj)
 	m_bridgeInfo.to.z = (m_bridgeInfo.toLeft.z + m_bridgeInfo.toRight.z)/2.0f;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
+	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.unite(m_bridgeInfo.fromRight.getXY());
-	m_bounds.unite(m_bridgeInfo.toLeft.getXY());
-	m_bounds.unite(m_bridgeInfo.toRight.getXY());
+	m_bounds.unite(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.unite(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.unite(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -653,13 +653,13 @@ Bool Bridge::isCellOnEnd(const Region2D *cell)
 	if (PointInRegion2D(&toLeft, cell)) return false;
 	if (PointInRegion2D(&toRight, cell)) return false; */
 	Coord2D line1, line2;
-	line1 = fromLeft.getXY();
-	line2 = fromRight.getXY();
+	line1 = fromLeft.asCoord2D();
+	line2 = fromRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = toLeft.getXY();
-	line2 = toRight.getXY();
+	line1 = toLeft.asCoord2D();
+	line2 = toRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -697,13 +697,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.y += endVector.y;
 
 	Coord2D line1, line2;
-	line1 = fromLeft.getXY();
-	line2 = toLeft.getXY();
+	line1 = fromLeft.asCoord2D();
+	line2 = toLeft.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = fromRight.getXY();
-	line2 = toRight.getXY();
+	line1 = fromRight.asCoord2D();
+	line2 = toRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -719,13 +719,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.x += endVector.x;
 	toRight.y += endVector.y;
 
-	line1 = fromLeft.getXY();
-	line2 = toLeft.getXY();
+	line1 = fromLeft.asCoord2D();
+	line2 = toLeft.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = fromRight.getXY();
-	line2 = toRight.getXY();
+	line1 = fromRight.asCoord2D();
+	line2 = toRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -784,13 +784,13 @@ Bool Bridge::isCellEntryPoint(const Region2D *cell)
 	if (PointInRegion2D(&toRight, cell)) return false;
 	*/
 	Coord2D line1, line2;
-	line1 = fromLeft.getXY();
-	line2 = fromRight.getXY();
+	line1 = fromLeft.asCoord2D();
+	line2 = fromRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = toLeft.getXY();
-	line2 = toRight.getXY();
+	line1 = toLeft.asCoord2D();
+	line2 = toRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -1745,7 +1745,7 @@ Bool TerrainLogic::objectInteractsWithBridgeLayer(Object *obj, Int layer, Bool c
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo = obj->getPosition()->getXY();
+			bounds.lo = obj->getPosition()->asCoord2D();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;
@@ -1793,7 +1793,7 @@ Bool TerrainLogic::objectInteractsWithBridgeEnd(Object *obj, Int layer) const
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo = obj->getPosition()->getXY();
+			bounds.lo = obj->getPosition()->asCoord2D();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -221,8 +221,7 @@ m_bridgeInfo(theInfo)
 	m_templateName = bridgeTemplateName;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo.x = m_bridgeInfo.fromLeft.x;
-	m_bounds.lo.y = m_bridgeInfo.fromLeft.y;
+	m_bounds.lo = m_bridgeInfo.fromLeft.xy();
 	m_bounds.hi = m_bounds.lo;
 	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
 	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
@@ -351,8 +350,7 @@ Bridge::Bridge(Object *bridgeObj)
 	m_bridgeInfo.to.z = (m_bridgeInfo.toLeft.z + m_bridgeInfo.toRight.z)/2.0f;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo.x = m_bridgeInfo.fromLeft.x;
-	m_bounds.lo.y = m_bridgeInfo.fromLeft.y;
+	m_bounds.lo = m_bridgeInfo.fromLeft.xy();
 	m_bounds.hi = m_bounds.lo;
 	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
 	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
@@ -661,17 +659,13 @@ Bool Bridge::isCellOnEnd(const Region2D *cell)
 	if (PointInRegion2D(&toLeft, cell)) return false;
 	if (PointInRegion2D(&toRight, cell)) return false; */
 	Coord2D line1, line2;
-	line1.x = fromLeft.x;
-	line1.y = fromLeft.y;
-	line2.x = fromRight.x;
-	line2.y = fromRight.y;
+	line1 = fromLeft.xy();
+	line2 = fromRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1.x = toLeft.x;
-	line1.y = toLeft.y;
-	line2.x = toRight.x;
-	line2.y = toRight.y;
+	line1 = toLeft.xy();
+	line2 = toRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -709,17 +703,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.y += endVector.y;
 
 	Coord2D line1, line2;
-	line1.x = fromLeft.x;
-	line1.y = fromLeft.y;
-	line2.x = toLeft.x;
-	line2.y = toLeft.y;
+	line1 = fromLeft.xy();
+	line2 = toLeft.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1.x = fromRight.x;
-	line1.y = fromRight.y;
-	line2.x = toRight.x;
-	line2.y = toRight.y;
+	line1 = fromRight.xy();
+	line2 = toRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -735,17 +725,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.x += endVector.x;
 	toRight.y += endVector.y;
 
-	line1.x = fromLeft.x;
-	line1.y = fromLeft.y;
-	line2.x = toLeft.x;
-	line2.y = toLeft.y;
+	line1 = fromLeft.xy();
+	line2 = toLeft.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1.x = fromRight.x;
-	line1.y = fromRight.y;
-	line2.x = toRight.x;
-	line2.y = toRight.y;
+	line1 = fromRight.xy();
+	line2 = toRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -804,17 +790,13 @@ Bool Bridge::isCellEntryPoint(const Region2D *cell)
 	if (PointInRegion2D(&toRight, cell)) return false;
 	*/
 	Coord2D line1, line2;
-	line1.x = fromLeft.x;
-	line1.y = fromLeft.y;
-	line2.x = fromRight.x;
-	line2.y = fromRight.y;
+	line1 = fromLeft.xy();
+	line2 = fromRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1.x = toLeft.x;
-	line1.y = toLeft.y;
-	line2.x = toRight.x;
-	line2.y = toRight.y;
+	line1 = toLeft.xy();
+	line2 = toRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -1769,8 +1751,7 @@ Bool TerrainLogic::objectInteractsWithBridgeLayer(Object *obj, Int layer, Bool c
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo.x = obj->getPosition()->x;
-			bounds.lo.y = obj->getPosition()->y;
+			bounds.lo = obj->getPosition()->xy();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;
@@ -1818,8 +1799,7 @@ Bool TerrainLogic::objectInteractsWithBridgeEnd(Object *obj, Int layer) const
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo.x = obj->getPosition()->x;
-			bounds.lo.y = obj->getPosition()->y;
+			bounds.lo = obj->getPosition()->xy();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -237,13 +237,13 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 
 		// find the bounding region of the yard area
 		Region2D yardRegion;
-		yardRegion.lo = yardPositions[ 0 ].xy();
-		yardRegion.hi = yardPositions[ 0 ].xy();
+		yardRegion.lo = yardPositions[ 0 ].getXY();
+		yardRegion.hi = yardPositions[ 0 ].getXY();
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.lo.min(yardPositions[ i ].xy());
-			yardRegion.hi.max(yardPositions[ i ].xy());
+			yardRegion.lo.min(yardPositions[ i ].getXY());
+			yardRegion.hi.max(yardPositions[ i ].getXY());
 
 		}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -242,8 +242,7 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.lo.min(yardPositions[ i ].getXY());
-			yardRegion.hi.max(yardPositions[ i ].getXY());
+			yardRegion.unite(yardPositions[ i ].getXY());
 
 		}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -242,7 +242,7 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.unite(yardPositions[ i ].asCoord2D());
+			yardRegion.expandWith(yardPositions[ i ].asCoord2D());
 
 		}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -237,10 +237,8 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 
 		// find the bounding region of the yard area
 		Region2D yardRegion;
-		yardRegion.lo.x = yardPositions[ 0 ].x;
-		yardRegion.lo.y = yardPositions[ 0 ].y;
-		yardRegion.hi.x = yardPositions[ 0 ].x;
-		yardRegion.hi.y = yardPositions[ 0 ].y;
+		yardRegion.lo = yardPositions[ 0 ].xy();
+		yardRegion.hi = yardPositions[ 0 ].xy();
 		for( i = 1; i < yardBones; i++ )
 		{
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -242,7 +242,7 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.expandWith(yardPositions[ i ].asCoord2D());
+			yardRegion.uniteWith(yardPositions[ i ].asCoord2D());
 
 		}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -237,12 +237,12 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 
 		// find the bounding region of the yard area
 		Region2D yardRegion;
-		yardRegion.lo = yardPositions[ 0 ].getXY();
-		yardRegion.hi = yardPositions[ 0 ].getXY();
+		yardRegion.lo = yardPositions[ 0 ].asCoord2D();
+		yardRegion.hi = yardPositions[ 0 ].asCoord2D();
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.unite(yardPositions[ i ].getXY());
+			yardRegion.unite(yardPositions[ i ].asCoord2D());
 
 		}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -244,14 +244,8 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			if( yardPositions[ i ].x < yardRegion.lo.x )
-				yardRegion.lo.x = yardPositions[ i ].x;
-			if( yardPositions[ i ].y < yardRegion.lo.y )
-				yardRegion.lo.y = yardPositions[ i ].y;
-			if( yardPositions[ i ].x > yardRegion.hi.x )
-				yardRegion.hi.x = yardPositions[ i ].x;
-			if( yardPositions[ i ].y > yardRegion.hi.y )
-				yardRegion.hi.y = yardPositions[ i ].y;
+			yardRegion.lo.min(yardPositions[ i ].xy());
+			yardRegion.hi.max(yardPositions[ i ].xy());
 
 		}
 

--- a/Generals/Code/Tools/WorldBuilder/src/RampTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/RampTool.cpp
@@ -159,9 +159,9 @@ void RampTool::applyRamp(CWorldBuilderDoc* pDoc)
 		pDoc->getCoordFromCellIndex(indices[i], &pt);
 
 		Real uVal;
-		Coord2D start = mStartPoint.xy();
-		Coord2D end = mEndPoint.xy();
-		Coord2D pt2D = pt.xy();
+		Coord2D start = mStartPoint.getXY();
+		Coord2D end = mEndPoint.getXY();
+		Coord2D pt2D = pt.getXY();
 
 		ShortestDistancePointToSegment2D(&start, &end, &pt2D, nullptr, nullptr, &uVal);
 		Real height = mStartPoint.z + uVal * (mEndPoint.z - mStartPoint.z);

--- a/Generals/Code/Tools/WorldBuilder/src/RampTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/RampTool.cpp
@@ -159,9 +159,9 @@ void RampTool::applyRamp(CWorldBuilderDoc* pDoc)
 		pDoc->getCoordFromCellIndex(indices[i], &pt);
 
 		Real uVal;
-		Coord2D start = { mStartPoint.x, mStartPoint.y };
-		Coord2D end = { mEndPoint.x, mEndPoint.y };
-		Coord2D pt2D = { pt.x, pt.y };
+		Coord2D start = mStartPoint.xy();
+		Coord2D end = mEndPoint.xy();
+		Coord2D pt2D = pt.xy();
 
 		ShortestDistancePointToSegment2D(&start, &end, &pt2D, nullptr, nullptr, &uVal);
 		Real height = mStartPoint.z + uVal * (mEndPoint.z - mStartPoint.z);

--- a/Generals/Code/Tools/WorldBuilder/src/RampTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/RampTool.cpp
@@ -159,9 +159,9 @@ void RampTool::applyRamp(CWorldBuilderDoc* pDoc)
 		pDoc->getCoordFromCellIndex(indices[i], &pt);
 
 		Real uVal;
-		Coord2D start = mStartPoint.getXY();
-		Coord2D end = mEndPoint.getXY();
-		Coord2D pt2D = pt.getXY();
+		Coord2D start = mStartPoint.asCoord2D();
+		Coord2D end = mEndPoint.asCoord2D();
+		Coord2D pt2D = pt.asCoord2D();
 
 		ShortestDistancePointToSegment2D(&start, &end, &pt2D, nullptr, nullptr, &uVal);
 		Real height = mStartPoint.z + uVal * (mEndPoint.z - mStartPoint.z);

--- a/Generals/Code/Tools/WorldBuilder/src/RoadTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/RoadTool.cpp
@@ -67,9 +67,9 @@ MapObject* RoadTool::findSegment(const Coord3D *pLoc, Coord3D *outLoc)
 			if (!pMapObj2->getFlag(FLAG_ROAD_POINT2))
 				continue;
 			Coord2D start, end, loc, snapLoc;
-			start = pMapObj->getLocation()->xy();
-			end = pMapObj2->getLocation()->xy();
-			loc = pLoc->xy();
+			start = pMapObj->getLocation()->getXY();
+			end = pMapObj2->getLocation()->getXY();
+			loc = pLoc->getXY();
 			Real dist;
 			Real u;
 

--- a/Generals/Code/Tools/WorldBuilder/src/RoadTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/RoadTool.cpp
@@ -67,12 +67,9 @@ MapObject* RoadTool::findSegment(const Coord3D *pLoc, Coord3D *outLoc)
 			if (!pMapObj2->getFlag(FLAG_ROAD_POINT2))
 				continue;
 			Coord2D start, end, loc, snapLoc;
-			start.x = pMapObj->getLocation()->x;
-			start.y = pMapObj->getLocation()->y;
-			end.x = pMapObj2->getLocation()->x;
-			end.y = pMapObj2->getLocation()->y;
-			loc.x = pLoc->x;
-			loc.y = pLoc->y;
+			start = pMapObj->getLocation()->xy();
+			end = pMapObj2->getLocation()->xy();
+			loc = pLoc->xy();
 			Real dist;
 			Real u;
 

--- a/Generals/Code/Tools/WorldBuilder/src/RoadTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/RoadTool.cpp
@@ -67,9 +67,9 @@ MapObject* RoadTool::findSegment(const Coord3D *pLoc, Coord3D *outLoc)
 			if (!pMapObj2->getFlag(FLAG_ROAD_POINT2))
 				continue;
 			Coord2D start, end, loc, snapLoc;
-			start = pMapObj->getLocation()->getXY();
-			end = pMapObj2->getLocation()->getXY();
-			loc = pLoc->getXY();
+			start = pMapObj->getLocation()->asCoord2D();
+			end = pMapObj2->getLocation()->asCoord2D();
+			loc = pLoc->asCoord2D();
 			Real dist;
 			Real u;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3848,10 +3848,8 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						if (objBounds.lo.x>pos.x) objBounds.lo.x = pos.x;
-						if (objBounds.lo.y>pos.y) objBounds.lo.y = pos.y;
-						if (objBounds.hi.x<pos.x) objBounds.hi.x = pos.x;
-						if (objBounds.hi.y<pos.y) objBounds.hi.y = pos.y;
+						objBounds.lo.min(pos.xy());
+						objBounds.hi.max(pos.xy());
 					}
 					if (firstStructure)
 					{
@@ -3861,10 +3859,8 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						if (bounds->lo.x>pos.x) bounds->lo.x = pos.x;
-						if (bounds->lo.y>pos.y) bounds->lo.y = pos.y;
-						if (bounds->hi.x<pos.x) bounds->hi.x = pos.x;
-						if (bounds->hi.y<pos.y) bounds->hi.y = pos.y;
+						bounds->lo.min(pos.xy());
+						bounds->hi.max(pos.xy());
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3848,7 +3848,7 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						objBounds.unite(pos.getXY());
+						objBounds.unite(pos.asCoord2D());
 					}
 					if (firstStructure)
 					{
@@ -3858,7 +3858,7 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						bounds->unite(pos.getXY());
+						bounds->unite(pos.asCoord2D());
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3848,7 +3848,7 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						objBounds.expandWith(pos.asCoord2D());
+						objBounds.uniteWith(pos.asCoord2D());
 					}
 					if (firstStructure)
 					{
@@ -3858,7 +3858,7 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						bounds->expandWith(pos.asCoord2D());
+						bounds->uniteWith(pos.asCoord2D());
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3848,8 +3848,7 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						objBounds.lo.min(pos.getXY());
-						objBounds.hi.max(pos.getXY());
+						objBounds.unite(pos.getXY());
 					}
 					if (firstStructure)
 					{
@@ -3859,8 +3858,7 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						bounds->lo.min(pos.getXY());
-						bounds->hi.max(pos.getXY());
+						bounds->unite(pos.getXY());
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3848,8 +3848,8 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						objBounds.lo.min(pos.xy());
-						objBounds.hi.max(pos.xy());
+						objBounds.lo.min(pos.getXY());
+						objBounds.hi.max(pos.getXY());
 					}
 					if (firstStructure)
 					{
@@ -3859,8 +3859,8 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						bounds->lo.min(pos.xy());
-						bounds->hi.max(pos.xy());
+						bounds->lo.min(pos.getXY());
+						bounds->hi.max(pos.getXY());
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -3848,7 +3848,7 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						objBounds.unite(pos.asCoord2D());
+						objBounds.expandWith(pos.asCoord2D());
 					}
 					if (firstStructure)
 					{
@@ -3858,7 +3858,7 @@ void AIPlayer::getPlayerStructureBounds( Region2D *bounds, Int playerNdx, Bool c
 					}
 					else
 					{
-						bounds->unite(pos.asCoord2D());
+						bounds->expandWith(pos.asCoord2D());
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -277,7 +277,7 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.expandWith(m_points[i].getXY());
+		m_bounds.uniteWith(m_points[i].getXY());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -277,7 +277,7 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.uniteWith(m_points[i].getXY());
+		m_bounds.uniteWith(m_points[i].asICoord2D());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -277,10 +277,8 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		if (m_points[i].x < m_bounds.lo.x) m_bounds.lo.x = m_points[i].x;
-		if (m_points[i].y < m_bounds.lo.y) m_bounds.lo.y = m_points[i].y;
-		if (m_points[i].x > m_bounds.hi.x) m_bounds.hi.x = m_points[i].x;
-		if (m_points[i].y > m_bounds.hi.y) m_bounds.hi.y = m_points[i].y;
+		m_bounds.lo.min(m_points[i].xy());
+		m_bounds.hi.max(m_points[i].xy());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -277,8 +277,7 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.lo.min(m_points[i].getXY());
-		m_bounds.hi.max(m_points[i].getXY());
+		m_bounds.unite(m_points[i].getXY());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -277,8 +277,8 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.lo.min(m_points[i].xy());
-		m_bounds.hi.max(m_points[i].xy());
+		m_bounds.lo.min(m_points[i].getXY());
+		m_bounds.hi.max(m_points[i].getXY());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -277,7 +277,7 @@ void PolygonTrigger::updateBounds()	const
 	m_bounds.hi.x = m_bounds.hi.y = -BIG_INT;
 	Int i;
 	for (i=0; i<m_numPoints; i++) {
-		m_bounds.unite(m_points[i].getXY());
+		m_bounds.expandWith(m_points[i].getXY());
 	}
 	m_boundsNeedsUpdate = 0;
 	Real halfWidth = (m_bounds.hi.x - m_bounds.lo.x) / 2.0f;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -223,12 +223,9 @@ m_bridgeInfo(theInfo)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.lo.min(m_bridgeInfo.fromRight.getXY());
-	m_bounds.hi.max(m_bridgeInfo.fromRight.getXY());
-	m_bounds.lo.min(m_bridgeInfo.toLeft.getXY());
-	m_bounds.hi.max(m_bridgeInfo.toLeft.getXY());
-	m_bounds.lo.min(m_bridgeInfo.toRight.getXY());
-	m_bounds.hi.max(m_bridgeInfo.toRight.getXY());
+	m_bounds.unite(m_bridgeInfo.fromRight.getXY());
+	m_bounds.unite(m_bridgeInfo.toLeft.getXY());
+	m_bounds.unite(m_bridgeInfo.toRight.getXY());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -352,12 +349,9 @@ Bridge::Bridge(Object *bridgeObj)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.lo.min(m_bridgeInfo.fromRight.getXY());
-	m_bounds.hi.max(m_bridgeInfo.fromRight.getXY());
-	m_bounds.lo.min(m_bridgeInfo.toLeft.getXY());
-	m_bounds.hi.max(m_bridgeInfo.toLeft.getXY());
-	m_bounds.lo.min(m_bridgeInfo.toRight.getXY());
-	m_bounds.hi.max(m_bridgeInfo.toRight.getXY());
+	m_bounds.unite(m_bridgeInfo.fromRight.getXY());
+	m_bounds.unite(m_bridgeInfo.toLeft.getXY());
+	m_bounds.unite(m_bridgeInfo.toRight.getXY());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -224,18 +224,12 @@ m_bridgeInfo(theInfo)
 	m_bounds.lo.x = m_bridgeInfo.fromLeft.x;
 	m_bounds.lo.y = m_bridgeInfo.fromLeft.y;
 	m_bounds.hi = m_bounds.lo;
-	if (m_bounds.lo.x > m_bridgeInfo.fromRight.x) m_bounds.lo.x = m_bridgeInfo.fromRight.x;
-	if (m_bounds.lo.y > m_bridgeInfo.fromRight.y) m_bounds.lo.y = m_bridgeInfo.fromRight.y;
-	if (m_bounds.hi.x < m_bridgeInfo.fromRight.x) m_bounds.hi.x = m_bridgeInfo.fromRight.x;
-	if (m_bounds.hi.y < m_bridgeInfo.fromRight.y) m_bounds.hi.y = m_bridgeInfo.fromRight.y;
-	if (m_bounds.lo.x > m_bridgeInfo.toLeft.x) m_bounds.lo.x = m_bridgeInfo.toLeft.x;
-	if (m_bounds.lo.y > m_bridgeInfo.toLeft.y) m_bounds.lo.y = m_bridgeInfo.toLeft.y;
-	if (m_bounds.hi.x < m_bridgeInfo.toLeft.x) m_bounds.hi.x = m_bridgeInfo.toLeft.x;
-	if (m_bounds.hi.y < m_bridgeInfo.toLeft.y) m_bounds.hi.y = m_bridgeInfo.toLeft.y;
-	if (m_bounds.lo.x > m_bridgeInfo.toRight.x) m_bounds.lo.x = m_bridgeInfo.toRight.x;
-	if (m_bounds.lo.y > m_bridgeInfo.toRight.y) m_bounds.lo.y = m_bridgeInfo.toRight.y;
-	if (m_bounds.hi.x < m_bridgeInfo.toRight.x) m_bounds.hi.x = m_bridgeInfo.toRight.x;
-	if (m_bounds.hi.y < m_bridgeInfo.toRight.y) m_bounds.hi.y = m_bridgeInfo.toRight.y;
+	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
+	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
+	m_bounds.lo.min(m_bridgeInfo.toLeft.xy());
+	m_bounds.hi.max(m_bridgeInfo.toLeft.xy());
+	m_bounds.lo.min(m_bridgeInfo.toRight.xy());
+	m_bounds.hi.max(m_bridgeInfo.toRight.xy());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -360,18 +354,12 @@ Bridge::Bridge(Object *bridgeObj)
 	m_bounds.lo.x = m_bridgeInfo.fromLeft.x;
 	m_bounds.lo.y = m_bridgeInfo.fromLeft.y;
 	m_bounds.hi = m_bounds.lo;
-	if (m_bounds.lo.x > m_bridgeInfo.fromRight.x) m_bounds.lo.x = m_bridgeInfo.fromRight.x;
-	if (m_bounds.lo.y > m_bridgeInfo.fromRight.y) m_bounds.lo.y = m_bridgeInfo.fromRight.y;
-	if (m_bounds.hi.x < m_bridgeInfo.fromRight.x) m_bounds.hi.x = m_bridgeInfo.fromRight.x;
-	if (m_bounds.hi.y < m_bridgeInfo.fromRight.y) m_bounds.hi.y = m_bridgeInfo.fromRight.y;
-	if (m_bounds.lo.x > m_bridgeInfo.toLeft.x) m_bounds.lo.x = m_bridgeInfo.toLeft.x;
-	if (m_bounds.lo.y > m_bridgeInfo.toLeft.y) m_bounds.lo.y = m_bridgeInfo.toLeft.y;
-	if (m_bounds.hi.x < m_bridgeInfo.toLeft.x) m_bounds.hi.x = m_bridgeInfo.toLeft.x;
-	if (m_bounds.hi.y < m_bridgeInfo.toLeft.y) m_bounds.hi.y = m_bridgeInfo.toLeft.y;
-	if (m_bounds.lo.x > m_bridgeInfo.toRight.x) m_bounds.lo.x = m_bridgeInfo.toRight.x;
-	if (m_bounds.lo.y > m_bridgeInfo.toRight.y) m_bounds.lo.y = m_bridgeInfo.toRight.y;
-	if (m_bounds.hi.x < m_bridgeInfo.toRight.x) m_bounds.hi.x = m_bridgeInfo.toRight.x;
-	if (m_bounds.hi.y < m_bridgeInfo.toRight.y) m_bounds.hi.y = m_bridgeInfo.toRight.y;
+	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
+	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
+	m_bounds.lo.min(m_bridgeInfo.toLeft.xy());
+	m_bounds.hi.max(m_bridgeInfo.toLeft.xy());
+	m_bounds.lo.min(m_bridgeInfo.toRight.xy());
+	m_bounds.hi.max(m_bridgeInfo.toRight.xy());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -221,14 +221,14 @@ m_bridgeInfo(theInfo)
 	m_templateName = bridgeTemplateName;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo = m_bridgeInfo.fromLeft.xy();
+	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
-	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
-	m_bounds.lo.min(m_bridgeInfo.toLeft.xy());
-	m_bounds.hi.max(m_bridgeInfo.toLeft.xy());
-	m_bounds.lo.min(m_bridgeInfo.toRight.xy());
-	m_bounds.hi.max(m_bridgeInfo.toRight.xy());
+	m_bounds.lo.min(m_bridgeInfo.fromRight.getXY());
+	m_bounds.hi.max(m_bridgeInfo.fromRight.getXY());
+	m_bounds.lo.min(m_bridgeInfo.toLeft.getXY());
+	m_bounds.hi.max(m_bridgeInfo.toLeft.getXY());
+	m_bounds.lo.min(m_bridgeInfo.toRight.getXY());
+	m_bounds.hi.max(m_bridgeInfo.toRight.getXY());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -350,14 +350,14 @@ Bridge::Bridge(Object *bridgeObj)
 	m_bridgeInfo.to.z = (m_bridgeInfo.toLeft.z + m_bridgeInfo.toRight.z)/2.0f;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo = m_bridgeInfo.fromLeft.xy();
+	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
-	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
-	m_bounds.lo.min(m_bridgeInfo.toLeft.xy());
-	m_bounds.hi.max(m_bridgeInfo.toLeft.xy());
-	m_bounds.lo.min(m_bridgeInfo.toRight.xy());
-	m_bounds.hi.max(m_bridgeInfo.toRight.xy());
+	m_bounds.lo.min(m_bridgeInfo.fromRight.getXY());
+	m_bounds.hi.max(m_bridgeInfo.fromRight.getXY());
+	m_bounds.lo.min(m_bridgeInfo.toLeft.getXY());
+	m_bounds.hi.max(m_bridgeInfo.toLeft.getXY());
+	m_bounds.lo.min(m_bridgeInfo.toRight.getXY());
+	m_bounds.hi.max(m_bridgeInfo.toRight.getXY());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -659,13 +659,13 @@ Bool Bridge::isCellOnEnd(const Region2D *cell)
 	if (PointInRegion2D(&toLeft, cell)) return false;
 	if (PointInRegion2D(&toRight, cell)) return false; */
 	Coord2D line1, line2;
-	line1 = fromLeft.xy();
-	line2 = fromRight.xy();
+	line1 = fromLeft.getXY();
+	line2 = fromRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = toLeft.xy();
-	line2 = toRight.xy();
+	line1 = toLeft.getXY();
+	line2 = toRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -703,13 +703,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.y += endVector.y;
 
 	Coord2D line1, line2;
-	line1 = fromLeft.xy();
-	line2 = toLeft.xy();
+	line1 = fromLeft.getXY();
+	line2 = toLeft.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = fromRight.xy();
-	line2 = toRight.xy();
+	line1 = fromRight.getXY();
+	line2 = toRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -725,13 +725,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.x += endVector.x;
 	toRight.y += endVector.y;
 
-	line1 = fromLeft.xy();
-	line2 = toLeft.xy();
+	line1 = fromLeft.getXY();
+	line2 = toLeft.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = fromRight.xy();
-	line2 = toRight.xy();
+	line1 = fromRight.getXY();
+	line2 = toRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -790,13 +790,13 @@ Bool Bridge::isCellEntryPoint(const Region2D *cell)
 	if (PointInRegion2D(&toRight, cell)) return false;
 	*/
 	Coord2D line1, line2;
-	line1 = fromLeft.xy();
-	line2 = fromRight.xy();
+	line1 = fromLeft.getXY();
+	line2 = fromRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = toLeft.xy();
-	line2 = toRight.xy();
+	line1 = toLeft.getXY();
+	line2 = toRight.getXY();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -1751,7 +1751,7 @@ Bool TerrainLogic::objectInteractsWithBridgeLayer(Object *obj, Int layer, Bool c
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo = obj->getPosition()->xy();
+			bounds.lo = obj->getPosition()->getXY();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;
@@ -1799,7 +1799,7 @@ Bool TerrainLogic::objectInteractsWithBridgeEnd(Object *obj, Int layer) const
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo = obj->getPosition()->xy();
+			bounds.lo = obj->getPosition()->getXY();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -223,9 +223,9 @@ m_bridgeInfo(theInfo)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.expandWith(m_bridgeInfo.fromRight.asCoord2D());
-	m_bounds.expandWith(m_bridgeInfo.toLeft.asCoord2D());
-	m_bounds.expandWith(m_bridgeInfo.toRight.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -349,9 +349,9 @@ Bridge::Bridge(Object *bridgeObj)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.expandWith(m_bridgeInfo.fromRight.asCoord2D());
-	m_bounds.expandWith(m_bridgeInfo.toLeft.asCoord2D());
-	m_bounds.expandWith(m_bridgeInfo.toRight.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.uniteWith(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -223,9 +223,9 @@ m_bridgeInfo(theInfo)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.unite(m_bridgeInfo.fromRight.asCoord2D());
-	m_bounds.unite(m_bridgeInfo.toLeft.asCoord2D());
-	m_bounds.unite(m_bridgeInfo.toRight.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -349,9 +349,9 @@ Bridge::Bridge(Object *bridgeObj)
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
 	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.unite(m_bridgeInfo.fromRight.asCoord2D());
-	m_bounds.unite(m_bridgeInfo.toLeft.asCoord2D());
-	m_bounds.unite(m_bridgeInfo.toRight.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.expandWith(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -221,11 +221,11 @@ m_bridgeInfo(theInfo)
 	m_templateName = bridgeTemplateName;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
+	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.unite(m_bridgeInfo.fromRight.getXY());
-	m_bounds.unite(m_bridgeInfo.toLeft.getXY());
-	m_bounds.unite(m_bridgeInfo.toRight.getXY());
+	m_bounds.unite(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.unite(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.unite(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -347,11 +347,11 @@ Bridge::Bridge(Object *bridgeObj)
 	m_bridgeInfo.to.z = (m_bridgeInfo.toLeft.z + m_bridgeInfo.toRight.z)/2.0f;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo = m_bridgeInfo.fromLeft.getXY();
+	m_bounds.lo = m_bridgeInfo.fromLeft.asCoord2D();
 	m_bounds.hi = m_bounds.lo;
-	m_bounds.unite(m_bridgeInfo.fromRight.getXY());
-	m_bounds.unite(m_bridgeInfo.toLeft.getXY());
-	m_bounds.unite(m_bridgeInfo.toRight.getXY());
+	m_bounds.unite(m_bridgeInfo.fromRight.asCoord2D());
+	m_bounds.unite(m_bridgeInfo.toLeft.asCoord2D());
+	m_bounds.unite(m_bridgeInfo.toRight.asCoord2D());
 
 	m_bridgeInfo.curDamageState = BODY_PRISTINE;
 
@@ -653,13 +653,13 @@ Bool Bridge::isCellOnEnd(const Region2D *cell)
 	if (PointInRegion2D(&toLeft, cell)) return false;
 	if (PointInRegion2D(&toRight, cell)) return false; */
 	Coord2D line1, line2;
-	line1 = fromLeft.getXY();
-	line2 = fromRight.getXY();
+	line1 = fromLeft.asCoord2D();
+	line2 = fromRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = toLeft.getXY();
-	line2 = toRight.getXY();
+	line1 = toLeft.asCoord2D();
+	line2 = toRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -697,13 +697,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.y += endVector.y;
 
 	Coord2D line1, line2;
-	line1 = fromLeft.getXY();
-	line2 = toLeft.getXY();
+	line1 = fromLeft.asCoord2D();
+	line2 = toLeft.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = fromRight.getXY();
-	line2 = toRight.getXY();
+	line1 = fromRight.asCoord2D();
+	line2 = toRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -719,13 +719,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.x += endVector.x;
 	toRight.y += endVector.y;
 
-	line1 = fromLeft.getXY();
-	line2 = toLeft.getXY();
+	line1 = fromLeft.asCoord2D();
+	line2 = toLeft.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = fromRight.getXY();
-	line2 = toRight.getXY();
+	line1 = fromRight.asCoord2D();
+	line2 = toRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -784,13 +784,13 @@ Bool Bridge::isCellEntryPoint(const Region2D *cell)
 	if (PointInRegion2D(&toRight, cell)) return false;
 	*/
 	Coord2D line1, line2;
-	line1 = fromLeft.getXY();
-	line2 = fromRight.getXY();
+	line1 = fromLeft.asCoord2D();
+	line2 = fromRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1 = toLeft.getXY();
-	line2 = toRight.getXY();
+	line1 = toLeft.asCoord2D();
+	line2 = toRight.asCoord2D();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -1745,7 +1745,7 @@ Bool TerrainLogic::objectInteractsWithBridgeLayer(Object *obj, Int layer, Bool c
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo = obj->getPosition()->getXY();
+			bounds.lo = obj->getPosition()->asCoord2D();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;
@@ -1793,7 +1793,7 @@ Bool TerrainLogic::objectInteractsWithBridgeEnd(Object *obj, Int layer) const
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo = obj->getPosition()->getXY();
+			bounds.lo = obj->getPosition()->asCoord2D();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -221,8 +221,7 @@ m_bridgeInfo(theInfo)
 	m_templateName = bridgeTemplateName;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo.x = m_bridgeInfo.fromLeft.x;
-	m_bounds.lo.y = m_bridgeInfo.fromLeft.y;
+	m_bounds.lo = m_bridgeInfo.fromLeft.xy();
 	m_bounds.hi = m_bounds.lo;
 	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
 	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
@@ -351,8 +350,7 @@ Bridge::Bridge(Object *bridgeObj)
 	m_bridgeInfo.to.z = (m_bridgeInfo.toLeft.z + m_bridgeInfo.toRight.z)/2.0f;
 
 	//Coord3D fromLeft, fromRight, toLeft, toRight; /// The 4 corners of the rectangle that the bridge covers.
-	m_bounds.lo.x = m_bridgeInfo.fromLeft.x;
-	m_bounds.lo.y = m_bridgeInfo.fromLeft.y;
+	m_bounds.lo = m_bridgeInfo.fromLeft.xy();
 	m_bounds.hi = m_bounds.lo;
 	m_bounds.lo.min(m_bridgeInfo.fromRight.xy());
 	m_bounds.hi.max(m_bridgeInfo.fromRight.xy());
@@ -661,17 +659,13 @@ Bool Bridge::isCellOnEnd(const Region2D *cell)
 	if (PointInRegion2D(&toLeft, cell)) return false;
 	if (PointInRegion2D(&toRight, cell)) return false; */
 	Coord2D line1, line2;
-	line1.x = fromLeft.x;
-	line1.y = fromLeft.y;
-	line2.x = fromRight.x;
-	line2.y = fromRight.y;
+	line1 = fromLeft.xy();
+	line2 = fromRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1.x = toLeft.x;
-	line1.y = toLeft.y;
-	line2.x = toRight.x;
-	line2.y = toRight.y;
+	line1 = toLeft.xy();
+	line2 = toRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -709,17 +703,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.y += endVector.y;
 
 	Coord2D line1, line2;
-	line1.x = fromLeft.x;
-	line1.y = fromLeft.y;
-	line2.x = toLeft.x;
-	line2.y = toLeft.y;
+	line1 = fromLeft.xy();
+	line2 = toLeft.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1.x = fromRight.x;
-	line1.y = fromRight.y;
-	line2.x = toRight.x;
-	line2.y = toRight.y;
+	line1 = fromRight.xy();
+	line2 = toRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -735,17 +725,13 @@ Bool Bridge::isCellOnSide(const Region2D *cell)
 	toRight.x += endVector.x;
 	toRight.y += endVector.y;
 
-	line1.x = fromLeft.x;
-	line1.y = fromLeft.y;
-	line2.x = toLeft.x;
-	line2.y = toLeft.y;
+	line1 = fromLeft.xy();
+	line2 = toLeft.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1.x = fromRight.x;
-	line1.y = fromRight.y;
-	line2.x = toRight.x;
-	line2.y = toRight.y;
+	line1 = fromRight.xy();
+	line2 = toRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -804,17 +790,13 @@ Bool Bridge::isCellEntryPoint(const Region2D *cell)
 	if (PointInRegion2D(&toRight, cell)) return false;
 	*/
 	Coord2D line1, line2;
-	line1.x = fromLeft.x;
-	line1.y = fromLeft.y;
-	line2.x = fromRight.x;
-	line2.y = fromRight.y;
+	line1 = fromLeft.xy();
+	line2 = fromRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
-	line1.x = toLeft.x;
-	line1.y = toLeft.y;
-	line2.x = toRight.x;
-	line2.y = toRight.y;
+	line1 = toLeft.xy();
+	line2 = toRight.xy();
 	if (LineInRegion(&line1, &line2, cell)) {
 		return true;
 	}
@@ -1769,8 +1751,7 @@ Bool TerrainLogic::objectInteractsWithBridgeLayer(Object *obj, Int layer, Bool c
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo.x = obj->getPosition()->x;
-			bounds.lo.y = obj->getPosition()->y;
+			bounds.lo = obj->getPosition()->xy();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;
@@ -1818,8 +1799,7 @@ Bool TerrainLogic::objectInteractsWithBridgeEnd(Object *obj, Int layer) const
 			Real radius = obj->getGeometryInfo().getMinorRadius();
 			radius += PATHFIND_CELL_SIZE_F/2.0f;
 			Region2D bounds;
-			bounds.lo.x = obj->getPosition()->x;
-			bounds.lo.y = obj->getPosition()->y;
+			bounds.lo = obj->getPosition()->xy();
 			bounds.hi = bounds.lo;
 			bounds.lo.x -= radius;
 			bounds.lo.y -= radius;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -237,13 +237,13 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 
 		// find the bounding region of the yard area
 		Region2D yardRegion;
-		yardRegion.lo = yardPositions[ 0 ].xy();
-		yardRegion.hi = yardPositions[ 0 ].xy();
+		yardRegion.lo = yardPositions[ 0 ].getXY();
+		yardRegion.hi = yardPositions[ 0 ].getXY();
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.lo.min(yardPositions[ i ].xy());
-			yardRegion.hi.max(yardPositions[ i ].xy());
+			yardRegion.lo.min(yardPositions[ i ].getXY());
+			yardRegion.hi.max(yardPositions[ i ].getXY());
 
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -242,8 +242,7 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.lo.min(yardPositions[ i ].getXY());
-			yardRegion.hi.max(yardPositions[ i ].getXY());
+			yardRegion.unite(yardPositions[ i ].getXY());
 
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -242,7 +242,7 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.unite(yardPositions[ i ].asCoord2D());
+			yardRegion.expandWith(yardPositions[ i ].asCoord2D());
 
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -237,10 +237,8 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 
 		// find the bounding region of the yard area
 		Region2D yardRegion;
-		yardRegion.lo.x = yardPositions[ 0 ].x;
-		yardRegion.lo.y = yardPositions[ 0 ].y;
-		yardRegion.hi.x = yardPositions[ 0 ].x;
-		yardRegion.hi.y = yardPositions[ 0 ].y;
+		yardRegion.lo = yardPositions[ 0 ].xy();
+		yardRegion.hi = yardPositions[ 0 ].xy();
 		for( i = 1; i < yardBones; i++ )
 		{
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -242,7 +242,7 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.expandWith(yardPositions[ i ].asCoord2D());
+			yardRegion.uniteWith(yardPositions[ i ].asCoord2D());
 
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -237,12 +237,12 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 
 		// find the bounding region of the yard area
 		Region2D yardRegion;
-		yardRegion.lo = yardPositions[ 0 ].getXY();
-		yardRegion.hi = yardPositions[ 0 ].getXY();
+		yardRegion.lo = yardPositions[ 0 ].asCoord2D();
+		yardRegion.hi = yardPositions[ 0 ].asCoord2D();
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			yardRegion.unite(yardPositions[ i ].getXY());
+			yardRegion.unite(yardPositions[ i ].asCoord2D());
 
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -244,14 +244,8 @@ void PrisonBehavior::pickVisualLocation( Coord3D *pos )
 		for( i = 1; i < yardBones; i++ )
 		{
 
-			if( yardPositions[ i ].x < yardRegion.lo.x )
-				yardRegion.lo.x = yardPositions[ i ].x;
-			if( yardPositions[ i ].y < yardRegion.lo.y )
-				yardRegion.lo.y = yardPositions[ i ].y;
-			if( yardPositions[ i ].x > yardRegion.hi.x )
-				yardRegion.hi.x = yardPositions[ i ].x;
-			if( yardPositions[ i ].y > yardRegion.hi.y )
-				yardRegion.hi.y = yardPositions[ i ].y;
+			yardRegion.lo.min(yardPositions[ i ].xy());
+			yardRegion.hi.max(yardPositions[ i ].xy());
 
 		}
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/RampTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/RampTool.cpp
@@ -161,9 +161,9 @@ void RampTool::applyRamp(CWorldBuilderDoc* pDoc)
 		pDoc->getCoordFromCellIndex(indices[i], &pt);
 
 		Real uVal;
-		Coord2D start = { mStartPoint.x, mStartPoint.y };
-		Coord2D end = { mEndPoint.x, mEndPoint.y };
-		Coord2D pt2D = { pt.x, pt.y };
+		Coord2D start = mStartPoint.xy();
+		Coord2D end = mEndPoint.xy();
+		Coord2D pt2D = pt.xy();
 
 		ShortestDistancePointToSegment2D(&start, &end, &pt2D, nullptr, nullptr, &uVal);
 		Real height = mStartPoint.z + uVal * (mEndPoint.z - mStartPoint.z);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/RampTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/RampTool.cpp
@@ -161,9 +161,9 @@ void RampTool::applyRamp(CWorldBuilderDoc* pDoc)
 		pDoc->getCoordFromCellIndex(indices[i], &pt);
 
 		Real uVal;
-		Coord2D start = mStartPoint.getXY();
-		Coord2D end = mEndPoint.getXY();
-		Coord2D pt2D = pt.getXY();
+		Coord2D start = mStartPoint.asCoord2D();
+		Coord2D end = mEndPoint.asCoord2D();
+		Coord2D pt2D = pt.asCoord2D();
 
 		ShortestDistancePointToSegment2D(&start, &end, &pt2D, nullptr, nullptr, &uVal);
 		Real height = mStartPoint.z + uVal * (mEndPoint.z - mStartPoint.z);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/RampTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/RampTool.cpp
@@ -161,9 +161,9 @@ void RampTool::applyRamp(CWorldBuilderDoc* pDoc)
 		pDoc->getCoordFromCellIndex(indices[i], &pt);
 
 		Real uVal;
-		Coord2D start = mStartPoint.xy();
-		Coord2D end = mEndPoint.xy();
-		Coord2D pt2D = pt.xy();
+		Coord2D start = mStartPoint.getXY();
+		Coord2D end = mEndPoint.getXY();
+		Coord2D pt2D = pt.getXY();
 
 		ShortestDistancePointToSegment2D(&start, &end, &pt2D, nullptr, nullptr, &uVal);
 		Real height = mStartPoint.z + uVal * (mEndPoint.z - mStartPoint.z);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/RoadTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/RoadTool.cpp
@@ -67,9 +67,9 @@ MapObject* RoadTool::findSegment(const Coord3D *pLoc, Coord3D *outLoc)
 			if (!pMapObj2->getFlag(FLAG_ROAD_POINT2))
 				continue;
 			Coord2D start, end, loc, snapLoc;
-			start = pMapObj->getLocation()->xy();
-			end = pMapObj2->getLocation()->xy();
-			loc = pLoc->xy();
+			start = pMapObj->getLocation()->getXY();
+			end = pMapObj2->getLocation()->getXY();
+			loc = pLoc->getXY();
 			Real dist;
 			Real u;
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/RoadTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/RoadTool.cpp
@@ -67,12 +67,9 @@ MapObject* RoadTool::findSegment(const Coord3D *pLoc, Coord3D *outLoc)
 			if (!pMapObj2->getFlag(FLAG_ROAD_POINT2))
 				continue;
 			Coord2D start, end, loc, snapLoc;
-			start.x = pMapObj->getLocation()->x;
-			start.y = pMapObj->getLocation()->y;
-			end.x = pMapObj2->getLocation()->x;
-			end.y = pMapObj2->getLocation()->y;
-			loc.x = pLoc->x;
-			loc.y = pLoc->y;
+			start = pMapObj->getLocation()->xy();
+			end = pMapObj2->getLocation()->xy();
+			loc = pLoc->xy();
 			Real dist;
 			Real u;
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/RoadTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/RoadTool.cpp
@@ -67,9 +67,9 @@ MapObject* RoadTool::findSegment(const Coord3D *pLoc, Coord3D *outLoc)
 			if (!pMapObj2->getFlag(FLAG_ROAD_POINT2))
 				continue;
 			Coord2D start, end, loc, snapLoc;
-			start = pMapObj->getLocation()->getXY();
-			end = pMapObj2->getLocation()->getXY();
-			loc = pLoc->getXY();
+			start = pMapObj->getLocation()->asCoord2D();
+			end = pMapObj2->getLocation()->asCoord2D();
+			loc = pLoc->asCoord2D();
 			Real dist;
 			Real u;
 


### PR DESCRIPTION
Split off from #3245 where an intersect function was needed for `IRegion2D`.

In the current PR we implement
- `intersectWith` and `uniteWith` functions for `IRegion3D`, `IRegion2D`, `Region3D` and `Region2D` 
- `updateMin` and `updateMax` functions for `ICoord3D`, `ICoord2D`, `Coord3D` and `Coord2D`
- `asCoord2D` and `asICoord2D` functions for `Coord3D` and `ICoord3D` respectively.

AI was used to implement this, every line was checked.