### PR TITLE
ci(release): Stop requesting permissions from the reusable workflow

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1,9 +1,6 @@
 name: Build Toolchain
 
-permissions:
-  contents: read
-  pull-requests: write
-  packages: write
+# No permissions here - callers grant contents: read, and packages: write if using vcpkg.
 
 on:
   workflow_call:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: GenCI
 
 permissions:
   contents: read
-  pull-requests: write
-  packages: write
 
 on:
   push:
@@ -61,6 +59,9 @@ jobs:
     name: Build Generals${{ matrix.preset && '' }}
     needs: detect-changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.generals == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -106,6 +107,8 @@ jobs:
     name: Build GeneralsMD${{ matrix.preset && '' }}
     needs: detect-changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.generalsmd == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -134,6 +137,9 @@ jobs:
     name: Build GeneralsMD${{ matrix.preset && '' }}
     needs: detect-changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.generalsmd == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -87,6 +87,8 @@ jobs:
     needs: [detect-scm-changes, get-date]
     if: needs.detect-scm-changes.outputs.changed == 'true'
     name: Build Generals${{ matrix.preset && '' }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -101,12 +103,13 @@ jobs:
       preset: ${{ matrix.preset }}
       tools: ${{ matrix.tools }}
       extras: ${{ matrix.extras }}
-    secrets: inherit
 
   build-generalsmd:
     needs: [detect-scm-changes, get-date]
     if: needs.detect-scm-changes.outputs.changed == 'true'
     name: Build GeneralsMD${{ matrix.preset && '' }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -121,7 +124,6 @@ jobs:
       preset: ${{ matrix.preset }}
       tools: ${{ matrix.tools }}
       extras: ${{ matrix.extras }}
-    secrets: inherit
 
   create-release:
     name: Create Release


### PR DESCRIPTION
Weekly Release was failing at startup because `build-toolchain.yml`
asked for `packages: write` but the callers never granted it
(`secrets: inherit` doesn't extend permissions).

Fixed by dropping the request from the reusable workflow and granting
`contents: read` (and `packages: write` for vcpkg presets) on the
caller jobs instead. Also dropped `ci.yml`'s top-level
`pull-requests: write`, unused there. Added a comment since a missing
grant fails silently - vcpkg just stops using the NuGet cache instead
of erroring.

Tested on my fork, workflow runs clean now.