### PR TITLE
fix(pointgroup): Prevent null dereference in PointGroupClass::RenderVolumeParticle() when no size array is given

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/pointgr.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/pointgr.cpp
@@ -1790,7 +1790,7 @@ void PointGroupClass::RenderVolumeParticle(RenderInfoClass &rinfo, unsigned int 
 			// 3 times per particle when we can do it once
 			float recipDepth = 0.1f / (float)depth;
 
-			float shiftInc = ( t *  *current_size * recipDepth );
+			float shiftInc = t * (current_size ? *current_size : DefaultPointSize) * recipDepth;
 
 			Vector3 volumeLayerShift;
 			Vector3 cameraPosition = rinfo.Camera.Get_Position();


### PR DESCRIPTION
Fixes a null-pointer dereference when rendering volume particles without a per-point size array. `RenderVolumeParticle()` previously dereferenced `current_size` while calculating the layer offset, even when the particles used `DefaultPointSize`.
Found by clang-tidy